### PR TITLE
CLC-4676: UpNext Selenium test

### DIFF
--- a/spec/ui_selenium/my_dashboard_google_tasks_spec.rb
+++ b/spec/ui_selenium/my_dashboard_google_tasks_spec.rb
@@ -353,48 +353,48 @@ describe 'The My Dashboard task manager', :testui => true do
     context 'when completing tasks' do
 
       it 'allows the user to show more completed tasks sorted first by descending task date and then by descending task creation date' do
-      expected_task_titles = []
-      @to_do_card.click_scheduled_tasks_tab
-      (1..3).each do |i|
-        @to_do_card.click_new_task_button
-        @to_do_card.edit_new_task("overdue task #{i.to_s}", WebDriverUtils.ui_date_input_format(yesterday), nil)
-        @to_do_card.click_add_task_button
-        wait_for_task.until { @to_do_card.overdue_task_one_title == "overdue task #{i.to_s}" }
-        expected_task_titles.push(@to_do_card.overdue_task_one_title)
-        @to_do_card.complete_overdue_task_one
+        expected_task_titles = []
+        @to_do_card.click_scheduled_tasks_tab
+        (1..3).each do |i|
+          @to_do_card.click_new_task_button
+          @to_do_card.edit_new_task("overdue task #{i.to_s}", WebDriverUtils.ui_date_input_format(yesterday), nil)
+          @to_do_card.click_add_task_button
+          wait_for_task.until { @to_do_card.overdue_task_one_title == "overdue task #{i.to_s}" }
+          expected_task_titles.push(@to_do_card.overdue_task_one_title)
+          @to_do_card.complete_overdue_task_one
+        end
+        (1..3).each do |i|
+          @to_do_card.click_new_task_button
+          @to_do_card.edit_new_task("today task #{i.to_s}", WebDriverUtils.ui_date_input_format(today), nil)
+          @to_do_card.click_add_task_button
+          wait_for_task.until { @to_do_card.today_task_one_title == "today task #{i.to_s}" }
+          expected_task_titles.push(@to_do_card.today_task_one_title)
+          @to_do_card.complete_today_task_one
+        end
+        (1..3).each do |i|
+          @to_do_card.click_new_task_button
+          @to_do_card.edit_new_task("future task #{i.to_s}", WebDriverUtils.ui_date_input_format(tomorrow), nil)
+          @to_do_card.click_add_task_button
+          wait_for_task.until { @to_do_card.future_task_one_title == "future task #{i.to_s}" }
+          expected_task_titles.push(@to_do_card.future_task_one_title)
+          @to_do_card.complete_future_task_one
+        end
+        @to_do_card.click_unscheduled_tasks_tab
+        (1..3).each do |i|
+          @to_do_card.click_new_task_button
+          @to_do_card.edit_new_task("unscheduled task #{i.to_s}", nil, nil)
+          @to_do_card.click_add_task_button
+          wait_for_task.until { @to_do_card.unsched_task_one_title == "unscheduled task #{i.to_s}" }
+          expected_task_titles.push(@to_do_card.unsched_task_one_title)
+          @to_do_card.complete_unsched_task_one
+        end
+        @to_do_card.click_completed_tasks_tab
+        @to_do_card.completed_task_one_element.when_visible(timeout=task_wait)
+        expect(@to_do_card.completed_task_count).to eql('12')
+        @to_do_card.completed_show_more_button
+        @to_do_card.completed_show_more_button_element.when_not_visible(timeout=task_wait)
+        expect(@to_do_card.all_completed_task_titles).to eql(expected_task_titles.reverse!)
       end
