### PR TITLE
OEC-531, secondary x-listed are expected in CSVs of both participating depts

### DIFF
--- a/app/models/oec/queries.rb
+++ b/app/models/oec/queries.rb
@@ -53,7 +53,6 @@ module Oec
       left outer join calcentral_class_schedule_vw s ON (s.course_cntl_num = c.course_cntl_num AND s.term_yr = c.term_yr AND s.term_cd = c.term_cd)
       where 1=1
         #{terms_query_clause('c', Settings.oec.current_terms_codes)}
-        #{depts_clause('c', Settings.oec.departments, false)}
         and c.primary_secondary_cd = 'S'
         and s.building_name IS NOT NULL and s.room_number IS NOT NULL and s.meeting_days IS NOT NULL and s.meeting_start_time IS NOT NULL
         and #{self.get_location_time_uid_ref('s')} IN

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -9,7 +9,9 @@ namespace :oec do
   task :courses => :environment do
     dept_set = Settings.oec.departments.to_set
     dept_set.each do |dept_name|
-      Oec::Courses.new(dept_name, dest_dir).export
+      exporter = Oec::Courses.new(dept_name, dest_dir)
+      exporter.export
+      Rails.logger.info "#{hr}#{dept_name} course data written to #{dest_dir}/#{exporter.base_file_name}.csv#{hr}"
     end
     Oec::BiologyPostProcessor.new(dest_dir).post_process if dept_set.include? biology_dept_name
     Rails.logger.warn "#{hr}File(s) wrote to #{dest_dir}#{hr}"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-531

For example, secondary MCELLBI sections with cross-listings in PSYCH dept should show in MCELLBI.csv and PSYCH.csv. This allows both depts to vote on whether course should be evaluated. (Reqts confusion has been ironed out. See the OEC-531.)

Fix was to remove the dept constraint in SQL where clause of *get_secondary_cross_listings*

Bonus: *oec.rake courses* gets more logging.