### PR TITLE
OEC-538, target CSV defaults to biology. Send row to mcellbi or integbi when appropriate

### DIFF
--- a/app/models/oec/biology_post_processor.rb
+++ b/app/models/oec/biology_post_processor.rb
@@ -22,14 +22,14 @@ module Oec
           elsif dept_name.include?(mcellbi_dept) || dept_name.include?(integbi_dept)
             Rails.logger.warn "#{row[0]} #{row[1]} #{biology.base_file_name} skipped. Course is listed #{dept_name} CSV file."
           else
+            target_csv = biology_dept
             if course_name.match("#{biology_dept} 1A[L]?").present?
-              row[4] = mcellbi_dept
+              target_csv = row[4] = mcellbi_dept
             elsif course_name.match("#{biology_dept} 1B[L]?").present?
-              row[4] = integbi_dept
+              target_csv = row[4] = integbi_dept
             end
-            updated_dept_name = row[4]
-            sorted_dept_rows[updated_dept_name] ||= []
-            sorted_dept_rows[updated_dept_name] << row
+            sorted_dept_rows[target_csv] ||= []
+            sorted_dept_rows[target_csv] << row
           end
         end
         File.delete path_to_biology_csv


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-538
Following up on https://github.com/ets-berkeley-edu/calcentral/pull/3304

If a BIO course is cross-listed and dept is something *other than* MCELLBI and INTEGBI then the row will remain in the BIO.csv file. In this scenario, the BIO.csv will not be deleted by post-processor.