### PR TITLE
CLC-4767 Enable Official Sections for the current sprint

### DIFF
--- a/app/models/canvas/external_app_configurations.rb
+++ b/app/models/canvas/external_app_configurations.rb
@@ -33,7 +33,7 @@ module Canvas
         'course_manage_official_sections' => {
           xml_name: 'lti_course_manage_official_sections',
           app_name: 'Official Sections',
-          account: nil
+          account: official_courses_account_id
         },
         'course_grade_export' => {
           xml_name: 'lti_course_grade_export',


### PR DESCRIPTION
Follow-up to https://github.com/ets-berkeley-edu/calcentral/pull/3411, making it easier to add support for this sprint's major user story, "Official Sections", in Beta and Test environments.

If the app has to be pulled from the release, just revert this commit.