### PR TITLE
CLC-4663 Remove unnecessary response parsing in Finaid module

### DIFF
--- a/app/models/finaid/proxy.rb
+++ b/app/models/finaid/proxy.rb
@@ -15,17 +15,13 @@ module Finaid
     end
 
     def get
-      request_internal("myfinaid")
+      FeedWrapper.new(request_internal("myfinaid"))
     end
 
     def request_internal(vcr_cassette)
       student_id = lookup_student_id
       if student_id.nil?
-        logger.info "Lookup of student_id for uid #@uid failed, cannot call Myfinaid API"
-        return {
-          :body => "Lookup of student_id for uid #@uid failed, cannot call Myfinaid API",
-          :statusCode => 400
-        }
+        raise Errors::ProxyError.new("Lookup of student_id for uid #{@uid} failed, cannot call Myfinaid API", nil)
       else
         url = "#{@settings.base_url}/#{student_id}/finaid"
         vcr_opts = {:match_requests_on => [:method, :path, VCR.request_matchers.uri_without_params(:token, :app_id, :app_key)]}
@@ -47,10 +43,7 @@ module Finaid
           raise Errors::ProxyError.new("Connection failed: #{response.code} #{response.body}", nil)
         end
         logger.debug "Remote server status #{response.code}, Body = #{response.body}"
-        return {
-          :body => response.body,
-          :statusCode => response.code
-        }
+        response
       end
     end
 

--- a/lib/proxies/feed_wrapper.rb
+++ b/lib/proxies/feed_wrapper.rb
@@ -1,0 +1,86 @@
+class FeedWrapper
+  include Enumerable
+
+  def initialize(obj)
+    @obj = obj
+  end
+
+  def [](key)
+    if @obj.is_a?(Hash) || (@obj.is_a?(Array) && key.is_a?(Integer))
+      self.class.new(@obj[key])
+    else
+      self.class.new(nil)
+    end
+  end
+
+  def ==(obj)
+    if obj.respond_to?(:unwrap)
+      self.unwrap == obj.unwrap
+    else
+      self.unwrap == obj
+    end
+  end
+
+  # This corrects for a quirk in XML-to-object parsing; usually an XML element
+  # is converted to a hash with the element name as key and a hash as a value,
+  # but sibling XML elements with the same name are converted to a hash with the
+  # element name as key and an array of hashes as value. In cases where the number
+  # of elements is unknown, this can ensure that single or blank results still come
+  # wrapped in an array.
+  def as_collection
+    @obj.is_a?(Array) ? self : self.class.new(self.to_a)
+  end
+
+  def blank?
+    @obj.blank?
+  end
+
+  def content(default='')
+    if @obj.is_a? String
+      self.to_text(default)
+    else
+      self['__content__'].to_text(default)
+    end
+  end
+
+  def each
+    if @obj.respond_to?(:each)
+      @obj.each { |e| yield self.class.new(e) }
+    end
+  end
+
+  def find_by(key, value)
+    self.find { |e| e[key].unwrap == value } || self.class.new(nil)
+  end
+
+  def to_a
+    if @obj.is_a?(Array)
+      @obj
+    elsif @obj.blank?
+      []
+    else
+      [@obj]
+    end
+  end
+
+  def to_date(default='')
+    Date.parse(self.to_text).in_time_zone.to_datetime rescue default
+  end
+
+  def to_text(default='')
+    @obj.try(:to_s).try(:strip) || default
+  end
+
+  def to_time(default='')
+    num = self.to_text.gsub(/^0/, '')
+    if num.match(/\A[0-9]+\Z/) && num.length > 2
+      num.insert(num.length - 2, ':')
+    else
+      default
+    end
+  end
+
+  def unwrap
+    @obj
+  end
+end

--- a/lib/proxies/http_requester.rb
+++ b/lib/proxies/http_requester.rb
@@ -6,13 +6,24 @@ module HttpRequester
   # HTTParty is our preferred HTTP connectivity lib. Use this get_response method wherever possible.
   def get_response(url, additional_options={})
     ActiveSupport::Notifications.instrument('proxy', {url: url, class: self.class}) do
