### PR TITLE
OEC-566, INTEGBI diff wrong; no DB_COURSE_NAME in some cases

### DIFF
--- a/app/models/oec/biology_post_processor.rb
+++ b/app/models/oec/biology_post_processor.rb
@@ -1,10 +1,13 @@
 module Oec
   class BiologyPostProcessor
 
+    attr_reader :csv_per_dept
+
     def initialize(src_dir, dest_dir, debug_mode = false)
       @src_dir = src_dir
       @dest_dir = dest_dir
       @debug_mode = debug_mode
+      @csv_per_dept = {}
     end
 
     def post_process
@@ -42,7 +45,9 @@ module Oec
           @debug_mode ? FileUtils.mv(path_to_csv, "#{path_to_csv}.OBSOLETE") : File.delete(path_to_csv)
           rows = sorted_dept_rows[next_dept_name]
           if rows && rows.length > 0
-            ExportWrapper.new(next_dept_name, biology.headers, rows, @dest_dir).export
+            wrapper = ExportWrapper.new(next_dept_name, biology.headers, rows, @dest_dir)
+            wrapper.export
+            @csv_per_dept[next_dept_name] = wrapper.output_filename
           end
         end
       else

--- a/app/models/oec/command_line.rb
+++ b/app/models/oec/command_line.rb
@@ -3,12 +3,16 @@ module Oec
 
     attr_reader :src_dir
     attr_reader :dest_dir
+    attr_reader :departments
     attr_reader :is_debug_mode
 
     def initialize
       @src_dir = get_path_arg 'src'
       @dest_dir = get_path_arg 'dest'
       @is_debug_mode = ENV['debug'].to_s =~ /true/i
+      departments_split = ENV['departments'].to_s.strip.upcase.split(/\s*,\s*/).reject { |s| s.nil? || s.empty? }
+      # Registry accounts for unusual case of BIOLOGY
+      @departments = departments_split.empty? ? nil : Oec::DepartmentRegistry.new(departments_split).to_a
     end
 
     private

--- a/app/models/oec/command_line.rb
+++ b/app/models/oec/command_line.rb
@@ -1,0 +1,23 @@
+module Oec
+  class CommandLine
+
+    attr_reader :src_dir
+    attr_reader :dest_dir
+    attr_reader :is_debug_mode
+
+    def initialize
+      @src_dir = get_path_arg 'src'
+      @dest_dir = get_path_arg 'dest'
+      @is_debug_mode = ENV['debug'].to_s =~ /true/i
+    end
+
+    private
+
+    def get_path_arg(arg_name)
+      path = ENV[arg_name]
+      return Rake.original_dir if path.blank?
+      path.start_with?('/') ? path : File.expand_path(path, Rake.original_dir)
+    end
+
+  end
+end

--- a/app/models/oec/courses_diff.rb
+++ b/app/models/oec/courses_diff.rb
@@ -1,14 +1,26 @@
 module Oec
   class CoursesDiff < Export
 
+    COLUMN_LDAP_UID = 'ldap_uid'
+    COLUMN_COURSE_ID = 'course_id'
+
     # true if course data provided by dept representative differs from campus db data
     attr_reader :was_difference_found
 
-    def initialize(dept_name, data_corrected_by_dept, export_dir)
+    def initialize(dept_name, campus_data, data_from_dept, export_dir)
       super export_dir
-      @dept_name = dept_name
-      @data_corrected_by_dept = data_corrected_by_dept
       @was_difference_found = false
+      @instructor_columns = %w(first_name last_name email_address instructor_func)
+      @columns_to_compare = %w(course_name).concat @instructor_columns
+      @dept_name = dept_name
+      @data_from_dept = data_from_dept
+      @campus_data_hash = {}
+      campus_data.each do |campus_record|
+        course_id = campus_record[COLUMN_COURSE_ID]
+        ldap_id = campus_record[COLUMN_LDAP_UID]
+        @campus_data_hash[course_id] = campus_record
+        @campus_data_hash["#{course_id}-#{ldap_id}"] = campus_record unless ldap_id.blank?
+      end
     end
 
     def base_file_name
@@ -16,96 +28,83 @@ module Oec
     end
 
     def headers
