### PR TITLE
CLC-4455 Organize cross-listed courses more reasonably

### DIFF
--- a/app/models/canvas/provide_course_site.rb
+++ b/app/models/canvas/provide_course_site.rb
@@ -278,7 +278,6 @@ module Canvas
 
     def candidate_courses_list
       raise RuntimeError, 'User ID not found for candidate' if @uid.blank?
-      terms_filter = current_terms
 
       # Get all sections for which this user is an instructor, sorted in a useful fashion.
       # Since this mostly matches what's shown by MyAcademics::Teaching for a given semester,
@@ -289,72 +288,12 @@ module Canvas
 
       academics_feed = MyAcademics::Merged.new(@uid).get_feed
       if (teaching_semesters = academics_feed[:teachingSemesters])
-        courses_list = terms_filter.collect do |term|
-          if term_index = teaching_semesters.index {|semester| semester[:slug] == term[:slug] }
-            teaching_semesters[term_index]
-          else
-            nil
-          end
-        end.compact
-        handle_cross_listed_courses(courses_list)
-        courses_list
+        current_teaching_semesters = current_terms.collect do |term|
+          teaching_semesters.find {|semester| semester[:slug] == term[:slug] }
+        end
+        current_teaching_semesters.compact
       else
         []
-      end
-    end
-
-    # Merge all sections of cross-listed courses into a single "course" item. This may change the
-    # structure and ordering of the original MyAcademics::Teaching feed.
-    # TODO Group cross-listed courses in the CalCentral UX as well.
-    def handle_cross_listed_courses(basic_terms_courses_list)
-      basic_terms_courses_list.each do |term_and_courses|
-        original_classes = term_and_courses[:classes]
-        new_classes = []
-        cross_listing_to_class = {}
-        original_classes.each do |course|
-          # Denormalize the course code into its sections to simplify client-side code.
-          course_code = course[:course_code]
-          course_sections = course[:sections]
-          cross_listing_hash = nil
-          course_sections.each do |section|
-            section[:courseCode] = course_code
-            # Campus data's current way of indicating cross-listing relies on links
-            # between the primary sections of each course.
-            cross_listing_hash = section[:cross_listing_hash] if section[:cross_listing_hash].present?
-          end
-          if cross_listing_hash.present?
-            # If the cross-listed course is already in the reorganized feed, append this
-            # bunch of sections to it.
-            if (existing_cross_listed_class = cross_listing_to_class[cross_listing_hash])
-              existing_cross_listed_class[:sections].concat(course_sections)
-              existing_cross_listed_class[:course_code] = nil
-              merge_class_sites(existing_cross_listed_class, course)
-            else
-              course[:crossListingHash] = cross_listing_hash
-              cross_listing_to_class[cross_listing_hash] = course
-              new_classes.append(course)
-            end
-          else
-            new_classes.append(course)
-          end
-        end
-        # Overwrite the original classes list for the term.
-        term_and_courses[:classes] = new_classes
-      end
-    end
-
-    def merge_class_sites(to_class, from_class)
-      if (from_site_list = from_class[:class_sites])
-        to_class[:class_sites] ||= []
-        to_site_list = to_class[:class_sites]
-        from_site_list.each do |from_site|
-          from_site_id = from_site[:id]
-          if (matching_site_index = to_site_list.index {|s| s[:id] == from_site_id})
-            to_site_list[matching_site_index][:sections].concat(from_site[:sections])
-          else
-            to_site_list.append(from_site)
-          end
-        end
       end
     end
 
@@ -371,7 +310,7 @@ module Canvas
         (term_yr, term_cd) = term_key.split("-")
         semester = my_academics.semester_info(term_yr, term_cd)
         feed[term_key].each do |course|
-          semester[:classes] << my_academics.class_info(course)
+          semester[:classes] << my_academics.course_info_with_multiple_listings(course)
         end
         courses_list << semester unless semester[:classes].empty?
       end

--- a/app/models/my_academics/semesters.rb
+++ b/app/models/my_academics/semesters.rb
@@ -17,7 +17,7 @@ module MyAcademics
         semester = semester_info(term_yr, term_cd)
         feed[term_key].each do |course|
           next unless course[:role] == 'Student'
-          class_item = class_info(course)
+          class_item = course_info(course)
           class_item[:sections].each do |section|
             if section[:is_primary_section]
               section[:gradeOption] = Berkeley::GradeOptions.grade_option_for_enrollment(section[:cred_cd], section[:pnp_flag])

--- a/app/models/my_academics/teaching.rb
+++ b/app/models/my_academics/teaching.rb
@@ -14,9 +14,8 @@ module MyAcademics
         teaching_semester = semester_info(term_yr, term_cd)
         feed[term_key].each do |course|
           next unless course[:role] == 'Instructor'
-          teaching_semester[:classes] << class_info(course).merge({
-              role: course[:role]
-          })
+          course_info = course_info_with_multiple_listings course
+          append_with_merged_crosslistings(teaching_semester[:classes], course_info)
         end
         teaching_semesters << teaching_semester unless teaching_semester[:classes].empty?
       end

