### PR TITLE
CLC-4941 Properly log Canvas proxy errors

### DIFF
--- a/lib/errors/proxy_error.rb
+++ b/lib/errors/proxy_error.rb
@@ -8,7 +8,11 @@ module Errors
       @uid = opts[:uid]
 
       if (response = opts[:response])
-        @status = response.code
+        @status = if response.respond_to? :code
+                    response.code
+                  elsif response.respond_to? :status
+                    response.status
+                  end
         @body = response.body
       end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4941