### PR TITLE
CLC-4909 Add Regstatus API as a new proxy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,6 +145,8 @@ group :development, :test , :testext do
   # Spork can speed up multiple test runs.
   gem 'spork', :git => 'https://github.com/sporkrb/spork.git'
   gem 'spork-rails', '~> 4.0.0'
+
+  gem 'webmock', '~> 1.20.4'
 end
 
 group :development do
@@ -162,8 +164,6 @@ group :test, :testext do
   # RSpec results that Hudson + Bamboo + xml happy CI servers can read. See https://rubygems.org/gems/rspec_junit_formatter
   # TODO: Use gem 'rspec_junit_formatter', '~> 0.2.x' when deprecated concern of CLC-3565 is resolved.
   gem 'rspec_junit_formatter', :git => 'https://github.com/sj26/rspec_junit_formatter.git'
-
-  gem 'webmock', '~> 1.20.4'
 end
 
 group :shell_debug do

--- a/app/models/regstatus/proxy.rb
+++ b/app/models/regstatus/proxy.rb
@@ -1,0 +1,68 @@
+module Regstatus
+  class Proxy < BaseProxy
+
+    include ClassLogger
+    include Cache::UserCacheExpiry
+    include Proxies::Mockable
+    include User::Student
+
+    def initialize(options = {})
+      super(Settings.regstatus_proxy, options)
+      initialize_mocks if @fake
+    end
+
+    def get(term=nil)
+      term ||= Berkeley::Terms.fetch.current
+      internal_response = self.class.smart_fetch_from_cache(id: "#{@uid}/#{term.slug}") do
+        get_internal term
+      end
+      if internal_response[:noStudentId] || internal_response[:statusCode] < 400
+        internal_response
+      else
+        {
+          errored: true
+        }
+      end
+    end
+
+    private
+
+    def get_internal(term)
+      student_id = lookup_student_id
+      if student_id.nil?
+        logger.info "Lookup of student_id for uid #{@uid} failed, cannot call Regstatus API"
+        {
+          noStudentId: true
+        }
+      else
+        url = @settings.base_url
+        logger.info "Fake = #{@fake}; Making request to #{url} on behalf of user #{@uid}, student_id = #{student_id}, term = #{term}; cache expiration #{self.class.expires_in}"
+        request_options = {
+          query: {
+            studentId: student_id,
+            termYear: term.year,
+            termName: term.name,
+            _type: 'json'
+          }
+        }
+        if @settings.app_id.present? && @settings.app_key.present?
+          request_options[:headers] = {
+            'app_id' => @settings.app_id,
+            'app_key' => @settings.app_key
+          }
+        end
+        response = get_response(url, request_options)
+        logger.debug "Remote server status #{response.code}, Body = #{response.body}"
+        {
+          statusCode: response.code,
+          feed: response.parsed_response
+        }
+      end
+    end
+
+    def mock_json
+      File.read(Rails.root.join('fixtures', 'json', 'regstatus.json'))
+    end
+
+  end
+end

--- a/fixtures/json/regstatus.json
+++ b/fixtures/json/regstatus.json
@@ -1,0 +1,8 @@
+{
+  "regStatus": {
+    "isRegistered": true,
+    "studentId": 11667051,
+    "termName": "Fall",
+    "termYear": 2013
+  }
+}

--- a/lib/proxies/mock_http_interaction.rb
+++ b/lib/proxies/mock_http_interaction.rb
@@ -1,0 +1,37 @@
+module Proxies
+  class MockHttpInteraction
+    include SafeJsonParser
+
+    def initialize(request, response)
+      extend WebMock::API
+      WebMock.enable!
+      @request = default_request.merge request
+      @response = response
+    end
+
+    def override_json
+      if block_given?
+        parsed_structure = safe_json @response[:body]
+        yield parsed_structure
+        @response[:body] = parsed_structure.to_json
+      end
+      set_response
+    end
+
+    def set_response(options={})
+      @response.merge! options
+      stub = stub_request(@request[:method], @request[:uri])
+      request_params = @request.slice(:body, :query, :headers)
+      stub = stub.with(request_params) if request_params.any?
+      stub.to_return @response
+    end
+
+    def default_request
+      {
+        method: :any,
+        uri: /.*/
+      }
+    end
+
+  end
+end

