### PR TITLE
CLC-4791: Selenium test for enrollment UIs

### DIFF
--- a/spec/ui_selenium/my_academics_data_enrollment_spec.rb
+++ b/spec/ui_selenium/my_academics_data_enrollment_spec.rb
@@ -1,0 +1,298 @@
+require 'spec_helper'
+require 'selenium-webdriver'
+require 'page-object'
+require 'csv'
+require 'json'
+require_relative 'util/web_driver_utils'
+require_relative 'util/user_utils'
+require_relative 'pages/cal_central_pages'
+require_relative 'pages/splash_page'
+require_relative 'pages/my_academics_semesters_card'
+require_relative 'pages/my_academics_enrollments_card'
+require_relative 'pages/my_academics_class_page'
+require_relative 'pages/api_my_status_page'
+require_relative 'pages/api_my_classes_page'
+require_relative 'pages/api_my_academics_page_semesters'
+
+describe 'My Academics enrollments', :testui => true do
+
+  if ENV["UI_TEST"]
+
+    include ClassLogger
+
+    begin
+
+      driver = WebDriverUtils.driver
+
+      test_users = UserUtils.load_test_users
+      test_output = UserUtils.initialize_output_csv(self)
+      testable_users = []
+
+      CSV.open(test_output, 'wb') do |user_info_csv|
+        user_info_csv << ['UID', 'Semester', 'CCN', 'Course Code', 'Course Title', 'Section', 'Grade Option', 'Units', 'Wait List Position']
+      end
+
+      test_users.each do |user|
+        if user['enrollments']
+          uid = user['uid'].to_s
+          logger.info("UID is #{uid}")
+
+          begin
+            splash_page = CalCentralPages::SplashPage.new(driver)
+            splash_page.load_page(driver)
+            splash_page.basic_auth(driver, uid)
+            status_api_page = ApiMyStatusPage.new(driver)
+            status_api_page.get_json(driver)
+            if status_api_page.has_student_history? && status_api_page.has_academics_tab?
+              testable_users.push(uid)
+              academics_api_page = ApiMyAcademicsPageSemesters.new(driver)
+              academics_api_page.get_json(driver)
+              all_semesters = academics_api_page.all_semesters
+              all_semester_names = academics_api_page.semester_names(all_semesters)
+              default_semester_names = academics_api_page.semester_names academics_api_page.default_semesters_in_ui
+
+              my_academics = CalCentralPages::MyAcademicsSemestersCard.new(driver)
+              my_academics.load_page(driver)
+              my_academics.page_heading_element.when_visible(timeout=WebDriverUtils.academics_timeout)
+
+              # MY ACADEMICS PAGE SEMESTER CARDS
+
+              shows_default_semesters = my_academics.student_terms_visible?(default_semester_names)
+              if all_semesters.any?
+                it "shows future, current, and most recent past semester by default for UID #{uid}" do
+                  expect(shows_default_semesters).to be true
+                end
+                show_more_button_visible = my_academics.show_more_element.visible?
+                if all_semester_names.length > default_semester_names.length
+                  it "offers a 'Show More' button for UID #{uid}" do
+                    expect(show_more_button_visible).to be true
+                  end
+                  my_academics.show_more
+                  shows_more_semesters = my_academics.student_terms_visible?(all_semester_names)
+                  it "can show all semesters for UID #{uid}" do
+                    expect(shows_more_semesters).to be true
+                  end
+                else
+                  it "offers no 'Show More' button for UID #{uid}" do
+                    expect(show_more_button_visible).to be false
+                  end
+                end
+
+                all_semesters.each do |semester|
+                  if my_academics.show_more_element.visible?
+                    my_academics.show_more
+                  end
+                  begin
+                    semester_name = academics_api_page.semester_name(semester)
+                    semester_courses = academics_api_page.semester_courses(semester)
+                    semester_card_courses = academics_api_page.courses_per_transcript(semester_courses)
+
+                    api_course_codes = academics_api_page.course_codes(semester_card_courses)
+                    api_course_titles = academics_api_page.course_titles(semester_card_courses)
+                    api_units = academics_api_page.units_per_transcript(semester_courses)
+                    api_grades = academics_api_page.grades(semester_courses, semester)
+
+                    academics_page_course_codes = my_academics.prim_sec_course_codes(driver, semester_name)
+                    academics_page_course_titles = my_academics.course_titles(driver, semester_name)
+                    academics_page_course_units = my_academics.units(driver, semester_name)
+                    academics_page_course_grades = my_academics.grades(driver, semester_name)
+
+                    it "shows the course codes for #{semester_name} for UID #{uid}" do
+                      expect(academics_page_course_codes).to eql(api_course_codes)
+                      expect(academics_page_course_codes.all? &:blank?).to be false
+                    end
+                    it "shows the course titles for #{semester_name} for UID #{uid}" do
+                      expect(academics_page_course_titles).to eql(api_course_titles)
+                      expect(academics_page_course_titles.all? &:blank?).to be false
+                    end
+                    it "shows the course units for #{semester_name} for UID #{uid}" do
+                      expect(academics_page_course_units).to eql(api_units)
+                      expect(academics_page_course_units.all? &:blank?).to be false
+                    end
+                    it "shows the grades for #{semester_name} for UID #{uid}" do
+                      expect(academics_page_course_grades).to eql(api_grades)
+                    end
+
+                    # SEMESTER PAGES
+
+                    my_academics.click_semester_link(driver, semester_name)
+                    semester_page = CalCentralPages::MyAcademicsPage::MyAcademicsEnrollmentsCard.new(driver)
+                    wait_list_courses = academics_api_page.wait_list_courses(semester_courses)
+                    enrolled_courses = (semester_courses - wait_list_courses)
+                    semester_page_enrolled_courses = academics_api_page.courses_per_prim_section(enrolled_courses)
+
+                    # ENROLLED COURSES
+
+                    api_enrolled_course_codes = academics_api_page.course_codes(semester_page_enrolled_courses)
+                    api_enrolled_course_titles = academics_api_page.course_titles(semester_page_enrolled_courses)
+                    api_enrolled_grade_options = academics_api_page.course_grade_options(enrolled_courses)
+                    api_enrolled_units = academics_api_page.units_per_prim_section(enrolled_courses)
+                    api_enrolled_section_labels = academics_api_page.all_section_labels(enrolled_courses)
+
+                    semester_page_codes = semester_page.all_enrolled_course_codes
+                    semester_page_titles = semester_page.all_enrolled_course_titles
+                    semester_page_grade_options = semester_page.all_enrolled_grade_options
+                    semester_page_units = semester_page.all_enrolled_units
+                    semester_page_sections = semester_page.all_enrolled_sections
+
+                    it "shows the enrolled course codes on the #{semester_name} semester page for UID #{uid}" do
+                      expect(semester_page_codes).to eql(api_enrolled_course_codes)
+                      expect(semester_page_codes.all? &:blank?).to be false
+                    end
+                    it "shows the enrolled course titles on the #{semester_name} semester page for UID #{uid}" do
+                      expect(semester_page_titles).to eql(api_enrolled_course_titles)
+                      expect(semester_page_titles.all? &:blank?).to be false
+                    end
+                    it "shows the enrolled course grade options on the #{semester_name} semester page for UID #{uid}" do
+                      expect(semester_page_grade_options).to eql(api_enrolled_grade_options)
+                      expect(semester_page_grade_options.all? &:blank?).to be false
+                    end
+                    it "shows the enrolled course units on the #{semester_name} semester page for UID #{uid}" do
+                      expect(semester_page_units).to eql(api_enrolled_units)
+                      expect(semester_page_units.all? &:blank?).to be false
+                    end
+                    it "shows the enrolled section labels on the #{semester_name} semester page for UID #{uid}" do
+                      expect(semester_page_sections).to eql(api_enrolled_section_labels)
+                      expect(semester_page_sections.all? &:blank?).to be false
+                    end
+
+                    # WAIT LIST COURSES
+
+                    if wait_list_courses.any?
+                      api_wait_list_course_codes = academics_api_page.wait_list_course_codes(wait_list_courses)
+                      api_wait_list_course_titles = academics_api_page.wait_list_course_titles(wait_list_courses)
+                      api_wait_list_sections = academics_api_page.all_section_labels(wait_list_courses)
+                      api_wait_list_positions = academics_api_page.wait_list_positions(wait_list_courses)
+                      api_wait_list_sizes = academics_api_page.enrollment_limits(wait_list_courses)
+
+                      sem_page_wait_list_codes = semester_page.all_waitlist_course_codes
+                      sem_page_wait_list_titles = semester_page.all_waitlist_course_titles
+                      sem_page_wait_list_sections = semester_page.all_waitlist_sections
+                      sem_page_wait_list_positions = semester_page.all_waitlist_positions
+                      sem_page_wait_list_sizes = semester_page.all_waitlist_class_sizes
+
+                      it "shows the wait list course codes on the #{semester_name} semester page for UID #{uid}" do
+                        expect(sem_page_wait_list_codes).to eql(api_wait_list_course_codes)
+                        expect(sem_page_wait_list_codes.all? &:blank?).to be false
+                      end
+                      it "shows the wait list course titles on the #{semester_name} semester page for UID #{uid}" do
+                        expect(sem_page_wait_list_titles).to eql(api_wait_list_course_titles)
+                        expect(sem_page_wait_list_titles.all? &:blank?).to be false
+                      end
+                      it "shows the wait list sections on the #{semester_name} semester page for UID #{uid}" do
+                        expect(sem_page_wait_list_sections).to eql(api_wait_list_sections)
+                        expect(sem_page_wait_list_sections.all? &:blank?).to be false
+                      end
+                      it "shows the wait list positions on the #{semester_name} semester page for UID #{uid}" do
+                        expect(sem_page_wait_list_positions).to eql(api_wait_list_positions)
+                        expect(sem_page_wait_list_positions.all? &:blank?).to be false
+                      end
+                      it "shows the wait list sizes on the #{semester_name} semester page for UID #{uid}" do
+                        expect(sem_page_wait_list_sizes).to eql(api_wait_list_sizes)
+                        expect(sem_page_wait_list_sizes.all? &:blank?).to be false
+                      end
+                    end
+
+                    # CLASS PAGES
+
+                    semester_courses.each do |course|
+                      begin
+                        api_course_code = academics_api_page.course_code(course)
+                        api_course_title = academics_api_page.course_title(course)
+                        api_course_instructors = academics_api_page.course_instructor_names(course)
+                        api_sections = academics_api_page.sections(course)
+                        api_section_labels = academics_api_page.section_labels(course)
+                        api_section_ccns = academics_api_page.section_ccns(course)
+                        api_section_units = academics_api_page.section_units(course)
+                        api_grade_options = academics_api_page.section_grade_options(course)
+                        api_section_schedules = academics_api_page.course_section_schedules(course)
+
+                        semester_page.click_class_link(driver, api_course_code)
+                        class_page = CalCentralPages::MyAcademicsClassPage.new(driver)
+                        class_page.class_info_heading_element.when_visible(WebDriverUtils.page_load_timeout)
+
+                        class_page_breadcrumb = class_page.class_breadcrumb
+                        class_page_course_title = class_page.course_title
+                        class_page_course_role = class_page.role
+                        class_page_section_labels = class_page.all_section_schedule_labels
+                        class_page_section_ccns = class_page.all_student_section_ccns
+                        class_page_section_units = class_page.all_section_units
+                        class_page_grade_options = class_page.all_section_grade_options
+                        class_page_section_schedules = class_page.all_section_schedules
+                        class_page_course_instructors = class_page.all_course_instructors(driver, api_section_labels)
+
+                        it "shows #{api_course_code} in the class page breadcrumb for #{semester_name} for UID #{uid}" do
+                          expect(class_page_breadcrumb).to eql(api_course_code)
+                        end
+                        it "shows the class title on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
+                          expect(class_page_course_title).to eql(api_course_title)
+                          expect(class_page_course_title.blank?).to be false
+                        end
+                        it "shows the student role on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
+                          expect(class_page_course_role).to eql('Student')
+                        end
+                        it "shows the enrolled section labels on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
+                          expect(class_page_section_labels).to eql(api_section_labels)
+                          expect(class_page_section_labels.all? &:blank?).to be false
+                        end
+                        it "shows the enrolled section CCNs on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
+                          expect(class_page_section_ccns).to eql(api_section_ccns)
+                          expect(class_page_section_ccns.all? &:blank?).to be false
+                        end
+                        it "shows the section units on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
+                          expect(class_page_section_units).to eql(api_section_units)
+                          expect(class_page_section_units.all? &:blank?).to be false
+                        end
+                        it "shows the section grade options on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
+                          expect(class_page_grade_options).to eql(api_grade_options)
+                          expect(class_page_grade_options.all? &:blank?).to be false
+                        end
+                        it "shows the section schedules on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
+                          expect(class_page_section_schedules).to eql(api_section_schedules)
+                        end
+                        it "shows the section instructors on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
+                          expect(class_page_course_instructors).to eql(api_course_instructors)
+                        end
+
+                        if academics_api_page.current_semester.include?(semester) || academics_api_page.future_semesters.include?(semester)
+                          api_sections.each do |section|
+                            i = api_sections.index(section)
+                            CSV.open(test_output, 'a+') do |user_info_csv|
+                              user_info_csv << [uid, semester_name, api_section_ccns[i], api_course_code, api_course_title, api_section_labels[i],
+                                                api_grade_options[i], api_section_units[i], academics_api_page.wait_list_position(section)]
+                            end
+                          end
+                        end
+
+                        class_page.back
+                      end
+                    end
+
+                    semester_page.back
+                  end
+                end
+              else
+                it "shows no semesters for UID #{uid}" do
+                  expect(shows_default_semesters).to be false
+                end
+              end
+            end
+
+          rescue => e
+            logger.error e.message + "\n" + e.backtrace.join("\n ")
+          end
+        end
+
+        it 'has enrollment information for at least one of the test UIDs' do
+          expect(testable_users.length).to be > 0
+        end
+      end
+
+    rescue => e
+      logger.error e.message + "\n" + e.backtrace.join("\n ")
+    ensure
+      logger.info('Quitting the browser')
+      driver.quit
+    end
+  end
+end

