### PR TITLE
CLC-4663 Remove unnecessary parsing in EtsBlog proxies

### DIFF
--- a/app/models/ets_blog/alerts.rb
+++ b/app/models/ets_blog/alerts.rb
@@ -11,73 +11,43 @@ module EtsBlog
       self.class.smart_fetch_from_cache({
                                           id: "global-alert",
                                           user_message_on_exception: "Alert server unreachable",
-                                          return_nil_on_generic_error: true,
+                                          return_nil_on_generic_error: true
                                         }) do
-        (get_alerts.nil?) ? '' : get_alerts.first
+        alerts = get_alerts
+        alerts.empty? ? '' : alerts.first
       end
     end
 
     private
 
     def get_alerts
-      results = []
-      xml = get_raw_xml
-      begin
-        xml_doc = Hash.from_xml(xml)
-      rescue => e
-        logger.error("Unparseable XML content: #{e}")
-        return nil
-      end
-      unless xml_doc['xml'] && xml_doc['xml']['node']
-        logger.info("Unexpected XML content: #{xml_doc}")
-        return nil
-      end
-      node_list = xml_doc['xml']['node']
-      nodes = (node_list.is_a? Array) ? node_list : [node_list]
-      nodes.each do |node|
-        node_entry = {
-          :title => node['Title'],
-          :url => node['Link'],
-          :timestamp => format_date(Time.zone.at(node['PostDate'].to_i).to_datetime)
+      feed = FeedWrapper.new get_feed
+      logger.info("Unexpected data structure: #{feed.unwrap}") if feed['xml']['node'].blank?
+
+      alerts = []
+      feed['xml']['node'].as_collection.map do |node|
+        alert = {
+          title: node['Title'].to_text,
+          url: node['Link'].to_text,
+          timestamp: format_date(Time.zone.at(node['PostDate'].to_text.to_i).to_datetime)
         }
-        node_entry[:teaser] = node['Teaser'] if node['Teaser'].present?
-        next unless valid_result?(node_entry)
-        results << node_entry
-      end
-      (results.empty?) ? nil : results
-    end
-
-    def get_raw_xml
-      logger.info "#{self.class.name} Fetching alerts from blog (fake=#{@fake}, cache expiration #{self.class.expires_in}"
-      if @fake == true
-        xml = File.read(xml_source)
-      else
-        response = get_response xml_source
-        xml = response.body
-      end
-      xml
-    end
-
-    def xml_source
-      @fake ? Rails.root.join('fixtures', 'xml', 'app_alerts_feed.xml').to_s : @settings.feed_url
-    end
-
-    def valid_result?(r=nil)
-      unless r.is_a?(Hash)
-        logger.error("expected a hash argument #{r.inspect}")
-        return false
-      end
-      [:title, :url, :timestamp].each { |k|
-        unless r.key?(k) && r[k].present?
-          logger.error("missing required #{k} field for hash argument #{r.inspect}")
-          return false
+        alert[:teaser] = node['Teaser'] if node['Teaser'].present?
+        if alert[:title].blank? || alert[:url].blank? || alert[:timestamp].blank? || alert[:timestamp][:epoch].zero?
+          logger.error("Unexpected node in alert feed: #{node.unwrap}")
+        else
+          alerts << alert
         end
-      }
-      unless ((r[:timestamp].is_a?(Hash) && r[:timestamp][:epoch] > 0))
-        logger.error("unexpected timestamp value #{r.inspect}")
-        return false
       end
-      return true
+      alerts
+    end
+
+    def get_feed
+      logger.info "#{self.class.name} Fetching alerts from blog (fake=#{@fake}, cache expiration #{self.class.expires_in}"
+      if @fake
+        MultiXml.parse File.read(Rails.root.join('fixtures', 'xml', 'app_alerts_feed.xml').to_s)
+      else
+        get_response(@settings.feed_url).parsed_response
+      end
     end
 
   end

--- a/spec/models/ets_blog/alerts_spec.rb
+++ b/spec/models/ets_blog/alerts_spec.rb
@@ -5,60 +5,23 @@ require 'spec_helper'
 describe EtsBlog::Alerts do
 
   let(:fake_proxy) { EtsBlog::Alerts.new({fake: true}) }
-  let(:real_failing_proxy) { EtsBlog::Alerts.new({fake: false}) }
-  let(:bad_url) { 'http://alsdlksasgflasldsalfjsgj/snjlfdsalsfal/lsadfjfl.xml' }
-  let(:bad_file_path) { '/sajdljfsjaslaslsd/garbage/some.xml' }
-  let(:bad_xml) { '<xml><chicken>' }
+  let(:empty_xml) { '<xml><node><chicken>egg</chicken></node></xml>' }
   let(:unexpected_xml) { '<xml><node><chicken>egg</chicken></node></xml>' }
-  let(:empty_xml) { '<xml></xml>' }
   let(:xml_with_no_teaser){ Rails.root.join('fixtures', 'xml', 'app_alerts_feed_no_teaser.xml') }
-  let(:xml_multibye_diacriticals) { Rails.root.join('fixtures', 'xml', 'app_alerts_feed_diacriticals.xml') }
+  let(:xml_multibyte_characters) { Rails.root.join('fixtures', 'xml', 'app_alerts_feed_diacriticals.xml') }
 
-  context "failures" do
-    it "not finding fake xml feed on disk should return nil" do
-      fake_proxy.stub(:xml_source).and_return(bad_file_path)
-      fake_proxy.get_latest.should be_nil
-    end
-    it "not finding real feed url should return nil" do
-      real_failing_proxy.stub(:xml_source).and_return(bad_url)
-      real_failing_proxy.get_latest.should be_nil
-    end
-    it "that receive unexpected xml data should return nil" do
-      fake_proxy.stub(:get_raw_xml).and_return(unexpected_xml)
-      fake_proxy.get_latest.should eq ''
-    end
-    it "that receive empty xml data should return nil" do
-      fake_proxy.stub(:get_raw_xml).and_return(empty_xml)
-      fake_proxy.get_latest.should eq ''
-      fake_proxy.stub(:get_raw_xml).and_return(nil)
-      fake_proxy.get_latest.should eq ''
-      fake_proxy.stub(:get_raw_xml).and_return('')
-      fake_proxy.get_latest.should eq ''
-    end
+  it 'should format and return the latest well-formed feed message' do
+    alert = fake_proxy.get_latest
+    alert[:title].should == 'CalCentral Scheduled Upgrade (Test Announce Only)'
+    alert[:teaser].should == 'CalCentral Scheduled Upgrade (Test Announce Only)'
+    alert[:url].should == 'http://ets-dev.berkeley.edu/news/calcentral-scheduled-upgrade-test-announce-only'
+    alert[:timestamp][:epoch].should == 1393257625
   end
 
-  context "successful when" do
-    it "Alerts.get_latest returns four fields with values present" do
-      alert = fake_proxy.get_latest
-      alert.is_a?(Hash)
-      alert.count.should == 4
-    end
-    it "the xml alert is missing a teaser" do
-      fake_proxy.stub(:xml_source).and_return(xml_with_no_teaser)
-      alert = fake_proxy.get_latest
-      alert.is_a?(Hash)
-      alert.count.should == 3
-    end
-    it "Alerts.get_latest formats and returns the latest single well-formed feed message" do
-      alert = fake_proxy.get_latest
-      alert[:title].should == 'CalCentral Scheduled Upgrade (Test Announce Only)'
-      alert[:teaser].should == 'CalCentral Scheduled Upgrade (Test Announce Only)'
-      alert[:url].should == 'http://ets-dev.berkeley.edu/news/calcentral-scheduled-upgrade-test-announce-only'
-      alert[:timestamp].is_a?(Hash).should be_truthy
-      alert[:timestamp][:epoch].should == 1393257625
-    end
-    it "handling multi-byte diacritical strings in the reponse" do
-      fake_proxy.stub(:xml_source).and_return(xml_multibye_diacriticals)
+  context 'when the xml contains multibyte characters' do
+    before { allow(fake_proxy).to receive(:get_feed).and_return(MultiXml.parse File.read(xml_multibyte_characters)) }
+    it 'should parse' do
+      fake_proxy.stub(:get_feed).and_return(MultiXml.parse File.read(xml_multibyte_characters))
       alert = fake_proxy.get_latest
       alert[:title].should == '¡El Señor González se zampó un extraño sándwich de vodka y ajo! (¢, ®, ™, ©, •, ÷, –, ¿)'
       alert[:url].should == 'hדג סקרן שט בים מאוכזב ולפתע מצא לו חברה'
@@ -66,46 +29,52 @@ describe EtsBlog::Alerts do
     end
   end
 
-  context "caching successes" do
-    include_context 'it writes to the cache'
-    it "should write to cache" do
-      alert = EtsBlog::Alerts.new({fake:true}).get_latest
+  context 'when the xml is missing a teaser' do
+    before { allow(fake_proxy).to receive(:get_feed).and_return(MultiXml.parse File.read(xml_with_no_teaser)) }
+    it 'should return non-teaser attributes' do
+      alert = fake_proxy.get_latest
+      expect(alert[:title]).to be_present
+      expect(alert[:url]).to be_present
+      expect(alert[:timestamp][:epoch]).to be_present
     end
   end
 
-  context "caching failures" do
-    include_context 'short-lived cache write of NilClass on failures'
-    it "should write failure state to cache" do
-      fake_proxy.stub(:xml_source).and_return(bad_file_path)
-      lambda{
-        alert = fake_proxy.get_latest
-      }.should_not raise_exception
+  context 'when xml data is empty' do
+    before { allow(fake_proxy).to receive(:get_feed).and_return(MultiXml.parse empty_xml) }
+    it 'should return blank' do
+      expect(fake_proxy.get_latest).to eq ''
     end
   end
 
-  context "error handling" do
-    it "should raise an exception" do
-      fake_proxy.stub(:get_raw_xml).and_return(bad_xml);
-      lambda{
-        result = fake_proxy.get_alerts
-      }.should raise_exception
-    end
-    it "should log an xml parsing syntax error message" do
-      fake_proxy.stub(:get_raw_xml).and_return(bad_xml);
-      Rails.logger.should_receive(:error).with(/REXML\:\:ParseException/)
-      lambda{
-        result = fake_proxy.get_latest
-      }.should_not raise_exception
-    end
-    it "should log a no such file exception" do
-      Rails.logger.should_receive(:error).with(/ENOENT No such file or directory/)
-      fake_proxy.stub(:xml_source).and_return(bad_file_path)
-      fake_proxy.get_latest.should be_nil
-    end
-    it "should log a SocketError exception" do
-      Rails.logger.should_receive(:error).with(/SocketError/).at_least(:once)
-      real_failing_proxy.stub(:xml_source).and_return(bad_url)
-      real_failing_proxy.get_latest.should be_nil
+  context 'when xml data is unexpected' do
+    before { allow(fake_proxy).to receive(:get_feed).and_return(MultiXml.parse unexpected_xml) }
+    it 'should return blank' do
+      expect(fake_proxy.get_latest).to eq ''
     end
   end
+
+  context 'when xml data is nil' do
+    before { allow(fake_proxy).to receive(:get_feed).and_return(MultiXml.parse nil) }
+    it 'should return blank' do
+      expect(fake_proxy.get_latest).to eq ''
+    end
+  end
+
+  context 'when exceptions are raised' do
+    before { allow(fake_proxy).to receive(:get_feed).and_raise(SocketError) }
+
+    it 'should rescue exceptions and return nil from get_latest' do
+      expect { fake_proxy.get_alerts }.to raise_exception
+      expect { fake_proxy.get_latest }.not_to raise_exception
+      expect(fake_proxy.get_latest).to be_nil
+    end
+
+    context 'caching failures' do
+      include_context 'short-lived cache write of NilClass on failures'
+      it 'should write to cache when handling exceptions' do
+        expect { fake_proxy.get_latest }.not_to raise_exception
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Continuing cleanup on https://jira.ets.berkeley.edu/jira/browse/CLC-4663.

EtsBlog::Alerts uses the new FeedWrapper class. EtsBlog::ReleaseNotes is managing without it.

The tests for EtsBlog::Alerts have been slimmed down, because the removal of parsing has left them less to do, and because certain conditions, like a missing fake file, didn't seem to require an explicit test separate from the tests for exception handling.