### PR TITLE
CLC-4855: Fix expected bHive URL for making new advising appts

### DIFF
--- a/spec/ui_selenium/pages/my_academics_advising_card.rb
+++ b/spec/ui_selenium/pages/my_academics_advising_card.rb
@@ -15,7 +15,7 @@ module CalCentralPages
     h2(:advising_card_heading, :xpath => '//h2[text()="L&S Advising"]')
     div(:advising_card_spinner, :xpath => '//h2[text()="L&S Advising"]/../following-sibling::div[@class="cc-spinner"]')
     paragraph(:make_appt_msg, :xpath => '//p[@data-ng-if="urlToMakeAppointment"]')
-    link(:make_appt_link, :xpath => '//a[@href="https://bhive.berkeley.edu/appointments/new"][contains(.,"new appointment")]')
+    link(:make_appt_link, :xpath => '//a[@href="https://bhive.berkeley.edu/appointments"][contains(.,"new appointment")]')
     span(:college_adviser_link, :xpath => '//h3[contains(.,"College Advisor")]/following-sibling::a/span')
 
     h3(:future_appts_heading, :xpath => '//h3[text()="Current Appointments"]')


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4855

bHive changed the URL for making a new advising appointment. The new URL seems legit at bHive, so this updates the expected URL in the tests.