### PR TITLE
CLC-4865 Fix verbose ERROR logging on student ID lookup failure

### DIFF
--- a/app/models/bearfacts/proxy.rb
+++ b/app/models/bearfacts/proxy.rb
@@ -35,7 +35,10 @@ module Bearfacts
     def request_internal(path, vcr_cassette, params = {})
       student_id = lookup_student_id
       if student_id.nil?
-        raise Errors::ProxyError.new("Lookup of student_id for uid #{@uid} failed, cannot call Bearfacts API path #{path}", {noStudentId: true})
+        logger.info "Lookup of student_id for uid #{@uid} failed, cannot call Bearfacts API path #{path}"
+        {
+          noStudentId: true
+        }
       else
         url = "#{Settings.bearfacts_proxy.base_url}#{path}"
         logger.info "Fake = #{@fake}; Making request to #{url} on behalf of user #{@uid}, student_id = #{student_id}; cache expiration #{self.class.expires_in}"

--- a/app/models/finaid/proxy.rb
+++ b/app/models/finaid/proxy.rb
@@ -21,7 +21,8 @@ module Finaid
     def request_internal(vcr_cassette)
       student_id = lookup_student_id
       if student_id.nil?
-        raise Errors::ProxyError.new("Lookup of student_id for uid #{@uid} failed, cannot call Myfinaid API", nil)
+        logger.info "Lookup of student_id for uid #{@uid} failed, cannot call Finaid API"
+        return nil
       else
         url = "#{@settings.base_url}/#{student_id}/finaid"
         vcr_opts = {:match_requests_on => [:method, :path, VCR.request_matchers.uri_without_params(:token, :app_id, :app_key)]}

--- a/spec/models/finaid/proxy_spec.rb
+++ b/spec/models/finaid/proxy_spec.rb
@@ -31,8 +31,8 @@ describe Finaid::Proxy do
       #Never hits VCR so it should be fine for non-testext, but to make sure
       before(:each) { Finaid::Proxy.any_instance.stub(:lookup_student_id).and_return(nil) }
 
-      it 'should report failure on student ID lookup' do
-        expect { live_non_student }.to raise_error(Errors::ProxyError)
+      it 'should return empty feed on no student ID' do
+        expect(live_non_student).to be_blank
       end
     end
   end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4865

Fixes regressions from #3310 and #3326 that treated student ID lookup failure as an error condition rather than a fact of everyday life.