### PR TITLE
OEC-551, avoid duplicate rows in INTEGBI.csv caused by biology_post_process

### DIFF
--- a/app/models/oec/biology_post_processor.rb
+++ b/app/models/oec/biology_post_processor.rb
@@ -1,47 +1,85 @@
 module Oec
   class BiologyPostProcessor
 
-    def initialize(export_dir)
-      @export_dir = export_dir
+    def initialize(biology_dept_name, biology_relationship_matchers, src_dir, dest_dir)
+      @biology_dept_name = biology_dept_name
+      @biology_relationship_matchers = biology_relationship_matchers
+      @src_dir = src_dir
+      @dest_dir = dest_dir
     end
 
     def post_process
-      biology_dept = 'BIOLOGY'
-      biology = Oec::Courses.new(biology_dept, @export_dir)
-      path_to_biology_csv = biology.output_filename
+      path_to_biology_csv = path_to_csv @biology_dept_name
       if File.exist? path_to_biology_csv
-        header_row = nil
-        integbi_dept = 'INTEGBI'
-        mcellbi_dept = 'MCELLBI'
+        files_to_archive = { @biology_dept_name => path_to_biology_csv }
+        uids_in_target_files = {}
         sorted_dept_rows = {}
-        CSV.read(path_to_biology_csv).each_with_index do | row, index |
-          dept_name = row[4]
-          course_name = row[1]
-          if index == 0
-            header_row = row
-          elsif dept_name.include?(mcellbi_dept) || dept_name.include?(integbi_dept)
-            Rails.logger.warn "#{row[0]} #{row[1]} #{biology.base_file_name} skipped. Course is listed #{dept_name} CSV file."
-          else
-            target_csv = biology_dept
-            if course_name.match(' 1A[L]?').present?
-              target_csv = row[4] = mcellbi_dept
-            elsif course_name.match(' 1B[L]?').present?
-              target_csv = row[4] = integbi_dept
+        @biology_relationship_matchers.keys.each do |target_dept_name|
+          path_to_target_csv = path_to_csv target_dept_name
+          files_to_archive[target_dept_name] = path_to_target_csv
+          uids_in_target_files[target_dept_name] = []
+          CSV.read(path_to_target_csv).each_with_index do |row, index|
+            unless index == 0
+              uids_in_target_files[target_dept_name] << "#{get_row_uid row}"
+              put_row_per_dept(sorted_dept_rows, target_dept_name, row)
             end
-            sorted_dept_rows[target_csv] ||= []
-            sorted_dept_rows[target_csv] << row
           end
         end
-        File.delete path_to_biology_csv
-        export_rules = { biology_dept => true, integbi_dept => false, mcellbi_dept => false }
-        export_rules.each do | next_dept_name, overwrite_file |
+        header_row = nil
+        CSV.read(path_to_biology_csv).each_with_index do |row, index|
+          unless preexisting_uid?(get_row_uid(row), uids_in_target_files, files_to_archive.keys)
+            course_name = row[1]
+            if index == 0
+              header_row = row
+            else
+              target_csv = @biology_dept_name
+              @biology_relationship_matchers.each do |dept_name, pattern|
+                if course_name.match(pattern).present?
+                  target_csv = row[4] = dept_name
+                end
+              end
+              put_row_per_dept(sorted_dept_rows, target_csv, row)
+            end
+          end
+        end
+        files_to_archive.each do | next_dept_name, path_to_csv |
+          FileUtils.mv(path_to_csv, "#{path_to_csv}.OBSOLETE")
           rows = sorted_dept_rows[next_dept_name]
           if rows && rows.length > 0
-            ExportWrapper.new(next_dept_name, header_row, rows, @export_dir).export overwrite_file
+            ExportWrapper.new(next_dept_name, header_row, rows, @dest_dir).export
           end
         end
+      else
+        Rails.logger.error "File not found: #{path_to_biology_csv}"
       end
     end
