### PR TITLE
CLC-4435 Re-enable Spork for JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -174,6 +174,7 @@ group :development, :test , :testext do
   gem 'headless', '~> 1.0.2'
 
   # Spork can speed up multiple test runs.
+  gem 'spork', :git => 'https://github.com/sporkrb/spork.git'
   gem 'spork-rails', '~> 4.0.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,12 @@ GIT
       rspec (>= 2, < 4)
       rspec-core (!= 2.12.0)
 
+GIT
+  remote: https://github.com/sporkrb/spork.git
+  revision: 224df492657e617a0c93c0319e78f0eefee5b636
+  specs:
+    spork (1.0.0rc4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -376,7 +382,6 @@ GEM
     slop (3.6.0)
     spoon (0.0.4)
       ffi
-    spork (1.0.0rc4)
     spork-rails (4.0.0)
       rails (>= 3.0.0, < 5)
       spork (>= 1.0rc0)
@@ -521,6 +526,7 @@ DEPENDENCIES
   selenium-webdriver (~> 2.44.0)
   signet (~> 0.6.0)
   simplecov (~> 0.9.1)
+  spork!
   spork-rails (~> 4.0.0)
   therubyrhino (~> 2.0.4)
   torquebox (~> 3.1.1)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4435

The RubyMine integration is still broken, unfortunately.