### PR TITLE
OEC-537, oec:diff task should expect {dept_name}_courses_confirmed.csv

### DIFF
--- a/app/models/oec/courses_diff.rb
+++ b/app/models/oec/courses_diff.rb
@@ -8,7 +8,7 @@ module Oec
     end
 
     def base_file_name
-      "diff_#{@dept_name.gsub(/\s/, '_')}_courses"
+      "#{@dept_name.gsub(/\s/, '_')}_courses_confirmed"
     end
 
     def headers

--- a/spec/models/oec/courses_diff_spec.rb
+++ b/spec/models/oec/courses_diff_spec.rb
@@ -22,8 +22,9 @@ describe Oec::CoursesDiff do
     it {
       dept_names.each do |dept_name|
         Rails.logger.info "Evaluating diff where dept_name = #{dept_name}"
-        oec_courses_diff = Oec::CoursesDiff.new(dept_name, src_dir, 'tmp/oec')
-        actual_diff = CSV.read oec_courses_diff.export[:filename]
+        diff = Oec::CoursesDiff.new(dept_name, src_dir, 'tmp/oec')
+        expect(diff.base_file_name).to start_with dept_name
+        actual_diff = CSV.read diff.export[:filename]
         expected_diff = CSV.read "#{src_dir}/expected_diff_#{dept_name}_courses.csv"
         expect(actual_diff.length).to eq expected_diff.length
       end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-537

The oec:diff task file find source file based on naming convention. Justin wants *{dept_name}_courses_confirmed.csv*.  This is simple change.