### PR TITLE
OEC-539, use Rake.original_dir as base dir when src/dest not specified

### DIFF
--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -56,7 +56,7 @@ namespace :oec do
   def get_path_arg(arg_name)
     path = ENV[arg_name]
     return Rake.original_dir if path.blank?
-    path.start_with?('.') ? File.expand_path(path, Rake.original_dir) : Pathname.new(path).realpath
+    path.start_with?('/') ? path : File.expand_path(path, Rake.original_dir)
   end
 
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-539

OEC rake tasks have optional src and dest args (default is Rake.original_dir).  Arg values are expected to be relative or absolute directory paths. Valid usage would be:
> rake oec:courses dest=~/oec
> rake oec:courses dest=tmp/oec
> rake oec:courses dest=/var/tmp/oec
> rake oec:courses dest=../tmp/oec

Paths should be determined relative to user's working dir and *not* base of calcentral repo (as Dir.pwd would have it).