### PR TITLE
OEC-572, corrupt row data is reported but causes no crash

### DIFF
--- a/app/models/oec/command_line.rb
+++ b/app/models/oec/command_line.rb
@@ -11,7 +11,7 @@ module Oec
       @dest_dir = get_path_arg 'dest'
       @is_debug_mode = ENV['debug'].to_s =~ /true/i
       split = ENV['departments'].to_s.strip.upcase.split(/\s*,\s*/).reject { |s| s.nil? || s.empty? }
-      @departments = Oec::DepartmentRegistry.new(split.empty? ? Settings.oec.departments : split).to_a
+      @departments = split.empty? ? [] : Oec::DepartmentRegistry.new(split).to_a
     end
 
     private

--- a/app/models/oec/dept_confirmed_data.rb
+++ b/app/models/oec/dept_confirmed_data.rb
@@ -2,25 +2,39 @@ module Oec
   class DeptConfirmedData
 
     attr_reader :confirmed_data_per_dept
+    attr_reader :warnings_per_dept
 
     def initialize(src_dir, departments)
       @confirmed_data_per_dept = {}
+      @warnings_per_dept = {}
       csv_filename_suffix = '_courses_confirmed.csv'
       pattern = "#{src_dir}/*#{csv_filename_suffix}"
-      Rails.logger.debug "Find files matching #{pattern}"
+      csv_file_hash = {}
       Dir[pattern].each do |filename|
         dept_name = filename.split('/')[-1].chomp(csv_filename_suffix).gsub(/_/, ' ').upcase
-        Rails.logger.debug "Source directory contains #{filename} (owned by #{dept_name})"
-        if departments.include? dept_name
+        csv_file_hash[dept_name] = filename
+      end
+      (departments.empty? ? Settings.oec.departments : departments).each do |dept_name|
+        if csv_file_hash.has_key? dept_name
           corrected_data = []
+          filename = csv_file_hash[dept_name]
           CSV.read(filename).each_with_index do |row, index|
-            corrected_data << Oec::RowConverter.new(row).hashed_row if index > 0 && row.length > 0
+            if row.empty? || row[0].blank?
+              put_warning(dept_name, "#{dept_name}#{csv_filename_suffix} has corrupt or missing data at row #{index + 1}")
+            elsif index > 0
+              corrected_data << Oec::RowConverter.new(row).hashed_row
+            end
           end
           @confirmed_data_per_dept[dept_name] = corrected_data
-          departments.delete dept_name
+        elsif !departments.empty?
+          put_warning(dept_name, "The file #{dept_name}#{csv_filename_suffix} was not found in #{src_dir}")
         end
       end
-      Rails.logger.warn "Confirmed CSV file(s) NOT found for departments: #{departments.to_a}" if departments.length > 0
+    end
+
+    def put_warning(dept_name, message)
+      @warnings_per_dept[dept_name] ||= []
+      @warnings_per_dept[dept_name] << message
     end
 
   end

--- a/fixtures/oec/STAT_courses_confirmed.csv
+++ b/fixtures/oec/STAT_courses_confirmed.csv
@@ -3,6 +3,9 @@ COURSE_ID,COURSE_NAME,CROSS_LISTED_FLAG,CROSS_LISTED_NAME,DEPT_NAME,CATALOG_ID,I
 2015-B-55555_GSI,Course 5,N,,STAT,5,DIS,002,P,55,Joel,Five,joel@berkeley.edu,2,23,,,,,,,
 2015-B-44444_A,"Course 4",Y,,STAT,4,LEC,002,P,444,Jerome,Quatre,jerome@berkeley.edu,2,23,,,,,,,
 1999-E-BAD/CCN_X,"Course 2, edited",Y,,STAT,2,LEC,002,P,BAD/LDAP,Jim,Two,jim@berkeley.edu,5,23,,,,,,,
+
+,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,
 2015-B-44444_B,Course 4,N,,STAT,4,LEC,001,P,44,Jonas,Doe,jonas@berkeley.edu,1,23,,,,,,,
 2015-B-33333,Course 3,Y,,STAT,3,LEC,001,P,33,Johnny,Tres,johnny@berkeley.edu,2,23,,,,,,,
 2015-B-2222,"Course 2, edited",Y,,STAT,2,LEC,002,P,22,Jim,Two,jim@berkeley.edu,1,23,,,,,,,

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -33,7 +33,9 @@ namespace :oec do
   task :diff => :environment do
     args = Oec::CommandLine.new
     # Load CSVs edited by departments