-      HTTParty.get(
+      response = HTTParty.get(
         url,
         {
           timeout: Settings.application.outgoing_http_timeout,
           verify: verify_ssl?
         }.merge(additional_options)
       )
+      begin
+        if response.parsed_response.nil?
+          logger.error "Unable to parse response from URL (#{url}), remote server status: #{response.code}, body: #{response.body}"
+        end
+      rescue MultiXml::ParseError => e
+        raise Errors::ProxyError.new("Error parsing XML from URL (#{url}): #{e.message}, remote server status #{response.code}, body: #{response.body}", nil)
+      rescue JSON::ParserError => e
+        raise Errors::ProxyError.new("Error parsing JSON from URL (#{url}): #{e.message}, remote server status #{response.code}, body: #{response.body}", nil)
+      end
+      response
     end
   end
+
 end

--- a/spec/lib/proxies/feed_wrapper_spec.rb
+++ b/spec/lib/proxies/feed_wrapper_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+
+describe FeedWrapper do
+  subject do
+    FeedWrapper.new(MultiXml.parse('
+      <Document>
+        <Subdocument Initials="abcd">
+          <Ajax>a</Ajax>
+          <Boris>b</Boris>
+          <Charlotte>c</Charlotte>
+          <Delphine Alt="porpoise">d</Delphine>
+        </Subdocument>
+        <Subdocument Initials="efgh">
+          <Ernest>e</Ernest>
+          <Flora>f</Flora>
+          <Gawain>g</Gawain>
+          <Hrothgar>h</Hrothgar>
+        </Subdocument>
+      </Document>
+    '))
+  end
+
+  context 'wrapping a collection' do
+    it 'should wrap key lookups in a new FeedWrapper object' do
+      expect(subject['Document']['Subdocument']).to be_a FeedWrapper
+    end
+
+    it 'should return a blank object for missing keys' do
+      nonsense = subject['Non']['Sense']
+      expect(nonsense).to be_a FeedWrapper
+      expect(nonsense).to be_blank
+    end
+
+    it 'should implement Enumerable methods' do
+      expect(
+        subject['Document']['Subdocument'].inject('') { |m, i| m + i['Initials'].to_text }
+      ).to eq 'abcdefgh'
+    end
+
+    context 'finding by key and value' do
+      it 'should find elements by key and value' do
+        expect(subject['Document']['Subdocument'].find_by('Initials', 'efgh')).to be_a FeedWrapper
+      end
+
+      it 'should return blank on failed finds' do
+        failed = subject['Document']['Subdocument'].find_by('Initials', 'wxyz')
+        expect(failed).to be_a FeedWrapper
+        expect(failed).to be_blank
+      end
+    end
+  end
+
+  context 'wrapping a String' do
+    let(:text_wrapper) { FeedWrapper.new('text    ') }
+    let(:date_wrapper) { FeedWrapper.new('3rd Feb 2001    ') }
+    let(:time_wrapper) { FeedWrapper.new(923) }
+
+    it 'should strip string on coercion' do
+      expect(text_wrapper.to_text).to eq 'text'
+    end
+
+    it 'should return blank on key lookups' do
+      expect(text_wrapper[1]).to be_a FeedWrapper
+      expect(text_wrapper[1]).to be_blank
+    end
+
+    it 'should parse date strings' do
+      date = date_wrapper.to_date
+      expect(date.year).to eq 2001
+      expect(date.mon).to eq 2
+      expect(date.mday).to eq 3
+    end
+
+    it 'should format time strings' do
+      expect(time_wrapper.to_time).to eq '9:23'
+    end
+
+    it 'should return blank on unparseable dates or times' do
+      expect(text_wrapper.to_date).to eq ''
+      expect(text_wrapper.to_time).to eq ''
+    end
+  end
+
+  context 'wrapping blank' do
+    let(:blankwrapper) { FeedWrapper.new(nil) }
+
+    it 'should return blank or default on key lookups' do
+      expect(blankwrapper[1]).to be_a FeedWrapper
+      expect(blankwrapper[1]).to be_blank
+    end
+
+    it 'should return blank objects on coercion' do
+      expect(blankwrapper.to_text).to eq ''
+      expect(blankwrapper.to_a).to eq []
+    end
+
+    it 'should accept a default argument on coercion' do
+      expect(blankwrapper.to_text('Default')).to eq 'Default'
+    end
+  end
+
+  context 'as collection' do
+    it 'should wrap a non-Array in an Array' do
+      expect(subject['Document'].as_collection.unwrap).to eq [ subject['Document'].unwrap ]
+    end
+
+    it 'should not wrap an Array in another Array' do
+      expect(subject['Document']['Subdocument'].as_collection.unwrap).to eq subject['Document']['Subdocument'].unwrap
+    end
+  end
+
+end

--- a/spec/models/finaid/proxy_spec.rb
+++ b/spec/models/finaid/proxy_spec.rb
@@ -9,12 +9,10 @@ describe Finaid::Proxy do
   let(:live_non_student){ Finaid::Proxy.new({user_id: '212377', term_year: this_year}).get }
 
   shared_examples "oski tests" do
-    it { subject[:body].should be_present }
-    it { subject[:statusCode].should eq(200) }
-    it "should be valid xml" do
-      expect {
-        Nokogiri::XML(subject[:body]) { |config| config.strict }
-      }.to_not raise_exception
+    it 'should return a successful response' do
+      expect(subject.unwrap.code).to eq 200
+      expect(subject.unwrap.body).to be_present
+      expect { subject.unwrap.parsed_response }.to_not raise_exception
     end
   end
 
@@ -32,10 +30,10 @@ describe Finaid::Proxy do
     context "Test-Emeritus live feed with no data" do
       #Never hits VCR so it should be fine for non-testext, but to make sure
       before(:each) { Finaid::Proxy.any_instance.stub(:lookup_student_id).and_return(nil) }
-      subject { live_non_student }
 
-      it { subject[:body].should eq("Lookup of student_id for uid 212377 failed, cannot call Myfinaid API") }
-      it { subject[:statusCode].should eq(400) }
+      it 'should report failure on student ID lookup' do
+        expect { live_non_student }.to raise_error(Errors::ProxyError)
+      end
     end
   end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4663

The goal is to replace the current divergent state of our XML and JSON feed parsing, as described in the ticket, with a standard approach using the parsed_response Ruby object that HTTParty gives us for free. 

However, working directly with that parsed_response object brings in some of the headaches and pitfalls that come with traversing large data structures. My approach here is to wrap that object, and its children as extracted, in a new FeedWrapper class. The main benefits are two: 
- Soft failures on missing or unexpectedly formatted elements (without losing the ability to log surprises). Because we don't have to explicitly check for nils and types, we can keep the concision of the current CSS and XPath selectors without having to actually run CSS and XPath queries on everything.
- Reasonably formatted coercion to strings, dates, etc., in order to replace existing module methods such as `to_text`, `to_array`, etc. in MyAcademics::AcademicsModule.

This PR introduces the overhaul only in the Finaid module, which contained some of the gnarliest XML parsing. Once we have consensus on an approach, I can apply it to the rest of the proxy classes, a task which should involve deleting much more code than is added.