### PR TITLE
CLC-4837 Standardize logging of remote server errors

### DIFF
--- a/app/models/bearfacts/proxy.rb
+++ b/app/models/bearfacts/proxy.rb
@@ -57,11 +57,6 @@ module Bearfacts
           end
           get_response(url, request_options)
         }
-
-        if response.code >= 400
-          raise Errors::ProxyError.new("Connection failed: #{response.code} #{response.body}; url = #{url}")
-        end
-
         logger.debug "Remote server status #{response.code}, Body = #{response.body}"
         {
           body: response.parsed_response,

--- a/app/models/cal1card/my_cal1card.rb
+++ b/app/models/cal1card/my_cal1card.rb
@@ -33,14 +33,7 @@ module Cal1card
           url,
           basic_auth: {username: @settings.username, password: @settings.password}
         )
-        if response.code >= 400
-          raise Errors::ProxyError.new("Connection failed: #{response.code} #{response.body}; url = #{url}", {
-            body: "An error occurred retrieving data for Cal 1 Card. Please try again later.",
-            statusCode: response.code
-          })
-        else
-          feed = response.parsed_response
-        end
+        feed = response.parsed_response
         logger.debug "Cal1Card remote response: #{response.inspect}"
       end
       camelized = HashConverter.camelize feed

--- a/app/models/cal_link/memberships.rb
+++ b/app/models/cal_link/memberships.rb
@@ -23,9 +23,6 @@ module CalLink
           )
         }
       end
-      if response.code >= 400
-        raise Errors::ProxyError.new("Connection failed: #{response.code} #{response.body}; url = #{url}")
-      end
       Rails.logger.debug "#{self.class.name}: Remote server status #{response.code}, Body = #{response.body}"
       {
         :body => response.parsed_response,

--- a/app/models/cal_link/organization.rb
+++ b/app/models/cal_link/organization.rb
@@ -28,9 +28,6 @@ module CalLink
           )
         }
       end
-      if response.code >= 400
-        raise Errors::ProxyError.new("Connection failed: #{response.code} #{response.body}; url = #{url}")
-      end
       Rails.logger.debug "#{self.class.name}: Remote server status #{response.code}, Body = #{response.body}"
       {
         :body => response.parsed_response,

--- a/app/models/canvas/proxy.rb
+++ b/app/models/canvas/proxy.rb
@@ -64,8 +64,7 @@ module Canvas
               logger.debug("404 status returned for URL '#{fetch_options[:uri]}', UID #{@uid}")
               return nil
             end
-            raise Errors::ProxyError.new(
-                    "Connection failed for URL '#{fetch_options[:uri]}', UID #{@uid}: #{response.status} #{response.body}", nil, nil)
+            raise Errors::ProxyError.new('Connection failed', response: response, url: fetch_options[:uri], uid: @uid)
           else
             response
           end

--- a/app/models/finaid/proxy.rb
+++ b/app/models/finaid/proxy.rb
@@ -40,9 +40,6 @@ module Finaid
           end
           get_response(url, request_options)
         }
-        if response.code >= 400
-          raise Errors::ProxyError.new("Connection failed: #{response.code} #{response.body}", nil)
-        end
         logger.debug "Remote server status #{response.code}, Body = #{response.body}"
         response
       end

--- a/app/models/financials/proxy.rb
+++ b/app/models/financials/proxy.rb
@@ -18,7 +18,8 @@ module Financials
       FakeableProxy.wrap_request(APP_ID + "_financials", @fake, {match_requests_on: [:method, :path]}) {
         get_response(
           url,
-          digest_auth: {username: Settings.financials_proxy.username, password: Settings.financials_proxy.password}
+          digest_auth: {username: Settings.financials_proxy.username, password: Settings.financials_proxy.password},
+          on_error: {rescue_status: 404}
         )
       }
     end