--- a/spec/ui_selenium/pages/api_my_academics_page.rb
+++ b/spec/ui_selenium/pages/api_my_academics_page.rb
@@ -149,7 +149,7 @@ class ApiMyAcademicsPage
     dates
   end
 
-# FINAL EXAMS
+  # FINAL EXAMS
 
   def exam_schedules
     @parsed['examSchedule']
@@ -200,7 +200,7 @@ class ApiMyAcademicsPage
     all_locations.sort
   end
 
-# TELE-BEARS
+  # TELE-BEARS
 
   def tele_bears
     @parsed['telebears']

--- a/spec/ui_selenium/pages/api_my_academics_page.rb
+++ b/spec/ui_selenium/pages/api_my_academics_page.rb
@@ -30,19 +30,22 @@ class ApiMyAcademicsPage
     time
   end
 
+  # STANDING
+
   def colleges_and_majors
     @parsed['collegeAndLevel']['colleges']
   end
 
   def colleges
     colleges = []
-    colleges_and_majors.each { |college| colleges.push(college['college'])}
+    colleges_and_majors.each { |college| colleges.push(college['college']) }
     colleges
   end
 
   def majors
     majors = []
     colleges_and_majors.each { |major| majors.push(major['major']) }
+    majors
   end
 
   def has_no_standing
