### PR TITLE
OEC-533, omit wait listed students from course_students.csv

### DIFF
--- a/app/models/oec/queries.rb
+++ b/app/models/oec/queries.rb
@@ -98,7 +98,7 @@ module Oec
           c.section_cancel_flag is null
           #{terms_query_clause('c', Settings.oec.current_terms_codes)}
           #{self.query_in_chunks('c.course_cntl_num', course_cntl_nums)}
-          and r.enroll_status != 'D'
+          and (r.enroll_status = 'E' OR r.enroll_status = 'C')
           and r.term_yr = c.term_yr
           and r.term_cd = c.term_cd
           and r.course_cntl_num = c.course_cntl_num


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-533

Both student-related queries now use the clause: (r.enroll_status = 'E' OR r.enroll_status = 'C')

Also, we use two queries (instead of one per dept) to generate the global list of student and enrollment data.  