### PR TITLE
CLC-4887 Give the big bCourses refresh scripts more heap to fall back on

### DIFF
--- a/script/refresh-all-canvas-enrollments.sh
+++ b/script/refresh-all-canvas-enrollments.sh
@@ -18,7 +18,7 @@ source .rvmrc
 export RAILS_ENV=production
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcext.enabled=true -J-client -X-C"
+export JRUBY_OPTS="-Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled -J-XX:MaxPermSize=512m -J-Xmx1024m"
 
 echo | $LOGIT
 echo "------------------------------------------" | $LOGIT

--- a/script/refresh-canvas-enrollments.sh
+++ b/script/refresh-canvas-enrollments.sh
@@ -18,7 +18,7 @@ source .rvmrc
 export RAILS_ENV=production
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled -J-XX:MaxPermSize=512m"
+export JRUBY_OPTS="-Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled -J-XX:MaxPermSize=512m -J-Xmx1024m"
 
 echo | $LOGIT
 echo "------------------------------------------" | $LOGIT


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4887

The default MaxHeapSize is about 310M, so a boost for these two consistently-growing scripts seems reasonable.