### PR TITLE
CLC-4575: Selenium test for Cal 1 Card UI

### DIFF
--- a/spec/ui_selenium/my_finances_data_cal1card_spec.rb
+++ b/spec/ui_selenium/my_finances_data_cal1card_spec.rb
@@ -1,0 +1,148 @@
+require 'spec_helper'
+require 'selenium-webdriver'
+require 'page-object'
+require 'csv'
+require 'json'
+require_relative 'util/web_driver_utils'
+require_relative 'util/user_utils'
+require_relative 'pages/cal_central_pages'
+require_relative 'pages/splash_page'
+require_relative 'pages/api_my_status_page'
+require_relative 'pages/api_my_cal1_card_page'
+require_relative 'pages/my_finances_pages'
+require_relative 'pages/my_finances_landing_page'
+
+describe 'My Finances Cal1Card', :testui => true do
+
+  if ENV["UI_TEST"]
+
+    include ClassLogger
+
+    begin
+      driver = WebDriverUtils.driver
+      test_users = UserUtils.load_test_users
+      testable_users = []
+      test_output = UserUtils.initialize_output_csv(self)
+
+      CSV.open(test_output, 'wb') do |user_info_csv|
+        user_info_csv << ['UID', 'Has Meal Plan', 'Has Points', 'Has Non-Res Meal Plan', 'Has Debit Account', 'Has Balance',
+                          'Card Lost', 'Card Found' 'Error?']
+      end
+
+      test_users.each do |user|
+        if user['cal1card']
+          uid = user['uid'].to_s
+          logger.info("UID is #{uid}")
+          has_finances_tab = false
+          has_debit_account = false
+          has_debit_balance = false
+          has_meal_plan = false
+          has_nonres_meal_plan = false
+          has_meal_points = false
+          card_lost = false
+          card_found = false
+          threw_error = false
+
+          begin
+            splash_page = CalCentralPages::SplashPage.new(driver)
+            splash_page.load_page(driver)
+            splash_page.basic_auth(driver, uid)
+            status_api_page = ApiMyStatusPage.new(driver)
+            status_api_page.get_json(driver)
+            has_finances_tab = status_api_page.has_finances_tab?
+            cal1card_api = ApiMyCal1CardPage.new(driver)
+            cal1card_api.get_json(driver)
+            if has_finances_tab
+              my_finances_page = CalCentralPages::MyFinancesPages::MyFinancesLandingPage.new(driver)
+              my_finances_page.load_page(driver)
+              my_finances_page.wait_for_cal_1_card
+
+              # Debit account:
+              if cal1card_api.has_debit_account?
+                has_debit_account = true
+                testable_users.push(uid)
+                if cal1card_api.debit_balance.to_i > 0
+                  has_debit_balance = true
+                end
+                api_balance = "$#{cal1card_api.debit_balance}"
+                my_finances_balance = my_finances_page.debit_balance
+                has_manage_debit_link = WebDriverUtils.verify_external_link(driver, my_finances_page.manage_debit_card_element, 'Cal 1 Card: Home')
+                it "shows the debit account balance for UID #{uid}" do
+                  expect(my_finances_balance).to eql(api_balance)
+                end
+                it "shows a link to manage the debit balance at Cal 1 Card for UID #{uid}" do
+                  expect(has_manage_debit_link).to be true
+                end
+              else
+                has_learn_about_debit = WebDriverUtils.verify_external_link(driver, my_finances_page.learn_about_debit_card_element, 'Cal 1 Card: Home')
+                it "shows a link to learn about debit accounts at Cal 1 Card for UID #{uid}" do
+                  expect(has_learn_about_debit).to be true
+                end
+              end
+
+              # Meal plan:
+              if cal1card_api.has_meal_plan?
+                has_meal_plan = true
+                testable_users.push(uid)
+                if cal1card_api.meal_points_balance.to_i > 0
+                  has_meal_points = true
+                end
+                if cal1card_api.meal_points_plan.include?('Non-Resident')
+                  has_nonres_meal_plan = true
+                end
+                api_points = cal1card_api.meal_points_balance
+                api_plan = cal1card_api.meal_points_plan
+                my_finances_points = my_finances_page.meal_points_balance
+                my_finances_plan = my_finances_page.meal_points_plan
+                has_manage_points_link = WebDriverUtils.verify_external_link(driver, my_finances_page.manage_meal_card_element, 'Caldining')
+                it "shows the meal point balance for UID #{uid}" do
+                  expect(my_finances_points).to eql(api_points)
+                end
+                it "shows the meal plan type for UID #{uid}" do
+                  expect(my_finances_plan).to eql(api_plan)
+                end
+                it "shows a link to manage the points balance at Cal 1 Card for UID #{uid}" do
+                  expect(has_manage_points_link).to be true
+                end
+              else
+                has_learn_about_meals = WebDriverUtils.verify_external_link(driver, my_finances_page.learn_about_meal_plan_element, 'Caldining')
+                it "shows a link to learn about meal lans at Cal 1 Card for UID #{uid}" do
+                  expect(has_learn_about_meals).to be true
+                end
+              end
+
+              # Card lost & found
+              if cal1card_api.card_lost?
+                card_lost = true
+                my_finances_card_lost = my_finances_page.card_lost_msg?
+                it "shows a 'card lost' message for UID #{uid}" do
+                  expect(my_finances_card_lost).to be true
+                end
+              elsif cal1card_api.card_found?
+                card_found = true
+                my_finances_card_found = my_finances_page.card_found_msg?
+                it "shows a 'card found' message for UID #{uid}" do
+                  expect(my_finances_card_found).to be true
+                end
+              end
+            end
+
+          rescue => e
+            logger.error e.message + "\n" + e.backtrace.join("\n")
+            threw_error = true
+          ensure
+            CSV.open(test_output, 'a+') do |user_info_csv|
+              user_info_csv << [uid, has_meal_plan, has_meal_points, has_nonres_meal_plan, has_debit_account, has_debit_balance,
+                                card_lost, card_found, threw_error]
+            end
+          end
+        end
+      end
+    rescue => e
+      logger.error e.message + "\n" + e.backtrace.join("\n ")
+    ensure
+      logger.info('Quitting the browser')
+      driver.quit
+    end
+  end
+end

