### PR TITLE
CLC-4767 Script to configure all currently defined LTI tools on bCourses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ gem 'ims-lti', :git => 'https://github.com/instructure/ims-lti.git'
 
 # for VCR http recording tool
 gem 'vcr', '~> 2.9.3'
+# Replace with this line for a new recording, if you truly must make a new recording.
+# gem 'vcr', :git => 'https://github.com/vcr/vcr.git'
 
 # for memcached connection
 gem 'dalli', '~> 2.7.2'

--- a/app/models/canvas/external_app_configurations.rb
+++ b/app/models/canvas/external_app_configurations.rb
@@ -1,0 +1,80 @@
+module Canvas
+  module ExternalAppConfigurations
+    extend self
+    include ClassLogger
+
+    def lti_app_definitions
+      {
+        'site_creation' => {
+          xml_name: 'lti_site_creation',
+          app_name: 'Create a Site',
+          account: main_account_id
+        },
+        'rosters' => {
+          xml_name: 'lti_roster_photos',
+          app_name: 'Roster Photos',
+          account: official_courses_account_id
+        },
+        'user_provision' => {
+          xml_name: 'lti_user_provision',
+          app_name: 'User Provisioning',
+          account: main_account_id
+        },
+        'course_add_user' => {
+          xml_name: 'lti_course_add_user',
+          app_name: 'Find a Person to Add',
+          account: main_account_id
+        },
+        'course_mediacasts' => {
+          xml_name: 'lti_course_mediacasts',
+          app_name: 'Webcasts',
+          account: main_account_id
+        },
+        'course_manage_official_sections' => {
+          xml_name: 'lti_course_manage_official_sections',
+          app_name: 'Official Sections',
+          account: nil
+        },
+        'course_grade_export' => {
+          xml_name: 'lti_course_grade_export',
+          app_name: 'Download E-Grades',
+          account: official_courses_account_id
+        }
+      }
+    end
+
+    def main_account_id
+      Settings.canvas_proxy.account_id
+    end
+
+    def official_courses_account_id
+      Settings.canvas_proxy.official_courses_account_id
+    end
+
+    def app_code_to_xml_name(app_code)
+      lti_app_definitions[app_code] && lti_app_definitions[app_code][:xml_name]
+    end
+
+    def xml_name_to_app_code(xml_name)
+      lti_app_definitions.each do |app_code, definition|
+        return app_code if definition[:xml_name] == xml_name
+      end
+      nil
+    end
+
+    def parse_host_and_code_from_launch_url(launch_url)
+      # The interesting app URLs look like: "https://cc-dev.example.com/canvas/embedded/rosters".
+      url_regex = %r{(?<app_host>http[s]?://.+)/canvas/embedded/(?<app_code>.+)}
+      url_regex.match(launch_url)
+    end
+
+    def launch_url_for_host_and_code(app_host, app_code)
+      "#{app_host}/canvas/embedded/#{app_code}"
+    end
+
+    def refresh_accounts
+      [main_account_id, official_courses_account_id]
+    end
+
+  end
+end

--- a/app/models/canvas/reconfigure_external_apps.rb
+++ b/app/models/canvas/reconfigure_external_apps.rb
@@ -1,57 +1,123 @@
 module Canvas
-  module ReconfigureExternalApps
-    extend self
+  class ReconfigureExternalApps
     include ClassLogger
+    include Canvas::ExternalAppConfigurations
 
-    def app_to_xml
-      {
-        'site_creation' => 'lti_site_creation',
-        'rosters' => 'lti_roster_photos',
-        'user_provision' => 'lti_user_provision',
-        'course_add_user' => 'lti_course_add_user',
-        'course_mediacasts' => 'lti_course_mediacasts',
-        'course_manage_official_sections' => 'lti_course_manage_official_sections',
-        'course_grade_export' => 'lti_course_grade_export'
-      }
-    end
-
-    def reconfigure_external_apps(reachable_xml_host, canvas_hosts_to_calcentrals)
-      lti_subpath = 'canvas/embedded/'
-      # The interesting app URLs look like: "https://cc-dev.example.com/canvas/embedded/rosters".
-      url_regex = /https:\/\/(?<app_host>.+)\/#{lti_subpath}(?<app>.+)/
+    # This resets the existing tool configurations of a hard-coded list of Canvas servers to point
+    # to non-production LTI providers, but using the configurations of the production Junction server as a starting
+    # point. We take this roundabout route because the code sends the revised configurations by URL, and
+    # externally-hosted Canvas is not able to reach the URLs of our non-production Junction servers.
+    # However, this means the code can only communicate tool configurations which are known to production
+    # Junction; e.g., upcoming new apps can't be added to Dev/QA environments.
+    def reset_external_app_hosts_by_url(reachable_xml_host, canvas_hosts_to_calcentrals)
       canvas_hosts_to_calcentrals.each do |mapping|
         canvas_host = mapping[:host]
-        calcentral_host = mapping[:calcentral]
-
+        calcentral_host = "https://#{mapping[:calcentral]}"
         refresh_accounts.each do |canvas_account_id|
           proxy = Canvas::ExternalTools.new(url_root: canvas_host, canvas_account_id: canvas_account_id)
           external_tools_list = proxy.external_tools_list
           external_tools_list.each do |tool_config|
             tool_url = tool_config['url']
-            if (parsed_url = url_regex.match(tool_url))
+            if (parsed_url = parse_host_and_code_from_launch_url(tool_url))
               current_app_host = parsed_url[:app_host]
-              app_name = parsed_url[:app]
+              app_code = parsed_url[:app_code]
               if current_app_host == calcentral_host
-                logger.debug("App #{app_name} on #{canvas_host} already points to #{calcentral_host}")
+                logger.debug("App #{app_code} on #{canvas_host} already points to #{calcentral_host}")
               else
-                if app_to_xml[app_name]
-                  logger.warn("Resetting app #{app_name} on #{canvas_host} to #{calcentral_host}")
+                if (xml_name = app_code_to_xml_name(app_code))
+                  logger.warn("Resetting app #{app_code} on #{canvas_host} to #{calcentral_host}")
                   tool_id = tool_config['id']
-                  app_config_url = "#{reachable_xml_host}/canvas/#{app_to_xml[app_name]}.xml?app_host=#{calcentral_host}"
-                  proxy.reset_external_tool(tool_id, app_config_url)
+                  app_config_url = "#{reachable_xml_host}/canvas/#{xml_name}.xml?app_host=#{calcentral_host}"
+                  proxy.reset_external_tool_config_by_url(tool_id, app_config_url)
                 else
-                  logger.warn("No known XML for app #{app_name} on #{canvas_host}, skipping")
+                  logger.warn("No known XML for app #{app_code} on #{canvas_host}, skipping")
                 end
               end
             end
           end
         end
-
       end
     end
 
-    def refresh_accounts
-      [Settings.canvas_proxy.account_id] + Settings.canvas_proxy.lti_sub_accounts
+    # Unlike reset_external_app_hosts_by_url, this will always overwrite an existing configuration whether
+    # there are visible changes needed or not. This supports changes to the LTI shared_secret.
+    def configure_external_app_by_xml(app_host, app_code)
+      unless (app_definition = lti_app_definitions[app_code]) && (app_account = app_definition[:account])
+        return {status: 'unknown'}
+      end
+      xml_string = render_local_xml_config(app_host, app_definition[:xml_name])
+      external_tools_proxy = Canvas::ExternalTools.new(canvas_account_id: app_account)
+      if (existing_config = existing_app_config(app_account, app_code))
+        tool_id = existing_config['id']
+        log_message = "Overwriting configuration for #{app_code}, ID #{tool_id}"
+        existing_host = parse_host_and_code_from_launch_url(existing_config['url'])[:app_host]
+        log_message.concat(", provider from #{existing_host} to #{app_host}") if existing_host != app_host
+        log_message.concat(", name from #{existing_config['name']} to #{app_definition[:app_name]}") if existing_config['name'] != app_definition[:app_name]
+        logger.warn(log_message)
+        if (response = external_tools_proxy.reset_external_tool_by_xml(tool_id, xml_string))
+          {
+            app_id: tool_id,
+            status: 'overwritten'
+          }
+        else
+          {
+            app_id: tool_id,
+            status: 'error'
+          }
+        end
+      else
+        logger.warn("Adding configuration for #{app_code} to account #{app_account}")
+        if (response = external_tools_proxy.create_external_tool_by_xml(app_definition[:app_name], xml_string))
+          {
+            app_id: response['id'],
+            status: 'added'
+          }
+        else
+          {
+            status: 'error'
+          }
+        end
+      end
+    end
+
+    def existing_app_config(account_id, app_code)
+      @accounts ||= {}
+      @accounts[account_id] ||= Canvas::ExternalTools.new(canvas_account_id: account_id).external_tools_list
+      existing_tools = @accounts[account_id]
+      match_idx = existing_tools.index do |config|
+        tool_url = config['url']
+        if (parsed_url = parse_host_and_code_from_launch_url(tool_url))
+          tool_app_code = parsed_url[:app_code]
+          (tool_app_code == app_code)
+        end
+      end
+      if match_idx
+        existing_tools[match_idx]
+      else
+        nil
+      end
+    end
+
+
+    # Add or overwrite all Junction-defined LTI apps on the default Canvas host.
+    # (Deletion of undefined apps from Canvas accounts will have to be handled manually.)
+    def configure_all_apps_from_current_host(options = {})
+      app_provider_host = options[:app_provider_host] || Settings.canvas_proxy.app_provider_host
+      results = {}
+      lti_app_definitions.each_key do |app_code|
+        results[app_code] = configure_external_app_by_xml(app_provider_host, app_code)
+      end
+      logger.warn("Reset all defined LTI apps: #{results}")
+      results
+    end
+
+    def render_local_xml_config(app_host, xml_name)
+      app_code = xml_name_to_app_code(xml_name)
+      output_buffer = ActionView::Base.new('app/views/canvas_lti').render(file: xml_name, format: 'xml',
+        locals: {:@launch_url_for_app => launch_url_for_host_and_code(app_host, app_code)})
+      # A simple ".to_s" will leave the ActionView::OutputBuffer as is and cause an exception to be thrown when
+      # Faraday attempts to encode the parameter.
+      String.new(output_buffer)
     end
 
   end

--- a/app/views/canvas_lti/lti_course_add_user.xml.erb
+++ b/app/views/canvas_lti/lti_course_add_user.xml.erb
@@ -11,12 +11,12 @@
     <blti:title>Find a Person to Add</blti:title>
     <blti:description>Search and add users to course sections</blti:description>
     <blti:icon>NO ICO</blti:icon>
-    <blti:launch_url><%= launch_url('course_add_user') %></blti:launch_url>
+    <blti:launch_url><%= @launch_url_for_app %></blti:launch_url>
     <blti:extensions platform="canvas.instructure.com">
       <lticm:property name="tool_id">calcentral_course_add_user</lticm:property>
       <lticm:property name="privacy_level">public</lticm:property>
       <lticm:options name="course_navigation">
-        <lticm:property name="url"><%= launch_url('course_add_user') %></lticm:property>
+        <lticm:property name="url"><%= @launch_url_for_app %></lticm:property>
         <lticm:property name="text">Find a Person to Add</lticm:property>
         <lticm:property name="visibility">admins</lticm:property>
         <lticm:property name="default">disabled</lticm:property>

--- a/app/views/canvas_lti/lti_course_grade_export.xml.erb
+++ b/app/views/canvas_lti/lti_course_grade_export.xml.erb
@@ -11,12 +11,12 @@
     <blti:title>Download E-Grades</blti:title>
     <blti:description>Exports Course Grades to E-Grades CSV file</blti:description>
     <blti:icon>NO ICO</blti:icon>
-    <blti:launch_url><%= launch_url('course_grade_export') %></blti:launch_url>
+    <blti:launch_url><%= @launch_url_for_app %></blti:launch_url>
     <blti:extensions platform="canvas.instructure.com">
       <lticm:property name="tool_id">calcentral_course_grade_export</lticm:property>
       <lticm:property name="privacy_level">public</lticm:property>
       <lticm:options name="course_navigation">
-        <lticm:property name="url"><%= launch_url('course_grade_export') %></lticm:property>
+        <lticm:property name="url"><%= @launch_url_for_app %></lticm:property>
         <lticm:property name="text">Download E-Grades</lticm:property>
         <lticm:property name="visibility">admins</lticm:property>
         <lticm:property name="default">disabled</lticm:property>

--- a/app/views/canvas_lti/lti_course_manage_official_sections.xml.erb
+++ b/app/views/canvas_lti/lti_course_manage_official_sections.xml.erb
@@ -11,12 +11,12 @@
     <blti:title>Manage Official Sections</blti:title>
     <blti:description>Provides management options for official course sections</blti:description>
     <blti:icon>NO ICO</blti:icon>
-    <blti:launch_url><%= launch_url('course_manage_official_sections') %></blti:launch_url>
+    <blti:launch_url><%= @launch_url_for_app %></blti:launch_url>
     <blti:extensions platform="canvas.instructure.com">
       <lticm:property name="tool_id">calcentral_course_manage_official_sections</lticm:property>
       <lticm:property name="privacy_level">public</lticm:property>
       <lticm:options name="course_navigation">
-        <lticm:property name="url"><%= launch_url('course_manage_official_sections') %></lticm:property>
+        <lticm:property name="url"><%= @launch_url_for_app %></lticm:property>
         <lticm:property name="text">Official Sections</lticm:property>
         <lticm:property name="visibility">admins</lticm:property>
         <lticm:property name="default">enabled</lticm:property>

--- a/app/views/canvas_lti/lti_course_mediacasts.xml.erb
+++ b/app/views/canvas_lti/lti_course_mediacasts.xml.erb
@@ -11,12 +11,12 @@
     <blti:title>Mediacasts</blti:title>
     <blti:description>Video and audio for this course</blti:description>
     <blti:icon></blti:icon>
-    <blti:launch_url><%= launch_url('course_mediacasts')  %></blti:launch_url>
+    <blti:launch_url><%= @launch_url_for_app  %></blti:launch_url>
     <blti:extensions platform="canvas.instructure.com">
       <lticm:property name="tool_id">calcentral_mediacasts</lticm:property>
       <lticm:property name="privacy_level">public</lticm:property>
       <lticm:options name="course_navigation">
-        <lticm:property name="url"><%= launch_url('course_mediacasts')  %></lticm:property>
+        <lticm:property name="url"><%= @launch_url_for_app %></lticm:property>
         <lticm:property name="text">Webcasts</lticm:property>
         <lticm:property name="visibility">members</lticm:property>
         <lticm:property name="default">disabled</lticm:property>

--- a/app/views/canvas_lti/lti_roster_photos.xml.erb
+++ b/app/views/canvas_lti/lti_roster_photos.xml.erb
@@ -11,12 +11,12 @@
     <blti:title>Roster Photos</blti:title>
     <blti:description>Browse and search official roster photos</blti:description>
     <blti:icon></blti:icon>
-    <blti:launch_url><%= launch_url('rosters')  %></blti:launch_url>
+    <blti:launch_url><%= @launch_url_for_app %></blti:launch_url>
     <blti:extensions platform="canvas.instructure.com">
       <lticm:property name="tool_id">calcentral_roster_photos</lticm:property>
       <lticm:property name="privacy_level">public</lticm:property>
       <lticm:options name="course_navigation">
-        <lticm:property name="url"><%= launch_url('rosters')  %></lticm:property>
+        <lticm:property name="url"><%= @launch_url_for_app %></lticm:property>
         <lticm:property name="text">Roster Photos</lticm:property>
         <lticm:property name="visibility">admins</lticm:property>
         <lticm:property name="default">enabled</lticm:property>

--- a/app/views/canvas_lti/lti_site_creation.xml.erb
+++ b/app/views/canvas_lti/lti_site_creation.xml.erb
@@ -11,12 +11,12 @@
   <blti:title>Create a Site</blti:title>
   <blti:description>Provides access to Course and Project site creation</blti:description>
   <blti:icon>NO ICO</blti:icon>
-  <blti:launch_url><%= launch_url('site_creation') %></blti:launch_url>
+  <blti:launch_url><%= @launch_url_for_app %></blti:launch_url>
   <blti:extensions platform="canvas.instructure.com">
     <lticm:property name="tool_id">calcentral_site_create_user_navigation</lticm:property>
     <lticm:property name="privacy_level">public</lticm:property>
     <lticm:options name="user_navigation">
-      <lticm:property name="url"><%= launch_url('site_creation') %></lticm:property>
+      <lticm:property name="url"><%= @launch_url_for_app %></lticm:property>
       <lticm:property name="text">Create a Site</lticm:property>
       <lticm:property name="enabled">true</lticm:property>
     </lticm:options>

--- a/app/views/canvas_lti/lti_user_provision.xml.erb
+++ b/app/views/canvas_lti/lti_user_provision.xml.erb
@@ -11,12 +11,12 @@
     <blti:title>bCourses User Provisioning</blti:title>
     <blti:description>Automated user provisioning</blti:description>
     <blti:icon>NO ICO</blti:icon>
-    <blti:launch_url><%= launch_url('user_provision') %></blti:launch_url>
+    <blti:launch_url><%= @launch_url_for_app %></blti:launch_url>
     <blti:extensions platform="canvas.instructure.com">
       <lticm:property name="tool_id">calcentral_user_provision</lticm:property>
       <lticm:property name="privacy_level">public</lticm:property>
       <lticm:options name="account_navigation">
-        <lticm:property name="url"><%= launch_url('user_provision') %></lticm:property>
+        <lticm:property name="url"><%= @launch_url_for_app %></lticm:property>
         <lticm:property name="text">User Provisioning</lticm:property>
         <lticm:property name="visibility">admins</lticm:property>
         <lticm:property name="default">enabled</lticm:property>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -62,12 +62,11 @@ oauth2:
 # Set "fake: true" for any inaccessible ones
 canvas_proxy:
   admin_access_token: "someMumboJumbo"
+  # URL for Canvas server
   url_root: "http://localhost:12345"
   fake: false
   account_id: '90242'
   official_courses_account_id: '129410'
-  lti_sub_accounts:
-    - '129410'
   projects_account_id: '129407'
   projects_term_id: '5494'
   projects_owner_role_id: '1766'
@@ -83,6 +82,8 @@ canvas_proxy:
   dry_run_import: <%= ENV['CANVAS_DRY_RUN_IMPORT'] || '' %>
   # Set to false to disable synchronization of obfuscated names in Dev/QA.
   maintain_user_names: true
+  # URL for scripts to point to CalCentral/Junction
+  app_provider_host: 'http://localhost:3000'
 ldap:
   host: 'nds.berkeley.edu'
   port: 636

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -7,6 +7,7 @@ application:
   layer: "test"
 canvas_proxy:
   fake: true
+  app_provider_host: 'https://cc-dev.example.com'
 ldap:
   host: 'nds-test.berkeley.edu'
 google_proxy:

--- a/fixtures/pretty_vcr_recordings/Canvas_create_external_tool.json
+++ b/fixtures/pretty_vcr_recordings/Canvas_create_external_tool.json
@@ -1,0 +1,151 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "post",
+        "uri": "https://ucberkeley.beta.instructure.com/api/v1/courses/767330/external_tools",
+        "body": {
+          "encoding": "US-ASCII",
+          "string": "config_type=by_xml&config_xml=%3C%3Fxml+version%3D%221.0%22+encoding%3D%22UTF-8%22%3F%3E%0A%3Ccartridge_basiclti_link+xmlns%3D%22http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Fimslticc_v1p0%22%0A++++xmlns%3Ablti+%3D+%22http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Fimsbasiclti_v1p0%22%0A++++xmlns%3Alticm+%3D%22http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Fimslticm_v1p0%22%0A++++xmlns%3Alticp+%3D%22http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Fimslticp_v1p0%22%0A++++xmlns%3Axsi+%3D+%22http%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema-instance%22%0A++++xsi%3AschemaLocation+%3D+%22http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Fimslticc_v1p0+http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Flti%2Fltiv1p0%2Fimslticc_v1p0.xsd%0A++++http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Fimsbasiclti_v1p0+http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Flti%2Fltiv1p0%2Fimsbasiclti_v1p0.xsd%0A++++http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Fimslticm_v1p0+http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Flti%2Fltiv1p0%2Fimslticm_v1p0.xsd%0A++++http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Fimslticp_v1p0+http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Flti%2Fltiv1p0%2Fimslticp_v1p0.xsd%22%3E%0A++++%3Cblti%3Atitle%3ERoster+Photos%3C%2Fblti%3Atitle%3E%0A++++%3Cblti%3Adescription%3EBrowse+and+search+official+roster+photos%3C%2Fblti%3Adescription%3E%0A++++%3Cblti%3Aicon%3E%3C%2Fblti%3Aicon%3E%0A++++%3Cblti%3Alaunch_url%3Ehttps%3A%2F%2Fcalcentral-dev.berkeley.edu%2Fcanvas%2Fembedded%2Frosters%3C%2Fblti%3Alaunch_url%3E%0A++++%3Cblti%3Aextensions+platform%3D%22canvas.instructure.com%22%3E%0A++++++%3Clticm%3Aproperty+name%3D%22tool_id%22%3Ecalcentral_roster_photos%3C%2Flticm%3Aproperty%3E%0A++++++%3Clticm%3Aproperty+name%3D%22privacy_level%22%3Epublic%3C%2Flticm%3Aproperty%3E%0A++++++%3Clticm%3Aoptions+name%3D%22course_navigation%22%3E%0A++++++++%3Clticm%3Aproperty+name%3D%22url%22%3Ehttps%3A%2F%2Fcalcentral-dev.berkeley.edu%2Fcanvas%2Fembedded%2Frosters%3C%2Flticm%3Aproperty%3E%0A++++++++%3Clticm%3Aproperty+name%3D%22text%22%3ERoster+Photos%3C%2Flticm%3Aproperty%3E%0A++++++++%3Clticm%3Aproperty+name%3D%22visibility%22%3Eadmins%3C%2Flticm%3Aproperty%3E%0A++++++++%3Clticm%3Aproperty+name%3D%22default%22%3Eenabled%3C%2Flticm%3Aproperty%3E%0A++++++++%3Clticm%3Aproperty+name%3D%22enabled%22%3Etrue%3C%2Flticm%3Aproperty%3E%0A++++++%3C%2Flticm%3Aoptions%3E%0A++++%3C%2Fblti%3Aextensions%3E%0A++++%3Ccartridge_bundle+identifierref%3D%22BLTI001_Bundle%22%2F%3E%0A++++%3Ccartridge_icon+identifierref%3D%22BLTI001_Icon%22%2F%3E%0A%3C%2Fcartridge_basiclti_link%3E%0A&consumer_key=someMumboJumbo&name=Ray+test+roster&shared_secret=someMumboJumbo"
+        },
+        "headers": {
+          "Authorization": [
+            ""
+          ],
+          "Cache-Control": [
+            "no-store"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "x-sakai-token": [
+
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": null
+        },
+        "headers": {
+          "cache-control": [
+            "max-age=0, private, must-revalidate"
+          ],
+          "content-type": [
+            "application/json; charset=utf-8"
+          ],
+          "date": [
+            "Fri, 13 Feb 2015 00:18:19 GMT"
+          ],
+          "etag": [
+            "\"3a7e1a4b849ec692aaaba78319374899\""
+          ],
+          "p3p": [
+            "CP=\"None, see http://www.instructure.com/privacy-policy\""
+          ],
+          "server": [
+            "Apache"
+          ],
+          "set-cookie": [
+            "_csrf_token=fff; path=/; secure, canvas_session=fff; path=/; secure; HttpOnly"
+          ],
+          "status": [
+            "200 OK"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "x-canvas-meta": [
+            "a=90242"
+          ],
+          "x-canvas-user-id": [
+            "190000003057506"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-rack-cache": [
+            "invalidate, pass"
+          ],
+          "x-request-context-id": [
+            "bc4df700-9543-0132-7dbe-02f8856d54b5"
+          ],
+          "x-runtime": [
+            "0.295132"
+          ],
+          "x-session-id": [
+            "c8d6391aaf9b0d06b6f08b9587658bc8"
+          ],
+          "x-ua-compatible": [
+            "IE=Edge,chrome=1"
+          ],
+          "transfer-encoding": [
+            "chunked"
+          ],
+          "connection": [
+            "keep-alive"
+          ],
+          "Authorization": [
+            ""
+          ],
+          "x-sakai-token": [
+
+          ]
+        },
+        "body": {
+          "encoding": "US-ASCII",
+          "string": "",
+          "debug_json": {
+            "consumer_key": "someMumboJumbo",
+            "created_at": "2015-02-13T00:18:19Z",
+            "description": "Browse and search official roster photos",
+            "domain": null,
+            "id": 40786,
+            "name": "Ray test roster",
+            "updated_at": "2015-02-13T00:18:19Z",
+            "url": "https://cc-dev.example.com/canvas/embedded/rosters",
+            "privacy_level": "public",
+            "custom_fields": {
+
+            },
+            "workflow_state": "public",
+            "vendor_help_link": null,
+            "user_navigation": null,
+            "course_navigation": {
+              "url": "https://cc-dev.example.com/canvas/embedded/rosters",
+              "text": "Roster Photos",
+              "visibility": "admins",
+              "default": "enabled",
+              "enabled": "true",
+              "label": "Roster Photos",
+              "selection_width": 800,
+              "selection_height": 400,
+              "icon_url": ""
+            },
+            "account_navigation": null,
+            "resource_selection": null,
+            "editor_button": null,
+            "homework_submission": null,
+            "migration_selection": null,
+            "course_home_sub_navigation": null,
+            "course_settings_sub_navigation": null,
+            "global_navigation": null,
+            "assignment_menu": null,
+            "file_menu": null,
+            "discussion_topic_menu": null,
+            "module_menu": null,
+            "quiz_menu": null,
+            "wiki_page_menu": null,
+            "tool_configuration": null,
+            "icon_url": "",
+            "not_selectable": false
+          }
+        },
+        "http_version": null
+      },
+      "recorded_at": "Fri, 13 Feb 2015 00:18:19 GMT"
+    }
+  ],
+  "recorded_with": "VCR 2.9.3"
+}

--- a/fixtures/pretty_vcr_recordings/Canvas_modify_external_tool.json
+++ b/fixtures/pretty_vcr_recordings/Canvas_modify_external_tool.json
@@ -1,0 +1,147 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://ucberkeley.beta.instructure.com/api/v1/courses/767330/external_tools/40786",
+        "body": {
+          "encoding": "UTF-8",
+          "string": "course_navigation[text]=NoRosterNoPhoto"
+        },
+        "headers": {
+          "Authorization": [
+            ""
+          ],
+          "Cache-Control": [
+            "no-store"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "x-sakai-token": [
+
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": null
+        },
+        "headers": {
+          "cache-control": [
+            "max-age=0, private, must-revalidate"
+          ],
+          "content-type": [
+            "application/json; charset=utf-8"
+          ],
+          "date": [
+            "Fri, 13 Feb 2015 00:20:43 GMT"
+          ],
+          "etag": [
+            "\"460c6e43361295118c0eb3a67bbd5a02\""
+          ],
+          "p3p": [
+            "CP=\"None, see http://www.instructure.com/privacy-policy\""
+          ],
+          "server": [
+            "Apache"
+          ],
+          "set-cookie": [
+            "_csrf_token=zzz; path=/; secure, canvas_session=zzz; path=/; secure; HttpOnly"
+          ],
+          "status": [
+            "200 OK"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "x-canvas-meta": [
+            "a=90242;"
+          ],
+          "x-canvas-user-id": [
+            "190000003057506"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-rack-cache": [
+            "invalidate, pass"
+          ],
+          "x-request-context-id": [
+            "126cf5b0-9544-0132-7dbe-02f8856d54b5"
+          ],
+          "x-runtime": [
+            "0.319906"
+          ],
+          "x-session-id": [
+            "3281991c9e5cf1d4575898ea132fd1cb"
+          ],
+          "x-ua-compatible": [
+            "IE=Edge,chrome=1"
+          ],
+          "transfer-encoding": [
+            "chunked"
+          ],
+          "connection": [
+            "keep-alive"
+          ],
+          "Authorization": [
+            ""
+          ],
+          "x-sakai-token": [
+
+          ]
+        },
+        "body": {
+          "encoding": "US-ASCII",
+          "string": "",
+          "debug_json": {
+            "consumer_key": "someMumboJumbo",
+            "created_at": "2015-02-10T20:15:03Z",
+            "description": "Browse and search official roster photos",
+            "domain": null,
+            "id": 40782,
+            "name": "Course-site test roster",
+            "updated_at": "2015-02-10T20:16:56Z",
+            "url": "https://cc-dev.example.com/canvas/embedded/rosters",
+            "privacy_level": "public",
+            "custom_fields": {
+
+            },
+            "workflow_state": "public",
+            "vendor_help_link": null,
+            "user_navigation": null,
+            "course_navigation": {
+              "text": "NoRosterNoPhoto",
+              "label": "NoRosterNoPhoto",
+              "selection_width": 800,
+              "selection_height": 400,
+              "icon_url": ""
+            },
+            "account_navigation": null,
+            "resource_selection": null,
+            "editor_button": null,
+            "homework_submission": null,
+            "migration_selection": null,
+            "course_home_sub_navigation": null,
+            "course_settings_sub_navigation": null,
+            "global_navigation": null,
+            "assignment_menu": null,
+            "file_menu": null,
+            "discussion_topic_menu": null,
+            "module_menu": null,
+            "quiz_menu": null,
+            "wiki_page_menu": null,
+            "tool_configuration": null,
+            "icon_url": "",
+            "not_selectable": false
+          }
+        },
+        "http_version": null
+      },
+      "recorded_at": "Fri, 13 Feb 2015 00:20:43 GMT"
+    }
+  ],
+  "recorded_with": "VCR 2.9.3"
+}