-    confirmed_csv_hash = Oec::DeptConfirmedData.new(args.src_dir, args.departments).confirmed_data_per_dept
+    confirmed_data = Oec::DeptConfirmedData.new(args.src_dir, args.departments)
+    confirmed_csv_hash = confirmed_data.confirmed_data_per_dept
+    messages_per_dept = confirmed_data.warnings_per_dept
 
     # Query campus data and post-process BIOLOGY, if necessary.
     Rails.logger.warn "Perform diff operation on confirmed CSVs provided by: #{confirmed_csv_hash.keys.to_a}"
@@ -41,7 +43,6 @@ namespace :oec do
     debug_mode = args.is_debug_mode
     courses = Oec::CoursesGroup.new(confirmed_csv_hash.keys, tmp_dir, debug_mode, debug_mode)
     # Do diff(s)
-    messages_per_dept = {}
     confirmed_csv_hash.each do |dept_name, data_from_dept|
       campus_data = courses.campus_data_per_dept[dept_name]
       courses_diff = Oec::CoursesDiff.new(dept_name, campus_data, data_from_dept, args.dest_dir)

--- a/spec/models/oec/command_line_spec.rb
+++ b/spec/models/oec/command_line_spec.rb
@@ -39,7 +39,7 @@ describe Oec::CommandLine do
 
   it 'should pull all OEC departments when none specified' do
     ENV['departments'] = nil
-    Oec::CommandLine.new.departments.should match_array Settings.oec.departments
+    Oec::CommandLine.new.departments.should be_empty
   end
 
 end

--- a/spec/models/oec/courses_diff_spec.rb
+++ b/spec/models/oec/courses_diff_spec.rb
@@ -27,7 +27,8 @@ describe Oec::CoursesDiff do
         dept_name_path = dept_name.gsub(/\s/, '_')
         data_from_dept = []
         CSV.read("#{src_dir}/#{dept_name_path}_courses_confirmed.csv").each_with_index do |row, index|
-          data_from_dept << Oec::RowConverter.new(row).hashed_row if index > 0 && row.length > 0
+          row_with_deliberate_errors = row.length == 0 || row[0].blank?
+          data_from_dept << Oec::RowConverter.new(row).hashed_row if index > 0 && !row_with_deliberate_errors
         end
         diff = Oec::CoursesDiff.new(dept_name, campus_data_per_dept[dept_name], data_from_dept, 'tmp/oec')
         expect(diff.base_file_name).to include dept_name_path

--- a/spec/models/oec/dept_confirmed_data_spec.rb
+++ b/spec/models/oec/dept_confirmed_data_spec.rb
@@ -1,0 +1,25 @@
+describe Oec::DeptConfirmedData do
+
+  it 'should load all courses_confirmed.csv files when no departments specified' do
+    actual_csv_files = %w(BIOLOGY POL\ SCI STAT)
+    missing_csv_files = %w(FOO BAZ)
+    confirmed_data = Oec::DeptConfirmedData.new('fixtures/oec', actual_csv_files + missing_csv_files)
+    confirmed_data_hash = confirmed_data.confirmed_data_per_dept
+    confirmed_data_hash.keys.should match_array actual_csv_files
+    confirmed_data.warnings_per_dept.length.should eq 4
+    confirmed_data.warnings_per_dept['POL SCI'].length.should eq 2
+    confirmed_data.warnings_per_dept['STAT'].length.should eq 3
+  end
+
+  it 'should not load the STAT_courses_confirmed.csv because it was not requested' do
+    csv_files = %w(BIOLOGY POL\ SCI)
+    dept_set = Oec::DepartmentRegistry.new csv_files
+    confirmed_data = Oec::DeptConfirmedData.new('fixtures/oec', dept_set)
+    confirmed_data.confirmed_data_per_dept.keys.should match_array csv_files
+    # Expect report of missing MCELLBI and INTEGBI files because BIOLOGY was requested
+    confirmed_data.warnings_per_dept.length.should eq 3
+    confirmed_data.warnings_per_dept['POL SCI'].length.should eq 2
+  end
+
+end
+


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/OEC-585
https://jira.ets.berkeley.edu/jira/browse/OEC-572

We further the use of end-of-script summary. Reporting on CSVs requested but not found (per OEC-585) required a slight refactor of *dept_confirmed_data.rb*.  Specifically:
```
(departments.empty? ? Settings.oec.departments : departments).each do |dept_name|
```
I moved the logic of "if no departments specified then default to all Settings.oec.departments" out of command_line.rb. We can now report missing CSVs in case where **!departments.empty?**