### PR TITLE
OEC-566, DeptRegistry encapsulates logic: if BIO then include INTEGBI and MCELLBI, too

### DIFF
--- a/app/models/oec/biology_post_processor.rb
+++ b/app/models/oec/biology_post_processor.rb
@@ -1,21 +1,21 @@
 module Oec
   class BiologyPostProcessor
 
-    def initialize(biology_dept_name, biology_relationship_matchers, src_dir, dest_dir)
-      @biology_dept_name = biology_dept_name
-      @biology_relationship_matchers = biology_relationship_matchers
+    def initialize(src_dir, dest_dir, debug_mode = false)
       @src_dir = src_dir
       @dest_dir = dest_dir
+      @debug_mode = debug_mode
     end
 
     def post_process
-      biology = Oec::Courses.new(@biology_dept_name, @src_dir)
+      dept_registry = Oec::DepartmentRegistry.new
+      biology = Oec::Courses.new(dept_registry.biology_dept_name, @src_dir)
       path_to_biology_csv = biology.output_filename
       if File.exist? path_to_biology_csv
-        files_to_archive = { @biology_dept_name => path_to_biology_csv }
+        files_to_archive = { dept_registry.biology_dept_name => path_to_biology_csv }
         uids_in_target_files = {}
         sorted_dept_rows = {}
-        @biology_relationship_matchers.keys.each do |target_dept_name|
+        dept_registry.biology_relationship_matchers.keys.each do |target_dept_name|
           path_to_target_csv = Oec::Courses.new(target_dept_name, @src_dir).output_filename
           files_to_archive[target_dept_name] = path_to_target_csv
           uids_in_target_files[target_dept_name] = []
@@ -29,8 +29,8 @@ module Oec
         CSV.read(path_to_biology_csv).each_with_index do |row, index|
           unless preexisting_uid?(get_row_uid(row), uids_in_target_files, files_to_archive.keys) || index == 0
             course_name = row[1]
-            target_csv = @biology_dept_name
-            @biology_relationship_matchers.each do |dept_name, pattern|
+            target_csv = dept_registry.biology_dept_name
+            dept_registry.biology_relationship_matchers.each do |dept_name, pattern|
               if course_name.match(pattern).present?
                 target_csv = row[4] = dept_name
               end
@@ -39,7 +39,7 @@ module Oec
           end
         end
         files_to_archive.each do | next_dept_name, path_to_csv |
-          FileUtils.mv(path_to_csv, "#{path_to_csv}.OBSOLETE")
+          @debug_mode ? FileUtils.mv(path_to_csv, "#{path_to_csv}.OBSOLETE") : File.delete(path_to_csv)
           rows = sorted_dept_rows[next_dept_name]
           if rows && rows.length > 0
             ExportWrapper.new(next_dept_name, biology.headers, rows, @dest_dir).export

--- a/app/models/oec/department_registry.rb
+++ b/app/models/oec/department_registry.rb
@@ -1,0 +1,25 @@
+module Oec
+  class DepartmentRegistry < Set
+
+    attr_reader :biology_relationship_matchers
+    attr_reader :biology_dept_name
+
+    def initialize(dept_set = Settings.oec.departments)
+      super dept_set
+      @biology_dept_name = 'BIOLOGY'
+      @biology_relationship_matchers = { 'MCELLBI' => ' 1A[L]?', 'INTEGBI' => ' 1B[L]?' }
+      if include? @biology_dept_name
+        merge @biology_relationship_matchers.keys
+      else
+        @biology_relationship_matchers.each_key do |dept_name|
+          if include? dept_name
+            add @biology_dept_name
+            merge @biology_relationship_matchers.keys
+            break
+          end
+        end
+      end
+    end
+
+  end
+end

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -6,14 +6,13 @@ namespace :oec do
   task :courses => :environment do
     dest_dir = get_path_arg 'dest'
     files_created = []
-    dept_set = Settings.oec.departments.to_set
-    dept_set.each do |dept_name|
+    Oec::DepartmentRegistry.new.each do |dept_name|
       exporter = Oec::Courses.new(dept_name, dest_dir)
       exporter.export
       files_created << "#{dest_dir}/#{exporter.base_file_name}.csv"
     end
-    biology_relationship_matchers = { 'MCELLBI' => ' 1A[L]?', 'INTEGBI' => ' 1B[L]?' }
-    post_processor = Oec::BiologyPostProcessor.new('BIOLOGY', biology_relationship_matchers, dest_dir, dest_dir)
+    debug_mode = ENV['debug'].to_s =~ /true/i
+    post_processor = Oec::BiologyPostProcessor.new(dest_dir, dest_dir, debug_mode)
     post_processor.post_process
     Rails.logger.warn "#{hr}Find CSV files in directory: #{dest_dir}#{hr}"
   end

--- a/spec/models/oec/biology_post_processor_spec.rb
+++ b/spec/models/oec/biology_post_processor_spec.rb
@@ -4,7 +4,7 @@ describe Oec::BiologyPostProcessor do
 
   before do
     export_dir = 'tmp/oec'
-    dept_names = %w(BIOLOGY INTEGBI MCELLBI 'POL SCI')
+    dept_names = %w(BIOLOGY INTEGBI MCELLBI POL\ SCI)
     expect(Settings.oec).to receive(:departments).at_least(:once).and_return dept_names
     dept_names.each do |dept_name|
       courses_query = []
@@ -17,8 +17,7 @@ describe Oec::BiologyPostProcessor do
       export = Oec::Courses.new(dept_name, export_dir).export
       csv_file_hash[dept_name] = CSV.read export[:filename]
     end
-    biology_post_processor_patterns = { 'MCELLBI' => ' 1A[L]?', 'INTEGBI' => ' 1B[L]?' }
-    Oec::BiologyPostProcessor.new('BIOLOGY', biology_post_processor_patterns, export_dir, export_dir).post_process
+    Oec::BiologyPostProcessor.new(export_dir, export_dir).post_process
   end
 
   context 'Biology 1A and 1B entries moved to MCELLBI and INTEGBI, respectively' do

--- a/spec/models/oec/department_registry_spec.rb
+++ b/spec/models/oec/department_registry_spec.rb
@@ -1,0 +1,28 @@
+describe Oec::DepartmentRegistry do
+
+    it 'should load OEC settings when no departments specified' do
+      registry = Oec::DepartmentRegistry.new
+      registry.should match_array Settings.oec.departments
+    end
+
+    it 'should add BIOLOGY if, for example, INTEGBI is requested' do
+      registry = Oec::DepartmentRegistry.new %w(INTEGBI 'POL SCI')
+      registry.should match_array %w(BIOLOGY INTEGBI MCELLBI 'POL SCI')
+    end
+
+    it 'should add sister departments' do
+      registry = Oec::DepartmentRegistry.new %w(MCELLBI)
+      registry.should match_array %w(BIOLOGY INTEGBI MCELLBI)
+    end
+
+    it 'should add, for example, INTEGBI because BIOLOGY is present' do
+      registry = Oec::DepartmentRegistry.new %w('POL SCI' BIOLOGY)
+      registry.should match_array %w(BIOLOGY INTEGBI MCELLBI 'POL SCI')
+    end
+
+    it 'should add nothing if BIOLOGY and related are not found' do
+      registry = Oec::DepartmentRegistry.new %w('POL SCI' STAT)
+      registry.should match_array %w('POL SCI' STAT)
+    end
+
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-566

This is advance work on having the oec:diff task work when running dept_name=INTEGBI or dept_name=MCELLBI. Because different operations will rely on BIOLOGY's special case I have encapsulated the logic in DepartmentRegistry. 