### PR TITLE
CLC-4448 Remove duplicate site listings under repeated courses in My Classes

### DIFF
--- a/app/models/my_classes/classes_module.rb
+++ b/app/models/my_classes/classes_module.rb
@@ -32,7 +32,7 @@ module MyClasses::ClassesModule
           siteType: 'course',
           term_cd: term_cd,
           term_yr: term_yr,
-          courses: linked_campus
+          courses: linked_campus.uniq
         }
       )
     else

--- a/src/assets/javascripts/angular/factories/myClassesFactory.js
+++ b/src/assets/javascripts/angular/factories/myClassesFactory.js
@@ -11,10 +11,11 @@
       for (var j = 0; j < classesHash.otherClasses.length; j++) {
         for (var k = 0; k < classesHash.otherClasses[j].courses.length; k++) {
           var course = classesHash.otherClasses[j].courses[k];
-          if (!classesHash.campusClassesById[course.id].subclasses) {
-            classesHash.campusClassesById[course.id].subclasses = [];
+          for (var l = 0; l < classesHash.campusClassesById[course.id].length; l++) {
+            var campusClass = classesHash.campusClassesById[course.id][l];
+            campusClass.subclasses = campusClass.subclasses || [];
+            campusClass.subclasses.push(classesHash.otherClasses[j]);
           }
-          classesHash.campusClassesById[course.id].subclasses.push(classesHash.otherClasses[j]);
         }
       }
       return classesHash;
@@ -28,7 +29,9 @@
         if (classes[i].emitter === 'Campus') {
           campusClasses.push(classes[i]);
           for (var j = 0; j < classes[i].listings.length; j++) {
-            campusClassesById[classes[i].listings[j].id] = classes[i];
+            var listing = classes[i].listings[j];
+            campusClassesById[listing.id] = campusClassesById[listing.id] || [];
+            campusClassesById[listing.id].push(classes[i]);
           }
         } else {
           otherClasses.push(classes[i]);


### PR DESCRIPTION
Fixes duplicate repeater error and hidden bCourses sites in https://jira.ets.berkeley.edu/jira/browse/CLC-4448.

The back-end change ensures that bCourses site data in the MyClasses feed does not include duplicate links to campus courses.

The front-end change ensures that even if a campus course appears multiple times in the feed, all entries will be correctly associated with course sites. This matching logic is getting a little unwieldy, and at some point it might be a good idea to move it to the back end.