### PR TITLE
OEC-555, rake oec:students task will expect a single input: courses.csv

### DIFF
--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -20,34 +20,20 @@ namespace :oec do
 
   desc 'Generate student files based on courses.csv input'
   task :students => :environment do
-    dept_set = Settings.oec.departments.to_set
-    if dept_set.include? biology_dept_name
-      dept_set.add 'INTEGBI'
-      dept_set.add 'MCELLBI'
-    end
-    ccn_set = Set.new
-    gsi_ccn_set = Set.new
-    dept_set.each do |dept_name|
-      filename = "#{dept_name.gsub(/\s/, '_')}_courses.csv"
-      csv_file = "#{src_dir}/#{filename}"
-      if File.exists? csv_file
-        reader = Oec::FileReader.new csv_file
-        ccn_set.merge reader.ccns.to_set
-        gsi_ccn_set.merge reader.gsi_ccns.to_set
-      elsif dept_name == biology_dept_name
-        Rails.logger.info "As expected, #{biology_dept_name} CSV not found. BIO entries are in MCELLBI, etc."
-      else
-        Rails.logger.warn <<-eos
-        #{hr}File not found: #{csv_file}
-        Usage: rake oec:students [src=/path/to/source/] [dest=/export/path/]#{hr}
-        eos
-        raise ArgumentError, "Directory does not exist or is missing expected CSV file(s): #{src_dir}"
+    csv_file = "#{src_dir}/courses.csv"
+    if File.exists? csv_file
+      reader = Oec::FileReader.new csv_file
+      [Oec::Students, Oec::CourseStudents].each do |klass|
+        klass.new(reader.ccns, reader.gsi_ccns, dest_dir).export
       end
+      Rails.logger.warn "#{hr}Files wrote to #{dest_dir}#{hr}"
+    else
+      Rails.logger.warn <<-eos
+      #{hr}File not found: #{csv_file}
+      Usage: rake oec:students [src=/path/to/source/] [dest=/export/path/]#{hr}
+      eos
+      raise ArgumentError, "File not found: #{csv_file}"
     end
-    [Oec::Students, Oec::CourseStudents].each do |klass|
-      klass.new(ccn_set, gsi_ccn_set, dest_dir).export
-    end
-    Rails.logger.warn "#{hr}Files wrote to #{dest_dir}#{hr}"
   end
 
   desc 'Spreadsheet from dept is compared with campus data'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-555

Workflow:
1. *rake oec:courses* pulls raw course data (one CSV per dept)
1. Department admins add info to CSVs 
1. The "OEC secondary script" (i.e., Perl scripts owned by Ops) concats all CSVs into *courses.csv* 
1. Finally, this *oec:students* task is run. It will read CCNs from courses.csv then generate two CSVs which list course enrollments.

Previously, the *oec:students* task expected a set of CSVs, one per dept. 