### PR TITLE
OEC-538, BIO_post_processor should skip non-BIO depts in BIO csv (e.g., MCB cross-listing)

### DIFF
--- a/app/models/oec/biology_post_processor.rb
+++ b/app/models/oec/biology_post_processor.rb
@@ -19,10 +19,12 @@ module Oec
           course_name = row[1]
           if index == 0
             header_row = row
+          elsif dept_name.include?(mcellbi_dept) || dept_name.include?(integbi_dept)
+            Rails.logger.warn "#{row[0]} #{row[1]} #{biology.base_file_name} skipped. Course is listed #{dept_name} CSV file."
           else
-            if course_name.match("#{biology_dept} 1A[L]?").present? || dept_name.include?(mcellbi_dept)
+            if course_name.match("#{biology_dept} 1A[L]?").present?
               row[4] = mcellbi_dept
-            elsif course_name.match("#{biology_dept} 1B[L]?").present? || dept_name.include?(integbi_dept)
+            elsif course_name.match("#{biology_dept} 1B[L]?").present?
               row[4] = integbi_dept
             end
             updated_dept_name = row[4]

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -7,14 +7,15 @@ namespace :oec do
 
   desc 'Export courses.csv file'
   task :courses => :environment do
+    files_created = []
     dept_set = Settings.oec.departments.to_set
     dept_set.each do |dept_name|
       exporter = Oec::Courses.new(dept_name, dest_dir)
       exporter.export
-      Rails.logger.info "#{hr}#{dept_name} course data written to #{dest_dir}/#{exporter.base_file_name}.csv#{hr}"
+      files_created << "#{dest_dir}/#{exporter.base_file_name}.csv"
     end
     Oec::BiologyPostProcessor.new(dest_dir).post_process if dept_set.include? biology_dept_name
-    Rails.logger.warn "#{hr}File(s) wrote to #{dest_dir}#{hr}"
+    Rails.logger.warn "#{hr}Files created:#{"\n " + files_created.join("\n ")}#{hr}"
   end
 
   desc 'Generate student files based on courses.csv input'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-538

One example: The BIO.csv would legitimately get:
  2015-B-42154,INTEGBI 95 LEC 002 SPEC RES IN BIO 1B...

Next, BIO_post_processor would move that row to INTEGBI.csv based on its dept_name=INTEGBI.  Problem is that INTEGBI.csv, based on its own SQL query, already has that data.

Our fix is to have BIO_post_processor skip rows in BIO.csv where dept_name = INTEGBI or MCELLBI.

I've also cleaned up logging summary in *oec.rake*.