--- a/lib/proxies/mockable.rb
+++ b/lib/proxies/mockable.rb
@@ -1,0 +1,42 @@
+module Proxies
+  module Mockable
+
+    def initialize_mocks
+      if defined? WebMock
+        set_response
+      end
+    end
+
+    def on_request(options={})
+      MockHttpInteraction.new(mock_request.merge(options), mock_response)
+    end
+
+    def override_json(&blk)
+      on_request.override_json(&blk)
+    end
+
+    def set_response(options={})
+      on_request.set_response(options)
+    end
+
+    def mock_request
+      {
+        method: :get,
+        uri: /\A#{Regexp.quote @settings.base_url}/
+      }
+    end
+
+    def mock_response
+      {
+        status: 200,
+        headers: {'Content-Type' => 'application/json'},
+        body: mock_json
+      }
+    end
+
+    def mock_json
+      ''
+    end
+
+  end
+end

--- a/spec/models/regstatus/proxy_spec.rb
+++ b/spec/models/regstatus/proxy_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe Regstatus::Proxy do
+
+  it_should_behave_like 'a student data proxy' do
+    let(:proxy_class) { Regstatus::Proxy }
+    let(:feed_key) { 'regStatus' }
+  end
+
+  context 'mock proxy' do
+    let(:oski_uid) { '61889' }
+    let(:oski_student_id) { 11667051 }
+    let(:fake_proxy) { Regstatus::Proxy.new(user_id: oski_uid, fake: true) }
+    let(:feed) { fake_proxy.get[:feed] }
+
+    it 'returns JSON fixture data by default' do
+      expect(feed['regStatus']['isRegistered']).to eq true
+      expect(feed['regStatus']['studentId']).to eq oski_student_id
+      expect(feed['regStatus']['termName']).to eq 'Fall'
+      expect(feed['regStatus']['termYear']).to eq 2013
+    end
+
+    it 'can be overridden selectively' do
+      fake_proxy.override_json { |json| json['regStatus']['isRegistered'] = false }
+      expect(feed['regStatus']['isRegistered']).to eq false
+      expect(feed['regStatus']['studentId']).to eq oski_student_id
+      expect(feed['regStatus']['termName']).to eq 'Fall'
+      expect(feed['regStatus']['termYear']).to eq 2013
+    end
+
+    it 'can be overridden with variable data' do
+      current_term = Berkeley::Terms.fetch.current
+      fake_proxy.override_json do |json|
+        json['regStatus']['termName'] = current_term.name
+        json['regStatus']['termYear'] = current_term.year
+      end
+      expect(feed['regStatus']['termName']).to eq current_term.name
+      expect(feed['regStatus']['termYear']).to eq current_term.year
+    end
+
+    it 'can be overridden to return errors' do
+      fake_proxy.set_response(status: 506, body: '')
+      response = fake_proxy.get
+      expect(response[:errored]).to eq true
+    end
+
+    it 'can selectively override data based on request parameters' do
+      fake_proxy.on_request(query: hash_including(termYear: '2014')).override_json do |json|
+        json['regStatus']['termYear'] = 2014
+        json['regStatus']['isRegistered'] = false
+      end
+
+      current_feed = fake_proxy.get[:feed]
+      expect(current_feed['regStatus']['termYear']).to eq 2013
+      expect(current_feed['regStatus']['isRegistered']).to eq true
+
+      spring_2014 = Berkeley::Terms.fetch.campus['spring-2014']
+      future_feed = fake_proxy.get(spring_2014)[:feed]
+      expect(future_feed['regStatus']['termYear']).to eq 2014
+      expect(future_feed['regStatus']['isRegistered']).to eq false
+    end
+
+  end
+end

--- a/spec/support/proxy_shared_examples.rb
+++ b/spec/support/proxy_shared_examples.rb
@@ -36,7 +36,7 @@ shared_examples 'a student data proxy' do
     end
   end
 
-  it 'should get Oski data from fake vcr recordings' do
+  it 'should get fake data for Oski' do
     response = fake_proxy('61889').get
     expect_feed(response, feed_key)
   end
@@ -53,7 +53,7 @@ shared_examples 'a student data proxy' do
   end
 
   context 'connection failure' do
-    before(:each) { stub_request(:any, /#{Regexp.quote(Settings.bearfacts_proxy.base_url)}.*/).to_raise(Errno::EHOSTUNREACH) }
+    before(:each) { stub_request(:any, /.*/).to_raise(Errno::EHOSTUNREACH) }
     after(:each) { WebMock.reset! }
     it 'returns an error status and a nil feed' do
       response = real_proxy('61889').get


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4909

The structure of this new proxy is based on the Bearfacts proxies. It returns the same custom hashes on error conditions, so that tests can be conveniently bundled in with the other student data proxies.

This simple API endpoint also affords a opportunity to try out a different, VCR-less approach to mocking up web responses. (See https://jira.ets.berkeley.edu/jira/browse/CLC-3383 .) A mock proxy class uses WebMock to intercept HTTP requests and creates a fake response matching the query parameters.