### PR TITLE
OEC-580, oec:diff should validate CCN, term, ldap, annotation

### DIFF
--- a/app/models/oec/courses_diff.rb
+++ b/app/models/oec/courses_diff.rb
@@ -134,12 +134,11 @@ module Oec
         errors << "INSTRUCTOR_FUNC is invalid: #{instructor_func}" unless (0..4).include? instructor_func.to_i
       end
 
-      errors_found = errors.length > 0
-      if errors_found
+      if errors.any?
         @errors_per_course_id[annotated_course_id] ||= []
         @errors_per_course_id[annotated_course_id].concat errors
       end
-      errors_found ? nil : id_hash
+      errors.any? ? nil : id_hash
     end
 
     def create_course_id_hash(annotated_course_id)

--- a/fixtures/oec/STAT_courses_confirmed.csv
+++ b/fixtures/oec/STAT_courses_confirmed.csv
@@ -2,6 +2,7 @@ COURSE_ID,COURSE_NAME,CROSS_LISTED_FLAG,CROSS_LISTED_NAME,DEPT_NAME,CATALOG_ID,I
 2015-B-666,Course 6,N,,STAT,6,LEC,002,P,,,,,,23,,,,,,,
 2015-B-55555_GSI,Course 5,N,,STAT,5,DIS,002,P,55,Joel,Five,joel@berkeley.edu,2,23,,,,,,,
 2015-B-44444_A,"Course 4",Y,,STAT,4,LEC,002,P,444,Jerome,Quatre,jerome@berkeley.edu,2,23,,,,,,,
+1999-E-BAD/CCN_X,"Course 2, edited",Y,,STAT,2,LEC,002,P,BAD/LDAP,Jim,Two,jim@berkeley.edu,5,23,,,,,,,
 2015-B-44444_B,Course 4,N,,STAT,4,LEC,001,P,44,Jonas,Doe,jonas@berkeley.edu,1,23,,,,,,,
 2015-B-33333,Course 3,Y,,STAT,3,LEC,001,P,33,Johnny,Tres,johnny@berkeley.edu,2,23,,,,,,,
 2015-B-2222,"Course 2, edited",Y,,STAT,2,LEC,002,P,22,Jim,Two,jim@berkeley.edu,1,23,,,,,,,

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -52,16 +52,16 @@ namespace :oec do
         File.delete courses_diff.output_filename
         summaries << "#{dept_name}: Confirmed CSV matches campus data. No diff to report."
       end
-      if courses_diff.errors_per_course_id.length > 0
+      if courses_diff.errors_per_course_id.any?
         errors_per_dept[dept_name] = courses_diff.errors_per_course_id
       end
     end
-    if confirmed_csv_hash.length > 0
+    if confirmed_csv_hash.any?
       Rails.logger.warn "#{hr}#{summaries.join("\n")}#{hr}"
     else
       Rails.logger.warn "#{hr}No files matching {DEPT}_courses_confirmed.csv were found in #{args.src_dir}#{hr}"
     end
-    if errors_per_dept.length > 0
+    if errors_per_dept.any?
       Rails.logger.warn hr
       Rails.logger.warn 'VALIDATION ERROR(S)'
       errors_per_dept.each do |dept_name, errors_per_course_id|

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -41,6 +41,7 @@ namespace :oec do
     courses = Oec::CoursesGroup.new(confirmed_csv_hash.keys, tmp_dir, debug_mode, debug_mode)
     # Do diff(s)
     summaries = []
+    errors_per_dept = {}
     confirmed_csv_hash.each do |dept_name, data_from_dept|
       campus_data = courses.campus_data_per_dept[dept_name]
       courses_diff = Oec::CoursesDiff.new(dept_name, campus_data, data_from_dept, args.dest_dir)
@@ -51,11 +52,28 @@ namespace :oec do
         File.delete courses_diff.output_filename
         summaries << "#{dept_name}: Confirmed CSV matches campus data. No diff to report."
       end
+      if courses_diff.errors_per_course_id.length > 0
+        errors_per_dept[dept_name] = courses_diff.errors_per_course_id
+      end
     end
-    if summaries.length > 0
+    if confirmed_csv_hash.length > 0
       Rails.logger.warn "#{hr}#{summaries.join("\n")}#{hr}"
     else
-      Rails.logger.warn "#{hr}Nonesuch 'confirmed' CSV files found in #{src_dir}#{hr}"
+      Rails.logger.warn "#{hr}No files matching {DEPT}_courses_confirmed.csv were found in #{args.src_dir}#{hr}"
+    end
+    if errors_per_dept.length > 0
+      Rails.logger.warn hr
+      Rails.logger.warn 'VALIDATION ERROR(S)'
+      errors_per_dept.each do |dept_name, errors_per_course_id|
+        Rails.logger.warn "#{dept_name}"
+        errors_per_course_id.each do |course_id, errors|
+          Rails.logger.warn "    #{course_id}"
+          errors.each do |error|
+            Rails.logger.warn "        #{error}"
+          end
+        end
+      end
+      Rails.logger.warn hr
     end
   end
 

--- a/spec/models/oec/courses_diff_spec.rb
+++ b/spec/models/oec/courses_diff_spec.rb
@@ -32,11 +32,14 @@ describe Oec::CoursesDiff do
         end
         diff = Oec::CoursesDiff.new(dept_name, campus_data_per_dept[dept_name], data_from_dept, 'tmp/oec')
         expect(diff.base_file_name).to include dept_name_path
-        # IO.read("#{src_dir}/expected_diff_#{dept_name_path}_courses.csv").should eq IO.read(diff.export[:filename])
         actual_diff = CSV.read diff.export[:filename]
         expected_diff = CSV.read "#{src_dir}/expected_diff_#{dept_name_path}_courses.csv"
         expect(expected_diff.length).to eq actual_diff.length
         expect(expected_diff.length > 0).to eq diff.was_difference_found
+        if dept_name == 'STAT'
+          # Bogus id in STAT_courses_confirmed.csv
+          expect(diff.errors_per_course_id['1999-E-BAD/CCN_X'].length).to eq 6
+        end
       end
     }
   end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-580

The oec:diff task will validate CCN, term, ldap, annotation and instructor_func.  Errors will not cause abort. Instead, all errors will be logged at end of rake task run.