### PR TITLE
OEC-531, exclude zero enrollment courses in the rb code, not SQL

### DIFF
--- a/app/models/oec/courses.rb
+++ b/app/models/oec/courses.rb
@@ -49,7 +49,7 @@ module Oec
       unless visited_row_set.include? row_as_string
         enrollment_count = course['enrollment_count'].to_i
         catalog_id = course['catalog_id']
-        if enrollment_count > 0 || catalog_id.start_with?('C')
+        if enrollment_count > 0
           output << row
           visited_row_set << row_as_string
         else

--- a/app/models/oec/courses.rb
+++ b/app/models/oec/courses.rb
@@ -44,13 +44,16 @@ module Oec
 
     def append_row(output, row, visited_row_set, course, check_secondary_cross_listings = true)
       # Avoid duplicate rows
-      row_as_string = "#{course['course_id']}-#{course['ldap_uid']})"
+      course_id = course['course_id']
+      row_as_string = "#{course_id}-#{course['ldap_uid']})"
       unless visited_row_set.include? row_as_string
         enrollment_count = course['enrollment_count'].to_i
-        Rails.logger.warn "#{@dept_name}.csv: #{course['course_id']}, #{course['dept_name']} #{course['catalog_id']} - enrollment_count=#{enrollment_count}"
-        if enrollment_count > 0 || /c/ =~ course['catalog_id']
+        catalog_id = course['catalog_id']
+        if enrollment_count > 0 || catalog_id.start_with?('C')
           output << row
           visited_row_set << row_as_string
+        else
+          Rails.logger.warn "#{@dept_name}.csv: Skipping #{course_id}, #{course['dept_name']} #{catalog_id} because enrollment_count=#{enrollment_count}"
         end
         if course['primary_secondary_cd'] == 'S' && check_secondary_cross_listings
           Oec::Queries.get_secondary_cross_listings([course['course_cntl_num']]).each do |cross_listed_course|

--- a/app/models/oec/courses.rb
+++ b/app/models/oec/courses.rb
@@ -46,8 +46,12 @@ module Oec
       # Avoid duplicate rows
       row_as_string = "#{course['course_id']}-#{course['ldap_uid']})"
       unless visited_row_set.include? row_as_string
-        output << row
-        visited_row_set << row_as_string
+        enrollment_count = course['enrollment_count'].to_i
+        Rails.logger.warn "#{@dept_name}.csv: #{course['course_id']}, #{course['dept_name']} #{course['catalog_id']} - enrollment_count=#{enrollment_count}"
+        if enrollment_count > 0 || /c/ =~ course['catalog_id']
+          output << row
+          visited_row_set << row_as_string
+        end
         if course['primary_secondary_cd'] == 'S' && check_secondary_cross_listings
           Oec::Queries.get_secondary_cross_listings([course['course_cntl_num']]).each do |cross_listed_course|
             row_for_cross_listing = record_to_csv_row cross_listed_course

--- a/app/models/oec/queries.rb
+++ b/app/models/oec/queries.rb
@@ -19,12 +19,10 @@ module Oec
       left outer join calcentral_cross_listing_vw x ON ( x.term_yr = c.term_yr and x.term_cd = c.term_cd and x.course_cntl_num = c.course_cntl_num )
       left outer join calcentral_course_instr_vw i ON (i.course_cntl_num = c.course_cntl_num AND i.term_yr = c.term_yr AND i.term_cd = c.term_cd)
       left outer join calcentral_person_info_vw p ON (p.ldap_uid = i.instructor_ldap_uid)
-      left outer join calcentral_class_roster_vw r ON (r.course_cntl_num = c.course_cntl_num AND r.term_yr = c.term_yr AND r.term_cd = c.term_cd)
       where 1=1
         #{terms_query_clause('c', Settings.oec.current_terms_codes)}
         #{this_depts_clause}
         #{course_cntl_nums_clause}
-        and r.enroll_status != 'D'
       order by c.catalog_id, c.course_cntl_num, p.ldap_uid
         SQL
         result = connection.select_all(sql)
@@ -44,7 +42,6 @@ module Oec
       from calcentral_course_info_vw c
       left outer join calcentral_course_instr_vw i ON (i.course_cntl_num = c.course_cntl_num AND i.term_yr = c.term_yr AND i.term_cd = c.term_cd)
       left outer join calcentral_person_info_vw p ON (p.ldap_uid = i.instructor_ldap_uid)
-      left outer join calcentral_class_roster_vw r ON (r.course_cntl_num = c.course_cntl_num AND r.term_yr = c.term_yr AND r.term_cd = c.term_cd)
       left outer join calcentral_class_schedule_vw s ON (s.course_cntl_num = c.course_cntl_num AND s.term_yr = c.term_yr AND s.term_cd = c.term_cd)
       where 1=1
         #{terms_query_clause('c', Settings.oec.current_terms_codes)}
@@ -60,7 +57,6 @@ module Oec
             #{self.query_in_chunks('l.course_cntl_num', secondary_ccn_array) if secondary_ccn_array.present?}
             #{'and 0=1' unless secondary_ccn_array.present?}
         )
-        and r.enroll_status != 'D'
       order by c.catalog_id, c.course_cntl_num, p.ldap_uid
         SQL
         result = connection.select_all(sql)

--- a/spec/models/oec/courses_diff_spec.rb
+++ b/spec/models/oec/courses_diff_spec.rb
@@ -10,8 +10,11 @@ describe Oec::CoursesDiff do
         mock_data = "#{src_dir}/db_#{dept_name}_courses.csv"
         courses_query = []
         CSV.read(mock_data).each_with_index do |row, index|
-          if row.length > 0
-            courses_query << Oec::RowConverter.new(row).hashed_row if index > 0
+          if index > 0 && row.length > 0
+            hashed_row = Oec::RowConverter.new(row).hashed_row
+            # Arbitrary, non-zero enrollment
+            hashed_row['enrollment_count'] = 50
+            courses_query << hashed_row
           end
         end
         expect(Oec::Queries).to receive(:get_courses).with(nil, dept_name).exactly(1).times.and_return courses_query


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-531

In some cases of cross-listing, we have sections where there are zero enrollments in one department's cross-listing, but not in the other. The effect of this is that we see a few cases like 2015-B-11700 where it has enrollments, but its matched section 2015-B-53051 does not, so it fails to show up on the Chem spreadsheet.

If we exclude a zero enrollment course in the SQL then we never check the enrollment count of its cross-listings. Therefore, we move the exclusion logic out of SQL and specifically at the point of *output << row*.
 
(Apologies for four commits in one PR. The diff is not overwhelming.) 