-      '+/-,KEY,DB_COURSE_NAME,COURSE_NAME,DB_FIRST_NAME,FIRST_NAME,DB_LAST_NAME,LAST_NAME,DB_EMAIL_ADDRESS,EMAIL_ADDRESS,DB_INSTRUCTOR_FUNC,INSTRUCTOR_FUNC'
+      '+/-,KEY,LDAP_UID,DB_COURSE_NAME,COURSE_NAME,DB_FIRST_NAME,FIRST_NAME,DB_LAST_NAME,LAST_NAME,DB_EMAIL_ADDRESS,EMAIL_ADDRESS,DB_INSTRUCTOR_FUNC,INSTRUCTOR_FUNC'
     end
 
     def append_records(output)
-      campus_records = campus_data_to_hash @dept_name
-      length = campus_records.length
-      Rails.logger.warn "#{length} records in campus db for #{@dept_name}"
-      if length > 0
-        keys_matching = []
-        @data_corrected_by_dept.each do |edited_course|
-          course_id = edited_course['course_id'].split('_')[0]
-          ldap_uid = edited_course['ldap_uid']
-          primary_key = ldap_uid.blank? ? course_id : "#{course_id}-#{ldap_uid}"
-          if campus_records.has_key? primary_key
-            keys_matching << primary_key
-            db_record = campus_records[primary_key]
-            columns_to_compare.each do |column_name|
-              file_value = edited_course[column_name.downcase].to_s
-              db_value = db_record[column_name].to_s
-              if db_value.casecmp(file_value) != 0
-                diff = get_diff_row(primary_key, edited_course, db_record)
-                Rails.logger.info "Diff found: #{diff.to_s}"
-                output << get_csv_row(diff)
-                break
-              end
-            end
-          else
-            Rails.logger.warn "No campus data found for #{primary_key}"
-            diff = get_diff_row(primary_key, edited_course, nil)
-            output << get_csv_row(diff)
+      Rails.logger.warn "Diff the CSV confirmed by #{@dept_name} dept against latest campus data."
+      @aligned_rows = []
+      @data_from_dept.each do |data_from_dept_row|
+        ldap_uid = data_from_dept_row[COLUMN_LDAP_UID]
+        course_id = data_from_dept_row[COLUMN_COURSE_ID].split('_')[0]
+        key_with_ldap_uid = "#{course_id}-#{ldap_uid}" if ldap_uid
+        if ldap_uid.blank? && @campus_data_hash.has_key?(course_id)
+          output_diff(course_id, @campus_data_hash[course_id], data_from_dept_row, output)
+        elsif @campus_data_hash.has_key? key_with_ldap_uid
+          output_diff(key_with_ldap_uid, @campus_data_hash[key_with_ldap_uid], data_from_dept_row, output)
+        elsif @campus_data_hash.has_key? course_id
+          ignore_db_instructor = !@campus_data_hash[course_id][COLUMN_LDAP_UID].blank?
+          output_diff(key_with_ldap_uid, @campus_data_hash[course_id], data_from_dept_row, output, ignore_db_instructor)
+        else
+          Rails.logger.warn "No campus data found for #{course_id}"
+          output_diff(course_id, nil, data_from_dept_row, output)
+        end
+      end
+      @campus_data_hash.each do |key, db_record|
+        unless @aligned_rows.any? { |aligned_row| aligned_row.start_with?(key) }
+          # Ignore this campus_data_hash entry if key equals {course_id} and yet hash also includes {course_id}-{ldap_uid}
+          unless @campus_data_hash.has_key? "#{key}-#{db_record[COLUMN_LDAP_UID]}"
+            output_diff(db_record[COLUMN_COURSE_ID], db_record, nil, output)
+            Rails.logger.warn "dept_data does NOT contain course_id=#{key}"
           end
         end
-        campus_records.each do |course_id, db_record|
-          ldap_uid = db_record['ldap_uid'].to_s
-          primary_key = ldap_uid == '' ? "#{course_id}" : "#{course_id}-#{ldap_uid}"
-          unless keys_matching.include? primary_key
-            diff = get_diff_row(primary_key, nil, db_record)
-            output << get_csv_row(diff)
-            Rails.logger.warn "edited_course does NOT contain course_id=#{primary_key}"
-          end
-        end
-      else
-        Rails.logger.warn "No campus data where dept_name = #{@dept_name}"
       end
     end
 