@@ -146,7 +149,7 @@ class ApiMyAcademicsPage
     dates
   end
 
-  # FINAL EXAMS
+# FINAL EXAMS
 
   def exam_schedules
     @parsed['examSchedule']
@@ -197,7 +200,7 @@ class ApiMyAcademicsPage
     all_locations.sort
   end
 
-  # TELE-BEARS
+# TELE-BEARS
 
   def tele_bears
     @parsed['telebears']

--- a/spec/ui_selenium/pages/api_my_academics_page_semesters.rb
+++ b/spec/ui_selenium/pages/api_my_academics_page_semesters.rb
@@ -1,0 +1,317 @@
+require 'selenium-webdriver'
+require 'page-object'
+require_relative 'api_my_academics_page'
+require_relative '../util/web_driver_utils'
+
+class ApiMyAcademicsPageSemesters < ApiMyAcademicsPage
+
+  include PageObject
+  include ClassLogger
+
+  # SEMESTERS
+
+  def all_semesters
+    @parsed['semesters']
+  end
+
+  def semesters_in_time_bucket(time_bucket)
+    all_semesters.select { |semester| semester['timeBucket'] == time_bucket }
+  end
+
+  def past_semesters
+    semesters_in_time_bucket('past')
+  end
+
+  def current_semester
+    semesters_in_time_bucket('current')
+  end
+
+  def future_semesters
+    semesters_in_time_bucket('future')
+  end
+
+  def default_semesters_in_ui
+    default_semesters = future_semesters + current_semester
+    unless past_semesters.length == 0
+      default_semesters.push(past_semesters[0])
+    end
+    default_semesters
+  end
+
+  def semester_name(semester)
+    semester['name']
+  end
+
+  def semester_names(semesters)
+    names = []
+    semesters.each { |semester| names.push(semester_name(semester)) }
+    names
+  end
+
+  # COURSES
+
+  def semester_courses(semester)
+    semester['classes']
+  end
+
+  def course_code(course)
+    course['course_code']
+  end
+
+  def course_codes(courses)
+    codes = []
+    courses.each { |course| codes.push(course_code(course)) }
+    codes
+  end
+
+  def course_title(course)
+    (course['title'].gsub('  ', ' ')).strip
+  end
+
+  def course_titles(courses)
+    titles = []
+    courses.each { |course| titles.push(course_title(course)) }
+    titles
+  end
+
+  def course_transcript(course)
+    course['transcript']
+  end
+
+  def course_grade_options(courses)
+    options = []
+    courses.each { |course| options.concat(section_grade_options(course)) }
+    options
+  end
+
+  # Semester pages list enrolled courses once per primary section
+  def courses_per_prim_section(semester_courses)
+    courses = []
+    semester_courses.each do |course|
+      primary_sections(course).each { courses.push(course) }
+    end
+    courses
+  end
+
+  # Semester cards list courses once per transcript record (if record exists), otherwise once per primary section
+  def courses_per_transcript(semester_courses)
+    courses = []
+    semester_courses.each do |course|
+      if course_transcript(course).nil?
+        primary_sections(course).each { courses.push(course) }
+      else
+        course_transcript(course).each { courses.push(course) }
+      end
+    end
+    courses
+  end
+
+  def units_per_prim_section(courses)
+    units = []
+    courses.each do |course|
+      primary_sections(course).each { |section| units.push(section['units']) }
+    end
+    units
+  end
+
+  def units_per_transcript(courses)
+    units = []
+    courses.each do |course|
+      if course_transcript(course).nil?
+        primary_sections(course).each { |section| units.push(section['units']) }
+      else
+        course_transcript(course).each { |transcript| units.push(transcript['units']) }
+      end
+    end
+    units
+  end
+
+  def grades(courses, semester)
+    grades = []
+    courses.each do |course|
+      if past_semesters.include?(semester)
+        if course_transcript(course).nil?
+          primary_sections(course).each { | | grades.push('--') }
+        else
+          course_transcript(course).each do |transcript|
+            if transcript['grade'].nil?
+              grades.push('')
+            else
+              grades.push(transcript['grade'])
+            end
+          end
+        end
+      end
+    end
+    grades
+  end
+
+  # SECTIONS
+
+  def sections(course)
+    course['sections']
+  end
+
+  def primary_sections(course)
+    prim_sections = []
+    sections(course).each do |section|
+      if section['is_primary_section']
+        prim_sections.push(section)
+      end
+    end
+    prim_sections
+  end
+
+  def section_ccns(course)
+    ccns = []
+    sections(course).each { |section| ccns.push(section['ccn']) }
+    ccns
+  end
+
+  def section_units(course)
+    units = []
+    primary_sections(course).each { |section| units.push(section['units']) }
+    units
+  end
+
+  def section_labels(course)
+    labels = []
+    sections(course).each { |section| labels.push(section['section_label']) }
+    labels
+  end
+
+  def all_section_labels(courses)
+    labels = []
+    courses.each { |course| labels.concat(section_labels(course)) }
+    labels
+  end
+
+  def section_instruction_formats(course)
+    formats = []
+    sections(course).each { |section| formats.push(section['instruction_format']) }
+    formats
+  end
+
+  def section_schedules(section)
+    section['schedules']
+  end
+
+  def section_buildings(section)
+    buildings = []
+    section_schedules(section).each { |schedule| buildings.push(schedule['buildingName']) }
+    buildings
+  end
+
+  def section_rooms(section)
+    rooms = []
+    section_schedules(section).each { |schedule| rooms.push(schedule['roomNumber']) }
+    rooms
+  end
+
+  def section_times(section)
+    times = []
+    section_schedules(section).each { |schedule| times.push(schedule['schedule']) }
+    times
+  end
+
+  def course_section_schedules(course)
+    schedules = []
+    sections(course).each do |section|
+      section_schedules(section).each do |schedule|
+        index = section_schedules(section).index(schedule)
+        section_schedule = String.new
+        unless section_times(section)[index].nil? || section_times(section)[index].blank?
+          section_schedule.concat("#{section_times(section)[index]} ")
+        end
+        unless section_times(section)[index].nil? && section_buildings(section)[index].nil?
+          section_schedule.concat('| ')
+        end
+        unless section_rooms(section)[index].nil?
+          section_schedule.concat("#{section_rooms(section)[index].strip} ")
+        end
+        unless section_buildings(section)[index].nil?
+          section_schedule.concat("#{section_buildings(section)[index].strip}")
+        end
+        schedules.push(section_schedule)
+      end
+    end
+    schedules
+  end
+
+  def section_instructor_names(section)
+    names = []
+    section['instructors'].each { |instructor| names.push(instructor['name']) }
+    names
+  end
+
+  def course_instructor_names(course)
+    names = []
+    sections(course).each { |section| names.push(section_instructor_names(section)) }
+    names
+  end
+
+  def section_grade_options(course)
+    options = []
+    primary_sections(course).each { |section| options.push(section['gradeOption']) }
+    options
+  end
+
+  # WAIT LISTS
+
+  def wait_list_courses(semester_courses)
+    wait_lists = []
+    semester_courses.each do |course|
+      unless wait_list_sections(course).empty?
+        wait_lists.push(course)
+      end
+    end
+    wait_lists
+  end
+
+  def wait_list_sections(course)
+    wait_list_sections = []
+    sections(course).each do |section|
+      unless wait_list_position(section).nil?
+        wait_list_sections.push(section)
+      end
+    end
+    wait_list_sections
+  end
+
+  def wait_list_course_codes(wait_list_courses)
+    codes = []
+    wait_list_courses.each do |course|
+      wait_list_sections(course).each { codes.push(course_code(course)) }
+    end
+    codes
+  end
+
+  def wait_list_course_titles(wait_list_courses)
+    titles = []
+    wait_list_courses.each do |course|
+      wait_list_sections(course).each { titles.push(course_title(course)) }
+    end
+    titles
+  end
+
+  def wait_list_position(section)
+    section['waitlistPosition']
+  end
+
+  def wait_list_positions(wait_list_courses)
+    positions = []
+    wait_list_courses.each do |course|
+      sections(course).each { |section| positions.push(wait_list_position(section).to_s) }
+    end
+    positions
+  end
+
+  def enrollment_limits(wait_list_courses)
+    limits = []
+    wait_list_courses.each do |course|
+      sections(course).each { |section| limits.push(section['enroll_limit'].to_s) }
+    end
+    limits
+  end
+
+end

