### PR TITLE
CLC-4959: Selenium test for webcast UI

### DIFF
--- a/spec/ui_selenium/my_academics_data_webcasts_spec.rb
+++ b/spec/ui_selenium/my_academics_data_webcasts_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper'
+require 'selenium-webdriver'
+require 'page-object'
+require 'csv'
+require 'json'
+require_relative 'util/web_driver_utils'
+require_relative 'util/user_utils'
+require_relative 'pages/cal_central_pages'
+require_relative 'pages/splash_page'
+require_relative 'pages/my_academics_class_page'
+
+describe 'My Academics webcasts card', :testui => true do
+
+  if ENV["UI_TEST"]
+
+    include ClassLogger
+
+    begin
+
+      driver = WebDriverUtils.driver
+
+      test_users = UserUtils.load_test_users
+      test_users.each do |user|
+        unless user['webcast'].nil?
+          uid = user['uid'].to_s
+          logger.info("UID is #{uid}")
+          class_page = user['webcast']['classPagePath']
+          lecture_count = user['webcast']['lectures']
+          you_tube_video_id = user['webcast']['video']
+          audio_url = user['webcast']['audio']
+
+          begin
+            splash_page = CalCentralPages::SplashPage.new(driver)
+            splash_page.load_page(driver)
+            splash_page.basic_auth(driver, uid)
+            my_academics = CalCentralPages::MyAcademicsClassPage.new(driver)
+            my_academics.load_class_page(driver, class_page)
+
+            if !you_tube_video_id.nil?
+              my_academics.video_thumbnail_element.when_present(timeout=WebDriverUtils.academics_timeout)
+              has_right_default_tab = my_academics.video_thumbnail_element.visible?
+              it "shows the video tab by default for UID #{uid}" do
+                expect(has_right_default_tab).to be true
+              end
+            elsif you_tube_video_id.nil? && !audio_url.nil?
+              my_academics.audio_source_element.when_present(timeout=WebDriverUtils.academics_timeout)
+              has_right_default_tab = my_academics.audio_element.visible?
+              it "shows the audio tab by default for UID #{uid}" do
+                expect(has_right_default_tab).to be true
+              end
+            end
+
+            unless you_tube_video_id.nil?
+              my_academics.video_tab_element.when_present(timeout=WebDriverUtils.page_event_timeout)
+              my_academics.video_tab
+              all_visible_video_lectures = my_academics.video_select_element.options.length
+              thumbnail_present = my_academics.video_thumbnail_element.attribute('src').include? you_tube_video_id
+              auto_play = my_academics.you_tube_video_auto_plays?(driver)
+              it "shows all the available lecture videos for UID #{uid}" do
+                expect(all_visible_video_lectures).to eql(lecture_count)
+              end
+              it "shows the right video thumbnail for UID #{uid}" do
+                expect(thumbnail_present).to be true
+              end
+              it "plays the video automatically when clicked for UID #{uid}" do
+                expect(auto_play).to be true
+              end
+            end
+
+            unless audio_url.nil?
+              my_academics.audio_tab_element.when_present(timeout=WebDriverUtils.page_event_timeout)
+              my_academics.audio_tab
+              all_visible_audio_lectures = my_academics.audio_select_element.options.length
+              audio_player_present = my_academics.audio_source_element.attribute('src').include? audio_url
+              it "shows all the available lecture audio recordings for UID #{uid}" do
+                expect(all_visible_audio_lectures).to eql(lecture_count)
+              end
+              it "shows the right audio player content for UID #{uid}" do
+                expect(audio_player_present).to be true
+              end
+            end
+
+            if you_tube_video_id.nil? && !audio_url.nil?
+              my_academics.video_tab
+              has_no_video_message = my_academics.no_video_msg?
+              it "shows a 'no video' message for UID #{uid}" do
+                expect(has_no_video_message).to be true
+              end
+            end
+            if !you_tube_video_id.nil? && audio_url.nil?
+              my_academics.audio_tab
+              has_no_audio_message = my_academics.no_audio_msg?
+              it "shows a 'no audio' message for UID #{uid}" do
+                expect(has_no_audio_message).to be true
+              end
+            end
+            if you_tube_video_id.nil? && audio_url.nil?
+              has_no_webcast_message = my_academics.no_webcast_msg?
+              it "shows a 'no webcasts' message for UID #{uid}" do
+                expect(has_no_webcast_message).to be true
+              end
+            end
+
+          end
+        end
+      end
+    rescue => e
+      logger.error e.message + "\n" + e.backtrace.join("\n ")
+    ensure
+      logger.info('Quitting the browser')
+      driver.quit
+    end
+  end
+end