-    def get_csv_row(diff)
-      @was_difference_found = true
-      record_to_csv_row diff
+    def output_diff(key, db_record, dept_data, output, ignore_db_instructor = false)
+      @aligned_rows << key
+      @columns_to_compare.each do |column_name|
+        file_value = dept_data ? dept_data[column_name].to_s : nil
+        db_value = db_record ? db_record[column_name].to_s : nil
+        if file_value.nil? || db_value.nil? || file_value.casecmp(db_value) != 0
+          row = {}
+          # Row unique to edited CSV is indicated by '+'. Rows removed, relative to database, are indicated by '-'.
+          diff_type_column = '+/-'
+          row[diff_type_column] = ' '
+          course_id = key
+          ldap_uid = db_record[COLUMN_LDAP_UID] unless db_record.nil? || ignore_db_instructor
+          if db_record
+            if dept_data.nil?
+              row[diff_type_column] = '-'
+            elsif ignore_db_instructor
+              row[diff_type_column] = '+'
+            end
+            @columns_to_compare.each do |column|
+              force_nil = ignore_db_instructor && @instructor_columns.include?(column)
+              db_value = db_record[column].to_s
+              row["DB_#{column.upcase}"] = force_nil || db_value.blank? ? nil : db_value
+            end
+          end
+          if dept_data
+            course_id = dept_data[COLUMN_COURSE_ID]
+            ldap_uid = dept_data[COLUMN_LDAP_UID] if ldap_uid.blank?
+            row[diff_type_column] = '+' if db_record.nil?
+            @columns_to_compare.each do |column|
+              edited_value = dept_data[column].to_s
+              edited_value.strip!
+              row[column.upcase] = edited_value == '' ? nil : edited_value
+            end
+          end
+          row['KEY'] = course_id
+          row[COLUMN_LDAP_UID] = ldap_uid
+          output << record_to_csv_row(row)
+          @was_difference_found = true
+          break
+        end
+      end
     end
 
     private
-
-    def get_diff_row(primary_key, edited_course, db_record)
-      row = {}
-      # Row unique to edited CSV is indicated by '+'. Rows removed, relative to database, are indicated by '-'.
-      diff_type_column = '+/-'
-      row[diff_type_column] = ' '
-      row['KEY'] = primary_key
-      if db_record
-        row[diff_type_column] = '-' if edited_course.nil?
-        columns_to_compare.each do |column|
-          db_value = db_record[column].to_s
-          row["DB_#{column}"] = db_value == '' ? nil : db_value
-        end
-      end
-      if edited_course
-        row[diff_type_column] = '+' if db_record.nil?
-        columns_to_compare.each do |column|
-          edited_value = edited_course[column.downcase].to_s
-          edited_value.strip!
-          row[column] = edited_value == '' ? nil : edited_value
-        end
-      end
-      row
-    end
-
-    def campus_data_to_hash(dept_name)
-      campus_records = {}
-      database_records = []
-      Oec::Courses.new(dept_name, export_directory).append_records database_records
-      database_records.each do |campus_record|
-        course_id = campus_record['COURSE_ID']
-        ldap_id = campus_record['LDAP_UID']
-        empty_ldap_uid = ldap_id.to_s == ''
-        campus_records["#{course_id}"] = campus_record if empty_ldap_uid
-        campus_records["#{course_id}-#{ldap_id}"] = campus_record unless empty_ldap_uid
-      end
-      campus_records
-    end
 
     def to_evaluation(row)
       course_id = row[0]
@@ -137,10 +136,6 @@ module Oec
         'START_DATE' => row[20],
         'END_DATE' => row[21]
       }
-    end
-
-    def columns_to_compare
-      %w(COURSE_NAME FIRST_NAME LAST_NAME EMAIL_ADDRESS INSTRUCTOR_FUNC)
     end
 
   end