--- a/spec/ui_selenium/pages/api_my_status_page.rb
+++ b/spec/ui_selenium/pages/api_my_status_page.rb
@@ -20,6 +20,10 @@ class ApiMyStatusPage
     @parsed['roles']['student']
   end
 
+  def is_registered?
+    @parsed['roles']['registered']
+  end
+
   def is_ex_student?
     @parsed['roles']['exStudent']
   end
@@ -34,6 +38,14 @@ class ApiMyStatusPage
 
   def is_guest?
     @parsed['roles']['guest']
+  end
+
+  def is_concurrent_enroll_student?
+    @parsed['roles']['concurrentEnrollmentStudent']
+  end
+
+  def has_student_history?
+    @parsed['hasStudentHistory']
   end
 
   def has_academics_tab?

--- a/spec/ui_selenium/pages/my_academics_class_page.rb
+++ b/spec/ui_selenium/pages/my_academics_class_page.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+require 'selenium-webdriver'
+require 'page-object'
+require_relative 'cal_central_pages'
+require_relative 'my_academics_page'
+require_relative '../util/web_driver_utils'
+
+module CalCentralPages
+
+  class MyAcademicsClassPage < MyAcademicsPage
+
+    include PageObject
+    include CalCentralPages
+    include ClassLogger
+
+    span(:class_breadcrumb, :xpath => '//h1/span[@data-ng-bind="selectedCourse.course_code"]')
+
+    # CLASS INFO
+    h1(:class_info_heading, :xpath => '//h2[text()="Class information"]')
+    div(:course_title, :xpath => '//h3[text()="Class Title"]/following-sibling::div[@data-ng-bind="selectedCourse.title"]')
+    div(:role, :xpath => '//h3[text()="My Role"]/following-sibling::div[@data-ng-bind="selectedCourse.role"]')
+    elements(:student_section_label, :td, :xpath => '//h3[text()="My Enrollment"]/following-sibling::div[@data-ng-if="selectedCourse.sections.length && !isInstructorOrGsi"]//td[@data-ng-bind="sec.section_label"]')
+    elements(:student_section_ccn, :td, :xpath => '//h3[text()="My Enrollment"]/following-sibling::div[@data-ng-if="selectedCourse.sections.length && !isInstructorOrGsi"]//td[@data-ng-bind="sec.ccn"]')
+    elements(:section_units, :td, :xpath => '//h3[text()="Class Info"]/following-sibling::div[@data-ng-hide="isInstructorOrGsi"]//td[@data-ng-if="section.units"]')
+    elements(:section_grade_option, :td, :xpath => '//h4[text()="Course Offering"]/following-sibling::div[@data-ng-hide="isInstructorOrGsi"]//td[@data-ng-bind="section.gradeOption"]')
+    elements(:section_schedule_label, :div, :xpath => '//div[@data-ng-repeat="section in selectedCourse.sections"]/div[@data-ng-bind="section.section_label"]')
+    elements(:section_schedule, :div, :xpath => '//h4[text()="Section Schedules"]/following-sibling::div[@data-ng-repeat="section in selectedCourse.sections"]//div[@data-ng-repeat="schedule in section.schedules"]')
+    elements(:section_instructors_heading, :h3, :xpath => '//h3[@data-ng-bind="section.section_label"]')
+
+    def all_student_section_labels
+      labels = []
+      student_section_label_elements.each { |label| labels.push(label.text) }
+      labels
+    end
+
+    def all_student_section_ccns
+      ccns = []
+      student_section_ccn_elements.each { |ccn| ccns.push(ccn.text) }
+      ccns
+    end
+
+    def all_section_units
+      units = []
+      section_units_elements.each { |unit| units.push(unit.text) }
+      units
+    end
+
+    def all_section_grade_options
+      options = []
+      section_grade_option_elements.each { |option| options.push(option.text) }
+      options
+    end
+
+    def all_section_schedule_labels
+      labels = []
+      section_schedule_label_elements.each { |label| labels.push(label.text) }
+      labels
+    end
+
+    def all_section_schedules
+      schedules = []
+      section_schedule_elements.each { |schedule| schedules.push(schedule.text) }
+      schedules
+    end
+
+    def all_section_instructors(driver, section_label)
+      instructors = []
+      instructor_elements = driver.find_elements(:xpath => "//h3[text()='#{section_label}']/following-sibling::ul/li[@data-ng-repeat='instructor in section.instructors']/a")
+      instructor_elements.each { |instructor| instructors.push((instructor.text).gsub("\n- opens in new window", '')) }
+      instructors
+    end
+
+    def all_course_instructors(driver, sections)
+      instructors = []
+      sections.each do |section|
+        instructors.push(all_section_instructors(driver, section))
+      end
+      instructors
+    end
+  end
+end