--- a/fixtures/pretty_vcr_recordings/Canvas_reset_external_tool_by_xml.json
+++ b/fixtures/pretty_vcr_recordings/Canvas_reset_external_tool_by_xml.json
@@ -1,0 +1,151 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "put",
+        "uri": "https://ucberkeley.beta.instructure.com/api/v1/courses/767330/external_tools/40786",
+        "body": {
+          "encoding": "US-ASCII",
+          "string": "config_type=by_xml&config_xml=%3C%3Fxml+version%3D%221.0%22+encoding%3D%22UTF-8%22%3F%3E%0A%3Ccartridge_basiclti_link+xmlns%3D%22http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Fimslticc_v1p0%22%0A++++xmlns%3Ablti+%3D+%22http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Fimsbasiclti_v1p0%22%0A++++xmlns%3Alticm+%3D%22http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Fimslticm_v1p0%22%0A++++xmlns%3Alticp+%3D%22http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Fimslticp_v1p0%22%0A++++xmlns%3Axsi+%3D+%22http%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema-instance%22%0A++++xsi%3AschemaLocation+%3D+%22http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Fimslticc_v1p0+http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Flti%2Fltiv1p0%2Fimslticc_v1p0.xsd%0A++++http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Fimsbasiclti_v1p0+http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Flti%2Fltiv1p0%2Fimsbasiclti_v1p0.xsd%0A++++http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Fimslticm_v1p0+http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Flti%2Fltiv1p0%2Fimslticm_v1p0.xsd%0A++++http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Fimslticp_v1p0+http%3A%2F%2Fwww.imsglobal.org%2Fxsd%2Flti%2Fltiv1p0%2Fimslticp_v1p0.xsd%22%3E%0A++++%3Cblti%3Atitle%3ERoster+Photos%3C%2Fblti%3Atitle%3E%0A++++%3Cblti%3Adescription%3EBrowse+and+search+official+roster+photos%3C%2Fblti%3Adescription%3E%0A++++%3Cblti%3Aicon%3E%3C%2Fblti%3Aicon%3E%0A++++%3Cblti%3Alaunch_url%3Ehttps%3A%2F%2Fcalcentral-dev.berkeley.edu%2Fcanvas%2Fembedded%2Frosters%3C%2Fblti%3Alaunch_url%3E%0A++++%3Cblti%3Aextensions+platform%3D%22canvas.instructure.com%22%3E%0A++++++%3Clticm%3Aproperty+name%3D%22tool_id%22%3Ecalcentral_roster_photos%3C%2Flticm%3Aproperty%3E%0A++++++%3Clticm%3Aproperty+name%3D%22privacy_level%22%3Epublic%3C%2Flticm%3Aproperty%3E%0A++++++%3Clticm%3Aoptions+name%3D%22course_navigation%22%3E%0A++++++++%3Clticm%3Aproperty+name%3D%22url%22%3Ehttps%3A%2F%2Fcalcentral-dev.berkeley.edu%2Fcanvas%2Fembedded%2Frosters%3C%2Flticm%3Aproperty%3E%0A++++++++%3Clticm%3Aproperty+name%3D%22text%22%3ERoster+Photos%3C%2Flticm%3Aproperty%3E%0A++++++++%3Clticm%3Aproperty+name%3D%22visibility%22%3Eadmins%3C%2Flticm%3Aproperty%3E%0A++++++++%3Clticm%3Aproperty+name%3D%22default%22%3Eenabled%3C%2Flticm%3Aproperty%3E%0A++++++++%3Clticm%3Aproperty+name%3D%22enabled%22%3Etrue%3C%2Flticm%3Aproperty%3E%0A++++++%3C%2Flticm%3Aoptions%3E%0A++++%3C%2Fblti%3Aextensions%3E%0A++++%3Ccartridge_bundle+identifierref%3D%22BLTI001_Bundle%22%2F%3E%0A++++%3Ccartridge_icon+identifierref%3D%22BLTI001_Icon%22%2F%3E%0A%3C%2Fcartridge_basiclti_link%3E%0A&consumer_key=someMumboJumbo&shared_secret=someMumboJumbo"
+        },
+        "headers": {
+          "Authorization": [
+            ""
+          ],
+          "Cache-Control": [
+            "no-store"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "x-sakai-token": [
+
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": null
+        },
+        "headers": {
+          "cache-control": [
+            "max-age=0, private, must-revalidate"
+          ],
+          "content-type": [
+            "application/json; charset=utf-8"
+          ],
+          "date": [
+            "Fri, 13 Feb 2015 00:21:58 GMT"
+          ],
+          "etag": [
+            "\"5bcaeb224907e7947d17a6d14ae0aa17\""
+          ],
+          "p3p": [
+            "CP=\"None, see http://www.instructure.com/privacy-policy\""
+          ],
+          "server": [
+            "Apache"
+          ],
+          "set-cookie": [
+            "_csrf_token=zzz; path=/; secure, canvas_session=zzz; path=/; secure; HttpOnly"
+          ],
+          "status": [
+            "200 OK"
+          ],
+          "vary": [
+            "Accept-Encoding"
+          ],
+          "x-canvas-meta": [
+            "a=90242"
+          ],
+          "x-canvas-user-id": [
+            "190000003057506"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-rack-cache": [
+            "invalidate, pass"
+          ],
+          "x-request-context-id": [
+            "3f0b4b80-9544-0132-7dbe-02f8856d54b5"
+          ],
+          "x-runtime": [
+            "0.325553"
+          ],
+          "x-session-id": [
+            "d3585866c042588054f5449747356923"
+          ],
+          "x-ua-compatible": [
+            "IE=Edge,chrome=1"
+          ],
+          "transfer-encoding": [
+            "chunked"
+          ],
+          "connection": [
+            "keep-alive"
+          ],
+          "Authorization": [
+            ""
+          ],
+          "x-sakai-token": [
+
+          ]
+        },
+        "body": {
+          "encoding": "US-ASCII",
+          "string": "",
+          "debug_json": {
+            "consumer_key": "someMumboJumbo",
+            "created_at": "2015-02-10T20:15:03Z",
+            "description": "Browse and search official roster photos",
+            "domain": null,
+            "id": 40786,
+            "name": "Ray test roster",
+            "updated_at": "2015-02-10T20:20:14Z",
+            "url": "https://cc-dev.example.com/canvas/embedded/rosters",
+            "privacy_level": "public",
+            "custom_fields": {
+
+            },
+            "workflow_state": "public",
+            "vendor_help_link": null,
+            "user_navigation": null,
+            "course_navigation": {
+              "url": "https://cc-dev.example.com/canvas/embedded/rosters",
+              "text": "Roster Photos",
+              "visibility": "admins",
+              "default": "enabled",
+              "enabled": "true",
+              "label": "Roster Photos",
+              "selection_width": 800,
+              "selection_height": 400,
+              "icon_url": ""
+            },
+            "account_navigation": null,
+            "resource_selection": null,
+            "editor_button": null,
+            "homework_submission": null,
+            "migration_selection": null,
+            "course_home_sub_navigation": null,
+            "course_settings_sub_navigation": null,
+            "global_navigation": null,
+            "assignment_menu": null,
+            "file_menu": null,
+            "discussion_topic_menu": null,
+            "module_menu": null,
+            "quiz_menu": null,
+            "wiki_page_menu": null,
+            "tool_configuration": null,
+            "icon_url": "",
+            "not_selectable": false
+          }
+        },
+        "http_version": null
+      },
+      "recorded_at": "Fri, 13 Feb 2015 00:21:58 GMT"
+    }
+  ],
+  "recorded_with": "VCR 2.9.3"
+}