--- a/spec/ui_selenium/my_academics_data_webcasts_spec.rb
+++ b/spec/ui_selenium/my_academics_data_webcasts_spec.rb
@@ -39,16 +39,37 @@ describe 'My Academics webcasts card', :testui => true do
             my_academics.wait_for_webcasts
             testable_users.push(uid)
 
-            if !you_tube_video_id.nil?
+            if you_tube_video_id.nil? && !audio_url.nil?
+              my_academics.audio_source_element.when_present(timeout=WebDriverUtils.academics_timeout)
+              has_right_default_tab = my_academics.audio_element.visible?
+              it "shows the audio tab by default for UID #{uid}" do
+                expect(has_right_default_tab).to be true
+              end
+              my_academics.video_tab
+              has_no_video_message = my_academics.no_video_msg?
+              it "shows a 'no video' message for UID #{uid}" do
+                expect(has_no_video_message).to be true
+              end
+            elsif you_tube_video_id.nil? && audio_url.nil?
+              has_no_webcast_message = my_academics.no_webcast_msg?
+              it "shows a 'no webcasts' message for UID #{uid}" do
+                expect(has_no_webcast_message).to be true
+              end
+            elsif audio_url.nil? && !you_tube_video_id.nil?
               my_academics.video_thumbnail_element.when_present(timeout=WebDriverUtils.academics_timeout)
               has_right_default_tab = my_academics.video_thumbnail_element.visible?
               it "shows the video tab by default for UID #{uid}" do
                 expect(has_right_default_tab).to be true
               end
-            elsif you_tube_video_id.nil? && !audio_url.nil?
-              my_academics.audio_source_element.when_present(timeout=WebDriverUtils.academics_timeout)
-              has_right_default_tab = my_academics.audio_element.visible?
-              it "shows the audio tab by default for UID #{uid}" do
+              my_academics.audio_tab
+              has_no_audio_message = my_academics.no_audio_msg?
+              it "shows a 'no audio' message for UID #{uid}" do
+                expect(has_no_audio_message).to be true
+              end
+            else
+              my_academics.video_thumbnail_element.when_present(timeout=WebDriverUtils.academics_timeout)
+              has_right_default_tab = my_academics.video_thumbnail_element.visible?
+              it "shows the video tab by default for UID #{uid}" do
                 expect(has_right_default_tab).to be true
               end
             end
@@ -83,26 +104,6 @@ describe 'My Academics webcasts card', :testui => true do
               end
             end
 
-            if you_tube_video_id.nil? && !audio_url.nil?
-              my_academics.video_tab
-              has_no_video_message = my_academics.no_video_msg?
-              it "shows a 'no video' message for UID #{uid}" do
-                expect(has_no_video_message).to be true
-              end
-            end
-            if !you_tube_video_id.nil? && audio_url.nil?
-              my_academics.audio_tab
-              has_no_audio_message = my_academics.no_audio_msg?
-              it "shows a 'no audio' message for UID #{uid}" do
-                expect(has_no_audio_message).to be true
-              end
-            end
-            if you_tube_video_id.nil? && audio_url.nil?
-              has_no_webcast_message = my_academics.no_webcast_msg?
-              it "shows a 'no webcasts' message for UID #{uid}" do
-                expect(has_no_webcast_message).to be true
-              end
-            end
           rescue => e
             logger.error e.message + "\n" + e.backtrace.join("\n ")
           end

