### PR TITLE
CLC-4696 Ensure that LTI frame size updates do in fact update

### DIFF
--- a/app/assets/javascripts/angular/services/utilService.js
+++ b/app/assets/javascripts/angular/services/utilService.js
@@ -102,9 +102,9 @@
      */
     var iframeUpdateHeight = function() {
       if (isInIframe) {
-        var frameHeight = document.body.scrollHeight;
-        var messageSubject = frameHeight > 5000 ? 'resizeLargeFrame' : 'lti.frameResize';
         $window.setInterval(function updateHeight() {
+          var frameHeight = document.body.scrollHeight;
+          var messageSubject = frameHeight > 5000 ? 'resizeLargeFrame' : 'lti.frameResize';
           var message = {subject: messageSubject, height: frameHeight};
           iframePostMessage(JSON.stringify(message));
         }, 250);


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4696

This one's a facepalm. #3289 added variable assignments outside the `updateHeight` function, so they were only set once and wouldn't respond to subsequent changes in the frame height -- or, in the case of slow-loading tools, the initial height of the fully loaded frame.