-      (1..3).each do |i|
-        @to_do_card.click_new_task_button
-        @to_do_card.edit_new_task("today task #{i.to_s}", WebDriverUtils.ui_date_input_format(today), nil)
-        @to_do_card.click_add_task_button
-        wait_for_task.until { @to_do_card.today_task_one_title == "today task #{i.to_s}" }
-        expected_task_titles.push(@to_do_card.today_task_one_title)
-        @to_do_card.complete_today_task_one
-      end
-      (1..3).each do |i|
-        @to_do_card.click_new_task_button
-        @to_do_card.edit_new_task("future task #{i.to_s}", WebDriverUtils.ui_date_input_format(tomorrow), nil)
-        @to_do_card.click_add_task_button
-        wait_for_task.until { @to_do_card.future_task_one_title == "future task #{i.to_s}" }
-        expected_task_titles.push(@to_do_card.future_task_one_title)
-        @to_do_card.complete_future_task_one
-      end
-      @to_do_card.click_unscheduled_tasks_tab
-      (1..3).each do |i|
-        @to_do_card.click_new_task_button
-        @to_do_card.edit_new_task("unscheduled task #{i.to_s}", nil, nil)
-        @to_do_card.click_add_task_button
-        wait_for_task.until { @to_do_card.unsched_task_one_title == "unscheduled task #{i.to_s}" }
-        expected_task_titles.push(@to_do_card.unsched_task_one_title)
-        @to_do_card.complete_unsched_task_one
-      end
-      @to_do_card.click_completed_tasks_tab
-      @to_do_card.completed_task_one_element.when_visible(timeout=task_wait)
-      expect(@to_do_card.completed_task_count).to eql('12')
-      @to_do_card.completed_show_more_button
-      @to_do_card.completed_show_more_button_element.when_not_visible(timeout=task_wait)
-      expect(@to_do_card.all_completed_task_titles).to eql(expected_task_titles.reverse!)
-    end
 
       it 'allows the user to mark a completed tasks as un-completed' do
         @to_do_card.click_new_task_button

--- a/spec/ui_selenium/my_dashboard_google_up_next_spec.rb
+++ b/spec/ui_selenium/my_dashboard_google_up_next_spec.rb
@@ -78,46 +78,46 @@ describe 'My Dashboard Up Next card', :testui => true do
 
     context 'for Google calendar events' do
 
-      it 'shows today\'s date' do
+      it 'shows the current date' do
         expect(@up_next_card.day).to eql(today.strftime("%A"))
         expect(@up_next_card.date).to eql(today.strftime("%^b %e"))
       end
 
-      it 'shows today\'s event times' do
+      it 'shows event times' do
         logger.info("#{@up_next_card.all_event_times}")
         expect(@up_next_card.all_event_times).to eql(@initial_event_times + [@event_start_time.strftime("%l:%M\n%p").gsub(' ', '')])
       end
 
-      it 'shows today\'s event summaries' do
+      it 'shows event summaries' do
         logger.info("#{@up_next_card.all_event_summaries}")
         expect(@up_next_card.all_event_summaries).to eql(@initial_event_summaries + [@event_title])
       end
 
-      it 'shows today\'s event locations' do
+      it 'shows event locations' do
         logger.info("#{@up_next_card.all_event_locations}")
         expect(@up_next_card.all_event_locations).to eql(@initial_event_locations + [@event_location])
       end
 
       context 'when expanded' do
 
-        it 'shows today\'s event start times' do
+        it 'shows event start times' do
           logger.info("#{@up_next_card.all_event_start_times}")
           expect(@up_next_card.all_event_start_times).to eql(@initial_event_start_times + [@event_start_time.strftime("%-m/%e/%y %l:%M %P").gsub('  ', ' ')])
         end
 
-        it 'shows today\'s event end times' do
+        it 'shows event end times' do
           logger.info("#{@up_next_card.all_event_end_times}")
           expect(@up_next_card.all_event_end_times).to eql (@initial_event_end_times + [@event_end_time.strftime("%-m/%e/%y %l:%M %P").gsub('  ', ' ')])
         end
 
-        it 'shows today\'s event organizers' do
+        it 'shows event organizers' do
           logger.info("#{@up_next_card.all_event_organizers}")
           expect(@up_next_card.all_event_organizers).to eql(@initial_event_organizers + ['ETS Quality'])
         end
 
       end
 
-      context 'when viewing an event in bCal' do
+      context 'when opening an event in bCal' do
 
         before(:all) do
           @up_next_card.click_bcal_link(@driver, id)
@@ -125,7 +125,7 @@ describe 'My Dashboard Up Next card', :testui => true do
           @google.event_title_displayed_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
         end
 
-        it 'shows the Google calendar event detail' do
+        it 'shows the event detail in Google calendar' do
           expect(@google.event_title_displayed).to eql(@event_title)
         end
 

--- a/spec/ui_selenium/my_dashboard_google_up_next_spec.rb
+++ b/spec/ui_selenium/my_dashboard_google_up_next_spec.rb
@@ -59,14 +59,16 @@ describe 'My Dashboard Up Next card', :testui => true do
       @event_title = "Event #{id}"
       @event_location = "#{id} DWINELLE"
       event = @google.send_invite(@event_title, @event_location)
