### PR TITLE
CLC-4847 Fix NODEONE so it will work in calcentral-sis-dev; bring calcen...

### DIFF
--- a/script/init.d/calcentral
+++ b/script/init.d/calcentral
@@ -30,7 +30,7 @@ if [ $CURR_USER != "$RUN_AS_USER" ]; then
   exit 1
 fi
 
-if [[ "${HOSTNAME}" = ets-calcentral-*-01\.ist.berkeley.edu ]]; then
+if [[ "${HOSTNAME}" = *calcentral-*-01\.ist.berkeley.edu ]]; then
   NODEONE="yes"
 fi
 
@@ -91,6 +91,7 @@ case "$1" in
         ;;
   restart)
         stop
+        sleep 10
         start
         ;;
   status)

--- a/script/upgrade.sh
+++ b/script/upgrade.sh
@@ -4,7 +4,7 @@
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
 HOSTNAME=`uname -n`
-if [[ "${HOSTNAME}" = ets-calcentral-*-01\.ist.berkeley.edu ]]; then
+if [[ "${HOSTNAME}" = *calcentral-*-01\.ist.berkeley.edu ]]; then
   NODEONE="yes"
 fi
 


### PR DESCRIPTION
...tral init.d script up to date with what's actually in use

The "sleep" command is present in the copy of the "calcentral" start script that Ops actually uses (which lives in /calcentral-dev/init.d). 

https://jira.ets.berkeley.edu/jira/browse/CLC-4847
