### PR TITLE
CLC-4745 Fix type inconsistency in roster feeds

### DIFF
--- a/app/assets/javascripts/angular/controllers/pages/rosterController.js
+++ b/app/assets/javascripts/angular/controllers/pages/rosterController.js
@@ -14,8 +14,7 @@
       if (!$scope.searchSection) {
         return true;
       }
-      var section_ccn = parseInt($scope.searchSection, 10);
-      return (student.section_ccns.indexOf(section_ccn) !== -1);
+      return (student.section_ccns.indexOf($scope.searchSection) !== -1);
     };
 
     var getRoster = function() {

--- a/app/models/canvas/canvas_rosters.rb
+++ b/app/models/canvas/canvas_rosters.rb
@@ -15,7 +15,7 @@ module Canvas
       official_sections = Canvas::CourseSections.new(course_id: @canvas_course_id).official_section_identifiers
       return feed unless official_sections
       official_sections.each do |official_section|
-        canvas_section_id = official_section['id']
+        canvas_section_id = official_section['id'].to_s
         sis_id = official_section['sis_section_id']
         feed[:sections] << {
           id: canvas_section_id,

--- a/spec/controllers/canvas_rosters_controller_spec.rb
+++ b/spec/controllers/canvas_rosters_controller_spec.rb
@@ -4,13 +4,14 @@ require "support/canvas_shared_examples"
 describe CanvasRostersController do
   let(:user_id)           { Settings.canvas_proxy.test_user_id }
   let(:canvas_course_id)  { '767330' }
+  let(:section_ccn)       { '1394824' }
   let(:student_id)        { rand(99999) }
   let(:roster_feed) do
     {
       :canvas_course => {"id" => 27},
       :sections => [
         {
-          :id => 34,
+          :id => section_ccn,
           :name => 'COMPSCI 47C SLF 001',
           :sis_id => 'SEC:2014-D-25749'
         }
@@ -23,8 +24,8 @@ describe CanvasRostersController do
           :email => 'sam.samwich@example.com',
           :enroll_status => 'E',
           :id => 4886773,
-          :section_ccns => [1394824],
-          :sections => [{:id => 1394824}],
+          :section_ccns => [section_ccn],
+          :sections => [{:id => section_ccn}],
           :login_id => '1038892',
           :photo => '/canvas/1224681/photo/4886773'
         },
@@ -35,8 +36,8 @@ describe CanvasRostersController do
           :email => 'kkathimyer@example.com',
           :enroll_status => 'W',
           :id => 4911017,
-          :section_ccns => [1394824],
-          :sections => [{:id => 1394824}],
+          :section_ccns => [section_ccn],
+          :sections => [{:id => section_ccn}],
           :login_id => '1006997',
           :photo => '/canvas/1224681/photo/4911017'
         },

--- a/spec/models/canvas/canvas_rosters_spec.rb
+++ b/spec/models/canvas/canvas_rosters_spec.rb
@@ -95,6 +95,7 @@ describe Canvas::CanvasRosters do
       expect(student_in_discussion_section[:email]).to_not be_blank
       expect(student_in_discussion_section[:sections].length).to eq 2
       expect(student_in_discussion_section[:section_ccns].length).to eq 2
+      expect(student_in_discussion_section[:section_ccns].first).to be_a String
 
       student_not_in_discussion_section = feed[:students].find{|student| student[:student_id] == student_not_in_discussion_section_student_id}
       expect(student_not_in_discussion_section).to_not be_nil
@@ -105,6 +106,7 @@ describe Canvas::CanvasRosters do
       expect(student_not_in_discussion_section[:email]).to_not be_blank
       expect(student_not_in_discussion_section[:sections].length).to eq 1
       expect(student_not_in_discussion_section[:section_ccns].length).to eq 1
+      expect(student_not_in_discussion_section[:section_ccns].first).to be_a String
     end
   end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4745

Changed CanvasRosters to return section CCNs as strings, as CampusRosters does. The front-end rosterController may receive feeds from either endpoint and was understandably getting confused.

