### PR TITLE
CLC-4682 Find a Person to Add: fix formatting of UID parameter

### DIFF
--- a/app/assets/javascripts/angular/controllers/pages/canvasCourseAddUserController.js
+++ b/app/assets/javascripts/angular/controllers/pages/canvasCourseAddUserController.js
@@ -33,7 +33,7 @@
     };
 
     var setSearchTypeNotice = function() {
-      if ($scope.searchType === 'ldapUserId') {
+      if ($scope.searchType === 'ldap_user_id') {
         $scope.searchTypeNotice = 'CalNet UIDs must be an exact match.';
       } else {
         $scope.searchTypeNotice = '';
@@ -66,7 +66,7 @@
     };
 
     $scope.updateSearchTextType = function() {
-      $scope.searchTextType = (['ldapUserId'].indexOf($scope.searchType) === -1) ? 'text' : 'number';
+      $scope.searchTextType = (['ldap_user_id'].indexOf($scope.searchType) === -1) ? 'text' : 'number';
     };
 
     $scope.searchUsers = function() {

--- a/app/assets/templates/canvas_embedded/course_add_user.html
+++ b/app/assets/templates/canvas_embedded/course_add_user.html
@@ -83,7 +83,7 @@
                   <select id="search-type" data-ng-model="searchType" data-ng-change="updateSearchTextType()" class="bc-form-entity">
                     <option value="name">Last Name, First Name</option>
                     <option value="email">Email</option>
-                    <option value="ldapUserId">CalNet UID</option>
+                    <option value="ldap_user_id">CalNet UID</option>
                   </select>
                 </div>
               </div>


### PR DESCRIPTION
Fixes broken UID search in "Find a Person to Add": https://jira.ets.berkeley.edu/jira/browse/CLC-4682

The API endpoint expects an underscored parameter value, and changing the view code to match seemed less inconsistent than telling the API to expect camelcase.