### PR TITLE
CLC-4841 Standardize XML/HTML parsing, removing Nokogiri

### DIFF
--- a/app/models/my_badges/google_mail.rb
+++ b/app/models/my_badges/google_mail.rb
@@ -5,7 +5,7 @@ module MyBadges
 
     def initialize(uid)
       @uid = uid
-      @count_limiter = 25
+      @max_entries = 25
     end
 
     def fetch_counts(params = {})
@@ -22,103 +22,36 @@ module MyBadges
       google_proxy = GoogleApps::MailList.new(user_id: @uid)
       google_mail_results = google_proxy.mail_unread
       logger.debug "Processing GMail XML results: #{google_mail_results.inspect}"
-      response = {:count => 0, :items => []}
-      if google_mail_results && google_mail_results.response && google_mail_results.response.status == 200
-        nokogiri_xml = nil
-
-        begin
-          nokogiri_xml = Nokogiri::XML.parse(google_mail_results.response.body)
-        rescue => e
-          logger.fatal "Error parsing XML output for GoogleApps::MailList: #{e}"
-          nokogiri_xml = nil
-        end
-
-        if nokogiri_xml
-          response[:count] = get_count nokogiri_xml
-          response[:items] = get_items nokogiri_xml
-        end
-      end
-      response
+      parse_feed google_mail_results
     end
 
-    def get_count(nokogiri_xml)
-      begin
-        nokogiri_xml.search('fullcount').first.content.to_i
-      rescue => e
-        logger.warn "Error parsing XML output for unread counts from GoogleApps::MailList: #{e}"
-        return 0
-      end
-    end
-
-    def get_items(nokogiri_xml)
+    def parse_feed(google_mail_results)
+      count = 0
       items = []
       begin
-        iter_count = 0
-        raw_items = get_nodeset('entry', nokogiri_xml)
-        raw_items.each do |raw_entry|
-          break if iter_count >= @count_limiter
-          entry = {}
-
-          begin
-            %w(title summary).each do |key|
-              entry[key.to_sym] = get_node_value(key, raw_entry)
-            end
-            entry[:modifiedTime] = get_node_value("modified", raw_entry)
-            entry[:link] = "http://bmail.berkeley.edu/"
-
-            author_set = get_nodeset('author', raw_entry.search('author'))
-            entry[:editor] = get_node_value('name', author_set)
-
-            #change modified into a proper date.
-            if entry[:modifiedTime]
-              begin
-                entry[:modifiedTime] = format_date DateTime.iso8601(entry[:modifiedTime])
-              rescue => e
-                logger.warn "Could not parse modified: #{entry[:modifiedTime]}"
-                next
-              end
-            end
-            items << entry
-            iter_count +=1
-          rescue => e
-            logger.warn "Unable to parse entry - #{raw_entry}"
-            next
+        if google_mail_results && google_mail_results.response && google_mail_results.response.status == 200
+          feed = FeedWrapper.new MultiXml.parse(google_mail_results.response.body)
+          count = feed['feed']['fullcount'].to_i
+          items = feed['feed']['entry'].as_collection.each_with_index.map do |entry, index|
+            break if index == @max_entries
+            {
+              editor: entry['author']['name'].to_text,
+              link: 'http://bmail.berkeley.edu/',
+              modifiedTime: format_date(entry['modified'].to_date),
+              summary: entry['summary'].to_text,
+              title: entry['title'].to_text
+            }
           end
         end
-        items
       rescue => e
-        logger.fatal "Error parsing XML output for mail items from GoogleApps::MailList: #{e}"
-        logger.debug "Full dump of xml: #{nokogiri_xml}"
+        logger.fatal "Error parsing XML output for GoogleApps::MailList: #{e}"
+        logger.debug "Full dump of xml: #{google_mail_results.response.body}"
       end
-      items
+      {
+        count: count,
+        items: items
+      }
     end
 
-    def get_nodeset(key, nodeset, optional = false)
-      result = nodeset.search(key)
-      if result.nil? && !optional
-        raise ArgumentError, "unmatched key: #{key} on nodeset: #{nodeset}"
-      end
-
-      if result && result.is_a?(Nokogiri::XML::NodeSet)
-        result
-      else
-        raise ArgumentError, "Not a Nodeset on key: #{key} type: #{result.class}"
-      end
-
-    end
-
-    def get_node_value(key, nodeset, optional = false)
-      # TODO: should tidy this up...
-      result = nodeset.at_css(key)
-      if result.nil? && !optional
-        raise ArgumentError, "unmatched key: #{key} on nodeset: #{nodeset}"
-      end
-
-      if !result.nil? && !result.content.nil?
-        result.content
-      elsif !optional
-        raise ArgumentError, "non-leaf node on key: #{key} value: #{result}"
-      end
-    end
   end
 end