+
+    private
+
+    def put_row_per_dept(dept_rows_hash, dept_name, row)
+      dept_rows_hash[dept_name] ||= []
+      dept_rows_hash[dept_name] << row
+    end
+
+    def preexisting_uid?(uid, pre_existing_uid, dept_names)
+      dept_names.each do |dept_name|
+        dept_uids = pre_existing_uid[dept_name]
+        if dept_uids && dept_uids.include?(uid)
+          Rails.logger.warn "#{dept_name}.csv already has #{uid}"
+          return true
+        end
+      end
+      false
+    end
+
+    def get_row_uid(row)
+      "#{row[0]}-#{row[9]}"
+    end
+
+    def path_to_csv(dept_name)
+      Oec::Courses.new(dept_name, @src_dir).output_filename
+    end
+
   end
 
   class ExportWrapper < Oec::Courses

--- a/spec/models/oec/biology_post_processor_spec.rb
+++ b/spec/models/oec/biology_post_processor_spec.rb
@@ -1,8 +1,11 @@
 describe Oec::BiologyPostProcessor do
 
-  before(:suite) do
+  let!(:csv_file_hash) { {} }
+
+  before do
+    export_dir = 'tmp/oec'
     dept_names = %w(BIOLOGY INTEGBI MCELLBI 'POL SCI')
-    expect(Settings.oec).to receive(:departments).exactly(1).and_return dept_names
+    expect(Settings.oec).to receive(:departments).at_least(:once).and_return dept_names
     dept_names.each do |dept_name|
       courses_query = []
       CSV.read('fixtures/oec/courses_wrapper.csv').each_with_index do |row, index|
@@ -11,43 +14,41 @@ describe Oec::BiologyPostProcessor do
         end
       end
       expect(Oec::Queries).to receive(:get_courses).with(nil, dept_name).exactly(1).times.and_return courses_query
+      export = Oec::Courses.new(dept_name, export_dir).export
+      csv_file_hash[dept_name] = CSV.read export[:filename]
     end
-    Oec::BiologyPostProcessor.new.post_process
+    biology_post_processor_patterns = { 'MCELLBI' => ' 1A[L]?', 'INTEGBI' => ' 1B[L]?' }
+    Oec::BiologyPostProcessor.new('BIOLOGY', biology_post_processor_patterns, export_dir, export_dir).post_process
   end
 
   context 'Biology 1A and 1B entries moved to MCELLBI and INTEGBI, respectively' do
 
     context 'reading BIOLOGY csv file' do
-      subject { get_csv 'BIOLOGY' }
+      subject { csv_file_hash['BIOLOGY'] }
       it {
         contain_exactly('COURSE_ID', '2015-B-87672')
       }
     end
 
     context 'reading INTEGBI csv file' do
-      subject { get_csv 'INTEGBI' }
+      subject { csv_file_hash['INTEGBI'] }
       it {
         contain_exactly('COURSE_ID', '2015-B-54432', '2015-B-87675')
       }
     end
 
     context 'reading MCELLBI csv file' do
-      subject { get_csv 'MCELLBI' }
+      subject { csv_file_hash['MCELLBI'] }
       it {
         contain_exactly('COURSE_ID', '2015-B-54441', '2015-B-87690', '2015-B-87693', '2015-B-87691')
       }
     end
 
     context 'reading POL SCI csv file' do
-      subject { get_csv 'POL SCI' }
+      subject { csv_file_hash['POL SCI'] }
       it {
         contain_exactly('COURSE_ID', '2015-B-72198')
       }
-    end
-
-    def get_csv(dept_name)
-      export = Oec::Courses.new(dept_name, 'tmp/oec').export
-      CSV.read export[:filename]
     end
 
   end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-551
Avoid duplicate rows in INTEGBI.csv caused by biology_post_process. BIO.csv entries were being moved to INTEGBI.csv causing, in the case of certain cross-listings, duplicates. The fix is to identify all unique CCN/UID entries in INTEGBI.csv before moving more over from BIO.csv.

This PR includes simple fix for https://jira.ets.berkeley.edu/jira/browse/OEC-567 in oec.rake:

>      if courses_diff.was_difference_found
>        Rails.logger.warn "#{hr}Find summary in #{courses_diff.output_filename}#{hr}"
>      else
>        File.delete courses_diff.output_filename
>        Rails.logger.warn "#{hr}No diff found in #{dept_name} csv.#{hr}"
>      end
