### PR TITLE
CLC-4705 - Course Provisioning: Ensure form only visible to instructors associated with sections in current terms

### DIFF
--- a/app/assets/templates/canvas_embedded/_shared/canvas_feed_error.html
+++ b/app/assets/templates/canvas_embedded/_shared/canvas_feed_error.html
@@ -1,6 +1,6 @@
 <div data-ng-show="feedFetched && !isCourseCreator" class="cc-page-unexpected-error-notice">
   <i class="fa fa-warning"></i>
-  <span>This function is currently only available to instructors.</span>
+  <span>This feature is currently only available to instructors with course sections scheduled in the current or upcoming terms.</span>
 </div>
 
 <div data-ng-show="!feedFetched && feedFetchError" class="cc-page-unexpected-error-notice">


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4705

Simply updates the error message displayed to users with no current official sections to display "This feature is currently only available to instructors with course sections scheduled in the current or upcoming terms". This is valid for students or instructors with no current official sections in the current or upcoming terms.