### PR TITLE
CLC-3515 Replace class Foo::Bar with module Foo; class Bar

### DIFF
--- a/app/models/my_classes/campus.rb
+++ b/app/models/my_classes/campus.rb
@@ -1,55 +1,58 @@
-class MyClasses::Campus
-  include MyClasses::ClassesModule
+module MyClasses
+  class Campus
+    include ClassesModule
 
-  def fetch
-    # Only include classes for current terms.
-    classes = []
-    all_courses = CampusOracle::UserCourses::All.new(user_id: @uid).get_all_campus_courses
-    semester_key = "#{current_term.year}-#{current_term.code}"
-    if all_courses[semester_key]
-      # Ask My Academics for the URL to this class info page in My Academics.
-      my_academics = MyAcademics::Semesters.new(@uid)
-      all_courses[semester_key].each do |course|
-        course[:site_url] = my_academics.class_to_url(course)
-        append_class_info(course, classes)
+    def fetch
+      # Only include classes for current terms.
+      classes = []
+      all_courses = CampusOracle::UserCourses::All.new(user_id: @uid).get_all_campus_courses
+      semester_key = "#{current_term.year}-#{current_term.code}"
+      if all_courses[semester_key]
+        # Ask My Academics for the URL to this class info page in My Academics.
+        my_academics = MyAcademics::Semesters.new(@uid)
+        all_courses[semester_key].each do |course|
+          course[:site_url] = my_academics.class_to_url(course)
+          append_class_info(course, classes)
+        end
+      end
+      classes
+    end
+
+    def append_class_info(campus_course, class_list)
+      if campus_course[:role] != 'Student'
+        class_list << campus_course
+        return
+      end
+      # If a student is enrolled or waitlisted in multiple primary sections with the
+      # same department and catalog ID, show them as separate "classes" on the dashboard.
+      # In very rare cases (notably a student who is waitlisted for multiple primary
+      # sections of a large course offering with secondary sections), the sections list
+      # of the split class will be somewhat arbitrary. This has no visible effect in
+      # the current UX, however.
+      split_primaries = multiple_primaries?(campus_course)
+      working_course = nil
+      campus_course[:sections].each do |section|
+        if section[:is_primary_section]
+          working_course = campus_course.deep_dup
+          if split_primaries
+            working_course[:id] = "#{campus_course[:id]}-#{section[:section_number]}"
+            working_course[:courseCodeSection] = "#{section[:instruction_format]} #{section[:section_number]}"
+          end
+          if section[:waitlistPosition] && section[:waitlistPosition] > 0
+            working_course[:enroll_limit] = section[:enroll_limit]
+            working_course[:waitlistPosition] = section[:waitlistPosition]
+          end
+          working_course[:sections] = [section]
+          class_list << working_course
+        else
+          working_course[:sections] << section
+        end
       end
     end
-    classes
-  end
 
-  def append_class_info(campus_course, class_list)
-    if campus_course[:role] != 'Student'
-      class_list << campus_course
-      return
+    def multiple_primaries?(campus_course)
+      (campus_course[:sections].select {|section| section[:is_primary_section]}).size > 1
     end
-    # If a student is enrolled or waitlisted in multiple primary sections with the
-    # same department and catalog ID, show them as separate "classes" on the dashboard.
-    # In very rare cases (notably a student who is waitlisted for multiple primary
-    # sections of a large course offering with secondary sections), the sections list
-    # of the split class will be somewhat arbitrary. This has no visible effect in
-    # the current UX, however.
-    split_primaries = multiple_primaries?(campus_course)
-    working_course = nil
-    campus_course[:sections].each do |section|
-      if section[:is_primary_section]
-        working_course = campus_course.deep_dup
-        if split_primaries
-          working_course[:id] = "#{campus_course[:id]}-#{section[:section_number]}"
-          working_course[:courseCodeSection] = "#{section[:instruction_format]} #{section[:section_number]}"
-        end
-        if section[:waitlistPosition] && section[:waitlistPosition] > 0
-          working_course[:enroll_limit] = section[:enroll_limit]
-          working_course[:waitlistPosition] = section[:waitlistPosition]
-        end
-        working_course[:sections] = [section]
-        class_list << working_course
-      else
-        working_course[:sections] << section
-      end
-    end
-  end
 
-  def multiple_primaries?(campus_course)
-    (campus_course[:sections].select {|section| section[:is_primary_section]}).size > 1
   end
 end

--- a/app/models/my_classes/canvas.rb
+++ b/app/models/my_classes/canvas.rb
@@ -1,38 +1,41 @@
-class MyClasses::Canvas
-  include MyClasses::ClassesModule
+module MyClasses
+  class Canvas
+    include ClassesModule
 