--- a/spec/ui_selenium/my_academics_data_webcasts_spec.rb
+++ b/spec/ui_selenium/my_academics_data_webcasts_spec.rb
@@ -25,10 +25,14 @@ describe 'My Academics webcasts card', :testui => true do
         unless user['webcast'].nil?
           uid = user['uid'].to_s
           logger.info("UID is #{uid}")
+          course = user['webcast']['course']
           class_page = user['webcast']['classPagePath']
           lecture_count = user['webcast']['lectures']
-          you_tube_video_id = user['webcast']['video']
+          video_you_tube_id = user['webcast']['video']
+          video_itunes = user['webcast']['itunesVideo']
           audio_url = user['webcast']['audio']
+          audio_download = user['webcast']['audioDownload']
+          audio_itunes = user['webcast']['itunesAudio']
 
           begin
             splash_page = CalCentralPages::SplashPage.new(driver)
@@ -39,7 +43,7 @@ describe 'My Academics webcasts card', :testui => true do
             my_academics.wait_for_webcasts
             testable_users.push(uid)
 
-            if you_tube_video_id.nil? && !audio_url.nil?
+            if video_you_tube_id.nil? && !audio_url.nil?
               my_academics.audio_source_element.when_present(timeout=WebDriverUtils.academics_timeout)
               has_right_default_tab = my_academics.audio_element.visible?
               it "shows the audio tab by default for UID #{uid}" do
@@ -50,12 +54,12 @@ describe 'My Academics webcasts card', :testui => true do
               it "shows a 'no video' message for UID #{uid}" do
                 expect(has_no_video_message).to be true
               end
-            elsif you_tube_video_id.nil? && audio_url.nil?
+            elsif video_you_tube_id.nil? && audio_url.nil?
               has_no_webcast_message = my_academics.no_webcast_msg?
               it "shows a 'no webcasts' message for UID #{uid}" do
                 expect(has_no_webcast_message).to be true
               end
-            elsif audio_url.nil? && !you_tube_video_id.nil?
+            elsif audio_url.nil? && !video_you_tube_id.nil?
               my_academics.video_thumbnail_element.when_present(timeout=WebDriverUtils.academics_timeout)
               has_right_default_tab = my_academics.video_thumbnail_element.visible?
               it "shows the video tab by default for UID #{uid}" do
@@ -74,11 +78,11 @@ describe 'My Academics webcasts card', :testui => true do
               end
             end
 
-            unless you_tube_video_id.nil?
+            unless video_you_tube_id.nil?
               my_academics.video_tab_element.when_present(timeout=WebDriverUtils.page_event_timeout)
               my_academics.video_tab
               all_visible_video_lectures = my_academics.video_select_element.options.length
-              thumbnail_present = my_academics.video_thumbnail_element.attribute('src').include? you_tube_video_id
+              thumbnail_present = my_academics.video_thumbnail_element.attribute('src').include? video_you_tube_id
               auto_play = my_academics.you_tube_video_auto_plays?(driver)
               it "shows all the available lecture videos for UID #{uid}" do
                 expect(all_visible_video_lectures).to eql(lecture_count)
@@ -88,6 +92,12 @@ describe 'My Academics webcasts card', :testui => true do
               end
               it "plays the video automatically when clicked for UID #{uid}" do
                 expect(auto_play).to be true
+              end
+              unless video_itunes.nil?
+                itunes_video_link_present = WebDriverUtils.verify_external_link(driver, my_academics.itunes_video_link_element, "#{course} - Download free content from UC Berkeley on iTunes")
+                it "shows an iTunes video URL for UID #{uid}" do
+                  expect(itunes_video_link_present).to be true
+                end
               end
             end
 
@@ -101,6 +111,18 @@ describe 'My Academics webcasts card', :testui => true do
               end
               it "shows the right audio player content for UID #{uid}" do
                 expect(audio_player_present).to be true
