### PR TITLE
CLC-4639 Only show official sections in bCourses Roster Photos

### DIFF
--- a/app/assets/javascripts/angular/controllers/pages/rosterController.js
+++ b/app/assets/javascripts/angular/controllers/pages/rosterController.js
@@ -5,7 +5,7 @@
   /**
    * Canvas roster photos LTI app controller
    */
-  angular.module('calcentral.controllers').controller('RosterController', function(apiService, rosterFactory, $routeParams, $scope) {
+  angular.module('calcentral.controllers').controller('RosterController', function(apiService, rosterFactory, $routeParams, $scope, $window) {
     if ($routeParams.canvasCourseId) {
       apiService.util.setTitle('Roster Photos');
     }
@@ -14,12 +14,14 @@
       if (!$scope.searchSection) {
         return true;
       }
-      return (student.section_ccns.indexOf($scope.searchSection) !== -1);
+      var section_ccn = parseInt($scope.searchSection, 10);
+      return (student.section_ccns.indexOf(section_ccn) !== -1);
     };
 
     var getRoster = function() {
       $scope.context = $scope.campusCourseId ? 'campus' : 'canvas';
       $scope.courseId = $scope.campusCourseId || $routeParams.canvasCourseId || 'embedded';
+      $scope.origin = $window.location.origin;
 
       rosterFactory.getRoster($scope.context, $scope.courseId).success(function(data) {
         angular.extend($scope, data);

--- a/app/assets/templates/canvas_embedded/roster.html
+++ b/app/assets/templates/canvas_embedded/roster.html
@@ -22,14 +22,14 @@
 
   <ul class="cc-page-roster-list">
     <li data-ng-repeat="student in students | filter:search | filter:studentInSectionFilter | orderBy:'last_name'">
-      <div data-ng-show="student.photo">
-        <a data-ng-href="{{student.profile_url}}">
-          <img data-ng-src="{{student.photo}}" width="72" height="96" />
+      <div data-ng-if="student.profile_url">
+        <a data-ng-href="student.profile_url" target="_top">
+          <div data-ng-include="'canvas_embedded/roster_photo.html'"></div>
         </a>
       </div>
-      <div data-ng-hide="student.photo">
-        <a data-ng-href="{{student.profile_url}}">
-          <div class="cc-image-responsive cc-page-roster-image-unavailable" title="Photo unavailable"></div>
+      <div data-ng-if="!student.profile_url">
+        <a data-ng-href="{{origin}}/{{context}}/{{courseId}}/profile/{{student.login_id}}" target="_top">
+          <div data-ng-include="'canvas_embedded/roster_photo.html'"></div>
         </a>
       </div>
       <div class="cc-page-roster-student-name" data-ng-bind="student.first_name"></div>

--- a/app/assets/templates/canvas_embedded/roster_photo.html
+++ b/app/assets/templates/canvas_embedded/roster_photo.html
@@ -1,0 +1,2 @@
+<img data-ng-if="student.photo" data-ng-src="{{student.photo}}" width="72" height="96" alt="Photo of {{student.first_name}} {{student.last_name}}"/>
+<div data-ng-if="!student.photo" class="cc-image-responsive cc-page-roster-image-unavailable" title="Photo unavailable"></div>

--- a/app/controllers/canvas_rosters_controller.rb
+++ b/app/controllers/canvas_rosters_controller.rb
@@ -37,4 +37,13 @@ class CanvasRostersController < RostersController
     serve_photo
   end
 
+  # GET /canvas/:canvas_course_id/profile/:person_id
+  def profile
+    user_id = Integer(params[:person_id], 10)
+    if (profile_url = Canvas::CanvasRosters.new(session[:user_id], course_id: canvas_course_id).profile_url_for_ldap_id(user_id))
+      redirect_to profile_url
+    else
+      redirect_to url_for_path '/404'
+    end
+  end
 end

--- a/app/models/canvas/canvas_rosters.rb
+++ b/app/models/canvas/canvas_rosters.rb
@@ -11,63 +11,60 @@ module Canvas
         students: []
       }
       campus_enrollment_map = {}
-      # Fill in the Canvas course sections (not to be confused with official campus sections).
-      response = Canvas::CourseSections.new(course_id: @canvas_course_id).sections_list
-      return feed unless (response && response.status == 200 && canvas_sections = safe_json(response.body))
-      canvas_sections.each do |canvas_section|
-        canvas_section_id = canvas_section['id']
-        sis_id = canvas_section['sis_section_id']
+      # Look up Canvas course sections associated with official campus sections.
+      official_sections = Canvas::CourseSections.new(course_id: @canvas_course_id).official_section_identifiers
+      return feed unless official_sections
+      official_sections.each do |official_section|
+        canvas_section_id = official_section['id']
+        sis_id = official_section['sis_section_id']
         feed[:sections] << {
           id: canvas_section_id,
-          name: canvas_section['name'],
+          name: official_section['name'],
           sis_id: sis_id
         }
-        # Get the official campus section enrollments (if any) which are associated with these Canvas course sections.
-        if (campus_section = Canvas::Proxy.sis_section_id_to_ccn_and_term(sis_id))
-          section_enrollments = CampusOracle::Queries.get_enrolled_students(campus_section[:ccn], campus_section[:term_yr], campus_section[:term_cd])
-          section_enrollments.each do |enr|
-            if (existing_entry = campus_enrollment_map[enr['ldap_uid']])
-              # We include waitlisted students in the roster. However, we do not show the official photo if the student
-              # is waitlisted in ALL sections.
-              if existing_entry[:enroll_status] == 'W' &&
-                enr['enroll_status'] == 'E'
-                existing_entry[:enroll_status] = 'E'
-              end
-            else
-              campus_enrollment_map[enr['ldap_uid']] = {
-                student_id: enr['student_id'],
-                first_name: enr['first_name'],
-                last_name: enr['last_name'],
-                email: enr['student_email_address'],
-                enroll_status: enr['enroll_status'],
-                photo_bytes: enr['photo_bytes']
-              }
+
+        section_enrollments = CampusOracle::Queries.get_enrolled_students(official_section[:ccn], official_section[:term_yr], official_section[:term_cd])
+        section_enrollments.each do |enr|
+          if (existing_entry = campus_enrollment_map[enr['ldap_uid']])
+            existing_entry[:sections] << {id: canvas_section_id}
+            existing_entry[:section_ccns] << canvas_section_id
+            # We include waitlisted students in the roster. However, we do not show the official photo if the student
+            # is waitlisted in ALL sections.
+            if existing_entry[:enroll_status] == 'W' &&
+              enr['enroll_status'] == 'E'
+              existing_entry[:enroll_status] = 'E'
             end
+          else
+            campus_enrollment_map[enr['ldap_uid']] = {
+              student_id: enr['student_id'],
+              first_name: enr['first_name'],
+              last_name: enr['last_name'],
+              email: enr['student_email_address'],
+              enroll_status: enr['enroll_status'],
+              photo_bytes: enr['photo_bytes'],
+              sections: [{id: canvas_section_id}],
+              section_ccns: [canvas_section_id]
+            }
           end
         end
       end
-      # We only show students with an official enrollment.
-      return feed if campus_enrollment_map.empty?
-      # Get the full list of students in the Canvas course for filtering and merging.
-      canvas_students = Canvas::CourseStudents.new(course_id: @canvas_course_id).full_students_list
-      # Filter and merge the two flavors of enrollment.
-      canvas_students.each do |canvas_student|
-        login_id = canvas_student['login_id']
-        if (campus_student = campus_enrollment_map[login_id])
-          campus_student[:id] = canvas_student['id']
-          if (canvas_enrollments = canvas_student['enrollments']) && !canvas_enrollments.blank?
-            campus_student[:sections] = canvas_enrollments.collect { |enr| {id: enr['course_section_id']} }
-            campus_student[:section_ccns] = canvas_enrollments.collect { |enr| enr['course_section_id'] }
-            campus_student[:profile_url] = canvas_enrollments[0]['html_url']
-          end
-          campus_student[:login_id] = login_id
-          if campus_student[:enroll_status] == 'E' && campus_student[:photo_bytes]
-            campus_student[:photo] = "/canvas/#{@canvas_course_id}/photo/#{canvas_student['id']}"
-          end
-          feed[:students] << campus_student
+
+      campus_enrollment_map.each do |ldap_uid, campus_student|
+        campus_student[:id] = ldap_uid
+        campus_student[:login_id] = ldap_uid
+        if campus_student[:enroll_status] == 'E' && campus_student[:photo_bytes]
+          campus_student[:photo] = "/canvas/#{@canvas_course_id}/photo/#{ldap_uid}"
         end
+        feed[:students] << campus_student
       end
+
       feed
+    end
+
+    def profile_url_for_ldap_id(ldap_id)
+      if (user_profile = Canvas::SisUserProfile.new(user_id: ldap_id).get) && user_profile['id']
+        "#{Settings.canvas_proxy.url_root}/courses/#{@canvas_course_id}/users/#{user_profile['id']}"
+      end
     end
 
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Calcentral::Application.routes.draw do
   get '/api/academics/rosters/canvas/csv/:canvas_course_id' => 'canvas_rosters#get_csv', :as => :canvas_roster_csv, :defaults => { :format => 'csv' }
   get '/api/academics/rosters/campus/csv/:campus_course_id' => 'campus_rosters#get_csv', :as => :campus_roster_csv, :defaults => { :format => 'csv' }
   get '/canvas/:canvas_course_id/photo/:person_id' => 'canvas_rosters#photo', :defaults => { :format => 'jpeg' }, :action => 'show'
+  get '/canvas/:canvas_course_id/profile/:person_id' => 'canvas_rosters#profile'
   get '/campus/:campus_course_id/photo/:person_id' => 'campus_rosters#photo', :defaults => { :format => 'jpeg' }, :action => 'show'
   get '/api/academics/canvas/course_provision' => 'canvas_course_provision#get_feed', :as => :canvas_course_provision, :defaults => { :format => 'json' }
   get '/api/academics/canvas/course_provision_as/:admin_acting_as' => 'canvas_course_provision#get_feed', :as => :canvas_course_provision_as, :defaults => { :format => 'json' }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4639

Per Ray's spec, the Roster Photos tool no longer checks Canvas course site memberships and relies solely on campus data when loading. This should substantially speed up loading, with some UX effects as detailed in the JIRA.