-      @event_start_time = event[0]
-      @event_end_time = event[1]
-      logger.info("Event start time is #{@event_start_time.strftime("%-m/%e/%y %l:%M %P")}")
-      logger.info("Event end time is #{@event_end_time.strftime("%-m/%e/%y %l:%M %P")}")
+      @event_time = event[0].strftime("%l:%M\n%p").gsub(' ', '')
+      @event_start_time = event[0].strftime("%-m/%e/%y %l:%M %P").gsub('  ', ' ')
+      @event_end_time = event[1].strftime("%-m/%e/%y %l:%M %P").gsub('  ', ' ')
+      logger.info("Event start time is #{@event_start_time}")
+      logger.info("Event end time is #{@event_end_time}")
 
-      # On the Dashboard, check for the new event.  If not there, wait for a live update to occur.
+      # On the Dashboard, wait a moment for the new event.  If not there, wait for a live update to occur.
       @up_next_card.load_page(@driver)
       @up_next_card.events_list_element.when_visible(timeout=WebDriverUtils.google_task_timeout)
+      sleep(WebDriverUtils.page_event_timeout)
       unless @up_next_card.all_event_summaries.include?(@event_title)
         @up_next_card.click_live_update_button(WebDriverUtils.mail_live_update_timeout)
       end
@@ -85,34 +87,34 @@ describe 'My Dashboard Up Next card', :testui => true do
 
       it 'shows event times' do
         logger.info("#{@up_next_card.all_event_times}")
-        expect(@up_next_card.all_event_times).to eql(@initial_event_times + [@event_start_time.strftime("%l:%M\n%p").gsub(' ', '')])
+        expect(@up_next_card.all_event_times).to eql(@initial_event_times.push(@event_time).sort)
       end
 
       it 'shows event summaries' do
         logger.info("#{@up_next_card.all_event_summaries}")
-        expect(@up_next_card.all_event_summaries).to eql(@initial_event_summaries + [@event_title])
+        expect(@up_next_card.all_event_summaries).to eql(@initial_event_summaries.push(@event_title).sort)
       end
 
       it 'shows event locations' do
         logger.info("#{@up_next_card.all_event_locations}")
-        expect(@up_next_card.all_event_locations).to eql(@initial_event_locations + [@event_location])
+        expect(@up_next_card.all_event_locations).to eql(@initial_event_locations.push(@event_location).sort)
       end
 
       context 'when expanded' do
 
         it 'shows event start times' do
           logger.info("#{@up_next_card.all_event_start_times}")
-          expect(@up_next_card.all_event_start_times).to eql(@initial_event_start_times + [@event_start_time.strftime("%-m/%e/%y %l:%M %P").gsub('  ', ' ')])
+          expect(@up_next_card.all_event_start_times).to eql(@initial_event_start_times.push(@event_start_time).sort)
         end
 
         it 'shows event end times' do
           logger.info("#{@up_next_card.all_event_end_times}")
-          expect(@up_next_card.all_event_end_times).to eql (@initial_event_end_times + [@event_end_time.strftime("%-m/%e/%y %l:%M %P").gsub('  ', ' ')])
+          expect(@up_next_card.all_event_end_times).to eql (@initial_event_end_times.push(@event_end_time).sort)
         end
 
         it 'shows event organizers' do
           logger.info("#{@up_next_card.all_event_organizers}")
-          expect(@up_next_card.all_event_organizers).to eql(@initial_event_organizers + ['ETS Quality'])
+          expect(@up_next_card.all_event_organizers).to eql(@initial_event_organizers.push('ETS Quality').sort)
         end
 
       end

--- a/spec/ui_selenium/pages/google_page.rb
+++ b/spec/ui_selenium/pages/google_page.rb
@@ -128,19 +128,13 @@ class GooglePage
     logger.info("Creating event with the subject #{event_name}")
     create_event_button_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
     create_event_button
-    # Enter title and location, and then verify that the input for each sticks.  Google and page-object don't always play nice.
     event_title_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
     event_title
     self.event_title = event_name
-    unless event_title == event_name
-      self.event_title = event_name
-    end
     event_location_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
     event_location
     self.event_location = location
-    unless event_location == location
-      self.event_location = location
-    end
+    sleep(WebDriverUtils.page_event_timeout)
     start_time = Time.strptime(event_start_time, "%l:%M%P")
     end_time = Time.strptime(event_end_time, "%l:%M%P")
     save_event

--- a/spec/ui_selenium/pages/google_page.rb
+++ b/spec/ui_selenium/pages/google_page.rb
@@ -42,10 +42,7 @@ class GooglePage
   text_area(:event_end_time, :xpath => '//input[@title="Until time"]')
   text_area(:event_end_date, :xpath => '//input[@title="Until date"]')
   text_area(:event_location, :xpath => '//input[@placeholder="Enter a location"]')