--- a/app/models/my_tasks/canvas_tasks.rb
+++ b/app/models/my_tasks/canvas_tasks.rb
@@ -1,6 +1,6 @@
 module MyTasks
   class CanvasTasks
-    include MyTasks::TasksModule, SafeJsonParser
+    include MyTasks::TasksModule, HtmlSanitizer, SafeJsonParser
 
     def initialize(uid, starting_date)
       @uid = uid
@@ -42,9 +42,8 @@ module MyTasks
                   "sourceUrl" => result["assignment"]["html_url"],
                   "status" => "inprogress"
                 }
-                if result["assignment"]["description"] != ""
-                  formatted_entry["notes"] = ActionView::Base.full_sanitizer.sanitize(result["assignment"]["description"])
-                end
+                formatted_entry['notes'] = sanitize_html(result['assignment']['description']) if result['assignment']['description'].present?
+
                 due_date = convert_date(result["assignment"]["due_at"])
                 format_date_into_entry!(due_date, formatted_entry, "dueDate")
                 bucket = determine_bucket(due_date, formatted_entry, @now_time, @starting_date)

--- a/app/models/sakai/sakai_data.rb
+++ b/app/models/sakai/sakai_data.rb
@@ -48,10 +48,12 @@ module Sakai
       select xml from #{table_prefix}sakai_preferences
         where preferences_id = #{connection.quote(sakai_user_id)}
         SQL
-        if (xml = connection.select_one(sql))
-          xml = Nokogiri::XML::Document.parse(xml['xml'])
-          xml.xpath('preferences/prefs/properties/property[@name="exclude"]').each do |el|
-            sites.push(Base64.decode64(el['value']))
+        if (row = connection.select_one(sql))
+          doc = FeedWrapper.new MultiXml.parse(row['xml'])
+          doc['preferences']['prefs']['properties']['property'].as_collection.each do |p|
+            if p['name'].to_text == 'exclude'
+              sites.push Base64.decode64(p['value'].to_text)
+            end
           end
         end
       }

--- a/lib/html_sanitizer.rb
+++ b/lib/html_sanitizer.rb
@@ -1,0 +1,21 @@
+module HtmlSanitizer
+
+  module ClassMethods
+    def sanitize_html(str)
+      if str
+        stripped = ActionController::Base.helpers.strip_tags str
+        #ActionController's strip_tags doesn't unescape HTML, and CGI.unescape_html doesn't convert the space entity
+        CGI.unescape_html(stripped).gsub('&nbsp;', ' ')
+      end
+    end
+  end
+
+  def self.included(klass)
+    klass.extend ClassMethods
+  end
+
+  def sanitize_html(str)
+    self.class.sanitize_html(str)
+  end
+
+end

--- a/lib/proxies/feed_wrapper.rb
+++ b/lib/proxies/feed_wrapper.rb
@@ -67,6 +67,10 @@ class FeedWrapper
     Date.parse(self.to_text).in_time_zone.to_datetime rescue default
   end
 
+  def to_i(default=0)
+    @obj.try(:to_i) || default
+  end
+
   def to_text(default='')
     @obj.try(:to_s).try(:strip) || default
   end

--- a/lib/tasks/vcr.rake
+++ b/lib/tasks/vcr.rake
@@ -1,4 +1,5 @@
 require 'json'
+require 'rexml/document'
 
 namespace :vcr do
 
@@ -45,7 +46,9 @@ namespace :vcr do
             begin
               interaction["response"]["body"]["debug_json"] = JSON.parse(original_string)
             rescue JSON::ParserError
-              interaction["response"]["body"]["debug_xml"] = Nokogiri::XML(original_string).to_xml(:indent=>2)
+              xml_doc = REXML::Document.new original_string
+              interaction['response']['body']['debug_xml'] = ''
+              REXML::Formatters::Pretty.new.write(xml_doc, interaction['response']['body']['debug_xml'])
             end
             interaction["response"]["body"]["string"] = ""
           end

--- a/spec/models/my_badges/my_badges_spec.rb
+++ b/spec/models/my_badges/my_badges_spec.rb
@@ -107,6 +107,12 @@ describe "MyBadges" do
     end
   end
 
+  it 'should return no badges when not authenticated' do
+    allow(GoogleApps::Proxy).to receive(:access_granted?).and_return(false)
+    badges = MyBadges::Merged.new(@user_id).get_feed[:badges]
+    expect(badges).to be_blank
+  end
+
   it "should ignore non png icons for bdrive" do
     proxy = MyBadges::GoogleDrive.new(@user_id)
     icon_class_result = proxy.send(:process_icon, "http://www.google.com/lol_cat.gif")


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4841

With these changes, our code no longer uses Nokogiri for anything, but I'm not touching the Gemfile for the moment as other gems (Capybara, omniauth_cas) still have it as a dependency.