--- a/spec/ui_selenium/pages/my_academics_enrollments_card.rb
+++ b/spec/ui_selenium/pages/my_academics_enrollments_card.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+require 'selenium-webdriver'
+require 'page-object'
+require_relative 'cal_central_pages'
+require_relative 'my_academics_page'
+require_relative '../util/web_driver_utils'
+
+module CalCentralPages
+
+  class MyAcademicsEnrollmentsCard < MyAcademicsPage
+
+    include PageObject
+    include CalCentralPages
+    include ClassLogger
+
+    elements(:enrolled_course_codes, :link, :xpath => '//tbody[@data-ng-repeat="course in enrolledCourses"]//a[@data-ng-bind="course.course_code"]')
+    elements(:enrolled_course_titles, :td, :xpath => '//tbody[@data-ng-repeat="course in enrolledCourses"]//td[@data-ng-bind="course.title"]')
+    elements(:enrolled_grade_options, :td, :xpath => '//tbody[@data-ng-repeat="course in enrolledCourses"]//td[@data-ng-bind="course.gradeOption"]')
+    elements(:enrolled_units, :td, :xpath => '//tbody[@data-ng-repeat="course in enrolledCourses"]//td[@data-ng-bind="course.units | number:1"]')
+    elements(:enrolled_sections, :span, :xpath => '//tbody[@data-ng-repeat="course in enrolledCourses"]//div[@data-ng-repeat="section in course.sections"]/span[@data-ng-bind="section.section_label"]')
+    elements(:waitlist_course_codes, :link, :xpath => '//h3[text()="Wait Lists"]/following-sibling::div//a[@data-ng-bind="course.course_code"]')
+    elements(:waitlist_sections, :span, :xpath => '//h3[text()="Wait Lists"]/following-sibling::div//span[@data-ng-bind="section.section_label"]')
+    elements(:waitlist_course_titles, :td, :xpath => '//h3[text()="Wait Lists"]/following-sibling::div//td[@data-ng-bind="course.title"]')
+    elements(:waitlist_positions, :td, :xpath => '//h3[text()="Wait Lists"]/following-sibling::div//strong[@data-ng-bind="section.waitlistPosition"]')
+    elements(:waitlist_class_size, :td, :xpath => '//h3[text()="Wait Lists"]/following-sibling::div//strong[@data-ng-bind="section.enroll_limit"]')
+
+    def all_enrolled_course_codes
+      codes = []
+      enrolled_course_codes_elements.each { |code| codes.push(code.text) }
+      codes
+    end
+
+    def all_enrolled_course_titles
+      titles = []
+      enrolled_course_titles_elements.each { |title| titles.push(title.text) }
+      titles
+    end
+
+    def all_enrolled_grade_options
+      options = []
+      enrolled_grade_options_elements.each { |option| options.push(option.text) }
+      options
+    end
+
+    def all_enrolled_units
+      units = []
+      enrolled_units_elements.each { |unit| units.push(unit.text)}
+      units
+    end
+
+    def all_enrolled_sections
+      sections = []
+      enrolled_sections_elements.each { |section| sections.push(section.text) }
+      sections
+    end
+
+    def all_waitlist_course_codes
+      codes = []
+      waitlist_course_codes_elements.each { |code| codes.push(code.text) }
+      codes
+    end
+
+    def all_waitlist_sections
+      sections = []
+      waitlist_sections_elements.each { |section| sections.push(section.text) }
+      sections
+    end
+
+    def all_waitlist_course_titles
+      titles = []
+      waitlist_course_titles_elements.each { |title| titles.push(title.text) }
+      titles
+    end
+
+    def all_waitlist_positions
+      positions = []
+      waitlist_positions_elements.each { |position| positions.push(position.text) }
+      positions
+    end
+
+    def all_waitlist_class_sizes
+      sizes = []
+      waitlist_class_size_elements.each { |size| sizes.push(size.text) }
+      sizes
+    end
+
+    def click_course_code(driver, code)
+      driver.find_element(:link_text => code).click
+    end
+  end
+end