-  text_area(:guest, :xpath => '//input[@title="Enter email addresses"]')
-  button(:add_guest, :xpath => '//div[text()="Add"]')
   button(:save_event, :xpath => '//div[text()="Save"]')
-  button(:send_no_invites, :name => 'no')
   div(:event_added, :xpath => '//div[contains(text(),"Added")]')
   div(:event_title_displayed, :xpath => '//div[@class="ui-sch-schmedit"]')
 

--- a/spec/ui_selenium/pages/google_page.rb
+++ b/spec/ui_selenium/pages/google_page.rb
@@ -35,17 +35,19 @@ class GooglePage
   link(:mail_sent_link, :id => "link_vsm")
 
   # CALENDAR
-  button(:create_event_button, :xpath => '//div[]text()="Create"')
+  button(:create_event_button, :xpath => '//div[text()="Create"]')
   text_area(:event_title, :xpath => '//input[@title="Event title"]')
   text_area(:event_start_date, :xpath => '//input[@title="From date"]')
   text_area(:event_start_time, :xpath => '//input[@title="From time"]')
   text_area(:event_end_time, :xpath => '//input[@title="Until time"]')
   text_area(:event_end_date, :xpath => '//input[@title="Until date"]')
+  text_area(:event_location, :xpath => '//input[@placeholder="Enter a location"]')
   text_area(:guest, :xpath => '//input[@title="Enter email addresses"]')
   button(:add_guest, :xpath => '//div[text()="Add"]')
   button(:save_event, :xpath => '//div[text()="Save"]')
   button(:send_no_invites, :name => 'no')
-  div(:event_added, :xpath => '//div[contains(text(),"Added"]')
+  div(:event_added, :xpath => '//div[contains(text(),"Added")]')
+  div(:event_title_displayed, :xpath => '//div[@class="ui-sch-schmedit"]')
 
   # TASKS
   button(:toggle_tasks_visibility, :xpath => '//div[@title="Tasks"]')
@@ -102,13 +104,13 @@ class GooglePage
 
   def log_out_google(driver, gmail_user)
     logger.info('Logging out of Google')
-    driver.find_element(:xpath, '//a[contains(@title,"' + gmail_user + '")]').click
+    driver.find_element(:xpath, "//a[contains(@title,#{gmail_user})]").click
     sign_out_link_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
     sign_out_link
   end
 
   def send_email(driver, recipient, subject, body)
-    logger.info('Sending an email with the subject ' + subject)
+    logger.info("Sending an email with the subject #{subject}")
     compose_email_button_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
     compose_email_button
     new_message_heading_element.when_present(timeout=WebDriverUtils.page_event_timeout)
@@ -125,26 +127,34 @@ class GooglePage
     mail_sent_link_element.when_present(timeout=WebDriverUtils.page_event_timeout)
   end
 
-  def send_invite(driver, event, invitee)
-    logger.info('Creating event with the subject ' + event)
+  def send_invite(event_name, location)
+    logger.info("Creating event with the subject #{event_name}")
     create_event_button_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
     create_event_button
+    # Enter title and location, and then verify that the input for each sticks.  Google and page-object don't always play nice.
     event_title_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
-    self.event_title = event
-    self.guest = invitee
-    add_guest
-    wait = Selenium::WebDriver::Wait.new(:timeout => WebDriverUtils.page_event_timeout)
-    wait.until { driver.find_element(:xpath, '//div[contains(@title,' + invitee + ')]') }
+    event_title
+    self.event_title = event_name
+    unless event_title == event_name
+      self.event_title = event_name
+    end
+    event_location_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
+    event_location
+    self.event_location = location
+    unless event_location == location
+      self.event_location = location
+    end
+    start_time = Time.strptime(event_start_time, "%l:%M%P")
+    end_time = Time.strptime(event_end_time, "%l:%M%P")
     save_event
-    send_no_invites_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
-    send_no_invites
     event_added_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
+    [start_time, end_time]
   end
 
   def create_unsched_task(driver, title)
-    logger.info('Creating task with title "' + title + '"')
+    logger.info("Creating task with title #{title}")
     toggle_tasks_visibility_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
-    if !tasks_heading_element.visible?
+    unless tasks_heading_element.visible?
       toggle_tasks_visibility
       tasks_heading_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
     end