--- a/lib/tasks/canvas.rake
+++ b/lib/tasks/canvas.rake
@@ -45,8 +45,8 @@ namespace :canvas do
     end
   end
 
-  desc 'Reconfigure Canvas external apps (CALCENTRAL_XML_HOST="https://cc.example.com" CANVAS_HOSTS_TO_CALCENTRALS="https://ucb.beta.example.com=cc-dev.example.com,https://ucb.test.example.com=cc-qa.example.com")'
-  task :reconfigure_external_apps => :environment do
+  desc 'Reconfigure Canvas external apps on other servers (CALCENTRAL_XML_HOST="https://cc.example.com" CANVAS_HOSTS_TO_CALCENTRALS="https://ucb.beta.example.com=cc-dev.example.com,https://ucb.test.example.com=cc-qa.example.com")'
+  task :reset_external_app_hosts_by_url => :environment do
     reachable_xml_host = ENV["CALCENTRAL_XML_HOST"]
     canvas_hosts_to_calcentrals_string = ENV["CANVAS_HOSTS_TO_CALCENTRALS"]
     if reachable_xml_host.blank?
@@ -58,9 +58,15 @@ namespace :canvas do
       canvas_hosts_to_calcentrals_string.split(/=|,/).each_slice(2) {|pair|
         canvas_hosts_to_calcentrals.push({host: pair[0], calcentral: pair[1]})
       }