-  def merge_sites(campus_courses, sites)
-    return unless Canvas::Proxy.access_granted?(@uid)
-    if (canvas_sites = Canvas::MergedUserSites.new(@uid).get_feed)
-      included_course_sites = {}
-      canvas_sites[:courses].each do |course_site|
-        if (entry = course_site_entry(campus_courses, course_site))
-          sites << entry
-          included_course_sites[entry[:id]] = {
-            source: entry[:name],
-            courses: entry[:courses]
-          }
+    def merge_sites(campus_courses, sites)
+      return unless ::Canvas::Proxy.access_granted?(@uid)
+      if (canvas_sites = ::Canvas::MergedUserSites.new(@uid).get_feed)
+        included_course_sites = {}
+        canvas_sites[:courses].each do |course_site|
+          if (entry = course_site_entry(campus_courses, course_site))
+            sites << entry
+            included_course_sites[entry[:id]] = {
+              source: entry[:name],
+              courses: entry[:courses]
+            }
+          end
         end
-      end
-      canvas_sites[:groups].each do |group_site|
-        if (entry = group_site_entry(included_course_sites, group_site))
-          sites << entry
+        canvas_sites[:groups].each do |group_site|
+          if (entry = group_site_entry(included_course_sites, group_site))
+            sites << entry
+          end
         end
       end
     end
-  end
 
-  def group_site_entry(included_course_sites, group_site)
-    if (linked_id = group_site[:course_id]) && (linked_entry = included_course_sites[linked_id])
-      {
-        emitter: group_site[:emitter],
-        id: group_site[:id],
-        name: group_site[:name],
-        siteType: 'group',
-        site_url: group_site[:site_url]
-      }.merge(linked_entry)
-    else
-      nil
+    def group_site_entry(included_course_sites, group_site)
+      if (linked_id = group_site[:course_id]) && (linked_entry = included_course_sites[linked_id])
+        {
+          emitter: group_site[:emitter],
+          id: group_site[:id],
+          name: group_site[:name],
+          siteType: 'group',
+          site_url: group_site[:site_url]
+        }.merge(linked_entry)
+      else
+        nil
+      end
     end
+
   end
 end

--- a/app/models/my_classes/merged.rb
+++ b/app/models/my_classes/merged.rb
@@ -1,20 +1,21 @@
-class MyClasses::Merged  < UserSpecificModel
+module MyClasses
+  class Merged < UserSpecificModel
+    include Cache::LiveUpdatesEnabled
+    include Cache::FreshenOnWarm
+    include Cache::JsonAddedCacher
 
-  include Cache::LiveUpdatesEnabled
-  include Cache::FreshenOnWarm
-  include Cache::JsonAddedCacher
+    def get_feed_internal
+      sites = []
+      campus = Campus.new(@uid)
+      campus_courses = campus.fetch
+      sites.concat(campus_courses)
+      Canvas.new(@uid).merge_sites(campus_courses, sites)
+      SakaiClasses.new(@uid).merge_sites(campus_courses, sites)
+      {
+        classes: sites,
+        current_term: campus.current_term.to_english
+      }
+    end
 
-  def get_feed_internal
-    sites = []
-    campus = MyClasses::Campus.new(@uid)
-    campus_courses = campus.fetch
-    sites.concat(campus_courses)
-    MyClasses::Canvas.new(@uid).merge_sites(campus_courses, sites)
-    MyClasses::SakaiClasses.new(@uid).merge_sites(campus_courses, sites)
-    {
-      classes: sites,
-      current_term: campus.current_term.to_english
-    }
   end
-
 end

--- a/app/models/my_groups/callink.rb
+++ b/app/models/my_groups/callink.rb
@@ -1,65 +1,67 @@
-class MyGroups::Callink
-  include MyGroups::GroupsModule, ClassLogger
+module MyGroups
+  class Callink
+    include GroupsModule, ClassLogger
 
-  def fetch
-    response = []
-    return response unless @uid.present?
-    membership_proxy = CalLink::Memberships.new({:user_id => @uid})
-    cal_link_groups = membership_proxy.get_memberships
-    return response unless cal_link_groups && cal_link_groups[:statusCode] == 200
+    def fetch
+      response = []
+      return response unless @uid.present?
+      membership_proxy = ::CalLink::Memberships.new({:user_id => @uid})
+      cal_link_groups = membership_proxy.get_memberships
+      return response unless cal_link_groups && cal_link_groups[:statusCode] == 200
 