--- a/app/models/google_apps/revoke.rb
+++ b/app/models/google_apps/revoke.rb
@@ -7,7 +7,9 @@ module GoogleApps
       # Google::APIClient does not implement the token revocation endpoint, so we get it via a regular HTTParty request.
       response = get_response(
         'https://accounts.google.com/o/oauth2/revoke',
-        query: {token: @authorization.access_token})
+        query: {token: @authorization.access_token},
+        on_error: {rescue_status: :all}
+      )
       if response.code == 200
         logger.warn "Successfully revoked Google access token for user #{@uid}"
         true

--- a/app/models/mediacasts/all_playlists.rb
+++ b/app/models/mediacasts/all_playlists.rb
@@ -31,21 +31,20 @@ module Mediacasts
         data = safe_json File.read(Rails.root.join('fixtures', 'json', 'webcasts.json').to_s)
       else
         response = get_response(
-            @settings.base_url,
-            basic_auth: {username: @settings.username, password: @settings.password}
+          @settings.base_url,
+          basic_auth: {username: @settings.username, password: @settings.password},
+          on_error: {return_feed: PROXY_ERROR}
         )
-        if response.code >= 400
-          raise Errors::ProxyError.new(
-                  "Connection failed: #{response.code} #{response.body}",
-                  PROXY_ERROR)
-        end
         data = response.parsed_response
       end
 
       if !data || !(data.is_a? Hash)
         raise Errors::ProxyError.new(
-                "Error occurred converting response to json: #{response.body}",
-                PROXY_ERROR)
+            'Error occurred converting response to json',
+            response: response,
+            url: @settings.base_url,
+            return_feed: PROXY_ERROR
+          )
       end
 
       processed_playlists = {

--- a/app/models/mediacasts/audio.rb
+++ b/app/models/mediacasts/audio.rb
@@ -24,9 +24,6 @@ module Mediacasts
         }
       end
       response = get_response(@audio_rss)
-      if response.code >= 400
-        raise Errors::ProxyError.new("Connection failed: #{response.code} #{response.body}")
-      end
       logger.debug "Remote server status #{response.code}, Body = #{response.body}"
       {
         audio: filter_audio(response)

--- a/app/models/textbooks/proxy.rb
+++ b/app/models/textbooks/proxy.rb
@@ -145,9 +145,6 @@ module Textbooks
         }
       )
       logger.debug "Remote server status #{response.code}; url = #{url}"
-      if response.code >= 400
-        raise Errors::ProxyError.new("Currently, we can't reach the bookstore. Check again later for updates, or contact your instructor directly.")
-      end
       response.parsed_response
     end
 

--- a/lib/errors/proxy_error.rb
+++ b/lib/errors/proxy_error.rb
@@ -1,14 +1,19 @@
 module Errors
   class ProxyError < StandardError
-    attr_accessor :log_message, :response, :wrapped_exception
+    attr_accessor :body, :log_message, :response, :status, :uid, :url, :wrapped_exception
 
-    def initialize(log_message = nil,
-      response = nil,
-      wrapped_exception = nil
-    )
+    def initialize(log_message = '', opts={})
       @log_message = log_message
-      @response = response
-      @wrapped_exception = wrapped_exception
+      @url = opts[:url]
+      @uid = opts[:uid]
+
+      if (response = opts[:response])
+        @status = response.code
+        @body = response.body
+      end
+
+      @response = opts[:return_feed]
+      @wrapped_exception = opts[:wrapped_exception]
     end
   end
 end

--- a/lib/proxies/http_requester.rb
+++ b/lib/proxies/http_requester.rb
@@ -6,6 +6,7 @@ module HttpRequester
   # HTTParty is our preferred HTTP connectivity lib. Use this get_response method wherever possible.
   def get_response(url, additional_options={})
     ActiveSupport::Notifications.instrument('proxy', {url: url, class: self.class}) do
+      error_options = additional_options.delete(:on_error) || {}
       response = HTTParty.get(
         url,
         {
@@ -14,16 +15,27 @@ module HttpRequester
         }.merge(additional_options)
       )
       begin
