### PR TITLE
CLC-4736: fix Selenium tests to handle logout redirect

### DIFF
--- a/spec/ui_selenium/authentication_deep_linking_spec.rb
+++ b/spec/ui_selenium/authentication_deep_linking_spec.rb
@@ -5,6 +5,7 @@ require_relative 'util/web_driver_utils'
 require_relative 'util/user_utils'
 require_relative 'pages/cal_net_auth_page'
 require_relative 'pages/cal_central_pages'
+require_relative 'pages/splash_page'
 require_relative 'pages/my_dashboard_page'
 require_relative 'pages/my_dashboard_to_do_card'
 require_relative 'pages/my_academics_page'
@@ -46,7 +47,8 @@ describe 'Logging in with deep linking', :testui => true do
       my_academics_page.click_first_student_semester
       semester_page = @driver.current_url
       my_academics_page.click_logout_link
-      cal_net_auth_page.logout_conf_heading_element.when_present(timeout=WebDriverUtils.page_load_timeout)
+      splash_page = CalCentralPages::SplashPage.new(@driver)
+      splash_page.wait_for_expected_title?
       @driver.get(semester_page)
       cal_net_auth_page.login(user, password)
       expect(@driver.current_url).to eql(semester_page)

--- a/spec/ui_selenium/authentication_opt_out_spec.rb
+++ b/spec/ui_selenium/authentication_opt_out_spec.rb
@@ -29,8 +29,7 @@ describe 'Opting out', :testui => true do
       cal_net_page.login(UserUtils.oski_username, UserUtils.oski_password)
       dashboard_page = CalCentralPages::MyDashboardPage.new(@driver)
       dashboard_page.opt_out(@driver)
-      cal_net_page.logout_conf_heading_element.when_present(WebDriverUtils.page_load_timeout)
-      splash_page.load_page(@driver)
+      splash_page.wait_for_expected_title?
       splash_page.click_sign_in_button(@driver)
       cal_net_page.login(UserUtils.oski_username, UserUtils.oski_password)
       dashboard_page.recent_activity_heading_element.when_visible(timeout=WebDriverUtils.page_load_timeout)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4736

A couple Selenium tests log out of CalCentral.  These tests were broken by the new redirect in CLC-4736.  The tests now expect the CalCentral splash page to load rather than the CAS "logout success" page.  The tests do still verify that the user is actually logged out of CalNet.