### PR TITLE
OEC-532, optional overwrite_file arg (export class) used by oec:students task

### DIFF
--- a/app/models/oec/biology_post_processor.rb
+++ b/app/models/oec/biology_post_processor.rb
@@ -37,7 +37,7 @@ module Oec
         export_rules.each do | next_dept_name, overwrite_file |
           rows = sorted_dept_rows[next_dept_name]
           if rows && rows.length > 0
-            ExportWrapper.new(next_dept_name, header_row, rows, @export_dir, overwrite_file).export
+            ExportWrapper.new(next_dept_name, header_row, rows, @export_dir).export overwrite_file
           end
         end
       end
@@ -46,27 +46,10 @@ module Oec
 
   class ExportWrapper < Oec::Courses
 
-    def initialize(dept_name, header_row, rows, export_dir, overwrite_file = false)
+    def initialize(dept_name, header_row, rows, export_dir)
       super(dept_name, export_dir)
       @header_row = header_row
       @rows = rows
-      @overwrite_file = overwrite_file
-    end
-
-    def export
-      file = output_filename
-      output = CSV.open(
-        file, @overwrite_file ? 'wb' : 'a',
-        {
-          headers: headers,
-          write_headers: @overwrite_file
-        }
-      )
-      append_records output
-      output.close
-      {
-        filename: file
-      }
     end
 
     def headers

--- a/app/models/oec/export.rb
+++ b/app/models/oec/export.rb
@@ -5,13 +5,13 @@ module Oec
       super export_dir
     end
 
-    def export
+    def export(overwrite_file = true)
       file = output_filename
       output = CSV.open(
-        file, 'wb',
+        file, overwrite_file ? 'wb' : 'a',
         {
           headers: headers,
-          write_headers: true
+          write_headers: overwrite_file
         }
       )
       append_records output
@@ -21,7 +21,7 @@ module Oec
       }
     end
 
-    def output_filename(basename = nil, timestamp = nil)
+    def output_filename
       "#{export_directory}/#{base_file_name}.csv"
     end
 

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -25,14 +25,16 @@ namespace :oec do
       dept_set.add 'INTEGBI'
       dept_set.add 'MCELLBI'
     end
+    students_csv_created = false
     dept_set.each do |dept_name|
       filename = "#{dept_name.gsub(/\s/, '_')}_courses.csv"
       csv_file = "#{src_dir}/#{filename}"
       if File.exists? csv_file
         reader = Oec::FileReader.new csv_file
         [Oec::Students, Oec::CourseStudents].each do |klass|
-          klass.new(reader.ccns, reader.gsi_ccns, dest_dir).export
+          klass.new(reader.ccns, reader.gsi_ccns, dest_dir).export !students_csv_created
         end
+        students_csv_created = true
         Rails.logger.warn "#{hr}Files wrote to #{dest_dir}#{hr}"
       elsif dept_name == biology_dept_name
         Rails.logger.info "As expected, #{biology_dept_name} CSV not found. BIO entries are in MCELLBI, etc."

--- a/spec/models/oec/export_spec.rb
+++ b/spec/models/oec/export_spec.rb
@@ -1,12 +1,37 @@
 describe Oec::Export do
 
-  describe '#configure' do
-    context 'setting export directory' do
-      tmp_dir = 'tmp/oec'
-      subject { Oec::Export.new tmp_dir }
-      it {
-        subject.export_directory.should eq tmp_dir
-      }
+  let!(:export_dir) { '/var/tmp/oec' }
+  let!(:base_file_name) { 'filename' }
+  let!(:exporter) { ExportStub.new(export_dir, base_file_name) }
+  let!(:expected_output_path) { '/var/tmp/oec/filename.csv' }
+  let!(:mock_output) { Object.new }
+
+  before do
+    allow(mock_output).to receive(:close)
+  end
+
+  it 'should construct proper directory paths' do
+    exporter.output_filename.should eq expected_output_path
+  end
+
+  it 'should create new file per flag' do
+    expect(CSV).to receive(:open).with(expected_output_path, 'wb', anything).once.and_return mock_output
+    exporter.export true
+  end
+
+  it 'should append to existing file per flag' do
+    expect(CSV).to receive(:open).with(expected_output_path, 'a', anything).once.and_return mock_output
+    exporter.export false
+  end
+
+  class ExportStub < Oec::Export
+    def initialize(export_dir, base_file_name)
+      super export_dir
+      @base_file_name = base_file_name
+    end
+
+    def base_file_name
+      @base_file_name
     end
   end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-532

Course data is in multiple CSVs - one per dept. When running oec:students we (1) create students.csv in first iteration (i.e., dept) and then (2) append to students.csv in subsequent. This actually simplifies some of the code. Increased test coverage a bit.