### PR TITLE
OEC-586, report errors of oec:diff in final summary output by oec.rake

### DIFF
--- a/app/models/oec/biology_post_processor.rb
+++ b/app/models/oec/biology_post_processor.rb
@@ -66,7 +66,7 @@ module Oec
       dept_names.each do |dept_name|
         dept_uids = pre_existing_uid[dept_name]
         if dept_uids && dept_uids.include?(uid)
-          Rails.logger.warn "#{dept_name}.csv already has #{uid}"
+          Rails.logger.debug "Skip row #{uid} in BIOLOGY data-set because #{dept_name} has accounted for that course."
           return true
         end
       end

--- a/app/models/oec/courses_diff.rb
+++ b/app/models/oec/courses_diff.rb
@@ -35,7 +35,8 @@ module Oec
     end
 
     def append_records(output)
-      Rails.logger.warn "Diff the CSV confirmed by #{@dept_name} dept against latest campus data."
+      courses_csv_file = "#{@dept_name}_courses_confirmed.csv"
+      Rails.logger.info "Start diff on #{courses_csv_file}"
       @aligned_rows = []
       @data_from_dept.each do |data_from_dept_row|
         id_hash = create_id_hash data_from_dept_row
@@ -51,7 +52,7 @@ module Oec
             ignore_db_instructor = !@campus_data_hash[course_id][COLUMN_LDAP_UID].blank?
             output_diff(key_with_ldap_uid, @campus_data_hash[course_id], data_from_dept_row, output, ignore_db_instructor)
           else
-            Rails.logger.warn "No campus data found for #{course_id}"
+            report_errors(course_id, ["Campus-db has NO record for #{course_id} (ldap_uid=#{ldap_uid}) as found in #{courses_csv_file}"])
             output_diff(course_id, nil, data_from_dept_row, output)
           end
         end
@@ -59,13 +60,19 @@ module Oec
       @campus_data_hash.each do |key, db_record|
         unless @aligned_rows.any? { |aligned_row| aligned_row.start_with?(key) }
           # Ignore this campus_data_hash entry if key equals {course_id} and yet hash also includes {course_id}-{ldap_uid}
-          unless @campus_data_hash.has_key? "#{key}-#{db_record[COLUMN_LDAP_UID]}"
-            output_diff(db_record[COLUMN_COURSE_ID], db_record, nil, output)
-            Rails.logger.warn "dept_data does NOT contain course_id=#{key}"
+          ldap_uid = db_record[COLUMN_LDAP_UID]
+          unless @campus_data_hash.has_key? "#{key}-#{ldap_uid}"
+            course_id = db_record[COLUMN_COURSE_ID]
+            output_diff(course_id, db_record, nil, output)
+            report_errors(course_id, ["#{courses_csv_file} does NOT contain course_id=#{course_id} with ldap_uid=#{ldap_uid}"])
           end
         end
       end
+      Rails.logger.info "Diff file generated per #{courses_csv_file}" if @was_difference_found
+      Rails.logger.info "No diff to report on #{courses_csv_file}" unless @was_difference_found
     end
+
+    private
 
     def output_diff(key, db_record, dept_data, output, ignore_db_instructor = false)
       @aligned_rows << key
@@ -109,8 +116,6 @@ module Oec
       end
     end
 
-    private
-
     def create_id_hash(row)
       annotated_course_id = row[COLUMN_COURSE_ID]
       id_hash = create_course_id_hash annotated_course_id
@@ -134,11 +139,15 @@ module Oec
         errors << "INSTRUCTOR_FUNC is invalid: #{instructor_func}" unless (0..4).include? instructor_func.to_i
       end
 
-      if errors.any?
-        @errors_per_course_id[annotated_course_id] ||= []
-        @errors_per_course_id[annotated_course_id].concat errors
-      end
+      report_errors(annotated_course_id, errors)
       errors.any? ? nil : id_hash
+    end
+
+    def report_errors(course_id, errors = [])
+      if errors.any?
+        @errors_per_course_id[course_id] ||= []
+        @errors_per_course_id[course_id].concat errors
+      end
     end
 
     def create_course_id_hash(annotated_course_id)

