### PR TITLE
CLC-4658 Handle Access Revoked status in Tele-BEARS

### DIFF
--- a/app/assets/templates/adviser_message.html
+++ b/app/assets/templates/adviser_message.html
@@ -1,5 +1,21 @@
 <div class="cc-clearfix cc-academics-adviser-message-container">
   <i class="cc-left fa" data-ng-class="{true:'fa-exclamation-circle cc-icon-red',false:'fa-check-circle cc-icon-green'}[telebears.adviserCodeRequired.required]">
   </i>
-  <div class="cc-academics-adviser-message" data-ng-bind="telebears.adviserCodeRequired.message"></div>
+  <div class="cc-academics-adviser-message" data-ng-switch="telebears.adviserCodeRequired.type">
+    <span data-ng-switch-when="adviser">
+      Before your Tele-BEARS appointment you need to get a code from your adviser.
+    </span>
+    <span data-ng-switch-when="revoked">
+      Your access to Tele-BEARS has been revoked!
+      Please contact Cal Student Central <a href="http://studentcentral.berkeley.edu/open-case">online</a>,
+      visit the office at 120 Sproul Hall, or call 510-664-9181.
+    </span>
+    <span data-ng-switch-when="calso">
+      To get into Tele-BEARS for your appointment, you need to get an adviser code from CalSO.
+      Contact <a href="http://uga.berkeley.edu/nss/">New Student Services</a> at 510-642-4970 for more information.
+    </span>
+    <span data-ng-switch-default>
+      You do not need an adviser code for this semester.
+    </span>
+  </div>
 </div>

--- a/app/models/my_academics/telebears.rb
+++ b/app/models/my_academics/telebears.rb
@@ -81,22 +81,26 @@ module MyAcademics
     def decode_adviser_code_required(code)
       default = {
         required: false,
-        message: "You do not need an adviser code for this semester"
+        type: 'none'
       }
 
       case code
-      when "P"
+      when 'P'
         default
-      when "A"
+      when 'A'
         {
           required: true,
-          message: "Before your Tele-BEARS appointment you need to get a code from your adviser"
+          type: 'adviser'
         }
-      when "C"
+      when 'C'
         {
           required: true,
-          message: "At CalSO you need to get an adviser code. You need this code to get " \
-            "into Tele-BEARS for your appointment"
+          type: 'calso'
+        }
+      when 'N'
+        {
+          required: true,
+          type: 'revoked'
         }
       else
         logger.warn "Unidentified adviser code value for UID #{@uid}: #{code}"

--- a/public/dummy/json/academics.json
+++ b/public/dummy/json/academics.json
@@ -1025,7 +1025,7 @@
       "slug": "spring-2014",
       "adviserCodeRequired": {
         "required": true,
-        "message": "Before your Tele-BEARS appointment you need to get a code from your adviser"
+        "type": "revoked"
       },
       "phases": [
         {

--- a/spec/models/my_academics/telebears_spec.rb
+++ b/spec/models/my_academics/telebears_spec.rb
@@ -73,7 +73,7 @@ describe MyAcademics::Telebears do
         expect(telebears[:year]).to eq 2013
         expect(telebears[:slug]).to eq 'fall-2013'
         expect(telebears[:adviserCodeRequired][:required]).to be_truthy
-        expect(telebears[:adviserCodeRequired][:message]).to eq 'Before your Tele-BEARS appointment you need to get a code from your adviser'
+        expect(telebears[:adviserCodeRequired][:type]).to eq 'adviser'
         expect(telebears[:phases].length).to eq 2
         expect(telebears[:url]).to be_present
       end
@@ -102,21 +102,28 @@ describe MyAcademics::Telebears do
         let(:fake_code) {'P'}
         it 'describes the code' do
           expect(adviser_code_required[:required]).to eq false
-          expect(adviser_code_required[:message]).to match /do not need/
+          expect(adviser_code_required[:type]).to eq 'none'
         end
       end
       context 'CalSO' do
         let(:fake_code) {'C'}
         it 'describes the code' do
           expect(adviser_code_required[:required]).to eq true
-          expect(adviser_code_required[:message]).to match /CalSO/
+          expect(adviser_code_required[:type]).to eq 'calso'
         end
       end
       context 'required' do
         let(:fake_code) {'A'}
         it 'describes the code' do
           expect(adviser_code_required[:required]).to eq true
-          expect(adviser_code_required[:message]).to match /you need to get a code/
+          expect(adviser_code_required[:type]).to eq 'adviser'
+        end
+      end
+      context 'access revoked' do
+        let(:fake_code) {'N'}
+        it 'describes the code' do
+          expect(adviser_code_required[:required]).to eq true
+          expect(adviser_code_required[:type]).to eq 'revoked'
         end
       end
       context 'unknown code' do
@@ -124,7 +131,7 @@ describe MyAcademics::Telebears do
         it 'returns the default' do
           expect(Rails.logger).to receive(:warn).at_least(1).times
           expect(adviser_code_required[:required]).to eq false
-          expect(adviser_code_required[:message]).to match /do not need/
+          expect(adviser_code_required[:type]).to eq 'none'
         end
       end
     end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4658

Also added direct links for CalSO adviser code handling.