+              end
+              unless audio_download.nil?
+                audio_download_link_present = my_academics.audio_download_link_element.attribute('href').eql? audio_download
+                it "shows an audio download link for UID #{uid}" do
+                  expect(audio_download_link_present).to be true
+                end
+              end
+              unless audio_itunes.nil?
+                itunes_audio_link_present = WebDriverUtils.verify_external_link(driver, my_academics.itunes_audio_link_element, "#{course} - Download free content from UC Berkeley on iTunes")
+                it "shows an iTunes audio URL for UID #{uid}" do
+                  expect(itunes_audio_link_present).to be true
+                end
               end
             end
 

--- a/spec/ui_selenium/my_academics_data_webcasts_spec.rb
+++ b/spec/ui_selenium/my_academics_data_webcasts_spec.rb
@@ -20,6 +20,7 @@ describe 'My Academics webcasts card', :testui => true do
       driver = WebDriverUtils.driver
 
       test_users = UserUtils.load_test_users
+      testable_users = []
       test_users.each do |user|
         unless user['webcast'].nil?
           uid = user['uid'].to_s
@@ -35,6 +36,8 @@ describe 'My Academics webcasts card', :testui => true do
             splash_page.basic_auth(driver, uid)
             my_academics = CalCentralPages::MyAcademicsClassPage.new(driver)
             my_academics.load_class_page(driver, class_page)
+            my_academics.wait_for_webcasts
+            testable_users.push(uid)
 
             if !you_tube_video_id.nil?
               my_academics.video_thumbnail_element.when_present(timeout=WebDriverUtils.academics_timeout)
@@ -100,9 +103,13 @@ describe 'My Academics webcasts card', :testui => true do
                 expect(has_no_webcast_message).to be true
               end
             end
-
+          rescue => e
+            logger.error e.message + "\n" + e.backtrace.join("\n ")
           end
         end
+      end
+      it 'has a webcast UI for at least one of the test users' do
+        expect(testable_users.length).to be > 0
       end
     rescue => e
       logger.error e.message + "\n" + e.backtrace.join("\n ")

--- a/spec/ui_selenium/pages/my_academics_class_page.rb
+++ b/spec/ui_selenium/pages/my_academics_class_page.rb
@@ -27,6 +27,21 @@ module CalCentralPages
     elements(:section_schedule, :div, :xpath => '//h4[text()="Section Schedules"]/following-sibling::div[@data-ng-repeat="section in selectedCourse.sections"]//div[@data-ng-repeat="schedule in section.schedules"]')
     elements(:section_instructors_heading, :h3, :xpath => '//h3[@data-ng-bind="section.section_label"]')
 
+    # WEBCAST
+    h2(:webcast_heading, :xpath => '//h2[text()="Webcasts"]')
+    div(:webcast_spinner, :xpath => '//h2[contains(text(),"Webcasts")]/../following-sibling::div/div[@class="cc-spinner"]')
+    button(:video_tab, :xpath => '//button[text()="Video"]')
+    div(:no_video_msg, :xpath => '//div[contains(.,"No video content available.")]')
+    select(:video_select, :xpath => '//select[@data-ng-model="selectedVideo"]')
+    button(:video_thumbnail, :xpath => '//button[@id="cc-youtube-image-placeholder"]/img')
+    element(:video_iframe, 'iframe')
+    button(:audio_tab, :xpath => '//button[text()="Audio"]')
+    div(:no_audio_msg, :xpath => '//div[contains(.,"No audio content available.")]')
+    select(:audio_select, :xpath => '//select[@data-ng-model="selectedAudio"]')
+    audio(:audio, :xpath => '//audio')
+    audio(:audio_source, :xpath => '//audio/source')
+    div(:no_webcast_msg, :xpath => '//div[contains(.,"There are no webcasts available.")]')
+
     def all_student_section_labels
       labels = []
       student_section_label_elements.each { |label| labels.push(label.text) }
@@ -76,6 +91,15 @@ module CalCentralPages
         instructors.push(all_section_instructors(driver, section))
       end
       instructors