--- a/app/models/oec/courses_diff.rb
+++ b/app/models/oec/courses_diff.rb
@@ -147,6 +147,7 @@ module Oec
       if errors.any?
         @errors_per_course_id[course_id] ||= []
         @errors_per_course_id[course_id].concat errors
+        Rails.logger.debug "Validation errors for #{@dept_name} per #{course_id}: #{errors.to_s}"
       end
     end
 

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -1,6 +1,7 @@
 namespace :oec do
 
-  hr = "\n" + '-------------------------------------------------------------' + "\n"
+  br = "\n"
+  hr = "#{br}-------------------------------------------------------------#{br}"
 
   desc 'Export courses.csv file'
   task :courses => :environment do
@@ -62,17 +63,17 @@ namespace :oec do
       Rails.logger.warn "#{hr}No files matching {DEPT}_courses_confirmed.csv were found in #{args.src_dir}#{hr}"
     end
     if errors_per_dept.any?
-      Rails.logger.warn 'VALIDATION ERROR(S)'
+      summary = "#{hr}VALIDATION ERROR(S)#{br}"
       errors_per_dept.each do |dept_name, errors_per_course_id|
-        Rails.logger.warn "#{dept_name}"
+        summary << "#{dept_name}#{br}"
         errors_per_course_id.each do |course_id, errors|
-          Rails.logger.warn "    #{course_id}"
+          summary << "    #{course_id}#{br}"
           errors.each do |error|
-            Rails.logger.warn "        #{error}"
+            summary << "        #{error}#{br}"
           end
         end
       end
-      Rails.logger.warn hr
+      Rails.logger.warn "#{br}#{summary}#{hr}"
     end
   end
 

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -62,7 +62,6 @@ namespace :oec do
       Rails.logger.warn "#{hr}No files matching {DEPT}_courses_confirmed.csv were found in #{args.src_dir}#{hr}"
     end
     if errors_per_dept.any?
-      Rails.logger.warn hr
       Rails.logger.warn 'VALIDATION ERROR(S)'
       errors_per_dept.each do |dept_name, errors_per_course_id|
         Rails.logger.warn "#{dept_name}"

--- a/spec/models/oec/courses_diff_spec.rb
+++ b/spec/models/oec/courses_diff_spec.rb
@@ -24,7 +24,6 @@ describe Oec::CoursesDiff do
 
     it {
       dept_names.each do |dept_name|
-        Rails.logger.info "Evaluating diff where dept_name = #{dept_name}"
         dept_name_path = dept_name.gsub(/\s/, '_')
         data_from_dept = []
         CSV.read("#{src_dir}/#{dept_name_path}_courses_confirmed.csv").each_with_index do |row, index|
@@ -37,8 +36,11 @@ describe Oec::CoursesDiff do
         expect(expected_diff.length).to eq actual_diff.length
         expect(expected_diff.length > 0).to eq diff.was_difference_found
         if dept_name == 'STAT'
-          # Bogus id in STAT_courses_confirmed.csv
-          expect(diff.errors_per_course_id['1999-E-BAD/CCN_X'].length).to eq 6
+          # Bogus ids in STAT_courses_confirmed.csv
+          expected_error_counts = { '2015-B-666' => 1, '2015-B-55555' => 1, '1999-E-BAD/CCN_X' => 6, '2015-B-111' => 1, '2015-B-33333' => 1 }
+          expected_error_counts.each do |course_id, error_count|
+            expect(diff.errors_per_course_id[course_id].length).to eq error_count
+          end
         end
       end
     }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-586

Sample errors reported of rake oec:diff
```ruby
> -----------------------------
>  VALIDATION ERROR(S)
>  PSYCH
>      2010-Z-73716
>          YEAR is invalid: 2010
>          TERM is invalid: Z
>          INSTRUCTOR_FUNC is invalid: 9
>      2015-B-73716
>          PSYCH_courses_confirmed.csv does NOT contain course_id=2015-B-73716 with ldap_uid=1037141
>  STAT
>      2019-S-XXXX
>          YEAR is invalid: 2019
>          TERM is invalid: S
>          CCN is invalid: XXXX
>          LDAP_UID is invalid: LDAP_UID
>          INSTRUCTOR_FUNC is invalid: 9
>      2015-B-GLOP
>          CCN is invalid: GLOP
>          INSTRUCTOR_FUNC is invalid: 10
> -----------------------------
```