+        if error_options[:rescue_status] == response.code || error_options[:rescue_status] == :all
+          return response
+        end
+
+        if response.code >= 400
+          error_options.merge!(url: url, response: response)
+          error_options.merge!(uid: @uid) if @uid
+          raise Errors::ProxyError.new('Connection failed', error_options)
+        end
         if response.parsed_response.nil?
           logger.error "Unable to parse response from URL (#{url}), remote server status: #{response.code}, body: #{response.body}"
         end
       rescue MultiXml::ParseError => e
-        raise Errors::ProxyError.new("Error parsing XML from URL (#{url}): #{e.message}, remote server status #{response.code}, body: #{response.body}", nil)
+        raise Errors::ProxyError.new("Error parsing XML: #{e.message}", url: url, response: response)
       rescue JSON::ParserError => e
-        raise Errors::ProxyError.new("Error parsing JSON from URL (#{url}): #{e.message}, remote server status #{response.code}, body: #{response.body}", nil)
+        raise Errors::ProxyError.new("Error parsing JSON: #{e.message}", url: url, response: response)
       end
       response
     end
+  rescue Timeout::Error
+    raise Errors::ProxyError.new('Timeout error', url: url)
   end
 
 end

--- a/lib/proxies/response_wrapper.rb
+++ b/lib/proxies/response_wrapper.rb
@@ -18,21 +18,23 @@ module ResponseWrapper
 
   # When an exception occurs, log an error and return the body with error info.
   def handle_exception(e, key, opts)
-    if e.is_a?(Errors::ProxyError)
-      log_message = e.log_message
-      response = e.response
-      if e.wrapped_exception && log_message
-        log_message += " #{e.wrapped_exception.class} #{e.wrapped_exception.message}."
-      end
+    if e.is_a? Errors::ProxyError
+      response = e.response || default_response(opts)
+      log_message = e.log_message || ''
+      log_message += "; #{e.wrapped_exception.class} #{e.wrapped_exception.message}" if e.wrapped_exception
+      log_message += "; url: #{e.url}" if e.url
+      log_message += "; status: #{e.status}" if e.status
     else
+      response = default_response(opts)
       log_message = "#{e.class} #{e.message}"
     end
-    response ||= default_response(opts)
-    if log_message
-      log_message += " Associated key: #{key}"
-      log_message += "\n" + e.backtrace.join("\n ")
-      Rails.logger.error(log_message)
+    log_message += "\nAssociated key: #{key}"
+    if e.is_a?(Errors::ProxyError)
+      log_message += "; uid: #{e.uid}" if e.uid
+      log_message += ". Response body: #{e.body}" if e.body
     end
+    log_message += "\n" + e.backtrace.join("\n ")
+    Rails.logger.error(log_message)
     response
   end
 
@@ -46,5 +48,6 @@ module ResponseWrapper
       }
     end
   end
+
 
 end

--- a/script/check_for_errors.sh
+++ b/script/check_for_errors.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+RECIPIENT=$1
+YESTERDAY=$(date --date="yesterday" +"%Y-%m-%d")
+CC_LOGFILE=$HOME/calcentral/log/calcentral*${YESTERDAY}.log
+EGREP_FILE=/calcentral-prod/scripts/egrep_file
+
+if [ -z "$1" ]; then
+        echo "Usage: $0 recipient_email" && exit 0
+fi
+
+cd $( dirname "${BASH_SOURCE[0]}" )/..
+
+# http://stackoverflow.com/questions/11176061/how-do-i-prevent-long-emails-from-becoming-attachments
+/bin/egrep "FATAL|ERROR" $CC_LOGFILE | egrep -vf $EGREP_FILE | cut -d" " -f5-30 | sort | uniq -c | /usr/bin/tr -d '\11\15\176' | /bin/mail -E -s "`hostname -s` CalCentral error/fatal audit" $RECIPIENT
+
+exit

--- a/spec/models/advising/my_advising_spec.rb
+++ b/spec/models/advising/my_advising_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
 describe Advising::MyAdvising do