-      Canvas::ReconfigureExternalApps.reconfigure_external_apps(reachable_xml_host, canvas_hosts_to_calcentrals)
+      Canvas::ReconfigureExternalApps.new.reset_external_app_hosts_by_url(reachable_xml_host, canvas_hosts_to_calcentrals)
       Rails.logger.info("Reconfigured external apps from #{reachable_xml_host} for #{canvas_hosts_to_calcentrals_string}")
     end
+  end
+
+  desc 'Configure all default Canvas external apps provided by the current server'
+  task :configure_all_apps_from_current_host => :environment do
+    results = Canvas::ReconfigureExternalApps.new.configure_all_apps_from_current_host
+    Rails.logger.info("Configured external apps: #{results}")
   end
 
   desc 'Repair Canvas Course SIS IDs (TERM_ID=x)'

--- a/script/configure-all-canvas-apps-from-current-host.sh
+++ b/script/configure-all-canvas-apps-from-current-host.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Script to configure (or reconfigure) all LTI apps on the linked bCourses server and provided
+# by the current CalCentral server. This will add any new apps and overwrite current LTI
+# keys and secrets.
+
+# Make sure the normal shell environment is in place, since it may not be
+# when running as a cron job.
+source "$HOME/.bash_profile"
+
+cd $( dirname "${BASH_SOURCE[0]}" )/..
+
+LOG=`date +"$PWD/log/canvas_configure_all_apps_%Y-%m-%d.log"`
+LOGIT="tee -a $LOG"
+
+# Enable rvm and use the correct Ruby version and gem set.
+[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
+source .rvmrc
+
+export RAILS_ENV=production
+export LOGGER_STDOUT=only
+export LOGGER_LEVEL=INFO
+export JRUBY_OPTS="-Xcext.enabled=true -J-client -X-C"
+
+echo | $LOGIT
+echo "------------------------------------------" | $LOGIT
+echo "`date`: About to run the LTI application configuration script..." | $LOGIT
+
+cd deploy
+
+bundle exec rake canvas:configure_all_apps_from_current_host | $LOGIT

--- a/script/reconfigure-canvas-external-apps.sh
+++ b/script/reconfigure-canvas-external-apps.sh
@@ -34,4 +34,4 @@ echo "`date`: About to run the external LTI application reconfiguration script..
 
 cd deploy
 
-bundle exec rake canvas:reconfigure_external_apps | $LOGIT
+bundle exec rake canvas:reset_external_app_hosts_by_url | $LOGIT

--- a/spec/models/canvas/external_tools_spec.rb
+++ b/spec/models/canvas/external_tools_spec.rb
@@ -2,14 +2,22 @@ require "spec_helper"
 
 describe Canvas::ExternalTools do
 
-  it "should use root canvas account by default" do
-    account_id = subject.instance_eval { @canvas_account_id }
-    expect(account_id).to eq Settings.canvas_proxy.account_id
-  end
-
-  it "supports alternative canvas account id" do
-    account_id = Canvas::ExternalTools.new(:canvas_account_id => '1234').instance_eval { @canvas_account_id }
-    expect(account_id).to eq '1234'
+  describe 'api_root' do
+    subject { Canvas::ExternalTools.new(options).instance_eval { @api_root } }
+    context 'default' do
+      let(:options) { {} }
+      it 'uses the root Canvas canvas account' do
+        is_expected.to eq "accounts/#{Settings.canvas_proxy.account_id}"
+      end
+    end
+    context 'specifying an account' do
+      let(:options) { {canvas_account_id: '123456'} }
+      it { is_expected.to eq 'accounts/123456' }
+    end
+    context 'specifying a course site' do
+      let(:options) { {canvas_course_id: '98765'} }
+      it { is_expected.to eq 'courses/98765' }
+    end
   end
 
   it "should return external tools list" do

--- a/spec/models/canvas/reconfigure_external_apps_spec.rb
+++ b/spec/models/canvas/reconfigure_external_apps_spec.rb
@@ -7,41 +7,182 @@ describe Canvas::ReconfigureExternalApps do
   let(:fake_external_tools_proxy) {Canvas::ExternalTools.new(fake: true)}
   let(:fake_reset_response) {double(nil, status: 200, body: {}.to_json)}
 
-  context 'when servers need resetting' do
-    let(:new_calcentral_host) {'jabberwock.example.com'}
-    it "resets all hosted apps" do
-      fake_external_tools_list = fake_external_tools_proxy.external_tools_list
-      external_tools_proxy = double()
-      external_tools_proxy.should_receive(:external_tools_list).exactly(2).times.and_return(fake_external_tools_list)
-      external_tools_proxy.should_receive(:reset_external_tool).exactly(6).times.and_return(fake_reset_response)
-      Canvas::ExternalTools.stub(:new).with({url_root: fake_canvas_host, canvas_account_id: '90242'}).and_return(external_tools_proxy)
-      Canvas::ExternalTools.stub(:new).with({url_root: fake_canvas_host, canvas_account_id: '129410'}).and_return(external_tools_proxy)
-      Canvas::ReconfigureExternalApps.reconfigure_external_apps(reachable_xml_host, [
-        {host: fake_canvas_host, calcentral: new_calcentral_host}
-      ])
+  describe '#reset_external_app_hosts_by_url' do
+    context 'when servers need resetting' do
+      let(:new_calcentral_host) {'jabberwock.example.com'}
+      it "resets all hosted apps" do
+        fake_external_tools_list = fake_external_tools_proxy.external_tools_list
+        external_tools_proxy = double()
+        external_tools_proxy.should_receive(:external_tools_list).exactly(2).times.and_return(fake_external_tools_list)
+        external_tools_proxy.should_receive(:reset_external_tool_config_by_url).exactly(6).times.and_return(fake_reset_response)
+        Canvas::ExternalTools.stub(:new).with({url_root: fake_canvas_host, canvas_account_id: '90242'}).and_return(external_tools_proxy)
+        Canvas::ExternalTools.stub(:new).with({url_root: fake_canvas_host, canvas_account_id: '129410'}).and_return(external_tools_proxy)
+        subject.reset_external_app_hosts_by_url(reachable_xml_host, [
+            {host: fake_canvas_host, calcentral: new_calcentral_host}
+          ])
+      end
+    end
+
+    context 'when servers are already up to date' do
+      it "leaves hosted apps alone" do
+        fake_external_tools_list = fake_external_tools_proxy.external_tools_list
+        external_tools_proxy = double()
+        external_tools_proxy.should_receive(:external_tools_list).twice.and_return(fake_external_tools_list)
+        external_tools_proxy.should_not_receive(:reset_external_tool_config_by_url)
+        Canvas::ExternalTools.stub(:new).with({url_root: fake_canvas_host, canvas_account_id: '90242'}).and_return(external_tools_proxy)
+        Canvas::ExternalTools.stub(:new).with({url_root: fake_canvas_host, canvas_account_id: '129410'}).and_return(external_tools_proxy)
+        subject.reset_external_app_hosts_by_url(reachable_xml_host, [
+            {host: fake_canvas_host, calcentral: fake_calcentral_host}
+          ])
+      end
     end
   end
 
-  context 'when servers are already up to date' do
-    it "leaves hosted apps alone" do
-      fake_external_tools_list = fake_external_tools_proxy.external_tools_list
-      external_tools_proxy = double()
-      external_tools_proxy.should_receive(:external_tools_list).twice.and_return(fake_external_tools_list)
-      external_tools_proxy.should_not_receive(:reset_external_tool)
-      Canvas::ExternalTools.stub(:new).with({url_root: fake_canvas_host, canvas_account_id: '90242'}).and_return(external_tools_proxy)
-      Canvas::ExternalTools.stub(:new).with({url_root: fake_canvas_host, canvas_account_id: '129410'}).and_return(external_tools_proxy)
-      Canvas::ReconfigureExternalApps.reconfigure_external_apps(reachable_xml_host, [
-        {host: fake_canvas_host, calcentral: fake_calcentral_host}
-      ])
-    end
-  end
-
-  context 'when providing array of accounts requiring LTI tool refresh' do
+  describe '#refresh_accounts' do
     it 'returns primary account as well as other lti accounts' do
-      accounts = Canvas::ReconfigureExternalApps.refresh_accounts
+      accounts = subject.refresh_accounts
       expect(accounts).to be_an_instance_of Array
-      expect(accounts[0]).to eq '90242'
-      expect(accounts[1]).to eq '129410'
+      expect(accounts[0]).to eq Settings.canvas_proxy.account_id
+      expect(accounts[1]).to eq Settings.canvas_proxy.official_courses_account_id
+    end
+  end
+
+  describe '#configure_external_app_by_xml' do
+    let(:fake_proxy) {instance_double(Canvas::ExternalTools)}
+    let(:app_host) {"http://localhost:#{random_id}"}
+    let(:app_code) {'rosters'}
+    let(:app_id) {random_id}
+    let(:configuration_result) do
+      {
+        app_id: app_id,
+        status: expected_action
+      }
+    end
+    let(:external_tool_configs) do
+      [{
+        'id' => app_id,
+        'name' => 'Funhouse Fotos',
+        'url' => "#{app_host}/canvas/embedded/#{app_code}"
+      }]
+    end
+    before do
+      allow(Canvas::ExternalTools).to receive(:new).with({canvas_account_id: Settings.canvas_proxy.official_courses_account_id}).and_return(fake_proxy)
+      allow(fake_proxy).to receive(:external_tools_list).and_return(external_tool_configs)
+    end
+
+    subject { Canvas::ReconfigureExternalApps.new.configure_external_app_by_xml(app_host, app_code) }
+
+    context 'the app is already in the Canvas account' do
+      let(:expected_action) {'overwritten'}
+      it 'fully reconfigures the app' do
+        expect(fake_proxy).to receive(:reset_external_tool_by_xml) do |the_app_id, the_xml|
+          expect(the_app_id).to eq app_id
+          config = MultiXml.parse(the_xml)['cartridge_basiclti_link']
+          expect(config['title']).to eq 'Roster Photos'
+          expect(config['launch_url']).to eq external_tool_configs[0]['url']
+          {
+            'id' => app_id
+          }
+        end
+        is_expected.to eq configuration_result
+      end
+    end
+    context 'the app is not yet in the Canvas account' do
+      let(:expected_action) {'added'}
+      let(:external_tool_configs) {[]}
+      it 'adds the app configuration' do
+        expect(fake_proxy).to receive(:create_external_tool_by_xml) do |the_app_name, the_xml|
+          expect(the_app_name).to eq 'Roster Photos'
+          config = MultiXml.parse(the_xml)['cartridge_basiclti_link']
+          expect(config['title']).to eq 'Roster Photos'
+          expect(config['launch_url']).to eq "#{app_host}/canvas/embedded/#{app_code}"
+          {
+            'id' => app_id
+          }
+        end
+        is_expected.to eq configuration_result
+      end
+    end
+    context 'Canvas throws an error' do
+      let(:expected_action) {'error'}
+      it 'confesses failure' do
+        expect(fake_proxy).to receive(:reset_external_tool_by_xml).and_return(nil)
+        is_expected.to eq configuration_result
+      end
+    end
+    context 'unknown app' do
+      let(:app_code) {"#{random_id}thNervousBreakdown"}
+      let(:configuration_result) do
+        {
+          status: 'unknown'
+        }
+      end
+      it 'expresses confusion' do
+        is_expected.to eq configuration_result
+      end
+    end
+  end
+
+  describe '#configure_all_apps_from_current_host' do
+    let(:unknown_tool_id) {random_id}
+    let(:webcasts_id) {random_id}
+    let(:egrades_id) {random_id}
+    let(:accounts_mocks) do
+      external_accounts_hash = {}
+      Canvas::ExternalAppConfigurations.refresh_accounts.each do |account_id|
+        external_accounts_hash[account_id] = {
+          fake_proxy: instance_double(Canvas::ExternalTools),
+          received_creates: [],
+          received_resets: []
+        }
+      end
+      external_accounts_hash[Settings.canvas_proxy.account_id][:tools_feed] = [
+        {
+          'consumer_key' => 'xx',
+          'id' => unknown_tool_id,
+          'name' => 'Attendance Tool',
+          'url' => 'https://rollcall.instructure.com/launch'
+        },
+        {
+          'consumer_key' => random_id,
+          'id' => webcasts_id,
+          'name' => 'America\'s Highest Educational Videos',
+          'url' => "#{Settings.canvas_proxy.app_provider_host}/canvas/embedded/course_mediacasts"
+        }
+      ]
+      external_accounts_hash[Settings.canvas_proxy.official_courses_account_id][:tools_feed] = [
+        {
+          'consumer_key' => random_id,
+          'id' => egrades_id,
+          'name' => 'Download E-Grades',
+          'url' => "https://not.really.the.same.webhost/canvas/embedded/course_grade_export"
+        }
+      ]
+      external_accounts_hash
+    end
+    before do
+      Canvas::ExternalAppConfigurations.refresh_accounts.each do |account_id|
+        account_mock = accounts_mocks[account_id]
+        allow(Canvas::ExternalTools).to receive(:new).with({canvas_account_id: account_id}).and_return(account_mock[:fake_proxy])
+        allow(account_mock[:fake_proxy]).to receive(:external_tools_list).and_return(account_mock[:tools_feed])
+        allow(account_mock[:fake_proxy]).to receive(:create_external_tool_by_xml) do |tool_name, xml_string|
+          account_mock[:received_creates] << tool_name
+          {'id' => random_id}
+        end
+        allow(account_mock[:fake_proxy]).to receive(:reset_external_tool_by_xml) do |tool_id, xml_string|
+          account_mock[:received_resets] << tool_id
+          {'id' => tool_id}
+        end
+      end
+    end
+    it 'overwrites existing known apps and adds others' do
+      Canvas::ReconfigureExternalApps.new.configure_all_apps_from_current_host
+      main_account = accounts_mocks[Settings.canvas_proxy.account_id]
+      expect(main_account[:received_resets]).to eq [webcasts_id]
+      expect(main_account[:received_creates]).to include 'Find a Person to Add'
+      official_courses_account = accounts_mocks[Settings.canvas_proxy.official_courses_account_id]
+      expect(official_courses_account[:received_resets]).to eq [egrades_id]
+      expect(official_courses_account[:received_creates]).to include 'Roster Photos'
     end
   end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4767

This gives us an easy way to add new LTI tools, to reset keys and secrets, and to configure apps on a Canvas server from the CalCentral environment associated with it (i.e., the script can configure bCourses-beta apps that CalCentral-production doesn't yet know about).