### PR TITLE
CLC-4329 Course provisioning: validate "Site Name" as required field

### DIFF
--- a/app/assets/javascripts/angular/controllers/pages/canvasCourseProvisionController.js
+++ b/app/assets/javascripts/angular/controllers/pages/canvasCourseProvisionController.js
@@ -92,6 +92,9 @@
     };
 
     $scope.createCourseSiteJob = function() {
+      if ($scope.createCourseSiteForm.$invalid) {
+        return;
+      }
       setErrorText();
       var ccns = selectedCcns();
       if (ccns.length > 0) {

--- a/app/assets/templates/canvas_embedded/course_provision.html
+++ b/app/assets/templates/canvas_embedded/course_provision.html
@@ -121,7 +121,7 @@
             </ul>
           </div>
 
-          <form data-ng-submit="createCourseSiteJob()" class="cc-page-course-provision-form cc-page-provision-site-labels-form">
+          <form name="createCourseSiteForm" data-ng-submit="createCourseSiteJob()" class="cc-page-course-provision-form cc-page-provision-site-labels-form">
             <div class="row">
               <div class="medium-6">
 
@@ -130,7 +130,11 @@
                     <label for="siteName" class="right">Site Name:</label>
                   </div>
                   <div class="medium-8 columns">
-                    <input type="text" id="siteName" data-ng-model="siteName" data-ng-required="true">
+                    <input type="text" name="siteName" id="siteName" data-ng-model="siteName" data-ng-required="true">
+                    <div ng-if="createCourseSiteForm.siteName.$error.required" class="cc-notice-box cc-notice-error cc-radius">
+                      <i class="cc-left fa fa-exclamation-circle cc-icon-red"></i>
+                      Please fill out a site name.
+                    </div>
                   </div>
                 </div>
                 <div class="row">
@@ -144,7 +148,7 @@
 
                 <div class="row">
                   <div class="medium-offset-4 medium-8 columns">
-                    <button class="cc-button cc-button-blue cc-page-provision-form-button" type="submit">Create Course Site</button>
+                    <button ng-disabled="createCourseSiteForm.$invalid" class="cc-button cc-button-blue cc-page-provision-form-button" type="submit">Create Course Site</button>
                     <button class="cc-button cc-page-button-grey" type="button" data-ng-click="showSelecting()">Go Back</button>
                   </div>
                 </div>


### PR DESCRIPTION
Fixes https://jira.ets.berkeley.edu/jira/browse/CLC-4329 along the lines of [this suggestion](http://stackoverflow.com/questions/25471429/angularjs-ng-required-not-working-on-ios) pointed out by @christianv: explicitly show an error message and disable the submit button instead of relying on HTML5 required attribute messaging, which isn't working in Safari.

The extra validity check in the controller code might be redundant, but safety first.

Someone who knows more Angular than me should definitely check this!