### PR TITLE
OEC-531, Primary and secondary sections (and x-listings) now nested within spreadsheet (csv)

### DIFF
--- a/app/models/oec/biology_post_processor.rb
+++ b/app/models/oec/biology_post_processor.rb
@@ -23,9 +23,9 @@ module Oec
             Rails.logger.warn "#{row[0]} #{row[1]} #{biology.base_file_name} skipped. Course is listed #{dept_name} CSV file."
           else
             target_csv = biology_dept
-            if course_name.match("#{biology_dept} 1A[L]?").present?
+            if course_name.match(' 1A[L]?').present?
               target_csv = row[4] = mcellbi_dept
-            elsif course_name.match("#{biology_dept} 1B[L]?").present?
+            elsif course_name.match(' 1B[L]?').present?
               target_csv = row[4] = integbi_dept
             end
             sorted_dept_rows[target_csv] ||= []

--- a/app/models/oec/courses.rb
+++ b/app/models/oec/courses.rb
@@ -42,16 +42,16 @@ module Oec
       end
     end
 
-    def append_row(output, row, visited_row_set, course)
+    def append_row(output, row, visited_row_set, course, check_secondary_cross_listings = true)
       # Avoid duplicate rows
       row_as_string = "#{course['course_id']}-#{course['ldap_uid']})"
       unless visited_row_set.include? row_as_string
         output << row
         visited_row_set << row_as_string
-        if course['primary_secondary_cd'] == 'S'
+        if course['primary_secondary_cd'] == 'S' && check_secondary_cross_listings
           Oec::Queries.get_secondary_cross_listings([course['course_cntl_num']]).each do |cross_listed_course|
-            row = record_to_csv_row cross_listed_course
-            append_row(output, row, visited_row_set, cross_listed_course)
+            row_for_cross_listing = record_to_csv_row cross_listed_course
+            append_row(output, row_for_cross_listing, visited_row_set, cross_listed_course, false)
           end
         end
       end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-531

Primary, secondary and then secondary cross-listed sections are now nested together in CSV. Primary sections for cross-listed sections were always listed first, followed by their secondaries and then the primary and any cross-listings from other department(s).

Plus, Biology CSV post-processor was missing certain 1A, 1B entries due to course-title-shorthand "BIO 1A" (found in campus data)