### PR TITLE
OEC-570, oec:diff w/ unspecified 'depts' should pull all dept_confirmed.csv files in src dir

### DIFF
--- a/app/models/oec/command_line.rb
+++ b/app/models/oec/command_line.rb
@@ -10,9 +10,8 @@ module Oec
       @src_dir = get_path_arg 'src'
       @dest_dir = get_path_arg 'dest'
       @is_debug_mode = ENV['debug'].to_s =~ /true/i
-      departments_split = ENV['departments'].to_s.strip.upcase.split(/\s*,\s*/).reject { |s| s.nil? || s.empty? }
-      # Registry accounts for unusual case of BIOLOGY
-      @departments = departments_split.empty? ? nil : Oec::DepartmentRegistry.new(departments_split).to_a
+      split = ENV['departments'].to_s.strip.upcase.split(/\s*,\s*/).reject { |s| s.nil? || s.empty? }
+      @departments = Oec::DepartmentRegistry.new(split.empty? ? Settings.oec.departments : split).to_a
     end
 
     private

--- a/app/models/oec/courses_group.rb
+++ b/app/models/oec/courses_group.rb
@@ -5,16 +5,17 @@ module Oec
     attr_reader :csv_per_dept
     attr_reader :dest_dir
 
-    def initialize(departments, dest_dir = "tmp/oec-#{DateTime.now.strftime('%s')}", keep_csv_files = false, debug_mode = false)
+    def initialize(departments, dest_dir, keep_csv_files = false, debug_mode = false)
       @dest_dir = dest_dir
       @csv_per_dept = {}
-      departments.each do |dept_name|
+      registry = Oec::DepartmentRegistry.new departments
+      registry.each do |dept_name|
         courses = Oec::Courses.new(dept_name, dest_dir)
         courses.export
         @csv_per_dept[dept_name] = courses.output_filename
       end
-      biology = Oec::DepartmentRegistry.new.biology_dept_name
-      if departments.include? biology
+      biology = registry.biology_dept_name
+      if registry.include? biology
         Rails.logger.info 'Running biology post-processor logic.'
         post_processor = Oec::BiologyPostProcessor.new(dest_dir, dest_dir, debug_mode)
         post_processor.post_process

--- a/spec/models/oec/command_line_spec.rb
+++ b/spec/models/oec/command_line_spec.rb
@@ -37,4 +37,9 @@ describe Oec::CommandLine do
     departments.should match_array %w(CHEM POL\ SCI)
   end
 
+  it 'should pull all OEC departments when none specified' do
+    ENV['departments'] = nil
+    Oec::CommandLine.new.departments.should match_array Settings.oec.departments
+  end
+
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-570

The significant work is in oec.rake. When diff task with unspecified list of departments we look to the 'src' directory for all files named *_courses_confirmed.csv. The regex is what determines list of departments to diff. 