### PR TITLE
OEC-580, info useful to Ops is put to final output of script

### DIFF
--- a/app/models/oec/courses_group.rb
+++ b/app/models/oec/courses_group.rb
@@ -33,7 +33,7 @@ module Oec
         File.delete csv_file unless keep_csv_files
         @campus_data_per_dept[dept_name] = campus_data
       end
-      Dir.delete @dest_dir unless keep_csv_files
+      Dir.delete @dest_dir if File.exist?(@dest_dir) && !keep_csv_files
     end
 
   end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-580

This is a follow up to resolved sub-tasks of OEC-580. When rake oec:diff is done the summary contain, in addition to errors, where the diff results can be found. For example:
```ruby
Summary
  STAT
    Diff report
      Created /Users/john/Projects/github/johncrossman/calcentral/tmp/oec/diff_STAT_courses.csv
    ... 
```