### PR TITLE
CLC-4775: Add hangout link to Up Next Selenium test

### DIFF
--- a/spec/ui_selenium/my_dashboard_google_up_next_spec.rb
+++ b/spec/ui_selenium/my_dashboard_google_up_next_spec.rb
@@ -44,12 +44,14 @@ describe 'My Dashboard Up Next card', :testui => true do
       @initial_event_times = @up_next_card.all_event_times
       @initial_event_summaries = @up_next_card.all_event_summaries
       @initial_event_locations = @up_next_card.all_event_locations
+      @initial_hangout_link_count = @up_next_card.hangout_link_count
       @initial_event_start_times = @up_next_card.all_event_start_times
       @initial_event_end_times = @up_next_card.all_event_end_times
       @initial_event_organizers = @up_next_card.all_event_organizers
       logger.info("#{@initial_event_times}")
       logger.info("#{@initial_event_summaries}")
       logger.info("#{@initial_event_locations}")
+      logger.info("There are #{@initial_hangout_link_count.to_s} video links")
       logger.info("#{@initial_event_start_times}")
       logger.info("#{@initial_event_end_times}")
       logger.info("#{@initial_event_organizers}")
@@ -101,6 +103,10 @@ describe 'My Dashboard Up Next card', :testui => true do
       end
 
       context 'when expanded' do
+
+        it 'shows event video hangout links' do
+          expect(@up_next_card.hangout_link_count).to eql(@initial_hangout_link_count + 1)
+        end
 
         it 'shows event start times' do
           logger.info("#{@up_next_card.all_event_start_times}")

--- a/spec/ui_selenium/pages/google_page.rb
+++ b/spec/ui_selenium/pages/google_page.rb
@@ -42,6 +42,7 @@ class GooglePage
   text_area(:event_end_time, :xpath => '//input[@title="Until time"]')
   text_area(:event_end_date, :xpath => '//input[@title="Until date"]')
   text_area(:event_location, :xpath => '//input[@placeholder="Enter a location"]')
+  button(:add_video_link, :xpath => '//span[text()="Add video call"]')
   button(:save_event, :xpath => '//div[text()="Save"]')
   div(:event_added, :xpath => '//div[contains(text(),"Added")]')
   div(:event_title_displayed, :xpath => '//div[@class="ui-sch-schmedit"]')
@@ -134,6 +135,7 @@ class GooglePage
     event_location_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
     event_location
     self.event_location = location
+    add_video_link
     sleep(WebDriverUtils.page_event_timeout)
     start_time = Time.strptime(event_start_time, "%l:%M%P")
     end_time = Time.strptime(event_end_time, "%l:%M%P")

--- a/spec/ui_selenium/pages/my_dashboard_up_next_card.rb
+++ b/spec/ui_selenium/pages/my_dashboard_up_next_card.rb
@@ -19,6 +19,7 @@ module CalCentralPages
     elements(:event_summary, :div, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]/li//strong[@data-ng-bind="item.summary"]')
     elements(:event_location, :div, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]/li//div[@data-ng-bind="item.location"]')
     elements(:event_detail_toggle, :div, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]/li//div[@data-ng-click="api.widget.toggleShow($event, items, item, \'Up Next\')"]')
+    div(:hangout_link, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]/li//a[contains(.,"Join Hangout")]')
     div(:event_start_time, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]//div[@data-ng-bind="item.start.epoch * 1000 | date:\'short\' | lowercase"]')
     div(:event_end_time, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]//div[@data-ng-bind="item.end.epoch * 1000 | date:\'short\' | lowercase"]')
     paragraph(:event_organizer, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]//p[@data-ng-bind="item.organizer"]')
@@ -40,6 +41,18 @@ module CalCentralPages
       locations = []
       event_location_elements.each { |location| locations.push(location.text) }
       locations.sort
+    end
+
+    def hangout_link_count
+      links = []
+      event_detail_toggle_elements.each do |toggle|
+        toggle.click
+        hangout_link_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
+        links.push(hangout_link)
+        toggle.click
+        hangout_link_element.when_not_visible(timeout=WebDriverUtils.page_event_timeout)
+      end
+      links.length
     end
 
     def all_event_start_times


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4775

In CLC-4775, we've added Google hangout links to Up Next event detail.  This change updates the existing Up Next Selenium test, whereby the test user adds a video link to the Google invite and verifies that the link shows up in CalCentral.