-    logger.debug "fetch: body = #{cal_link_groups[:body]}"
-    if cal_link_groups[:body] && cal_link_groups[:body]["items"]
-      seen_orgs = Set.new
-      cal_link_groups[:body]["items"].each do |group|
-        if seen_orgs.add? group["organizationId"]
-          org = CalLink::Organization.new({:org_id => group["organizationId"]}).get_organization
-          next unless org && org[:statusCode] == 200
-          next unless filter_callink_organization!(org).present?
-          organization = org[:body]
-          site_url = "https://callink.berkeley.edu/"
-          if organization["items"] && organization["items"][0] && organization["items"][0]["profileUrl"]
-            site_url = "https://" + organization["items"][0]["profileUrl"]
+      logger.debug "fetch: body = #{cal_link_groups[:body]}"
+      if cal_link_groups[:body] && cal_link_groups[:body]["items"]
+        seen_orgs = Set.new
+        cal_link_groups[:body]["items"].each do |group|
+          if seen_orgs.add? group["organizationId"]
+            org = ::CalLink::Organization.new({:org_id => group["organizationId"]}).get_organization
+            next unless org && org[:statusCode] == 200
+            next unless filter_callink_organization!(org).present?
+            organization = org[:body]
+            site_url = "https://callink.berkeley.edu/"
+            if organization["items"] && organization["items"][0] && organization["items"][0]["profileUrl"]
+              site_url = "https://" + organization["items"][0]["profileUrl"]
+            end
+            response.push({
+              name: group["organizationName"],
+              id: group["organizationId"].to_s,
+              emitter: ::CalLink::Proxy::APP_ID,
+              site_url: site_url
+            })
           end
-          response.push({
-            name: group["organizationName"],
-            id: group["organizationId"].to_s,
-            emitter: CalLink::Proxy::APP_ID,
-            site_url: site_url
-          })
         end
       end
+      response
     end
-    response
-  end
 
-  private
-  def filter_callink_organization!(org)
-    return [] unless org[:body] && org[:body]["items"].present?
-    org[:body]["items"].reject! do |item|
-      (type_name_blacklist.include?(item["typeName"].downcase) ||
-        status_blacklist.include?(item["status"].downcase))
+    private
+    def filter_callink_organization!(org)
+      return [] unless org[:body] && org[:body]["items"].present?
+      org[:body]["items"].reject! do |item|
+        (type_name_blacklist.include?(item["typeName"].downcase) ||
+          status_blacklist.include?(item["status"].downcase))
+      end
+      return [] if org[:body]["items"].blank?
+      org
     end
-    return [] if org[:body]["items"].blank?
-    org
-  end
 
-  def type_name_blacklist
-    [
-      "admin",
-      "asuc government office",
-      "asuc government program",
-      "campus departments",
-      "default",
-      "ga government office",
-      "ga government program",
-      "hidden",
-      "new organizations",
-    ]
-  end
+    def type_name_blacklist
+      [
+        "admin",
+        "asuc government office",
+        "asuc government program",
+        "campus departments",
+        "default",
+        "ga government office",
+        "ga government program",
+        "hidden",
+        "new organizations",
+      ]
+    end
 
-  def status_blacklist
-    %w(frozen inactive locked)
-  end
+    def status_blacklist
+      %w(frozen inactive locked)
+    end
 
+  end
 end

--- a/app/models/my_groups/canvas.rb
+++ b/app/models/my_groups/canvas.rb
@@ -1,53 +1,56 @@
-class MyGroups::Canvas
-  include MyGroups::GroupsModule
+module MyGroups
+  class Canvas
+    include GroupsModule
 
-  def fetch
-    sites = []
-    return sites unless Canvas::Proxy.access_granted?(@uid)
-    if (canvas_sites = Canvas::MergedUserSites.new(@uid).get_feed)
-      included_course_sites = []
-      canvas_sites[:courses].each do |course_site|
-        if (entry = course_site_entry(course_site))
-          sites << entry
-          included_course_sites << entry[:id]
+    def fetch
+      sites = []
+      return sites unless ::Canvas::Proxy.access_granted?(@uid)
+      if (canvas_sites = ::Canvas::MergedUserSites.new(@uid).get_feed)
+        included_course_sites = []
+        canvas_sites[:courses].each do |course_site|
+          if (entry = course_site_entry(course_site))
+            sites << entry
+            included_course_sites << entry[:id]
+          end
+        end
+        canvas_sites[:groups].each do |group_site|
+          if (entry = group_site_entry(included_course_sites, group_site))
+            sites << entry
+          end
         end
       end
-      canvas_sites[:groups].each do |group_site|
-        if (entry = group_site_entry(included_course_sites, group_site))
-          sites << entry
-        end
+      sites
+    end
+
+    def course_site_entry(course_site)
+      if course_site[:term_yr].blank? && course_site[:term_cd].blank?
+        {
+          emitter: course_site[:emitter],
+          id: course_site[:id],
+          name: course_site[:name],
+          shortDescription: course_site[:short_description],
+          siteType: 'course',
+          site_url: course_site[:site_url]
+        }
+      else
+        nil
       end
     end
-    sites
-  end
 