--- a/app/models/oec/courses_diff.rb
+++ b/app/models/oec/courses_diff.rb
@@ -90,9 +90,8 @@ module Oec
             ldap_uid = dept_data[COLUMN_LDAP_UID] if ldap_uid.blank?
             row[diff_type_column] = '+' if db_record.nil?
             @columns_to_compare.each do |column|
-              edited_value = dept_data[column].to_s
-              edited_value.strip!
-              row[column.upcase] = edited_value == '' ? nil : edited_value
+              edited_value = dept_data[column].to_s.strip
+              row[column.upcase] = edited_value.blank? ? nil : edited_value
             end
           end
           row['KEY'] = course_id

--- a/app/models/oec/courses_group.rb
+++ b/app/models/oec/courses_group.rb
@@ -1,0 +1,39 @@
+module Oec
+  class CoursesGroup
+
+    attr_reader :campus_data_per_dept
+    attr_reader :csv_per_dept
+    attr_reader :dest_dir
+
+    def initialize(departments, dest_dir = Dir.mktmpdir, keep_csv_files = false, debug_mode = false)
+      @dest_dir = dest_dir
+      @csv_per_dept = {}
+      departments.each do |dept_name|
+        courses = Oec::Courses.new(dept_name, dest_dir)
+        courses.export
+        @csv_per_dept[dept_name] = courses.output_filename
+      end
+      post_processor = Oec::BiologyPostProcessor.new(dest_dir, dest_dir, debug_mode)
+      post_processor.post_process
+      # Biology CSV file might be deleted by post-processor
+      additional = post_processor.csv_per_dept
+      biology = Oec::DepartmentRegistry.new.biology_dept_name
+      @csv_per_dept.delete biology unless additional.include? biology
+      @csv_per_dept.merge! additional
+      @campus_data_per_dept = campus_data_per_dept keep_csv_files
+    end
+
+    def campus_data_per_dept(keep_csv_files)
+      campus_data_per_dept = {}
+      Oec::CoursesGroup.new(confirmed_data_per_dept.keys, @dest_dir).csv_per_dept.each do |dept_name, csv_file|
+        campus_data = []
+        CSV.read(csv_file).each_with_index do |row, index|
+          campus_data << Oec::RowConverter.new(row).hashed_row if index > 0 && row.length > 0
+        end
+        campus_data_per_dept[dept_name] = campus_data
+      end
+      File.delete @dest_dir unless keep_csv_files
+    end
+
+  end
+end

--- a/app/models/oec/courses_group.rb
+++ b/app/models/oec/courses_group.rb
@@ -5,7 +5,7 @@ module Oec
     attr_reader :csv_per_dept
     attr_reader :dest_dir
 
-    def initialize(departments, dest_dir = Dir.mktmpdir, keep_csv_files = false, debug_mode = false)
+    def initialize(departments, dest_dir = "tmp/oec-#{DateTime.now.strftime('%s')}", keep_csv_files = false, debug_mode = false)
       @dest_dir = dest_dir
       @csv_per_dept = {}
       departments.each do |dept_name|
@@ -13,26 +13,26 @@ module Oec
         courses.export
         @csv_per_dept[dept_name] = courses.output_filename
       end
-      post_processor = Oec::BiologyPostProcessor.new(dest_dir, dest_dir, debug_mode)
-      post_processor.post_process
-      # Biology CSV file might be deleted by post-processor
-      additional = post_processor.csv_per_dept
       biology = Oec::DepartmentRegistry.new.biology_dept_name
-      @csv_per_dept.delete biology unless additional.include? biology
-      @csv_per_dept.merge! additional
-      @campus_data_per_dept = campus_data_per_dept keep_csv_files
-    end
-
-    def campus_data_per_dept(keep_csv_files)
-      campus_data_per_dept = {}
-      Oec::CoursesGroup.new(confirmed_data_per_dept.keys, @dest_dir).csv_per_dept.each do |dept_name, csv_file|
+      if departments.include? biology
+        Rails.logger.info 'Running biology post-processor logic.'
+        post_processor = Oec::BiologyPostProcessor.new(dest_dir, dest_dir, debug_mode)
+        post_processor.post_process
+        # Biology CSV file might be deleted by post-processor
+        additional = post_processor.csv_per_dept
+        @csv_per_dept.delete biology unless additional.include? biology
+        @csv_per_dept.merge! additional
+      end
+      @campus_data_per_dept = {}
+      @csv_per_dept.each do |dept_name, csv_file|
         campus_data = []
         CSV.read(csv_file).each_with_index do |row, index|
           campus_data << Oec::RowConverter.new(row).hashed_row if index > 0 && row.length > 0
         end