--- a/spec/ui_selenium/pages/my_dashboard_up_next_card.rb
+++ b/spec/ui_selenium/pages/my_dashboard_up_next_card.rb
@@ -1,0 +1,87 @@
+require 'selenium-webdriver'
+require 'page-object'
+require_relative 'cal_central_pages'
+require_relative 'my_dashboard_page'
+require_relative '../util/web_driver_utils'
+
+module CalCentralPages
+
+  class MyDashboardUpNextCard < MyDashboardPage
+
+    include PageObject
+    include CalCentralPages
+    include ClassLogger
+
+    span(:day, :xpath => '//span[@data-ng-bind="lastModifiedDate | date:\'EEEE\'"]')
+    span(:date, :xpath => '//span[@data-ng-bind="lastModifiedDate | date:\'MMM d\'"]')
+    unordered_list(:events_list, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]')
+    elements(:event_time, :div, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]/li//div[@class="cc-widget-mycalendar-datelist-time cc-left"]')
+    elements(:event_summary, :div, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]/li//strong[@data-ng-bind="item.summary"]')
+    elements(:event_location, :div, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]/li//div[@data-ng-bind="item.location"]')
+    elements(:event_detail_toggle, :div, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]/li//div[@data-ng-click="api.widget.toggleShow($event, items, item, \'Up Next\')"]')
+    div(:event_start_time, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]//div[@data-ng-bind="item.start.epoch * 1000 | date:\'short\' | lowercase"]')
+    div(:event_end_time, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]//div[@data-ng-bind="item.end.epoch * 1000 | date:\'short\' | lowercase"]')
+    paragraph(:event_organizer, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]//p[@data-ng-bind="item.organizer"]')
+    link(:view_in_bcal_button, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]//a[contains(.,"View in bCal")]')
+
+    def all_event_times
+      times = []
+      event_time_elements.each { |time| times.push(time.text) }
+      times.sort
+    end
+
+    def all_event_summaries
+      summaries = []
+      event_summary_elements.each { |summary| summaries.push(summary.text) }
+      summaries.sort
+    end
+
+    def all_event_locations
+      locations = []
+      event_location_elements.each { |location| locations.push(location.text) }
+      locations.sort
+    end
+
+    def all_event_start_times
+      start_times = []
+      event_detail_toggle_elements.each do |toggle|
+        toggle.click
+        event_start_time_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
+        start_times.push(event_start_time.gsub('  ', ' '))
+        toggle.click
+        event_start_time_element.when_not_visible(timeout=WebDriverUtils.page_event_timeout)
+      end
+      start_times.sort
+    end
+
+    def all_event_end_times
+      end_times = []
+      event_detail_toggle_elements.each do |toggle|
+        toggle.click
+        event_end_time_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
+        end_times.push(event_end_time.gsub('  ', ' '))
+        toggle.click
+        event_end_time_element.when_not_visible(timeout=WebDriverUtils.page_event_timeout)
+      end
+      end_times.sort
+    end
+
+    def all_event_organizers
+      organizers = []
+      event_detail_toggle_elements.each do |toggle|
+        toggle.click
+        event_organizer_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
+        organizers.push(event_organizer)
+        toggle.click
+        event_organizer_element.when_not_visible(timeout=WebDriverUtils.page_event_timeout)
+      end
+      organizers.sort
+    end
+
+    def click_bcal_link(driver, id)
+      driver.find_element(:xpath, "//ul[@class='cc-widget-list cc-widget-mycalendar-datelist']//span[contains(.,'#{id}')]//following-sibling::div").click
+      view_in_bcal_button_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
+      view_in_bcal_button
+    end
+  end
+end

--- a/spec/ui_selenium/util/user_utils.rb
+++ b/spec/ui_selenium/util/user_utils.rb
@@ -45,7 +45,7 @@ class UserUtils
 
   def self.initialize_output_csv(spec)
     output_dir = Rails.root.join('tmp', 'ui_selenium_ouput')
-    output_file = spec.inspect + '.csv'
+    output_file = spec.inspect.sub('RSpec::ExampleGroups::', '') + '.csv'
     logger.info("Initializing test output CSV named #{output_file}")
     unless File.exists?(output_dir)
       FileUtils.mkdir_p(output_dir)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4676

The new test creates a calendar event at Google and then verifies that the event appears in CalCentral, with all the expected detail. It also opens the event in Google and verifies that the event detail view loads. Since the test will run in the wee hours, it will ensure that the UpNext feed is updated immediately each day.

This also includes some clean-up of related Google mail and task tests.