--- a/spec/ui_selenium/my_finances_data_cal1card_spec.rb
+++ b/spec/ui_selenium/my_finances_data_cal1card_spec.rb
@@ -26,7 +26,7 @@ describe 'My Finances Cal1Card', :testui => true do
 
       CSV.open(test_output, 'wb') do |user_info_csv|
         user_info_csv << ['UID', 'Has Meal Plan', 'Has Points', 'Has Non-Res Meal Plan', 'Has Debit Account', 'Has Balance',
-                          'Card Lost', 'Card Found' 'Error?']
+                          'Card Lost', 'Card Found', 'Error?']
       end
 
       test_users.each do |user|
@@ -64,8 +64,8 @@ describe 'My Finances Cal1Card', :testui => true do
                 if cal1card_api.debit_balance.to_i > 0
                   has_debit_balance = true
                 end
-                api_balance = "$#{cal1card_api.debit_balance}"
-                my_finances_balance = my_finances_page.debit_balance
+                api_balance = cal1card_api.debit_balance
+                my_finances_balance = my_finances_page.debit_balance.delete('$, ')
                 has_manage_debit_link = WebDriverUtils.verify_external_link(driver, my_finances_page.manage_debit_card_element, 'Cal 1 Card: Home')
                 it "shows the debit account balance for UID #{uid}" do
                   expect(my_finances_balance).to eql(api_balance)
@@ -92,7 +92,7 @@ describe 'My Finances Cal1Card', :testui => true do
                 end
                 api_points = cal1card_api.meal_points_balance
                 api_plan = cal1card_api.meal_points_plan