-        campus_data_per_dept[dept_name] = campus_data
+        File.delete csv_file unless keep_csv_files
+        @campus_data_per_dept[dept_name] = campus_data
       end
-      File.delete @dest_dir unless keep_csv_files
+      Dir.delete @dest_dir unless keep_csv_files
     end
 
   end

--- a/app/models/oec/dept_confirmed_data.rb
+++ b/app/models/oec/dept_confirmed_data.rb
@@ -1,0 +1,27 @@
+module Oec
+  class DeptConfirmedData
+
+    attr_reader :confirmed_data_per_dept
+
+    def initialize(src_dir, departments)
+      @confirmed_data_per_dept = {}
+      csv_filename_suffix = '_courses_confirmed.csv'
+      pattern = "#{src_dir}/*#{csv_filename_suffix}"
+      Rails.logger.debug "Find files matching #{pattern}"
+      Dir[pattern].each do |filename|
+        dept_name = filename.split('/')[-1].chomp(csv_filename_suffix).gsub(/_/, ' ').upcase
+        Rails.logger.debug "Source directory contains #{filename} (owned by #{dept_name})"
+        if departments.empty? || departments.include?(dept_name)
+          corrected_data = []
+          CSV.read(filename).each_with_index do |row, index|
+            corrected_data << Oec::RowConverter.new(row).hashed_row if index > 0 && row.length > 0
+          end
+          @confirmed_data_per_dept[dept_name] = corrected_data
+          departments.delete dept_name
+        end
+      end
+      Rails.logger.warn "Confirmed CSV file(s) NOT found for departments: #{departments.to_a}" if departments.length > 0
+    end
+
+  end
+end

--- a/fixtures/oec/expected_diff_STAT_courses.csv
+++ b/fixtures/oec/expected_diff_STAT_courses.csv
@@ -1,9 +1,8 @@
-+/-,KEY,DB_COURSE_NAME,COURSE_NAME,DB_FIRST_NAME,FIRST_NAME,DB_LAST_NAME,LAST_NAME,DB_EMAIL_ADDRESS,EMAIL_ADDRESS,DB_INSTRUCTOR_FUNC,INSTRUCTOR_FUNC
--,2015-B-111-11,Course 1,,John,,Doe,,john@berkeley.edu,,1,
-+,2015-B-2222-22,,"Course 2, edited",,Jim,,Two,,jim@berkeley.edu,,1
--,2015-B-2222,Course 2,,,,,,,,,
- ,2015-B-33333-33,Course 3,Course 3,John,Johnny,Three,Tres,john@berkeley.edu,johnny@berkeley.edu,1,2
--,2015-B-33333-333,Course 3,,Joan,,Trois,,joan@berkeley.edu,,1,
-+,2015-B-44444-444,,Course 4,,Jerome,,Quatre,,jerome@berkeley.edu,,2
-+,2015-B-55555-55,,Course 5,,Joel,,Five,,joel@berkeley.edu,,2
-+,2015-B-666,,Course 6,,,,,,,,
++/-,KEY,LDAP_UID,DB_COURSE_NAME,COURSE_NAME,DB_FIRST_NAME,FIRST_NAME,DB_LAST_NAME,LAST_NAME,DB_EMAIL_ADDRESS,EMAIL_ADDRESS,DB_INSTRUCTOR_FUNC,INSTRUCTOR_FUNC
++,2015-B-666,,,Course 6,,,,,,,,
++,2015-B-55555_GSI,55,,Course 5,,Joel,,Five,,joel@berkeley.edu,,2
++,2015-B-44444_A,444,Course 4,Course 4,,Jerome,,Quatre,,jerome@berkeley.edu,,2
+ ,2015-B-33333,33,Course 3,Course 3,John,Johnny,Three,Tres,john@berkeley.edu,johnny@berkeley.edu,1,2
+ ,2015-B-2222,22,Course 2,"Course 2, edited",,Jim,,Two,,jim@berkeley.edu,,1
+-,2015-B-111,11,Course 1,,John,,Doe,,john@berkeley.edu,,1,
+-,2015-B-33333,333,Course 3,,Joan,,Trois,,joan@berkeley.edu,,1,

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -4,30 +4,21 @@ namespace :oec do
 
   desc 'Export courses.csv file'
   task :courses => :environment do