--- a/app/models/my_classes/classes_module.rb
+++ b/app/models/my_classes/classes_module.rb
@@ -22,7 +22,7 @@ module MyClasses::ClassesModule
         campus_courses.each do |campus|
           if campus[:term_yr] == term_yr && campus[:term_cd]
             if campus[:sections].index {|s| candidate_ccns.include?(s[:ccn].to_i)}.present?
-              linked_campus << {id: campus[:id]}
+              linked_campus << {id: campus[:listings].first[:id]}
             end
           end
         end

--- a/public/dummy/json/academics.json
+++ b/public/dummy/json/academics.json
@@ -807,11 +807,19 @@
       "termYear": "2013",
       "classes": [
         {
-          "course_code": "BIO 123A",
-          "dept": "BIO",
           "role": "GSI",
-          "slug": "bio-123a",
+          "slug": "biology-123a",
           "title": "General Biology and the Cambrian Biota",
+          "listings": [
+            {
+              "course_code": "BIOLOGY 123A",
+              "dept": "BIOLOGY"
+            },
+            {
+              "course_code": "INTEGBI 183A",
+              "dept": "INTEGBI"
+            }
+          ],
           "class_sites": [
             {
               "id": "11866397",
@@ -843,9 +851,25 @@
               ]
             }
           ],
+          "scheduledSectionCount": 3,
+          "scheduledSections": [
+            {
+              "format": "lecture",
+              "count": 1
+            },
+            {
+              "format": "discussion",
+              "count": 1
+            },
+            {
+              "format": "laboratory",
+              "count": 1
+            }
+          ],
           "sections": [
             {
               "ccn": "27606",
+              "courseCode": "BIOLOGY 123A",
               "instruction_format": "LEC",
               "section_label": "LEC 002",
               "section_number": "002",
@@ -859,14 +883,15 @@
               ],
               "instructors": [
                 {
-                  "name": "David Weisblatd",
-                  "email": "dw@example.edu",
-                  "uid": "21345"
+                  "name": "Mary Salinger",
+                  "email": "mary@example.edu",
+                  "uid": "9898989"
                 }
               ]
             },
             {
               "ccn": "27619",
+              "courseCode": "BIOLOGY 123A",
               "instruction_format": "LAB",
               "section_label": "LAB 201",
               "section_number": "201",
@@ -889,6 +914,7 @@
             {
               "section_label": "DIS 008",
               "ccn": "49713",
+              "courseCode": "BIOLOGY 123A",
               "instruction_format": "DIS",
               "section_number": "008",
               "is_primary_section": false,
@@ -905,9 +931,77 @@
                   "uid": "9898989"
                 }
               ]
+            },
+            {
+              "ccn": "37606",
+              "courseCode": "INTEGBI 183A",
+              "instruction_format": "LEC",
+              "section_label": "LEC 002",
+              "section_number": "002",
+              "scheduledWithCcn": "27606",
+              "is_primary_section": true,
+              "schedules": [
+                {
+                  "buildingName": "PIMENTAL",
+                  "roomNumber": "1",
+                  "schedule": "MWF 8:00A-9:00A"
+                }
+              ],
+              "instructors": [
+                {
+                  "name": "Mary Salinger",
+                  "email": "mary@example.edu",
+                  "uid": "9898989"
+                }
+              ]
+            },
+            {
+              "ccn": "37619",
+              "courseCode": "INTEGBI 183A",
+              "instruction_format": "LAB",
+              "section_label": "LAB 201",
+              "section_number": "201",
+              "scheduledWithCcn": "29713",
+              "is_primary_section": false,
+              "instructors": [
+                {
+                  "name": "Mary Salinger",
+                  "email": "mary@example.edu",
+                  "uid": "9898989"
+                }
+              ],
+              "schedules": [
+                {
+                  "buildingName": "LECONTE",
+                  "roomNumber": "0004",
+                  "schedule": "F 12:00P-1:00P"
+                }
+              ]
+            },
+            {
+              "section_label": "DIS 008",
+              "ccn": "59713",
+              "courseCode": "INTEGBI 183A",
+              "instruction_format": "DIS",
+              "section_number": "008",
+              "is_primary_section": false,
+              "schedules": [],
+              "scheduledWithCcn": "49713",
+              "instructors": [
+                {
+                  "name": "Oski Bear",
+                  "email": "oski@example.edu",
+                  "uid": "61889"
+                },
+                {
+                  "name": "Mary Salinger",
+                  "email": "mary@example.edu",
+                  "uid": "9898989"
+                }
+              ]
             }
           ],
-          "url": "/academics/teaching-semester/summer-2013/class/bio-123a"
+          "url": "/academics/teaching-semester/summer-2013/class/biology-123a"
         }
       ]
     },