-                my_finances_points = my_finances_page.meal_points_balance
+                my_finances_points = my_finances_page.meal_points_balance.delete(', ')
                 my_finances_plan = my_finances_page.meal_points_plan
                 has_manage_points_link = WebDriverUtils.verify_external_link(driver, my_finances_page.manage_meal_card_element, 'Caldining')
                 it "shows the meal point balance for UID #{uid}" do
@@ -137,6 +137,9 @@ describe 'My Finances Cal1Card', :testui => true do
             end
           end
         end
+      end
+      it 'has Cal 1 Card info for at least one of the test UIDs' do
+        expect(testable_users.length).to be > 0
       end
     rescue => e
       logger.error e.message + "\n" + e.backtrace.join("\n ")

--- a/spec/ui_selenium/my_finances_data_cal1card_spec.rb
+++ b/spec/ui_selenium/my_finances_data_cal1card_spec.rb
@@ -74,7 +74,11 @@ describe 'My Finances Cal1Card', :testui => true do
                   expect(has_manage_debit_link).to be true
                 end
               else
+                my_finances_balance = my_finances_page.debit_balance?
                 has_learn_about_debit = WebDriverUtils.verify_external_link(driver, my_finances_page.learn_about_debit_card_element, 'Cal 1 Card: Home')
+                it "shows no debit account balance for UID #{uid}" do
+                  expect(my_finances_balance).to be false
+                end
                 it "shows a link to learn about debit accounts at Cal 1 Card for UID #{uid}" do
                   expect(has_learn_about_debit).to be true
                 end
@@ -105,7 +109,15 @@ describe 'My Finances Cal1Card', :testui => true do
                   expect(has_manage_points_link).to be true
                 end
               else
+                my_finances_points = my_finances_page.meal_points_balance?
+                my_finances_plan = my_finances_page.meal_points_plan?
                 has_learn_about_meals = WebDriverUtils.verify_external_link(driver, my_finances_page.learn_about_meal_plan_element, 'Caldining')
+                it "shows no meal point balance for UID #{uid}" do
+                  expect(my_finances_points).to be false
+                end
+                it "shows no meal plan type for UID #{uid}" do
+                  expect(my_finances_plan).to be false
+                end
                 it "shows a link to learn about meal lans at Cal 1 Card for UID #{uid}" do
                   expect(has_learn_about_meals).to be true
                 end

--- a/spec/ui_selenium/pages/api_my_cal1_card_page.rb
+++ b/spec/ui_selenium/pages/api_my_cal1_card_page.rb
@@ -35,7 +35,7 @@ class ApiMyCal1CardPage
   end
 
   def debit_balance
-    @parsed['debit']
+    (sprintf '%.2f', @parsed['debit'].to_f).to_s
   end
 
   def has_meal_plan?

--- a/spec/ui_selenium/pages/api_my_cal1_card_page.rb
+++ b/spec/ui_selenium/pages/api_my_cal1_card_page.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require 'selenium-webdriver'
+require 'page-object'
+require 'json'
+require_relative '../util/web_driver_utils'
+
+class ApiMyCal1CardPage
+
+  include PageObject
+  include ClassLogger
+
+  def get_json(driver)
+    logger.info('Parsing JSON from /api/my/cal1card')
+    driver.get(WebDriverUtils.base_url + '/api/my/cal1card')
+    body = driver.find_element(:xpath, '//pre').text
+    @parsed = JSON.parse(body)
+  end
+
+  def card_lost?
+    if @parsed['cal1cardLost'] == 'Lost'
+      true
+    end
+  end
+
+  def card_found?
+    if @parsed['cal1cardLost'] == 'Found'
+      true
+    end
+  end
+
+  def has_debit_account?
+    if @parsed['debitMessage'] == 'OK'
+      true
+    end
+  end
+
+  def debit_balance
+    @parsed['debit']
+  end
+
+  def has_meal_plan?
+    unless @parsed['mealpointsPlan'].nil?
+      true
+    end
+  end
+
+  def meal_points_balance
+    @parsed['mealpoints']
+  end
+
+  def meal_points_plan
+    @parsed['mealpointsPlan']
+  end
+end