-    dest_dir = get_path_arg 'dest'
-    files_created = []
-    Oec::DepartmentRegistry.new.each do |dept_name|
-      exporter = Oec::Courses.new(dept_name, dest_dir)
-      exporter.export
-      files_created << "#{dest_dir}/#{exporter.base_file_name}.csv"
-    end
-    debug_mode = ENV['debug'].to_s =~ /true/i
-    post_processor = Oec::BiologyPostProcessor.new(dest_dir, dest_dir, debug_mode)
-    post_processor.post_process
-    Rails.logger.warn "#{hr}Find CSV files in directory: #{dest_dir}#{hr}"
+    args = Oec::CommandLine.new
+    Oec::CoursesGroup.new(Oec::DepartmentRegistry.new.to_a, args.dest_dir, true, args.is_debug_mode)
+    Rails.logger.warn "#{hr}Find CSV files in directory: #{args.dest_dir}#{hr}"
   end
 
   desc 'Generate student files based on courses.csv input'
   task :students => :environment do
-    src_dir = get_path_arg 'src'
-    dest_dir = get_path_arg 'dest'
-    csv_file = "#{src_dir}/courses.csv"
+    args = Oec::CommandLine.new
+    csv_file = "#{args.src_dir}/courses.csv"
     if File.exists? csv_file
       reader = Oec::FileReader.new csv_file
       [Oec::Students, Oec::CourseStudents].each do |klass|
-        klass.new(reader.ccns, reader.gsi_ccns, dest_dir).export
+        klass.new(reader.ccns, reader.gsi_ccns, args.dest_dir).export
       end
-      Rails.logger.warn "#{hr}Find CSV files in directory: #{dest_dir}#{hr}"
+      Rails.logger.warn "#{hr}Find CSV files in directory: #{args.dest_dir}#{hr}"
     else
       Rails.logger.warn <<-eos
       #{hr}File not found: #{csv_file}
@@ -39,16 +30,20 @@ namespace :oec do
 
   desc 'Spreadsheet from dept is compared with campus data'
   task :diff => :environment do
-    src_dir = get_path_arg 'src'
-    dest_dir = get_path_arg 'dest'
+    args = Oec::CommandLine.new
+    departments = ENV['departments'].to_s.strip.upcase.split(/\s*,\s*/).reject &:empty?
+    # Registry accounts for unusual case of BIOLOGY
+    departments = Oec::DepartmentRegistry.new(departments).to_a unless departments.empty?
+    confirmed_data_per_dept = Oec::DeptConfirmedData.new(args.src_dir, departments).confirmed_data_per_dept
+
+    courses_group = Oec::CoursesGroup.new(confirmed_data_per_dept.keys)
+    campus_data_per_dept = courses_group.campus_data_per_dept
+    File.delete courses_group.dest_dir
+
     summaries = []
-    get_confirmed_csv_file_hash(src_dir).each do |dept_name, confirmed_csv_file|
-      data_corrected_by_dept = []
-      CSV.read(confirmed_csv_file).each_with_index do |row, index|
-        data_corrected_by_dept << Oec::RowConverter.new(row).hashed_row if index > 0 && row.length > 0
-      end
-      Rails.logger.warn "CSV file #{confirmed_csv_file} contains #{data_corrected_by_dept.length} records"
-      courses_diff = Oec::CoursesDiff.new(dept_name, data_corrected_by_dept, dest_dir)
+    confirmed_data_per_dept.each do |dept_name, confirmed_data|
+      Rails.logger.warn "CSV from #{dept_name} contains #{confirmed_data.length} records"
+      courses_diff = Oec::CoursesDiff.new(dept_name, campus_data_per_dept[dept_name], confirmed_data, args.dest_dir)
       courses_diff.export
       if courses_diff.was_difference_found
         summaries << "#{dept_name}: #{courses_diff.output_filename}"