@@ -918,14 +1012,26 @@
       "termYear": "2013",
       "classes": [
         {
-          "course_code": "BIO 123A",
-          "dept": "BIO",
           "role": "Instructor",
           "slug": "bio-123a",
           "title": "General Biology and the Cambrian Biota",
+          "listings": [
+            {
+              "course_code": "BIO 123A",
+              "dept": "BIO"
+            }
+          ],
+          "scheduledSectionCount": 1,
+          "scheduledSections": [
+            {
+              "format": "lecture",
+              "count": 1
+            }
+          ],
           "sections": [
             {
               "ccn": "27607",
+              "courseCode": "BIOLOGY 123A",
               "instruction_format": "LEC",
               "section_label": "LEC 003",
               "section_number": "003",

--- a/public/dummy/json/classes.json
+++ b/public/dummy/json/classes.json
@@ -1,13 +1,17 @@
 {
   "classes": [
     {
-      "id": "BIOLOGY:1A:2013-C",
       "name": "General Biology Lecture",
-      "course_code": "BIOLOGY 1A",
       "term_yr": "2013",
       "term_cd": "C",
-      "dept": "BIOLOGY",
-      "catid": "1A",
+      "listings": [
+        {
+          "id": "BIOLOGY:1A:2013-C",
+          "course_code": "BIOLOGY 1A",
+          "dept": "BIOLOGY",
+          "catid": "1A"
+        }
+      ],
       "site_url": "/academics/semester/summer-2013/class/biology-1a",
       "sections": [
         {
@@ -27,13 +31,17 @@
       "emitter": "Campus"
     },
     {
-      "id": "LAW:2089S:2013-C",
       "name": "Fundamentals of U.S. Law",
-      "course_code": "LAW 2089S",
+      "listings": [
+        {
+          "id": "LAW:2089S:2013-C",
+          "course_code": "LAW 2089S",
+          "dept": "LAW",
+          "catid": "2089S"
+        }
+      ],
       "term_yr": "2013",
       "term_cd": "C",
-      "dept": "LAW",
-      "catid": "2089S",
       "site_url": "/academics/semester/summer-2013/class/law-2089s",
       "sections": [
         {
@@ -48,14 +56,18 @@
       "emitter": "Campus"
     },
     {
-      "id": "phys_ed:11_004:2013-C",
       "name": "Physical Education Activities",
-      "course_code": "PHYS ED 11",
-      "courseCodeSection": "LAB 004",
+      "listings": [
+        {
+          "id": "phys_ed:11_004:2013-C",
+          "course_code": "PHYS ED 11",
+          "courseCodeSection": "LAB 004",
+          "dept": "PHYS ED",
+          "catid": "11"
+        }
+      ],
       "term_yr": "2013",
       "term_cd": "C",
-      "dept": "PHYS ED",
-      "catid": "11",
       "site_url": "/academics/semester/summer-2013/class/phys_ed-11",
       "sections": [
         {
@@ -70,14 +82,18 @@
       "emitter": "Campus"
     },
     {
-      "id": "phys_ed:11_022:2013-C",
       "name": "Physical Education Activities",
-      "course_code": "PHYS ED 11",
-      "courseCodeSection": "LAB 022",
+      "listings": [
+        {
+          "id": "phys_ed:11_022:2013-C",
+          "course_code": "PHYS ED 11",
+          "courseCodeSection": "LAB 022",
+          "dept": "PHYS ED",
+          "catid": "11"
+        }
+      ],
       "term_yr": "2013",
       "term_cd": "C",
-      "dept": "PHYS ED",
-      "catid": "11",
       "site_url": "/academics/semester/summer-2013/class/phys_ed-11",
       "sections": [
         {
@@ -105,6 +121,178 @@
           "id": "phys_ed:11_022:2013-C"
         }
       ]
+    },
+    {
+      "name": "General Biology and the Cambrian Biota",
+      "listings": [
+        {
+          "id": "BIOLOGY:123A:2013-C",
+          "course_code": "BIOLOGY 123A",
+          "dept": "BIOLOGY",
+          "catid": "123A"
+        },
+        {
+          "id": "INTEGBI:183A:2013-C",
+          "course_code": "INTEGBI 183A",
+          "dept": "INTEGBI",
+          "catid": "183A"
+        }
+      ],
+      "term_yr": "2013",
+      "term_cd": "C",
+      "site_url": "/academics/semester/summer-2013/class/biology-123a",
+      "scheduledSectionCount": 3,
+      "scheduledSections": [
+        {
+          "format": "lecture",
+          "count": 1
+        },
+        {
+          "format": "discussion",
+          "count": 1
+        },
+        {
+          "format": "laboratory",
+          "count": 1
+        }
+      ],
+      "sections": [
+        {
+          "ccn": "27606",
+          "courseCode": "BIOLOGY 123A",
+          "instruction_format": "LEC",
+          "section_label": "LEC 002",
+          "section_number": "002",
+          "is_primary_section": true,
+          "schedules": [
+            {
+              "buildingName": "PIMENTAL",
+              "roomNumber": "1",
+              "schedule": "MWF 8:00A-9:00A"
+            }
+          ],
+          "instructors": [
+            {
+              "name": "Mary Salinger",
+              "email": "mary@example.edu",
+              "uid": "9898989"
+            }
+          ]
+        },
+        {
+          "ccn": "27619",
+          "courseCode": "BIOLOGY 123A",
+          "instruction_format": "LAB",
+          "section_label": "LAB 201",
+          "section_number": "201",
+          "is_primary_section": false,
+          "instructors": [
+            {
+              "name": "Mary Salinger",
+              "email": "mary@example.edu",
+              "uid": "9898989"
+            }
+          ],
+          "schedules": [
+            {
+              "buildingName": "LECONTE",
+              "roomNumber": "0004",
+              "schedule": "F 12:00P-1:00P"
+            }
+          ]
+        },
+        {
+          "section_label": "DIS 008",
+          "ccn": "49713",
+          "courseCode": "BIOLOGY 123A",
+          "instruction_format": "DIS",
+          "section_number": "008",
+          "is_primary_section": false,
+          "schedules": [],
+          "instructors": [
+            {
+              "name": "Oski Bear",
+              "email": "oski@example.edu",
+              "uid": "61889"
+            },
+            {
+              "name": "Mary Salinger",
+              "email": "mary@example.edu",
+              "uid": "9898989"
+            }
+          ]
+        },
+        {
+          "ccn": "37606",
+          "courseCode": "INTEGBI 183A",
+          "instruction_format": "LEC",
+          "section_label": "LEC 002",
+          "section_number": "002",
+          "scheduledWithCcn": "27606",
+          "is_primary_section": true,
+          "schedules": [
+            {
+              "buildingName": "PIMENTAL",
+              "roomNumber": "1",
+              "schedule": "MWF 8:00A-9:00A"
+            }
+          ],
+          "instructors": [
+            {
+              "name": "Mary Salinger",
+              "email": "mary@example.edu",
+              "uid": "9898989"
+            }
+          ]
+        },
+        {
+          "ccn": "37619",
+          "courseCode": "INTEGBI 183A",
+          "instruction_format": "LAB",
+          "section_label": "LAB 201",
+          "section_number": "201",
+          "scheduledWithCcn": "29713",
+          "is_primary_section": false,
+          "instructors": [
+            {
+              "name": "Mary Salinger",
+              "email": "mary@example.edu",
+              "uid": "9898989"
+            }
+          ],
+          "schedules": [
+            {
+              "buildingName": "LECONTE",
+              "roomNumber": "0004",
+              "schedule": "F 12:00P-1:00P"
+            }
+          ]
+        },
+        {
+          "section_label": "DIS 008",
+          "ccn": "59713",
+          "courseCode": "INTEGBI 183A",
+          "instruction_format": "DIS",
+          "section_number": "008",
+          "is_primary_section": false,
+          "schedules": [],
+          "scheduledWithCcn": "49713",
+          "instructors": [
+            {
+              "name": "Oski Bear",
+              "email": "oski@example.edu",
+              "uid": "61889"
+            },
+            {
+              "name": "Mary Salinger",
+              "email": "mary@example.edu",
+              "uid": "9898989"
+            }
+          ]
+        }
+      ],
+      "role": "Instructor",
+      "emitter": "Campus"
     },
     {
       "shortDescription": "Lessons from the Cambrian Explosion",

--- a/spec/models/my_academics/teaching_spec.rb
+++ b/spec/models/my_academics/teaching_spec.rb
@@ -14,22 +14,29 @@ describe 'MyAcademics::Teaching' do
     teaching[0][:termYear].should == "2013"
 
     teaching[0][:classes].length.should == 2
-    bio1a = teaching[0][:classes].select {|course| course[:course_code] == 'BIOLOGY 1A'}[0]
-    bio1a.empty?.should be_falsey
-    bio1a[:dept].should eq "BIOLOGY"
+    bio1a = teaching[0][:classes].select {|course| course[:listings].first[:course_code] == 'BIOLOGY 1A'}[0]
     bio1a[:title].should == "General Biology Lecture"
     bio1a[:role].should == "Instructor"
-    bio1a[:sections].length.should == 3
+
+    bio1a[:listings].count.should eq 1
+    bio1a[:listings].first[:dept].should eq "BIOLOGY"
+
+    bio1a[:scheduledSectionCount].should eq 3
+    bio1a[:scheduledSections].should include({format: 'lecture', count: 1})
+    bio1a[:scheduledSections].should include({format: 'discussion', count: 2})
+
+    bio1a[:sections].length.should eq 3
     bio1a[:sections][0][:is_primary_section].should be_truthy
     bio1a[:sections][1][:is_primary_section].should be_falsey
     bio1a[:sections][2][:is_primary_section].should be_falsey
     bio1a[:url].should == '/academics/teaching-semester/fall-2013/class/biology-1a'
 
-    cogsci = teaching[0][:classes].select {|course| course[:course_code] == 'COG SCI C147'}[0]
+    cogsci = teaching[0][:classes].select {|course| course[:listings].first[:course_code] == 'COG SCI C147'}[0]
     cogsci.empty?.should be_falsey
-    cogsci[:dept].should == "COG SCI"
     cogsci[:title].should == "Language Disorders"
     cogsci[:url].should == '/academics/teaching-semester/fall-2013/class/cog_sci-c147'
+
+    cogsci[:listings].first[:dept].should == "COG SCI"
 
     teaching[1][:name].should == "Spring 2012"
     teaching[1][:classes].length.should == 2
@@ -46,6 +53,18 @@ describe 'MyAcademics::Teaching' do
     teaching[0][:timeBucket].should == "future"
     teaching[1][:name].should == "Fall 2013"
     teaching[1][:timeBucket].should == "current"
+  end
+
+  context 'cross-listed courses', if: CampusOracle::Connection.test_data? do
+    include_context 'instructor for crosslisted courses'
+
+    subject do
+      feed = {}
+      MyAcademics::Teaching.new(instructor_id).merge feed
+      feed[:teachingSemesters][0][:classes]
+    end
+
+    it_should_behave_like 'a feed including crosslisted courses'
   end
 
 end

--- a/spec/models/my_classes/canvas_spec.rb
+++ b/spec/models/my_classes/canvas_spec.rb
@@ -7,7 +7,9 @@ describe MyClasses::Canvas do
   let(:course_id) {"econ-#{rand(999)}B"}
   let(:campus_course_base) do
     {
-      id: course_id,
+      listings: [{
+        id: course_id
+      }],
       term_yr: '2013',
       term_cd: 'D',
       sections: [{

--- a/spec/models/my_classes/sakai_classes_spec.rb
+++ b/spec/models/my_classes/sakai_classes_spec.rb
@@ -7,7 +7,9 @@ describe MyClasses::SakaiClasses do
   let(:course_id) {"econ-#{rand(999)}B"}
   let(:campus_courses) do
     [{
-      id: course_id,
+      listings: [{
+        id: course_id
+      }],
       term_yr: '2013',
       term_cd: 'D',
       sections: [{

--- a/spec/models/rosters/campus_spec.rb
+++ b/spec/models/rosters/campus_spec.rb
@@ -80,47 +80,62 @@ describe 'Rosters::Campus' do
     ]
   end
 
-  before do
-    allow(CampusOracle::UserCourses::All).to receive(:new).with(user_id: user_id).and_return(double(get_all_campus_courses: fake_campus))
-    allow(CampusOracle::UserCourses::All).to receive(:new).with(user_id: student_user_id).and_return(double(get_all_campus_courses: fake_campus_student))
-    allow(CampusOracle::Queries).to receive(:get_enrolled_students).with(ccn1, term_yr, term_cd).and_return(fake_students)
-    allow(CampusOracle::Queries).to receive(:get_enrolled_students).with(ccn2, term_yr, term_cd).and_return(fake_students)
+  context 'course with single section' do
+    before do
+      allow(CampusOracle::UserCourses::All).to receive(:new).with(user_id: user_id).and_return(double(get_all_campus_courses: fake_campus))
+      allow(CampusOracle::UserCourses::All).to receive(:new).with(user_id: student_user_id).and_return(double(get_all_campus_courses: fake_campus_student))
+      allow(CampusOracle::Queries).to receive(:get_enrolled_students).with(ccn1, term_yr, term_cd).and_return(fake_students)
+      allow(CampusOracle::Queries).to receive(:get_enrolled_students).with(ccn2, term_yr, term_cd).and_return(fake_students)
+    end
+
+    it 'should return a list of officially enrolled students for a course ccn' do
+      model = Rosters::Campus.new(user_id, course_id: campus_course_id)
+      feed = model.get_feed
+      expect(feed[:campus_course][:id]).to eq campus_course_id
+      expect(feed[:campus_course][:name]).to eq fake_campus["#{term_slug}"][0][:name]
+      expect(feed[:sections].length).to eq 2
+      expect(feed[:sections][0][:ccn]).to eq ccn1
+      expect(feed[:sections][0][:name]).to eq "INFO #{catid} LEC 001"
+      expect(feed[:sections][1][:ccn]).to eq ccn2
+      expect(feed[:sections][1][:name]).to eq "INFO #{catid} LAB 001"
+      expect(feed[:students].length).to eq 2
+
+      student = feed[:students][0]
+      expect(student[:id]).to eq enrolled_student_login_id
+      expect(student[:student_id]).to eq enrolled_student_student_id
+      expect(student[:first_name].blank?).to be_falsey
+      expect(student[:last_name].blank?).to be_falsey
+      expect(student[:email].blank?).to be_falsey
+      expect(student[:sections].length).to eq 2
+      expect(student[:sections][0][:ccn]).to eq ccn1
+      expect(student[:sections][0][:name]).to eq "INFO #{catid} LEC 001"
+      expect(student[:sections][1][:ccn]).to eq ccn2
+      expect(student[:sections][1][:name]).to eq "INFO #{catid} LAB 001"
+      expect(student[:profile_url].blank?).to be_falsey
+    end
+
+    it 'should show official photo links for students who are not waitlisted in all sections' do
+      model = Rosters::Campus.new(user_id, course_id: campus_course_id)
+      feed = model.get_feed
+      expect(feed[:sections].length).to eq 2
+      expect(feed[:students].length).to eq 2
+      expect(feed[:students].index {|student| student[:id] == waitlisted_student_login_id &&
+          student[:photo].nil?
+      }).to_not be_nil
+    end
   end
 
-  it 'should return a list of officially enrolled students for a course ccn' do
-    model = Rosters::Campus.new(user_id, course_id: campus_course_id)
-    feed = model.get_feed
-    expect(feed[:campus_course][:id]).to eq campus_course_id
-    expect(feed[:campus_course][:name]).to eq fake_campus["#{term_slug}"][0][:name]
-    expect(feed[:sections].length).to eq 2
-    expect(feed[:sections][0][:ccn]).to eq ccn1
-    expect(feed[:sections][0][:name]).to eq "INFO #{catid} LEC 001"
-    expect(feed[:sections][1][:ccn]).to eq ccn2
-    expect(feed[:sections][1][:name]).to eq "INFO #{catid} LAB 001"
-    expect(feed[:students].length).to eq 2
+  context 'cross-listed courses', if: CampusOracle::Connection.test_data? do
+    include_context 'instructor for crosslisted courses'
+    let!(:crosslisted_course_id) do
+      classes_for_instructor = MyClasses::Campus.new(instructor_id).fetch
+      classes_for_instructor.first[:listings].first[:id]
+    end
 
-    student = feed[:students][0]
-    expect(student[:id]).to eq enrolled_student_login_id
-    expect(student[:student_id]).to eq enrolled_student_student_id
-    expect(student[:first_name].blank?).to be_falsey
-    expect(student[:last_name].blank?).to be_falsey
-    expect(student[:email].blank?).to be_falsey
-    expect(student[:sections].length).to eq 2
-    expect(student[:sections][0][:ccn]).to eq ccn1
-    expect(student[:sections][0][:name]).to eq "INFO #{catid} LEC 001"
-    expect(student[:sections][1][:ccn]).to eq ccn2
-    expect(student[:sections][1][:name]).to eq "INFO #{catid} LAB 001"
-    expect(student[:profile_url].blank?).to be_falsey
-  end
-
-  it 'should show official photo links for students who are not waitlisted in all sections' do
-    model = Rosters::Campus.new(user_id, course_id: campus_course_id)
-    feed = model.get_feed
-    expect(feed[:sections].length).to eq 2
-    expect(feed[:students].length).to eq 2
-    expect(feed[:students].index {|student| student[:id] == waitlisted_student_login_id &&
-        student[:photo].nil?
-    }).to_not be_nil
+    it 'should merge sections for crosslisted courses' do
+      feed = Rosters::Campus.new(instructor_id, course_id: crosslisted_course_id).get_feed
+      expect(feed[:sections].length).to eq 6
+    end
   end
 
 end

--- a/spec/support/course_shared_examples.rb
+++ b/spec/support/course_shared_examples.rb
@@ -1,0 +1,37 @@
+shared_context 'instructor for crosslisted courses' do
+  let(:instructor_id) { '212388' }
+end
+
+shared_examples 'a feed including crosslisted courses' do
+  it 'merges crosslisted courses' do
+    expect(subject.size).to eq 2
+    crosslisted_course = subject[0]
+    expect(crosslisted_course[:listings].count).to eq 2
+    expect(crosslisted_course[:listings][0][:course_code]).to eq 'BUDDSTD C50'
+    expect(crosslisted_course[:listings][1][:course_code]).to eq 'S,SEASN C52'
+    expect(crosslisted_course[:crossListingHash]).to be_present
+  end
+
+  it 'concatenates and links crosslisted sections' do
+    crosslisted_sections = subject[0][:sections]
+    expect(crosslisted_sections.size).to eq 6
+    crosslisted_sections.each_with_index do |section, i|
+      expect(section[:courseCode]).to be_present
+      if i < 3
+        expect(section[:scheduledWithCcn]).to be_nil
+      else
+        expect(section[:scheduledWithCcn]).to eq crosslisted_sections[i-3][:ccn]
+      end
+    end
+
+    expect(subject[0][:scheduledSectionCount]).to eq 3
+    expect(subject[0][:scheduledSections]).to include({format: 'lecture', count: 1})
+    expect(subject[0][:scheduledSections]).to include({format: 'discussion', count: 2})
+  end
+
+  it 'does not mark non-crosslisted courses as crosslisted' do
+    non_crosslisted_course = subject[1]
+    expect(non_crosslisted_course[:listings].count).to eq 1
+    expect(non_crosslisted_course[:crossListingHash]).to be_blank
+  end
+end

--- a/src/assets/javascripts/angular/controllers/pages/academicsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicsController.js
@@ -253,7 +253,7 @@
             initMultiplePrimaries(course);
             $scope.selectedCourse = course;
             if (isOnlyInstructor) {
-              $scope.campusCourseId = course.course_id;
+              $scope.campusCourseId = course.listings[0].course_id;
             }
             break;
           }

--- a/src/assets/javascripts/angular/factories/myClassesFactory.js
+++ b/src/assets/javascripts/angular/factories/myClassesFactory.js
@@ -11,21 +11,25 @@
       for (var j = 0; j < classesHash.otherClasses.length; j++) {
         for (var k = 0; k < classesHash.otherClasses[j].courses.length; k++) {
           var course = classesHash.otherClasses[j].courses[k];
-          if (!classesHash.campusClasses[course.id].subclasses) {
-            classesHash.campusClasses[course.id].subclasses = [];
+          if (!classesHash.campusClassesById[course.id].subclasses) {
+            classesHash.campusClassesById[course.id].subclasses = [];
           }
-          classesHash.campusClasses[course.id].subclasses.push(classesHash.otherClasses[j]);
+          classesHash.campusClassesById[course.id].subclasses.push(classesHash.otherClasses[j]);
         }
       }
       return classesHash;
     };
 
     var splitClasses = function(classes) {
-      var campusClasses = {};
+      var campusClasses = [];
+      var campusClassesById = {};
       var otherClasses = [];
       for (var i = 0; i < classes.length; i++) {
         if (classes[i].emitter === 'Campus') {
-          campusClasses[classes[i].id] = classes[i];
+          campusClasses.push(classes[i]);
+          for (var j = 0; j < classes[i].listings.length; j++) {
+            campusClassesById[classes[i].listings[j].id] = classes[i];
+          }
         } else {
           otherClasses.push(classes[i]);
         }
@@ -33,6 +37,7 @@
 
       return {
         'campusClasses': campusClasses,
+        'campusClassesById': campusClassesById,
         'otherClasses': otherClasses
       };
     };

--- a/src/assets/stylesheets/_classes.scss
+++ b/src/assets/stylesheets/_classes.scss
@@ -4,7 +4,10 @@
   }
   .cc-widget-classes-subtitle {
     font-size: 12px;
-    margin: -4px 0;
+    margin-bottom: -4px;
+  }
+  .cc-widget-classes-title {
+    margin-bottom: -4px;
   }
   .cc-widget-list {
     font-size: 13px;

--- a/src/assets/templates/academics_classinfo.html
+++ b/src/assets/templates/academics_classinfo.html
@@ -8,7 +8,7 @@
     <h1 class="cc-heading-page-title">
       <a href="/academics">My Academics</a> &raquo;
       <a data-ng-href="/academics/semester/{{selectedSemester.slug}}"><span data-ng-bind="selectedSemester.name"></span></a> &raquo;
-      <span data-ng-bind="selectedCourse.course_code"></span>
+      <span data-ng-bind="selectedCourse.listings[0].course_code"></span>
       <div class="cc-academics-teaching-button-group" data-ng-if="isInstructorOrGsi">
         <ul class="cc-button-group cc-even-{{selectOptions.length}}" role="tablist">
           <li data-ng-repeat="selectOption in selectOptions">
@@ -35,6 +35,11 @@
         <div class="cc-widget-padding">
           <h3>Class Title</h3>
           <div data-ng-bind="selectedCourse.title"></div>
+
+          <h3 data-ng-if="selectedCourse.listings.length > 1">Crosslisted As</h3>
+          <div data-ng-if="selectedCourse.listings.length > 1" data-ng-repeat="listing in selectedCourse.listings">
+            <span data-ng-bind="listing.course_code"></span>
+          </div>
 
           <h3 data-ng-if="selectedCourse.role">My Role</h3>
           <div data-ng-bind="selectedCourse.role"></div>
@@ -83,7 +88,7 @@
 
           <h4 data-ng-if="selectedCourseCountSchedules">Section Schedules</h4>
 
-          <div class="row collapse" data-ng-repeat="section in selectedCourse.sections">
+          <div class="row collapse" data-ng-repeat="section in selectedCourse.sections" data-ng-if="!section.scheduledWithCcn">
             <div class="small-3 columns" data-ng-if="section.schedules" data-ng-bind="section.section_label"></div>
             <div class="small-9 columns">
               <div data-ng-repeat="schedule in section.schedules" data-ng-if="section.schedules" class="cc-academics-schedule-room">
@@ -102,7 +107,7 @@
           <h2 data-ng-pluralize count="selectedCourseCountInstructors" when="{'1': 'Instructor', 'other': 'Instructors'}">Instructors</h2>
         </div>
         <div class="cc-widget-padding">
-          <div data-ng-repeat="section in selectedCourse.sections">
+          <div data-ng-repeat="section in selectedCourse.sections" data-ng-if="!section.scheduledWithCcn">
             <h3 data-ng-bind="section.section_label"></h3>
             <ul class="cc-academics-instructors">
               <li data-ng-repeat="instructor in section.instructors">

--- a/src/assets/templates/academics_semester_classes.html
+++ b/src/assets/templates/academics_semester_classes.html
@@ -74,18 +74,27 @@
           <thead>
             <th scope="col" class="cc-table-right-spacing">Course Number</th>
             <th scope="col">Title</th>
+            <th scope="col" class="show-for-medium-up">Sections</th>
           </thead>
           <tbody data-ng-if="selectedTeachingSemester.classes.length" data-ng-repeat="course in selectedTeachingSemester.classes">
             <tr data-ng-class-even="'cc-academics-even'">
               <td class="cc-table-right-spacing cc-academics-course-number">
-                <a data-ng-href="{{course.url}}"
-                   data-ng-bind="course.course_code">
-                </a>
-                <div data-ng-repeat="section in course.sections">
-                  <span data-ng-bind="section.section_label"></span>
+                <div data-ng-repeat="listing in course.listings">
+                  <a data-ng-href="{{course.url}}"
+                     data-ng-bind="listing.course_code">
+                  </a>
+                </div>
+                <div class="show-for-small-only">
+                  <span data-ng-bind="course.scheduledSectionCount"></span>
+                  <span data-ng-pluralize count="course.scheduledSectionCount" when="{'1': 'section', 'other': 'sections'}">sections</span>
                 </div>
               </td>
               <td data-ng-bind="course.title"></td>
+              <td class="show-for-medium-up">
+                <div data-ng-repeat="scheduledSection in course.scheduledSections">
+                  <span data-ng-bind="scheduledSection.count"></span> <span data-ng-bind="scheduledSection.format"></span>
+                </div>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/src/assets/templates/academics_teaching.html
+++ b/src/assets/templates/academics_teaching.html
@@ -14,8 +14,8 @@
     <div class="cc-academics-teaching-semester" data-ng-if="hasTeachingClasses" data-ng-repeat="semester in teachingSemesters | limitTo:pastSemestersTeachingLimit">
       <h3><a data-ng-href="/academics/semester/{{semester.slug}}" data-ng-bind="semester.name"></a></h3>
       <div class="cc-academics-teaching-class" data-ng-repeat="class in semester.classes">
-        <div class="cc-academics-teaching-course-number">
-          <strong><a data-ng-bind="class.course_code" data-ng-href="{{class.url}}"></a></strong>
+        <div class="cc-academics-teaching-course-number" data-ng-repeat="listing in class.listings">
+          <strong><a data-ng-bind="listing.course_code" data-ng-href="{{class.url}}"></a></strong>
         </div>
         <div class="cc-text-light" data-ng-bind="class.title"></div>
       </div>

--- a/src/assets/templates/widgets/my_classes.html
+++ b/src/assets/templates/widgets/my_classes.html
@@ -19,16 +19,15 @@
               <span class="cc-ellipsis" data-ng-bind="class.name"></span>
             </a>
             <div data-ng-switch-default>
-              <div class="cc-ellipsis">
+              <div class="cc-ellipsis cc-widget-classes-title" data-ng-repeat="listing in class.listings">
                 <a data-ng-click="api.analytics.trackExternalLink('My Classes', class.emitter, class.site_url)"
                    data-ng-href="{{class.site_url}}">
-                  <strong data-ng-bind="class.course_code" data-ng-class="{'cc-italic': class.waitlistPosition}"></strong>
-                  <strong data-ng-bind="class.courseCodeSection" data-ng-class="{'cc-italic': class.waitlistPosition}"></strong>
+                  <strong data-ng-bind="listing.course_code" data-ng-class="{'cc-italic': class.waitlistPosition}"></strong>
+                  <strong data-ng-bind="listing.courseCodeSection" data-ng-class="{'cc-italic': class.waitlistPosition}"></strong>
                 </a>
-                <span class="cc-text-light" data-ng-show="class.waitlistPosition" data-ng-bind-template="- #{{ class.waitlistPosition }} on the wait list"></span>
               </div>
-              <div class="cc-ellipsis cc-text-light cc-widget-classes-subtitle" data-ng-class="{'cc-italic': class.waitlistPosition}" data-ng-show="!!class.name" data-ng-bind="class.name">
-              </div>
+              <span class="cc-text-light" data-ng-show="class.waitlistPosition" data-ng-bind-template="- #{{ class.waitlistPosition }} on the wait list"></span>
+              <div class="cc-ellipsis cc-text-light cc-widget-classes-subtitle" data-ng-class="{'cc-italic': class.waitlistPosition}" data-ng-show="!!class.name" data-ng-bind="class.name"></div>
               <ul class="cc-widget-sublist">
                 <li data-ng-repeat="subclass in class.subclasses">
                   <div class="cc-icon" data-ng-class="{'bSpace':'cc-icon-bspace', 'bCourses':'cc-icon-bcourses'}[subclass.emitter]">


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4455
subsumes https://jira.ets.berkeley.edu/jira/browse/CLC-3355

This PR collapses crosslisted courses for instructors in My Academics and My Classes. Because campus data indicates crosslisting by adding a code to primary sections, this change will only affect instructors assigned to a primary section (no love for GSIs this round).

On the UX side, the the list of section codes in the My Academics semester summary is replaced with a new  column containing summary information on the number and type of sections. When the screen gets small, it collapses to a two-column view that lists only the total number of sections under the course code.

Rather than jam multiple course codes into the breadcrumbs on the Class Info page, a new "Crosslisted As" heading signals the existence of multiple codes.

Most of the Class Info widgets ignore CCNs and display only one section out of a crosslisted group. The exception is Roster Photos, which groups students by CCN and separates out crosslistings that are implicitly merged elsewhere.

On the data-structure side, the code for merging crosslisted courses has been moved upstream from Canvas course provisioning to My Academics. The `teachingSemesters` portion of the My Academics feed, as well as the My Classes feed, now collapses crosslisted courses into single objects. To preserve listing-specific information such as department and course code, each course now includes a `listings` array which may contain one or more objects. There is still only one slug per course, and the client side now uses slugs instead of course codes when a unique identifier is needed.

The `semesters` portion of the My Academics feed, which is only for students and doesn't include crosslistings, is unchanged.