### PR TITLE
CLC-4716 - Fix disabled 'Next' button when provisioning by CCN

### DIFF
--- a/app/assets/javascripts/angular/controllers/pages/canvasCourseProvisionController.js
+++ b/app/assets/javascripts/angular/controllers/pages/canvasCourseProvisionController.js
@@ -174,6 +174,7 @@
         currentAdminSemester: semester.slug,
         selectedSectionsList: []
       });
+      $scope.updateSelected();
     };
 
     $scope.switchSemester = function(semester) {
@@ -182,6 +183,7 @@
         currentCourses: semester.classes,
         selectedSectionsList: []
       });
+      $scope.updateSelected();
     };
 
     $scope.toggleAdminMode = function() {

--- a/app/assets/javascripts/angular/controllers/pages/canvasCourseProvisionController.js
+++ b/app/assets/javascripts/angular/controllers/pages/canvasCourseProvisionController.js
@@ -65,6 +65,7 @@
         newSelectedCourses.push(course);
       });
       $scope.currentCourses = newSelectedCourses;
+      $scope.updateSelected();
     };
 
     var selectedCcns = function() {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4716

Resolves issue where all sections are pre-selected when creating course site by CCN, however the 'Next' button was disabled until you de-select and re-select a section.

Also resolves issue when switching between semesters by refreshing the selected sections for the currently selected semester.