@@ -62,32 +57,6 @@ namespace :oec do
     else
       Rails.logger.warn "#{hr}Nonesuch 'confirmed' CSV files found in #{src_dir}#{hr}"
     end
-  end
-
-  private
-
-  def get_confirmed_csv_file_hash(src_dir)
-    confirmed_csv_file_hash = {}
-    departments = ENV['departments'].to_s.strip.upcase.split(/\s*,\s*/).reject &:empty?
-    csv_filename_suffix = '_courses_confirmed.csv'
-    pattern = "#{src_dir}/*#{csv_filename_suffix}"
-    Rails.logger.debug "Find files matching #{pattern}"
-    Dir[pattern].each do |filename|
-      dept_name = filename.split('/')[-1].chomp(csv_filename_suffix).gsub(/_/, ' ').upcase
-      Rails.logger.debug "Source directory contains #{filename} (owned by #{dept_name})"
-      if departments.empty? || departments.include?(dept_name)
-        confirmed_csv_file_hash[dept_name] = filename
-        departments.delete dept_name
-      end
-    end
-    Rails.logger.warn "Confirmed CSV file(s) NOT found for departments: #{departments.to_a}" if departments.length > 0
-    confirmed_csv_file_hash
-  end
-
-  def get_path_arg(arg_name)
-    path = ENV[arg_name]
-    return Rake.original_dir if path.blank?
-    path.start_with?('/') ? path : File.expand_path(path, Rake.original_dir)
   end
 
 end

--- a/spec/models/oec/command_line_spec.rb
+++ b/spec/models/oec/command_line_spec.rb
@@ -1,0 +1,28 @@
+describe Oec::CommandLine do
+
+  it 'should pay attention ENV variables' do
+    src_path = '/path/to/src'
+    dest_path = '/path/to/dest'
+    ENV['src'] = src_path
+    ENV['dest'] = dest_path
+    ENV['debug'] = 'TrUe'
+    cmd_line = Oec::CommandLine.new
+    expect(cmd_line.src_dir).to eq src_path
+    expect(cmd_line.dest_dir).to eq dest_path
+    expect(cmd_line.is_debug_mode).to be_truthy
+  end
+
+  it 'should have default for each property' do
+    ENV['src'] = ENV['dest'] = ENV['debug'] = nil
+    cmd_line = Oec::CommandLine.new
+    expect(cmd_line.src_dir).should_not be_nil
+    expect(cmd_line.dest_dir).should_not be_nil
+    expect(cmd_line.is_debug_mode).to be_falsey
+  end
+
+  it 'should set debug_mode according to boolean value in string' do
+    ENV['debug'] = 'false'
+    expect(Oec::CommandLine.new.is_debug_mode).to be_falsey
+  end
+
+end

--- a/spec/models/oec/command_line_spec.rb
+++ b/spec/models/oec/command_line_spec.rb
@@ -25,4 +25,16 @@ describe Oec::CommandLine do
     expect(Oec::CommandLine.new.is_debug_mode).to be_falsey
   end
 
+  it 'should reference logic of department-registry to pick up BIOLOGY-related relationships' do
+    ENV['departments'] = 'POL SCI, CHEM, INTEGBI'
+    departments = Oec::CommandLine.new.departments
+    departments.should match_array %w(BIOLOGY INTEGBI MCELLBI CHEM POL\ SCI)
+  end
+
+  it 'should not pull in BIOLOGY-related relationships' do
+    ENV['departments'] = 'POL SCI, CHEM'
+    departments = Oec::CommandLine.new.departments
+    departments.should match_array %w(CHEM POL\ SCI)
+  end
+
 end

--- a/spec/models/oec/courses_diff_spec.rb
+++ b/spec/models/oec/courses_diff_spec.rb
@@ -1,38 +1,38 @@
 describe Oec::CoursesDiff do
 
   let!(:dept_names) { %w{STAT BIOLOGY POL\ SCI} }
-
+  let!(:data_corrected_by_dept) { {} }
+  let!(:campus_data_per_dept) { {} }
   let!(:src_dir) { 'fixtures/oec' }
 
   context 'comparing diff to expected CSV file' do
 
     before do
       dept_names.each do |dept_name|