-  let (:fake_oski_model) { Advising::MyAdvising.new('61889', fake: true) }
-  let (:real_oski_model) { Advising::MyAdvising.new('61889', fake: false) }
+  let (:uid) { '61889' }
+  let (:fake_oski_model) { Advising::MyAdvising.new(uid, fake: true) }
+  let (:real_oski_model) { Advising::MyAdvising.new(uid, fake: false) }
   let (:advising_uri) { URI.parse(Settings.advising_proxy.base_url) }
 
   describe 'proper caching behaviors' do
@@ -48,8 +49,10 @@ describe Advising::MyAdvising do
       end
 
       context 'error on remote server (5xx errors)' do
+        let!(:status) { 506 }
+        include_context 'expecting logs from server errors'
         before do
-          stub_request(:any, /.*#{advising_uri.hostname}.*/).to_return(status: 506)
+          stub_request(:any, /.*#{advising_uri.hostname}.*/).to_return(status: status)
         end
         it 'reports an error' do
           feed = subject.get_feed

--- a/spec/models/cal1card/my_cal1card_spec.rb
+++ b/spec/models/cal1card/my_cal1card_spec.rb
@@ -43,12 +43,14 @@ describe Cal1card::MyCal1card do
     end
 
     context "error on remote server (5xx errors)" do
-      before(:each) {
-        stub_request(:any, /.*#{cal1card_uri.hostname}.*/).to_return(status: 506)
-      }
+      let!(:status) { 506 }
+      let!(:uid) { oski_uid }
+      include_context 'expecting logs from server errors'
+      before(:each) { stub_request(:any, /.*#{cal1card_uri.hostname}.*/).to_return(status: status) }
+
       it 'reports an error' do
         expect(subject[:body]).to eq('An error occurred retrieving data for Cal 1 Card. Please try again later.')
-        expect(subject[:statusCode]).to eq 506
+        expect(subject[:statusCode]).to eq 503
       end
     end
   end

--- a/spec/models/cal_link/memberships_spec.rb
+++ b/spec/models/cal_link/memberships_spec.rb
@@ -18,4 +18,9 @@ describe CalLink::Memberships do
     data[:body].should_not be_nil
   end
 
+  it_should_behave_like 'a proxy logging errors' do
+    let! (:uid) { 300846 }
+    subject { CalLink::Memberships.new(user_id: uid, fake: false).get_memberships }
+  end
+
 end

--- a/spec/models/cal_link/organization_spec.rb
+++ b/spec/models/cal_link/organization_spec.rb
@@ -19,4 +19,8 @@ describe CalLink::Organization do
     data[:body].should_not be_nil
   end
 
+  it_should_behave_like 'a proxy logging errors' do
+    subject { CalLink::Organization.new(org_id: '65797', fake: false).get_organization }
+  end
+
 end

--- a/spec/models/ets_blog/alerts_spec.rb
+++ b/spec/models/ets_blog/alerts_spec.rb
@@ -77,4 +77,8 @@ describe EtsBlog::Alerts do
     end
   end
 
+  it_should_behave_like 'a proxy logging errors' do
+    subject { EtsBlog::Alerts.new(fake: false).get_latest }
+  end
+
 end

--- a/spec/models/mediacasts/all_playlists_spec.rb
+++ b/spec/models/mediacasts/all_playlists_spec.rb
@@ -26,8 +26,11 @@ describe Mediacasts::AllPlaylists do
     end
 
     context "on remote server errors" do
+      let! (:body) { 'An unknown error occurred.' }
+      let! (:status) { 506 }
+      include_context 'expecting logs from server errors'
       before(:each) {
-        stub_request(:any, /.*#{playlist_uri.hostname}.*/).to_return(status: 506)
+        stub_request(:any, /.*#{playlist_uri.hostname}.*/).to_return(status: status, body: body)
       }
       after(:each) { WebMock.reset! }
       it "should return the fetch error message" do

--- a/spec/models/mediacasts/audio_spec.rb
+++ b/spec/models/mediacasts/audio_spec.rb
@@ -32,8 +32,11 @@ describe Mediacasts::Audio do
     end
 
     context "on remote server errors" do
+      let! (:body) { 'An unknown error occurred.' }
+      let! (:status) { 506 }
+      include_context 'expecting logs from server errors'
       before(:each) {
-        stub_request(:any, rss_url).to_return(status: 506)
+        stub_request(:any, rss_url).to_return(status: status, body: body)
       }
       it "should return a 503 status code" do
         proxy_response = proxy.get

--- a/spec/models/textbooks/proxy_spec.rb
+++ b/spec/models/textbooks/proxy_spec.rb
@@ -127,6 +127,18 @@ describe Textbooks::Proxy do
         expect(parsed['body']).to be_present
       end
     end
+
+    it_should_behave_like 'a proxy logging errors' do
+      subject do
+        Textbooks::Proxy.new({
+          course_catalog: '109G',
+          dept: 'POL SCI',
+          section_numbers: ['001'],
+          slug: 'fall-2014',
+          fake: false
+        }).get_as_json
+      end
+    end
   end
 
 end

--- a/spec/support/proxy_shared_examples.rb
+++ b/spec/support/proxy_shared_examples.rb
@@ -1,6 +1,30 @@
 # Proxy Shared Examples
 # Used to provide test functionality that is shared across proxy tests.
 
+shared_context 'expecting logs from server errors' do
+  before(:each) do
+    expect(Rails.logger).to receive(:error) do |error_message|
+      lines = error_message.lines.to_a
+      expect(lines[0]).to match(/url: http/)
+      expect(lines[0]).to match(/status: #{status}/)
+      expect(lines[1]).to match(/Associated key:/)
+      expect(lines[1]).to match(/uid: #{uid}/) if defined? uid
+      expect(lines[1]).to match(/Response body: #{body}/) if defined? body
+    end
+  end
+end
+
+shared_examples 'a proxy logging errors' do
+  let! (:body) { 'An unknown error occurred.' }
+  let! (:status) { 506 }
+  include_context 'expecting logs from server errors'
+  before(:each) { stub_request(:any, /.*/).to_return(status: status, body: body) }
+
+  it 'logs errors' do
+    subject
+  end
+end
+
 shared_examples 'a student data proxy' do
   def fake_proxy(uid); proxy_class.new({user_id: uid, fake: true}); end
   def real_proxy(uid); proxy_class.new({user_id: uid, fake: false}); end
@@ -35,6 +59,20 @@ shared_examples 'a student data proxy' do
       response = real_proxy('61889').get
       expect(response[:errored]).to eq true
       expect(response[:feed]).to be_nil
+    end
+  end
+
+  context 'server error' do
+    let! (:uid) { '61889' }
+    let! (:body) { 'An unknown error occurred.' }
+    let! (:status) { 506 }
+    include_context 'expecting logs from server errors'
+
+    before(:each) { stub_request(:any, /.*/).to_return(status: status, body: body) }
+
+    it 'returns an error status' do
+      response = real_proxy(uid).get
+      expect(response[:errored]).to eq true
     end
   end
 end


### PR DESCRIPTION
This PR addresses https://jira.ets.berkeley.edu/jira/browse/CLC-4837 by making a couple of changes to consolidate our error logging.

First, Errors::ProxyError now takes more options and hands them over to ResponseWrapper to format the log output. This should make it easier to keep formatting consistent and avoid problems like CLC-4837, where a multi-line response body was pushing the important information out of view. 

Second, since almost all of the classes using HTTPRequester raise the same error on unexpected status codes, I’ve consolidated that error handling into HTTPRequester itself. Classes that need to raise specialized errors or handle particular status codes themselves can pass HTTPRequester an `on_error` option hash.

The first line of the log shows the actual error message along with URL and status code. More detailed information like UID, cache key and response body appears on the next line, before the stack trace.