### PR TITLE
Adviser Picture now on Academics Page

### DIFF
--- a/src/assets/templates/academics_ls_advising.html
+++ b/src/assets/templates/academics_ls_advising.html
@@ -10,6 +10,9 @@
       </p>
       <div data-ng-if="caseloadAdviser">
         <h3 class="cc-widget-lsadvising-heading-first">College Advisor</h3>
+        <div data-ng-if="caseloadAdviser.photoUrl" class="cc-widget-profile-picture">
+          <img data-cc-image-loaded-directive="profilePictureLoading" alt="{{caseloadAdviser.firstName + ' ' + caseloadAdviser.lastName}}'s Profile Picture" data-ng-src="{{caseloadAdviser.photoUrl}}" width="72" height="96">
+        </div>
         <a data-ng-href="mailto:{{caseloadAdviser.email}}">
           <span data-ng-bind-template="{{caseloadAdviser.firstName + ' ' + caseloadAdviser.lastName}}"></span>
         </a>


### PR DESCRIPTION
CLC-4641 - Integrate advisor picture into the L&S Advising card

https://jira.ets.berkeley.edu/jira/browse/CLC-4641

Advisers that don't have photos only have their names' displayed