+        campus_data_per_dept[dept_name] = []
         mock_data = "#{src_dir}/db_#{dept_name.gsub(/\s/, '_')}_courses.csv"
-        courses_query = []
         CSV.read(mock_data).each_with_index do |row, index|
           if index > 0 && row.length > 0
             hashed_row = Oec::RowConverter.new(row).hashed_row
             # Arbitrary, non-zero enrollment
             hashed_row['enrollment_count'] = 50
-            courses_query << hashed_row
+            campus_data_per_dept[dept_name] << hashed_row
           end
         end
-        expect(Oec::Queries).to receive(:get_courses).with(nil, dept_name).exactly(1).times.and_return courses_query
       end
-      expect(Oec::Queries).to receive(:get_courses).at_least(1).times.with(anything).and_return []
     end
 
     it {
       dept_names.each do |dept_name|
         Rails.logger.info "Evaluating diff where dept_name = #{dept_name}"
         dept_name_path = dept_name.gsub(/\s/, '_')
-        data_corrected_by_dept = []
+        data_from_dept = []
         CSV.read("#{src_dir}/#{dept_name_path}_courses_confirmed.csv").each_with_index do |row, index|
-          data_corrected_by_dept << Oec::RowConverter.new(row).hashed_row if index > 0 && row.length > 0
+          data_from_dept << Oec::RowConverter.new(row).hashed_row if index > 0 && row.length > 0
         end
-        diff = Oec::CoursesDiff.new(dept_name, data_corrected_by_dept, 'tmp/oec')
+        diff = Oec::CoursesDiff.new(dept_name, campus_data_per_dept[dept_name], data_from_dept, 'tmp/oec')
         expect(diff.base_file_name).to include dept_name_path
+        # IO.read("#{src_dir}/expected_diff_#{dept_name_path}_courses.csv").should eq IO.read(diff.export[:filename])
         actual_diff = CSV.read diff.export[:filename]
         expected_diff = CSV.read "#{src_dir}/expected_diff_#{dept_name_path}_courses.csv"
         expect(expected_diff.length).to eq actual_diff.length

--- a/spec/models/oec/department_registry_spec.rb
+++ b/spec/models/oec/department_registry_spec.rb
@@ -6,8 +6,8 @@ describe Oec::DepartmentRegistry do
     end
 
     it 'should add BIOLOGY if, for example, INTEGBI is requested' do
-      registry = Oec::DepartmentRegistry.new %w(INTEGBI 'POL SCI')
-      registry.should match_array %w(BIOLOGY INTEGBI MCELLBI 'POL SCI')
+      registry = Oec::DepartmentRegistry.new %w(INTEGBI POL\ SCI)
+      registry.should match_array %w(BIOLOGY INTEGBI MCELLBI POL\ SCI)
     end
 
     it 'should add sister departments' do
@@ -16,13 +16,13 @@ describe Oec::DepartmentRegistry do
     end
 
     it 'should add, for example, INTEGBI because BIOLOGY is present' do
-      registry = Oec::DepartmentRegistry.new %w('POL SCI' BIOLOGY)
-      registry.should match_array %w(BIOLOGY INTEGBI MCELLBI 'POL SCI')
+      registry = Oec::DepartmentRegistry.new %w(POL\ SCI BIOLOGY)
+      registry.should match_array %w(BIOLOGY INTEGBI MCELLBI POL\ SCI)
     end
 
     it 'should add nothing if BIOLOGY and related are not found' do
-      registry = Oec::DepartmentRegistry.new %w('POL SCI' STAT)
-      registry.should match_array %w('POL SCI' STAT)
+      registry = Oec::DepartmentRegistry.new %w(POL\ SCI STAT)
+      registry.should match_array %w(POL\ SCI STAT)
     end
 
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-566
https://jira.ets.berkeley.edu/jira/browse/OEC-564

Couple issues resolved here:
1. Refactor oec.rake and create models to encapsulate (a) csv generation for a group of courses (CoursesGroup) and (b) command line options.
1. Diff task gets minor overhaul. See expected behavior in file fixtures/oec/expected_diff_STAT_courses.csv