--- a/spec/ui_selenium/pages/my_finances_landing_page.rb
+++ b/spec/ui_selenium/pages/my_finances_landing_page.rb
@@ -17,6 +17,17 @@ module CalCentralPages
 
       # CAL 1 CARD CARD
       h2(:cal_1_card_heading, :xpath => '//h2[text()="Cal 1 Card"]')
+      div(:cal_1_card_content, :xpath => '//div[@data-ng-if=\'api.user.profile.features.cal1card\']//ul')
+      list_item(:card_lost_msg, :xpath => '//li[contains(text(),"Your Cal 1 Card is reported as lost."]')
+      list_item(:card_found_msg, :xpath => '//li[@data-ng-if="cal1cardLost === \'Lost\'"]')
+      div(:debit_account_header, :xpath => '//div[@class="cc-cal1card-header"]')
+      span(:debit_balance, :xpath => '//span[@data-ng-bind="debit + \'\' | currency"]')
+      link(:manage_debit_card, :xpath => '//div[contains(.,"Debit Account")]/following-sibling::a[contains(.,"Manage Your Card")]')
+      link(:learn_about_debit_card, :xpath => '//div[contains(.,"You don\'t have a debit account")]/following-sibling::a[contains(.,"Learn more about Cal 1 Card")]')
+      span(:meal_points_plan, :xpath => '//span[@data-ng-bind="mealpointsPlan"]')
+      span(:meal_points_balance, :xpath => '//span[@data-ng-bind="mealpoints | number"]')
+      link(:manage_meal_card, :xpath => '//div[contains(.,"Meal Plan")]/following-sibling::a[contains(.,"Manage Your Points")]')
+      link(:learn_about_meal_plan, :xpath => '//div[contains(.,"You don\'t have a meal plan")]/following-sibling::a[contains(.,"Learn more about Meal Plans")]')
 
       # FINANCIAL RESOURCES CARD
       h2(:fin_resources_heading, :xpath => '//h2[text()="Financial Resources"]')
@@ -57,13 +68,17 @@ module CalCentralPages
         driver.get(WebDriverUtils.base_url + '/finances')
       end
 
-      def wait_for_fin_resources_links
-        fin_resources_list_element.when_visible(timeout=WebDriverUtils.fin_resources_links_timeout)
-      end
-
       def click_details_link
         details_link
         activity_heading_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
+      end
+
+      def wait_for_cal_1_card
+        cal_1_card_content_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
+      end
+
+      def wait_for_fin_resources_links
+        fin_resources_list_element.when_visible(timeout=WebDriverUtils.fin_resources_links_timeout)
       end
 
       def wait_for_fin_aid

--- a/spec/ui_selenium/pages/my_finances_landing_page.rb
+++ b/spec/ui_selenium/pages/my_finances_landing_page.rb
@@ -18,7 +18,7 @@ module CalCentralPages
       # CAL 1 CARD CARD
       h2(:cal_1_card_heading, :xpath => '//h2[text()="Cal 1 Card"]')
       div(:cal_1_card_content, :xpath => '//div[@data-ng-if=\'api.user.profile.features.cal1card\']//ul')
-      list_item(:card_lost_msg, :xpath => '//li[contains(text(),"Your Cal 1 Card is reported as lost."]')
+      list_item(:card_lost_msg, :xpath => '//li[contains(.,"Your Cal 1 Card is reported as lost.")]')
       list_item(:card_found_msg, :xpath => '//li[@data-ng-if="cal1cardLost === \'Lost\'"]')
       div(:debit_account_header, :xpath => '//div[@class="cc-cal1card-header"]')
       span(:debit_balance, :xpath => '//span[@data-ng-bind="debit + \'\' | currency"]')


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4575

This test verifies different permutations of the Cal 1 Card UI on My Finances, using a set of real UIDs.  The test verifies that Cal 1 Card data exists for at least one of the test UIDs, so it will fail if the feed is down or if the test UIDs are not useful.  It also verifies the external links to Cal 1 Card and Caldining.  Finally, it generates a CSV containing information about the UIDs to facilitate manual testing and management of the pool of test UIDs themselves.