--- a/spec/ui_selenium/pages/my_academics_page.rb
+++ b/spec/ui_selenium/pages/my_academics_page.rb
@@ -44,7 +44,15 @@ module CalCentralPages
 
     def click_semester_link(driver, semester)
       logger.info("Clicking link for #{semester}")
+      wait = Selenium::WebDriver::Wait.new(:timeout => WebDriverUtils.page_load_timeout)
+      wait.until { driver.find_element(:link_text => semester) }
       driver.find_element(:link_text => semester).click
+    end
+
+    def click_class_link(driver, course_code)
+      wait = Selenium::WebDriver::Wait.new(:timeout => WebDriverUtils.page_load_timeout)
+      wait.until { driver.find_element(:link_text => course_code) }
+      driver.find_element(:link_text => course_code).click
     end
   end
 end

--- a/spec/ui_selenium/pages/my_academics_semesters_card.rb
+++ b/spec/ui_selenium/pages/my_academics_semesters_card.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+require 'selenium-webdriver'
+require 'page-object'
+require_relative 'cal_central_pages'
+require_relative 'my_academics_page'
+require_relative '../util/web_driver_utils'
+
+module CalCentralPages
+
+  class MyAcademicsSemestersCard < MyAcademicsPage
+
+    include PageObject
+    include CalCentralPages
+    include ClassLogger
+
+    elements(:semester_links, :link, :xpath => '//h2[text()="Semesters"]/../following-sibling::div//a[@data-ng-bind="semester.name"]')
+    link(:order_transcripts_link, :xpath => '//h2[text()="Semesters"]/following-sibling::a[contains(.,"Order Transcripts")]')
+    button(:show_more, :xpath => '//button[@data-ng-if="pastSemestersCount > 1"]/span[text()="Show More"]')
+    button(:show_less, :xpath => '//button[@data-ng-if="pastSemestersCount > 1"]/span[text()="Show Less"]')
+
+    def student_terms_visible?(term_names)
+      links = []
+      semester_links_elements.each { |link| links.push(link.text) }
+      if links.sort == term_names.sort
+        true
+      else
+        false
+      end
+    end
+
+    def prim_sec_course_codes(driver, semester_name)
+      codes = []
+      code_elements = driver.find_elements(:xpath => "//h3[contains(.,'#{semester_name}')]/following-sibling::table//a[@data-ng-bind='class.course_code']")
+      code_elements.each { |element| codes.push(element.text) }
+      codes
+    end
+
+    def course_titles(driver, semester_name)
+      titles = []
+      title_elements = driver.find_elements(:xpath => "//h3[contains(.,'#{semester_name}')]/following-sibling::table//td[2]")
+      title_elements.each { |element| titles.push(element.text) }
+      titles
+    end
+
+    def units(driver, semester_name)
+      units = []
+      units_elements = driver.find_elements(:xpath => "//h3[contains(.,'#{semester_name}')]/following-sibling::table//td[3]")
+      units_elements.each { |element| units.push(element.text) }
+      units
+    end
+
+    def grades(driver, semester_name)
+      grades = []
+      grades_elements = driver.find_elements(:xpath => "//h3[contains(.,'#{semester_name}')]/following-sibling::table//td[4]")
+      grades_elements.each { |element| grades.push(element.text) }
+      grades
+    end
+  end
+end


### PR DESCRIPTION
This new spec covers the following student enrollment UIs:
* Semester cards on the My Academics page:
** The default semester cards shown
** The 'show more' feature
** The expected content of each semester card
* Semester page enrollment card for each semester
** The expected content for enrolled courses
** The expected content for wait listed courses
* Class page class info and instructor cards for each course

The test also produces a CSV containing enrollment info about the test UIDs in the current and future semester(s), for use in manual testing and for managing the test UIDs themselves.  The test takes a long time to run, so nightly builds will use UIDs sparingly.