+    end
+
+    def you_tube_video_auto_plays?(driver)
+      video_thumbnail_element.click
+      wait_until(timeout=WebDriverUtils.page_event_timeout) { driver.find_element(:xpath, '//iframe') }
+      driver.switch_to.frame driver.find_element(:xpath, '//iframe')
+      auto_play = driver.find_element(:xpath, '//div[@class="ytp-button ytp-button-pause"]').displayed?
+      driver.switch_to.default_content
+      auto_play
     end
   end
 end

--- a/spec/ui_selenium/pages/my_academics_class_page.rb
+++ b/spec/ui_selenium/pages/my_academics_class_page.rb
@@ -29,7 +29,7 @@ module CalCentralPages
 
     # WEBCAST
     h2(:webcast_heading, :xpath => '//h2[text()="Webcasts"]')
-    div(:webcast_spinner, :xpath => '//h2[contains(text(),"Webcasts")]/../following-sibling::div/div[@class="cc-spinner"]')
+    div(:webcast_spinner_gone, :xpath => '//div[@class="cc-widget-padding cc-widget-webcast-content"]/div[@data-cc-spinner-directive=""]')
     button(:video_tab, :xpath => '//button[text()="Video"]')
     div(:no_video_msg, :xpath => '//div[contains(.,"No video content available.")]')
     select(:video_select, :xpath => '//select[@data-ng-model="selectedVideo"]')
@@ -91,6 +91,11 @@ module CalCentralPages
         instructors.push(all_section_instructors(driver, section))
       end
       instructors
+    end
+
+    def wait_for_webcasts
+      webcast_heading_element.when_present(WebDriverUtils.page_load_timeout)
+      webcast_spinner_gone_element.when_present(WebDriverUtils.page_load_timeout)
     end
 
     def you_tube_video_auto_plays?(driver)

--- a/spec/ui_selenium/pages/my_academics_class_page.rb
+++ b/spec/ui_selenium/pages/my_academics_class_page.rb
@@ -35,11 +35,14 @@ module CalCentralPages
     select(:video_select, :xpath => '//select[@data-ng-model="selectedVideo"]')
     button(:video_thumbnail, :xpath => '//button[@id="cc-youtube-image-placeholder"]/img')
     element(:video_iframe, 'iframe')
+    link(:itunes_video_link, :xpath => '//li[@class="cc-widget-webcast-itunes-link"]/a')
     button(:audio_tab, :xpath => '//button[text()="Audio"]')
     div(:no_audio_msg, :xpath => '//div[contains(.,"No audio content available.")]')
     select(:audio_select, :xpath => '//select[@data-ng-model="selectedAudio"]')
     audio(:audio, :xpath => '//audio')
     audio(:audio_source, :xpath => '//audio/source')
+    link(:audio_download_link, :xpath => '//li[@data-ng-if="selectedAudio.downloadUrl"]/a')
+    link(:itunes_audio_link, :xpath => '//li[@data-ng-if="itunes.audio"]/a')
     div(:no_webcast_msg, :xpath => '//div[contains(.,"There are no webcasts available.")]')
 
     def all_student_section_labels
@@ -102,6 +105,7 @@ module CalCentralPages
       video_thumbnail_element.click
       wait_until(timeout=WebDriverUtils.page_event_timeout) { driver.find_element(:xpath, '//iframe') }
       driver.switch_to.frame driver.find_element(:xpath, '//iframe')
+      wait_until(timeout=WebDriverUtils.page_event_timeout) { driver.find_element(:xpath, '//div[@class="html5-player-chrome"]') }
       auto_play = driver.find_element(:xpath, '//div[@class="ytp-button ytp-button-pause"]').displayed?
       driver.switch_to.default_content
       auto_play


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4959

This is a data-driven test for the various permutations of webcast UI.  The expected webcast content will be in the external test user file.  The test checks for the following variations:
* has webcasts or not
* has video or not
* has audio or not
* has valid iTunes links or not
* has valid audio download links or not
* if has video, then loads and auto-plays upon click
* has all expected lectures