### PR TITLE
CLC-3831 Reconfigure ccadmin so that the View As column displays on the main Authorizations page

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -125,6 +125,29 @@ RailsAdmin.config do |config|
 
   config.model 'User::Auth' do
     label 'User Authorizations'
+    list do
+      field :uid do
+        column_width 60
+      end
+      field :is_superuser do
+        column_width 20
+      end
+      field :is_author do
+        column_width 20
+      end
+      field :is_viewer do
+        column_width 20
+      end
+      field :active do
+        column_width 20
+      end
+      field :created_at do
+        column_width 130
+      end
+      field :updated_at do
+        column_width 130
+      end
+    end
   end
 
   config.model 'Finaid::FinAidYear' do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-3831

Added is_author and is_viewer to table headers; played around with the header widths to get the necessary data showing when the page is half width.

Screenshots are on at the Jira page