-  def course_site_entry(course_site)
-    if course_site[:term_yr].blank? && course_site[:term_cd].blank?
-      {
-        emitter: course_site[:emitter],
-        id: course_site[:id],
-        name: course_site[:name],
-        shortDescription: course_site[:short_description],
-        siteType: 'course',
-        site_url: course_site[:site_url]
-      }
-    else
-      nil
+    def group_site_entry(included_course_sites, group_site)
+      course_link = group_site[:course_id]
+      if course_link.blank? || included_course_sites.include?(course_link)
+        {
+          emitter: group_site[:emitter],
+          id: group_site[:id],
+          name: group_site[:name],
+          siteType: 'group',
+          site_url: group_site[:site_url]
+        }
+      else
+        nil
+      end
     end
-  end
 
-  def group_site_entry(included_course_sites, group_site)
-    course_link = group_site[:course_id]
-    if course_link.blank? || included_course_sites.include?(course_link)
-      {
-        emitter: group_site[:emitter],
-        id: group_site[:id],
-        name: group_site[:name],
-        siteType: 'group',
-        site_url: group_site[:site_url]
-      }
-    else
-      nil
-    end
   end
 end

--- a/app/models/my_groups/merged.rb
+++ b/app/models/my_groups/merged.rb
@@ -1,23 +1,24 @@
-class MyGroups::Merged  < UserSpecificModel
+module MyGroups
+  class Merged < UserSpecificModel
+    include Cache::LiveUpdatesEnabled
+    include Cache::FreshenOnWarm
+    include Cache::JsonAddedCacher
 
-  include Cache::LiveUpdatesEnabled
-  include Cache::FreshenOnWarm
-  include Cache::JsonAddedCacher
-
-  def get_feed_internal
-    groups = []
-    [
-      MyGroups::Callink,
-      MyGroups::Canvas,
-      MyGroups::Sakai,
-      MyGroups::Research
-    ].each do |provider|
-      groups.concat(provider.new(@uid).fetch)
+    def get_feed_internal
+      groups = []
+      [
+        Callink,
+        Canvas,
+        Sakai,
+        Research
+      ].each do |provider|
+        groups.concat(provider.new(@uid).fetch)
+      end
+      groups.sort! { |x, y| x[:name].casecmp(y[:name]) }
+      {
+        groups: groups
+      }
     end
-    groups.sort! { |x, y| x[:name].casecmp(y[:name]) }
-    {
-      groups: groups
-    }
-  end
 
+  end
 end

--- a/app/models/my_groups/research.rb
+++ b/app/models/my_groups/research.rb
@@ -1,9 +1,11 @@
 # TODO collapse this class into ResearchHub::Proxy
-class MyGroups::Research
-  include MyGroups::GroupsModule
+module MyGroups
+  class Research
+    include GroupsModule
 
-  def fetch
-    ResearchHub::Proxy.new({:user_id => @uid}).get_sites
+    def fetch
+      ResearchHub::Proxy.new({:user_id => @uid}).get_sites
+    end
+
   end
-
 end

--- a/app/models/my_groups/sakai.rb
+++ b/app/models/my_groups/sakai.rb
@@ -1,20 +1,22 @@
-class MyGroups::Sakai
-  include MyGroups::GroupsModule
+module MyGroups
+  class Sakai
+    include GroupsModule
 
-  def fetch
-    sites = []
-    return sites unless Sakai::Proxy.access_granted?(@uid)
-    sakai_sites = Sakai::SakaiMergedUserSites.new(user_id: @uid).get_feed
-    sakai_sites[:groups].each do |group_site|
-      sites << {
-        emitter: group_site[:emitter],
-        id: group_site[:id],
-        name: group_site[:name],
-        shortDescription: group_site[:short_description],
-        site_url: group_site[:site_url]
-      }
+    def fetch
+      sites = []
+      return sites unless ::Sakai::Proxy.access_granted?(@uid)
+      sakai_sites = ::Sakai::SakaiMergedUserSites.new(user_id: @uid).get_feed
+      sakai_sites[:groups].each do |group_site|
+        sites << {
+          emitter: group_site[:emitter],
+          id: group_site[:id],
+          name: group_site[:name],
+          shortDescription: group_site[:short_description],
+          site_url: group_site[:site_url]
+        }
+      end
+      sites
     end
-    sites
-  end
 
+  end
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-3513

I'm really sorry that the differ isn't smarter about indentation changes. Apart from the first and last lines of the classes, the only changes I made were to namespacing: 
 - removing explicit module references where they weren't needed; 
 - and prepending a double colon to top-level modules (Sakai, Canvas) where the namespaced module would otherwise be assumed.

I also prepended a double colon to CalLink, which escapes confusion with MyGroups::Callink only by virtue of capitalization (and perhaps that should be standardized in a follow-up PR).