### PR TITLE
CLC-4725 - Roster Print: Remove SIS ID when printing the roster

### DIFF
--- a/app/assets/stylesheets/_canvas_roster.scss
+++ b/app/assets/stylesheets/_canvas_roster.scss
@@ -77,10 +77,6 @@
       white-space: pre-wrap;
     }
 
-    .cc-page-roster-student-id {
-      display: none;
-    }
-
     .cc-page-roster-list {
       li {
         margin-top: 15px;

--- a/app/assets/stylesheets/_canvas_roster.scss
+++ b/app/assets/stylesheets/_canvas_roster.scss
@@ -77,6 +77,10 @@
       white-space: pre-wrap;
     }
 
+    .cc-page-roster-student-id {
+      display: none;
+    }
+
     .cc-page-roster-list {
       li {
         margin-top: 15px;

--- a/app/assets/templates/canvas_embedded/roster.html
+++ b/app/assets/templates/canvas_embedded/roster.html
@@ -34,7 +34,7 @@
       </div>
       <div class="cc-page-roster-student-name" data-ng-bind="student.first_name"></div>
       <div class="cc-page-roster-student-name"><strong data-ng-bind="student.last_name"></strong></div>
-      <div class="cc-page-roster-student-id" data-ng-bind="student.student_id"></div>
+      <div class="cc-print-hide" data-ng-bind="student.student_id"></div>
     </li>
   </ul>
 

--- a/app/assets/templates/canvas_embedded/roster.html
+++ b/app/assets/templates/canvas_embedded/roster.html
@@ -34,7 +34,7 @@
       </div>
       <div class="cc-page-roster-student-name" data-ng-bind="student.first_name"></div>
       <div class="cc-page-roster-student-name"><strong data-ng-bind="student.last_name"></strong></div>
-      <div data-ng-bind="student.student_id"></div>
+      <div class="cc-page-roster-student-id" data-ng-bind="student.student_id"></div>
     </li>
   </ul>
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4725

Applies 'cc-page-roster-student-id' class to all student ids displayed. Hides these student IDs from print media using CSS.