### PR TITLE
CLC-5004 Standardize "params"/"session" hash access

### DIFF
--- a/app/controllers/act_as_controller.rb
+++ b/app/controllers/act_as_controller.rb
@@ -6,22 +6,22 @@ class ActAsController < ApplicationController
 
   def start
     authorize current_user, :can_view_as?
-    return redirect_to root_path unless valid_params?(params[:uid])
-    logger.warn "ACT-AS: User #{current_user.real_user_id} acting as #{params[:uid]} begin"
-    session[:original_user_id] = session[:user_id] unless session[:original_user_id]
-    session[:user_id] = params[:uid]
+    return redirect_to root_path unless valid_params?(params['uid'])
+    logger.warn "ACT-AS: User #{current_user.real_user_id} acting as #{params['uid']} begin"
+    session['original_user_id'] = session['user_id'] unless session['original_user_id']
+    session['user_id'] = params['uid']
 
     render :nothing => true, :status => 204
   end
 
   def stop
-    return redirect_to root_path unless session[:user_id] && session[:original_user_id]
+    return redirect_to root_path unless session['user_id'] && session['original_user_id']
 
     #To avoid any potential stale data issues, we might have to be aggressive with cache invalidation.
-    Cache::UserCacheExpiry.notify session[:user_id]
-    logger.warn "ACT-AS: User #{session[:original_user_id]} acting as #{session[:user_id]} ends"
-    session[:user_id] = session[:original_user_id]
-    session[:original_user_id] = nil
+    Cache::UserCacheExpiry.notify session['user_id']
+    logger.warn "ACT-AS: User #{session['original_user_id']} acting as #{session['user_id']} ends"
+    session['user_id'] = session['original_user_id']
+    session['original_user_id'] = nil
 
     render :nothing => true, :status => 204
   end

--- a/app/controllers/bootstrap_controller.rb
+++ b/app/controllers/bootstrap_controller.rb
@@ -16,7 +16,7 @@ class BootstrapController < ApplicationController
   # chance to become fully authenticated on the browser's initial visit to a CalCentral page.
   # If the user's CAS login state is still active, no visible redirect will occur.
   def check_lti_only
-    if session[:lti_authenticated_only]
+    if session['lti_authenticated_only']
       authenticate(true)
     end
   end
@@ -35,7 +35,7 @@ class BootstrapController < ApplicationController
   end
 
   def warmup_live_updates
-    LiveUpdatesWarmer.warmup_request session[:user_id] if session[:user_id]
+    LiveUpdatesWarmer.warmup_request session['user_id'] if session['user_id']
   end
 
 end

--- a/app/controllers/campus_rosters_controller.rb
+++ b/app/controllers/campus_rosters_controller.rb
@@ -7,30 +7,30 @@ class CampusRostersController < RostersController
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   def authorize_viewing_rosters
-    raise Errors::BadRequestError, "campus_course_id required" unless params[:campus_course_id]
-    course = Berkeley::Course.new(:course_id => params[:campus_course_id])
+    raise Errors::BadRequestError, "campus_course_id required" unless params['campus_course_id']
+    course = Berkeley::Course.new(:course_id => params['campus_course_id'])
     authorize course, :can_view_roster_photos?
   end
 
   # GET /api/academics/rosters/campus/:campus_course_id
   def get_feed
-    feed = Rosters::Campus.new(session[:user_id], course_id: params[:campus_course_id]).get_feed_filtered
+    feed = Rosters::Campus.new(session['user_id'], course_id: params['campus_course_id']).get_feed_filtered
     render :json => feed.to_json
   end
 
   # GET /api/academics/rosters/campus/csv/:canvas_course_id.csv
   def get_csv
-    rosters_csv = Rosters::Campus.new(session[:user_id], course_id: params[:campus_course_id]).get_csv
+    rosters_csv = Rosters::Campus.new(session['user_id'], course_id: params['campus_course_id']).get_csv
     respond_to do |format|
-      format.csv { render csv: rosters_csv.to_s, filename: "course_#{params[:campus_course_id]}_rosters" }
+      format.csv { render csv: rosters_csv.to_s, filename: "course_#{params['campus_course_id']}_rosters" }
     end
   end
 
   # GET /campus/:campus_course_id/photo/:person_id
   def photo
-    course_id = params[:campus_course_id]
-    course_user_id = Integer(params[:person_id], 10)
-    @photo = Rosters::Campus.new(session[:user_id], course_id: course_id).photo_data_or_file(course_user_id)
+    course_id = params['campus_course_id']
+    course_user_id = Integer(params['person_id'], 10)
+    @photo = Rosters::Campus.new(session['user_id'], course_id: course_id).photo_data_or_file(course_user_id)
     serve_photo
   end
 

--- a/app/controllers/canvas_controller.rb
+++ b/app/controllers/canvas_controller.rb
@@ -20,7 +20,7 @@ class CanvasController < ApplicationController
   # Indicates if a Canvas user is authorized to provision course or project sites
   # GET /api/academics/canvas/user_can_create_site
   def user_can_create_site
-    authorization = Canvas::PublicAuthorizer.new(params[:canvas_user_id]).can_create_site?
+    authorization = Canvas::PublicAuthorizer.new(params['canvas_user_id']).can_create_site?
     render json: {'canCreateSite' => authorization}.to_json
   end
 end

--- a/app/controllers/canvas_course_add_user_controller.rb
+++ b/app/controllers/canvas_course_add_user_controller.rb
@@ -10,7 +10,7 @@ class CanvasCourseAddUserController < ApplicationController
   def authorize_adding_user
     course_id = canvas_course_id
     raise Pundit::NotAuthorizedError, "Canvas Course ID not present" if course_id.blank?
-    canvas_course = Canvas::Course.new(:user_id => session[:user_id], :canvas_course_id => course_id)
+    canvas_course = Canvas::Course.new(:user_id => session['user_id'], :canvas_course_id => course_id)
     authorize canvas_course, :can_add_users?
   end
 
@@ -38,8 +38,8 @@ class CanvasCourseAddUserController < ApplicationController
   # POST /api/academics/canvas/course_add_user/add_user.json
   def add_user
     authorize_granted_role
-    Canvas::CourseAddUser.add_user_to_course_section(params[:ldapUserId], params[:roleId], params[:sectionId])
-    user_added = { :ldapUserId => params[:ldapUserId], :roleId => params[:roleId], :sectionId => params[:sectionId] }
+    Canvas::CourseAddUser.add_user_to_course_section(params['ldapUserId'], params['roleId'], params['sectionId'])
+    user_added = { :ldapUserId => params['ldapUserId'], :roleId => params['roleId'], :sectionId => params['sectionId'] }
     render json: { userAdded: user_added }.to_json
   end
 
@@ -48,13 +48,13 @@ class CanvasCourseAddUserController < ApplicationController
   def authorize_granted_role
     granted_role_ids = []
     user_profile[:grantingRoles].each {|role| granted_role_ids << role['id']}
-    raise Pundit::NotAuthorizedError, "Role specified is unauthorized" unless granted_role_ids.include?(params[:roleId])
+    raise Pundit::NotAuthorizedError, "Role specified is unauthorized" unless granted_role_ids.include?(params['roleId'])
   end
 
   def user_profile
-    canvas_user_profile = Canvas::SisUserProfile.new(user_id: session[:user_id]).get
+    canvas_user_profile = Canvas::SisUserProfile.new(user_id: session['user_id']).get
     course_user_roles = Canvas::CourseUser.new(:user_id => canvas_user_profile['id'], :course_id => canvas_course_id).roles
-    global_admin = Canvas::Admins.new.admin_user?(session[:user_id])
+    global_admin = Canvas::Admins.new.admin_user?(session['user_id'])
     granting_roles = Canvas::CourseAddUser.granting_roles(course_user_roles, global_admin)
     { roles: course_user_roles.merge({'globalAdmin' => global_admin}), grantingRoles: granting_roles }
   end

--- a/app/controllers/canvas_course_grade_export_controller.rb
+++ b/app/controllers/canvas_course_grade_export_controller.rb
@@ -9,31 +9,31 @@ class CanvasCourseGradeExportController < ApplicationController
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   def authorize_exporting_grades
-    raise Pundit::NotAuthorizedError, "Canvas Course ID not present in session" if session[:canvas_course_id].blank?
+    raise Pundit::NotAuthorizedError, "Canvas Course ID not present in session" if session['canvas_course_id'].blank?
     authorize canvas_course, :can_export_grades?
   end
 
   # GET /api/academics/canvas/egrade_export/download.csv
   def download_egrades_csv
-    raise Errors::BadRequestError, "term_cd required" unless params[:term_cd]
-    raise Errors::BadRequestError, "term_yr required" unless params[:term_yr]
-    raise Errors::BadRequestError, "ccn required" unless params[:ccn]
-    raise Errors::BadRequestError, "type required" unless params[:type]
-    raise Errors::BadRequestError, "invalid value for 'type' parameter" unless Canvas::Egrades::GRADE_TYPES.include?(params[:type])
-    canvas_course_id = session[:canvas_course_id].to_i
+    raise Errors::BadRequestError, "term_cd required" unless params['term_cd']
+    raise Errors::BadRequestError, "term_yr required" unless params['term_yr']
+    raise Errors::BadRequestError, "ccn required" unless params['ccn']
+    raise Errors::BadRequestError, "type required" unless params['type']
+    raise Errors::BadRequestError, "invalid value for 'type' parameter" unless Canvas::Egrades::GRADE_TYPES.include?(params['type'])
+    canvas_course_id = session['canvas_course_id'].to_i
     egrades_worker = Canvas::Egrades.new(:canvas_course_id => canvas_course_id)
-    official_student_grades = egrades_worker.official_student_grades_csv(params[:term_cd], params[:term_yr], params[:ccn], params[:type])
+    official_student_grades = egrades_worker.official_student_grades_csv(params['term_cd'], params['term_yr'], params['ccn'], params['type'])
     respond_to do |format|
       format.csv { render csv: official_student_grades.to_s, filename: "course_#{canvas_course_id}_grades" }
     end
   end
 
   def export_options
-    course_settings_worker = Canvas::CourseSettings.new(:course_id => session[:canvas_course_id].to_i)
+    course_settings_worker = Canvas::CourseSettings.new(:course_id => session['canvas_course_id'].to_i)
     course_settings = course_settings_worker.settings(:cache => false)
     grading_standard_enabled = course_settings['grading_standard_enabled']
 
-    egrades_worker = Canvas::Egrades.new(:canvas_course_id => session[:canvas_course_id].to_i)
+    egrades_worker = Canvas::Egrades.new(:canvas_course_id => session['canvas_course_id'].to_i)
     course_sections = egrades_worker.official_sections
     section_terms = egrades_worker.section_terms
     render json: { :officialSections => course_sections, :gradingStandardEnabled => grading_standard_enabled, :sectionTerms => section_terms }.to_json
@@ -47,8 +47,8 @@ class CanvasCourseGradeExportController < ApplicationController
   end
 
   def is_official_course
-    raise Pundit::NotAuthorizedError, "Canvas Course ID not present in params" if params[:canvas_course_id].blank?
-    egrades_worker = Canvas::Egrades.new(:canvas_course_id => params[:canvas_course_id])
+    raise Pundit::NotAuthorizedError, "Canvas Course ID not present in params" if params['canvas_course_id'].blank?
+    egrades_worker = Canvas::Egrades.new(:canvas_course_id => params['canvas_course_id'])
     is_official_course = egrades_worker.is_official_course?
     render json: { :isOfficialCourse => is_official_course }.to_json
   end
@@ -56,7 +56,7 @@ class CanvasCourseGradeExportController < ApplicationController
   private
 
   def canvas_course
-    canvas_course = Canvas::Course.new(:canvas_course_id => session[:canvas_course_id].to_i)
+    canvas_course = Canvas::Course.new(:canvas_course_id => session['canvas_course_id'].to_i)
   end
 
 end

--- a/app/controllers/canvas_course_provision_controller.rb
+++ b/app/controllers/canvas_course_provision_controller.rb
@@ -10,7 +10,7 @@ class CanvasCourseProvisionController < ApplicationController
   # GET /api/academics/canvas/course_provision.json
   # GET /api/academics/canvas/course_provision_as/:instructor_id.json
   def get_feed
-    if (feed = Canvas::CourseProvision.new(session[:user_id], options_from_params).get_feed)
+    if (feed = Canvas::CourseProvision.new(session['user_id'], options_from_params).get_feed)
       render json: feed.to_json
     else
       render nothing: true, status: 401
@@ -19,29 +19,29 @@ class CanvasCourseProvisionController < ApplicationController
 
   # POST /api/academics/canvas/course_provision/create.json
   def create_course_site
-    worker = Canvas::CourseProvision.new(session[:user_id], options_from_params)
+    worker = Canvas::CourseProvision.new(session['user_id'], options_from_params)
     # Since we expect the CCNs to have been provided by our own code rather than a human being,
     # we don't worry so much about invalid numbers.
-    job_id = worker.create_course_site(params[:siteName], params[:siteAbbreviation], params[:termSlug], params[:ccns])
+    job_id = worker.create_course_site(params['siteName'], params['siteAbbreviation'], params['termSlug'], params['ccns'])
     render json: { job_request_status: "Success", job_id: job_id}.to_json
   end
 
   # POST /api/academics/canvas/course_provision/edit_sections.json
   def edit_sections
-    worker = Canvas::CourseProvision.new(session[:user_id], options_from_params)
-    job_id = worker.edit_sections(params[:ccns_to_remove], params[:ccns_to_add])
+    worker = Canvas::CourseProvision.new(session['user_id'], options_from_params)
+    job_id = worker.edit_sections(params['ccns_to_remove'], params['ccns_to_add'])
     render json: { job_request_status: "Success", job_id: job_id}.to_json
   end
 
   # GET /api/academics/canvas/course_provision/status.json
   def job_status
-    course_provision_job = Canvas::ProvideCourseSite.find(params[:job_id])
+    course_provision_job = Canvas::ProvideCourseSite.find(params['job_id'])
     render json: course_provision_job.to_json and return if course_provision_job.class == Canvas::ProvideCourseSite
-    render json: { job_id: params[:job_id], jobStatus: "jobNotFoundError", error: "Unable to find course management job" }.to_json
+    render json: { job_id: params['job_id'], jobStatus: "jobNotFoundError", error: "Unable to find course management job" }.to_json
   end
 
   def options_from_params
-    params['canvas_course_id'] ||= session[:canvas_course_id]
+    params['canvas_course_id'] ||= session['canvas_course_id']
     params.select {|k, v| [
       'admin_acting_as',
       'admin_by_ccns',
@@ -52,8 +52,8 @@ class CanvasCourseProvisionController < ApplicationController
   end
 
   def validate_admin_mode
-    if params[:admin_acting_as] && (params[:admin_by_ccns] || params[:admin_term_slug])
-      logger.warn("Conflicting request parameters sent to Canvas Course Provision: session user = #{session[:user_id]}, params = #{params.inspect}")
+    if params['admin_acting_as'] && (params['admin_by_ccns'] || params['admin_term_slug'])
+      logger.warn("Conflicting request parameters sent to Canvas Course Provision: session user = #{session['user_id']}, params = #{params.inspect}")
       raise ArgumentError, "Conflicting request parameters sent to Canvas Course Provision"
     end
   end

--- a/app/controllers/canvas_lti_controller.rb
+++ b/app/controllers/canvas_lti_controller.rb
@@ -16,28 +16,28 @@ class CanvasLtiController < ApplicationController
 
   def authenticate_by_lti(lti)
     lti_user_id = lti.get_custom_param('canvas_user_login_id')
-    if (existing_user_id = session[:user_id])
+    if (existing_user_id = session['user_id'])
       if existing_user_id != lti_user_id
         logger.error("LTI is authenticated as #{lti_user_id}; logging out existing CalCentral session for #{existing_user_id}")
         reset_session
-        session[:lti_authenticated_only] = true
+        session['lti_authenticated_only'] = true
       else
         logger.debug("LTI user #{lti_user_id} already has a CalCentral session")
       end
     else
-      session[:lti_authenticated_only] = true
+      session['lti_authenticated_only'] = true
       logger.debug("LTI user #{lti_user_id} was not already logged into CalCentral")
     end
-    session[:user_id] = lti_user_id
-    session[:canvas_user_id] = lti.get_custom_param('canvas_user_id')
-    session[:canvas_course_id] = lti.get_custom_param('canvas_course_id')
+    session['user_id'] = lti_user_id
+    session['canvas_user_id'] = lti.get_custom_param('canvas_user_id')
+    session['canvas_course_id'] = lti.get_custom_param('canvas_course_id')
   end
 
   def embedded
     lti = Canvas::Lti.new.validate_tool_provider(request)
     if lti
       authenticate_by_lti(lti)
-      logger.warn("Session authenticated by LTI; user = #{session[:user_id]}")
+      logger.warn("Session authenticated by LTI; user = #{session['user_id']}")
       render "public/bcourses_embedded.html"
     else
       logger.error("Error parsing LTI request; returning error message")

--- a/app/controllers/canvas_mediacasts_controller.rb
+++ b/app/controllers/canvas_mediacasts_controller.rb
@@ -11,7 +11,7 @@ class CanvasMediacastsController < ApplicationController
   def get_media
     raise Errors::BadRequestError, "Bad course site ID #{canvas_course_id}" if canvas_course_id.blank?
     authorize Canvas::Course.new(canvas_course_id: canvas_course_id), :can_view_course?
-    render :json => Canvas::CanvasMediacasts.new(user_id: session[:user_id], course_id: canvas_course_id).get_feed
+    render :json => Canvas::CanvasMediacasts.new(user_id: session['user_id'], course_id: canvas_course_id).get_feed
   end
 
 end

--- a/app/controllers/canvas_project_provision_controller.rb
+++ b/app/controllers/canvas_project_provision_controller.rb
@@ -13,8 +13,8 @@ class CanvasProjectProvisionController < ApplicationController
 
   # POST /api/academics/canvas/project_provision/create.json
   def create_project_site
-    worker = Canvas::ProjectProvision.new(session[:user_id])
-    course_details = worker.create_project(params[:name])
+    worker = Canvas::ProjectProvision.new(session['user_id'])
+    course_details = worker.create_project(params['name'])
     render json: course_details.to_json
   end
 end

--- a/app/controllers/canvas_rosters_controller.rb
+++ b/app/controllers/canvas_rosters_controller.rb
@@ -10,20 +10,20 @@ class CanvasRostersController < RostersController
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   def authorize_viewing_rosters
-    raise Pundit::NotAuthorizedError, "Canvas Course ID not present in embedded rosters request: session user = #{session[:user_id]}" unless canvas_course_id
-    canvas_course = Canvas::Course.new(:user_id => session[:user_id], :canvas_course_id => canvas_course_id)
+    raise Pundit::NotAuthorizedError, "Canvas Course ID not present in embedded rosters request: session user = #{session['user_id']}" unless canvas_course_id
+    canvas_course = Canvas::Course.new(:user_id => session['user_id'], :canvas_course_id => canvas_course_id)
     authorize canvas_course, :can_view_course_roster_photos?
   end
 
   # GET /api/academics/rosters/canvas/:canvas_course_id
   def get_feed
-    feed = Canvas::CanvasRosters.new(session[:user_id], course_id: canvas_course_id).get_feed_filtered
+    feed = Canvas::CanvasRosters.new(session['user_id'], course_id: canvas_course_id).get_feed_filtered
     render :json => feed.to_json
   end
 
   # GET /api/academics/rosters/canvas/csv/:canvas_course_id.csv
   def get_csv
-    rosters_csv = Canvas::CanvasRosters.new(session[:user_id], course_id: canvas_course_id).get_csv
+    rosters_csv = Canvas::CanvasRosters.new(session['user_id'], course_id: canvas_course_id).get_csv
     respond_to do |format|
       format.csv { render csv: rosters_csv.to_s, filename: "course_#{canvas_course_id}_rosters" }
     end
@@ -31,16 +31,16 @@ class CanvasRostersController < RostersController
 
   # GET /canvas/:canvas_course_id/photo/:person_id
   def photo
-    course_id = params[:canvas_course_id]
-    course_user_id = Integer(params[:person_id], 10)
-    @photo = Canvas::CanvasRosters.new(session[:user_id], course_id: course_id).photo_data_or_file(course_user_id)
+    course_id = params['canvas_course_id']
+    course_user_id = Integer(params['person_id'], 10)
+    @photo = Canvas::CanvasRosters.new(session['user_id'], course_id: course_id).photo_data_or_file(course_user_id)
     serve_photo
   end
 
   # GET /canvas/:canvas_course_id/profile/:person_id
   def profile
-    user_id = Integer(params[:person_id], 10)
-    if (profile_url = Canvas::CanvasRosters.new(session[:user_id], course_id: canvas_course_id).profile_url_for_ldap_id(user_id))
+    user_id = Integer(params['person_id'], 10)
+    if (profile_url = Canvas::CanvasRosters.new(session['user_id'], course_id: canvas_course_id).profile_url_for_ldap_id(user_id))
       redirect_to profile_url
     else
       redirect_to url_for_path '/404'

--- a/app/controllers/canvas_site_creation_controller.rb
+++ b/app/controllers/canvas_site_creation_controller.rb
@@ -4,7 +4,7 @@ class CanvasSiteCreationController < ApplicationController
 
   # Serves feed determining access to course and project site creation tools
   def authorizations
-    authorizations = Canvas::SiteCreation.new(:uid => session[:user_id]).authorizations
+    authorizations = Canvas::SiteCreation.new(:uid => session['user_id']).authorizations
     render :json => authorizations.to_json
   end
 end

--- a/app/controllers/canvas_user_provision_controller.rb
+++ b/app/controllers/canvas_user_provision_controller.rb
@@ -8,7 +8,7 @@ class CanvasUserProvisionController < ApplicationController
   # POST /api/academics/canvas/user_provision/user_import.json
   def user_import
     authorize(current_user, :can_administrate_canvas?)
-    user_ids = params[:userIds].split(',')
+    user_ids = params['userIds'].split(',')
     Canvas::UserProvision.new.import_users(user_ids)
     render json: { status: 'success', userIds: user_ids }.to_json
   end

--- a/app/controllers/concerns/specific_to_course_site.rb
+++ b/app/controllers/concerns/specific_to_course_site.rb
@@ -1,8 +1,8 @@
 module SpecificToCourseSite
   def canvas_course_id
     begin
-      if (id = params[:canvas_course_id])
-        id = session[:canvas_course_id] if id == 'embedded'
+      if (id = params['canvas_course_id'])
+        id = session['canvas_course_id'] if id == 'embedded'
         id = Integer(id, 10)
       end
       id

--- a/app/controllers/is_updated_controller.rb
+++ b/app/controllers/is_updated_controller.rb
@@ -4,8 +4,8 @@ class IsUpdatedController < ApplicationController
 
   # kick off a live-updates warmup, and return the last modification time and hashes of all feeds.
   def list
-      LiveUpdatesWarmer.warmup_request session[:user_id]
-      whiteboard = Cache::FeedUpdateWhiteboard.get_whiteboard session[:user_id]
+      LiveUpdatesWarmer.warmup_request session['user_id']
+      whiteboard = Cache::FeedUpdateWhiteboard.get_whiteboard session['user_id']
       render :json => whiteboard.to_json, :status => 200
   end
 

--- a/app/controllers/mediacasts_controller.rb
+++ b/app/controllers/mediacasts_controller.rb
@@ -5,7 +5,7 @@ class MediacastsController < ApplicationController
   # GET /api/media/:year/:term_code/:dept/:catalog_id
   def get_media
     render :json => Mediacasts::CourseMedia.new(
-      params[:year], params[:term_code], params[:dept], params[:catalog_id]
+      params['year'], params['term_code'], params['dept'], params['catalog_id']
     ).get_feed
   end
 

--- a/app/controllers/my_events_controller.rb
+++ b/app/controllers/my_events_controller.rb
@@ -6,12 +6,12 @@ class MyEventsController < ApplicationController
   def create
     input = sanitize_input!(params)
     if input.present?
-      logger.info "Creating event for user #{session[:user_id]}: #{input}"
-      response = GoogleApps::EventsInsert.new(user_id: session[:user_id]).insert_event(input.stringify_keys)
+      logger.info "Creating event for user #{session['user_id']}: #{input}"
+      response = GoogleApps::EventsInsert.new(user_id: session['user_id']).insert_event(input.stringify_keys)
 
       result = response.data || {}
       if result.blank?
-        logger.warn "GoogleApps::EventsInsert.insert_event response for user #{session[:user_id]} should not be blank.
+        logger.warn "GoogleApps::EventsInsert.insert_event response for user #{session['user_id']} should not be blank.
           Payload: #{input.inspect}"
       end
       result = result.to_hash.merge({ status:true }) unless result.blank?
@@ -26,7 +26,7 @@ class MyEventsController < ApplicationController
   private
   def check_google_access
     return error_response unless current_user.policy.access_google?
-    return error_response unless GoogleApps::Proxy.access_granted?(session[:user_id])
+    return error_response unless GoogleApps::Proxy.access_granted?(session['user_id'])
   end
 
   def error_response
@@ -38,7 +38,7 @@ class MyEventsController < ApplicationController
 
   def sanitize_input!(params)
     result = {}
-    result[:summary] = params[:summary] if params[:summary].present?
+    result[:summary] = params['summary'] if params['summary'].present?
     %w(start end).each do |key|
       if params[key] && params[key][:epoch]
         date_time = DateTime.strptime(params[key][:epoch].to_s, '%s') rescue ''

--- a/app/controllers/my_textbooks_controller.rb
+++ b/app/controllers/my_textbooks_controller.rb
@@ -3,7 +3,7 @@ class MyTextbooksController < ApplicationController
   before_filter :api_authenticate
 
   def get_feed
-    render json: Textbooks::Proxy.new({course_catalog: params[:courseCatalog], slug: params[:slug], dept: params[:department], section_numbers: params[:sectionNumbers]}).get_as_json
+    render json: Textbooks::Proxy.new({course_catalog: params['courseCatalog'], slug: params['slug'], dept: params['department'], section_numbers: params['sectionNumbers']}).get_as_json
   end
 
 end

--- a/app/controllers/photo_controller.rb
+++ b/app/controllers/photo_controller.rb
@@ -3,7 +3,7 @@ class PhotoController < ApplicationController
   before_filter :api_authenticate_401
 
   def my_photo
-    photo_row = User::Photo.fetch(session[:user_id])
+    photo_row = User::Photo.fetch(session['user_id'])
     if (photo_row)
       data = photo_row['photo']
       send_data(

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,28 +6,28 @@ class SessionsController < ApplicationController
   def lookup
     auth = request.env["omniauth.auth"]
     auth_uid = auth['uid']
-    if params[:renew] == 'true'
+    if params['renew'] == 'true'
       # If we're reauthenticating due to view-as, then the CAS-provided UID should match
       # the session's "original_user_id".
-      if session[:original_user_id]
-        if session[:original_user_id] != auth_uid
-          logger.warn "ACT-AS: Active user session for #{session[:original_user_id]} exists, but CAS is giving us a different UID: #{auth_uid}. Logging user out."
+      if session['original_user_id']
+        if session['original_user_id'] != auth_uid
+          logger.warn "ACT-AS: Active user session for #{session['original_user_id']} exists, but CAS is giving us a different UID: #{auth_uid}. Logging user out."
           logout
           return redirect_to Settings.cas_logout_url
         else
           create_reauth_cookie
         end
-      elsif session[:user_id] != auth_uid
+      elsif session['user_id'] != auth_uid
         # If we're reauthenticating for any other reason, then the CAS-provided UID should
         # match the session "user_id" from the previous authentication.
-        logger.warn "REAUTHENTICATION: Active user session for #{session[:user_id]} exists, but CAS is giving us a different UID: #{auth_uid}. Starting new session."
+        logger.warn "REAUTHENTICATION: Active user session for #{session['user_id']} exists, but CAS is giving us a different UID: #{auth_uid}. Starting new session."
         reset_session
       else
         create_reauth_cookie
       end
     else
-      if session[:lti_authenticated_only] && session[:user_id] != auth_uid
-        logger.warn "LTI user session for #{session[:user_id]} exists, but CAS is giving us a different UID: #{auth_uid}. Logging user out."
+      if session['lti_authenticated_only'] && session['user_id'] != auth_uid
+        logger.warn "LTI user session for #{session['user_id']} exists, but CAS is giving us a different UID: #{auth_uid}. Logging user out."
         logout
         return redirect_to Settings.cas_logout_url
       end
@@ -67,15 +67,15 @@ class SessionsController < ApplicationController
 
   def failure
     params ||= {}
-    params[:message] ||= ''
-    redirect_to root_path, :status => 401, :alert => "Authentication error: #{params[:message].humanize}"
+    params['message'] ||= ''
+    redirect_to root_path, :status => 401, :alert => "Authentication error: #{params['message'].humanize}"
   end
 
   private
 
   def smart_success_path
     # the :url parameter is returned by the CAS auth server
-    (params[:url].present?) ? params[:url] : url_for_path('/dashboard')
+    (params['url'].present?) ? params['url'] : url_for_path('/dashboard')
   end
 
   def continue_login_success(uid)
@@ -87,7 +87,7 @@ class SessionsController < ApplicationController
       redirect_to url_for_path('/uid_error')
     else
       # Unless we're re-authenticating after view-as, initialize the session.
-      session[:user_id] = uid unless session[:original_user_id]
+      session['user_id'] = uid unless session['original_user_id']
       redirect_to smart_success_path, :notice => "Signed in!"
     end
   end

--- a/app/controllers/stored_users_controller.rb
+++ b/app/controllers/stored_users_controller.rb
@@ -40,7 +40,7 @@ class StoredUsersController < ApplicationController
 
   def numeric_uid?
     begin
-      Integer(params[:uid], 10)
+      Integer(params['uid'], 10)
     rescue ArgumentError
       error_response
     end

--- a/app/controllers/user_api_controller.rb
+++ b/app/controllers/user_api_controller.rb
@@ -12,7 +12,7 @@ class UserApiController < ApplicationController
     response.headers["Pragma"] = "no-cache"
     response.headers["Expires"] = "-1"
     render :json => {
-      :amILoggedIn => !!session[:user_id]
+      :amILoggedIn => !!session['user_id']
     }.to_json
   end
 
@@ -20,10 +20,10 @@ class UserApiController < ApplicationController
     ActiveRecordHelper.clear_stale_connections
     status = {}
 
-    if session[:user_id]
+    if session['user_id']
       # wrap User::Visit.record_session inside a cache lookup so that we have to write User::Visit records less often.
-      self.class.fetch_from_cache session[:user_id] do
-        User::Visit.record session[:user_id] if current_user.directly_authenticated?
+      self.class.fetch_from_cache session['user_id'] do
+        User::Visit.record session['user_id'] if current_user.directly_authenticated?
         true
       end
       status.merge!({
@@ -52,8 +52,8 @@ class UserApiController < ApplicationController
   end
 
   def delete
-    if session[:user_id] && current_user.directly_authenticated?
-      User::Api.delete(session[:user_id])
+    if session['user_id'] && current_user.directly_authenticated?
+      User::Api.delete(session['user_id'])
       render :nothing => true, :status => 204
     else
       render :nothing => true, :status => 403
@@ -62,8 +62,8 @@ class UserApiController < ApplicationController
 
   def calendar_opt_in
     expire_current_user
-    if session[:user_id] && current_user.directly_authenticated?
-      Calendar::User.where(uid: session[:user_id]).first_or_create
+    if session['user_id'] && current_user.directly_authenticated?
+      Calendar::User.where(uid: session['user_id']).first_or_create
       render :nothing => true, :status => 204
     else
       render :nothing => true, :status => 403
@@ -72,8 +72,8 @@ class UserApiController < ApplicationController
 
   def calendar_opt_out
     expire_current_user
-    if session[:user_id] && current_user.directly_authenticated?
-      Calendar::User.where(uid: session[:user_id]).delete_all
+    if session['user_id'] && current_user.directly_authenticated?
+      Calendar::User.where(uid: session['user_id']).delete_all
       render :nothing => true, :status => 204
     else
       render :nothing => true, :status => 403

--- a/app/models/canvas/course_provision.rb
+++ b/app/models/canvas/course_provision.rb
@@ -99,7 +99,7 @@ module Canvas
     end
 
     def user_admin?
-      @is_admin ||= @uid.present? && AuthenticationState.new(user_id: @uid).policy.can_administrate_canvas?
+      @is_admin ||= @uid.present? && AuthenticationState.new('user_id' => @uid).policy.can_administrate_canvas?
     end
 
     def user_authorized?

--- a/app/models/canvas/lti.rb
+++ b/app/models/canvas/lti.rb
@@ -23,15 +23,15 @@ module Canvas
       params = request.request_parameters
       logger.debug("LTI params = #{params.inspect}")
       current_time = Time.new
-      timestamp = params[:oauth_timestamp]
+      timestamp = params['oauth_timestamp']
       if !timestamp.blank?
         timestamp = Time.at(timestamp.to_i)
         if timestamp > (current_time - 300) && timestamp < (current_time + 300)
-          nonce_check = params[:oauth_nonce]
+          nonce_check = params['oauth_nonce']
           if !nonce_check.blank?
             if !self.class.in_cache?(nonce_check)
               Rails.cache.write(self.class.cache_key(nonce_check), timestamp, expires_id: self.class.expires_in)
-              request_key = params[:oauth_consumer_key]
+              request_key = params['oauth_consumer_key']
               if @lti_key == request_key
                 lti = IMS::LTI::ToolProvider.new(request_key, @lti_secret, params)
                 lti.extend IMS::LTI::Extensions::OutcomeData::ToolProvider
@@ -46,11 +46,11 @@ module Canvas
                 logger.warn("LTI unrecognized consumer key")
               end
             else
-              logger.warn("LTI repeated nonce = #{params[:oauth_nonce]}")
+              logger.warn("LTI repeated nonce = #{params['oauth_nonce']}")
             end
           end
         else
-          logger.warn("LTI timestamp outdated: raw = #{params[:oauth_timestamp]}, parsed = #{timestamp}")
+          logger.warn("LTI timestamp outdated: raw = #{params['oauth_timestamp']}, parsed = #{timestamp}")
         end
       end
       nil

--- a/app/models/canvas/public_authorizer.rb
+++ b/app/models/canvas/public_authorizer.rb
@@ -11,7 +11,7 @@ module Canvas
         authorization = false
         campus_uid = Canvas::UserProfile.new(:canvas_user_id => @canvas_user_id).login_id
         if campus_uid
-          user = AuthenticationState.new(user_id: campus_uid)
+          user = AuthenticationState.new('user_id' => campus_uid)
           policy = user.policy
           # if you cannot create a project site (i.e. you are not affiliated as a staff or faculty member),
           # then you surely will not have official sections available to create a course site

--- a/app/models/canvas/site_creation.rb
+++ b/app/models/canvas/site_creation.rb
@@ -7,7 +7,7 @@ module Canvas
     end
 
     def authorizations
-      policy = AuthenticationState.new(user_id: @uid).policy
+      policy = AuthenticationState.new('user_id' => @uid).policy
       {
         :authorizations => {
           :canCreateCourseSite => policy.can_create_canvas_course_site?,

--- a/app/models/user_specific_model.rb
+++ b/app/models/user_specific_model.rb
@@ -4,16 +4,16 @@ class UserSpecificModel
   attr_reader :authentication_state
 
   def self.from_session(session_state)
-    self.new(session_state[:user_id], {
-      original_user_id: session_state[:original_user_id],
-      lti_authenticated_only: session_state[:lti_authenticated_only]
+    self.new(session_state['user_id'], {
+        'original_user_id' => session_state['original_user_id'],
+        'lti_authenticated_only' => session_state['lti_authenticated_only']
     })
   end
 
   def initialize(uid, options={})
     @uid = uid
     @options = options
-    @authentication_state = AuthenticationState.new(@options.merge(user_id: @uid))
+    @authentication_state = AuthenticationState.new(@options.merge('user_id' => @uid))
   end
 
   def instance_key

--- a/app/policies/authentication_state.rb
+++ b/app/policies/authentication_state.rb
@@ -3,10 +3,10 @@ class AuthenticationState
 
   LTI_AUTHENTICATED_ONLY = 'Authenticated through LTI'
 
-  def initialize(session_state)
-    @user_id = session_state[:user_id]
-    @original_user_id = session_state[:original_user_id]
-    @lti_authenticated_only = session_state[:lti_authenticated_only]
+  def initialize(session)
+    @user_id = session['user_id']
+    @original_user_id = session['original_user_id']
+    @lti_authenticated_only = session['lti_authenticated_only']
   end
 
   def directly_authenticated?

--- a/spec/controllers/act_as_controller_spec.rb
+++ b/spec/controllers/act_as_controller_spec.rb
@@ -5,14 +5,14 @@ describe ActAsController do
   def it_succeeds
     post :start, uid: target_uid
     expect(response).to be_success
-    expect(session[:user_id]).to eq target_uid
-    expect(session[:original_user_id]).to eq real_user_id
+    expect(session['user_id']).to eq target_uid
+    expect(session['original_user_id']).to eq real_user_id
   end
   def it_fails
     post :start, uid: target_uid
     expect(response).to_not be_success
-    expect(session[:user_id]).to_not eq target_uid
-    expect(session[:original_user_id]).to be_nil
+    expect(session['user_id']).to_not eq target_uid
+    expect(session['original_user_id']).to be_nil
   end
 
   describe '#start' do
@@ -29,12 +29,12 @@ describe ActAsController do
     end
     shared_examples 'successful view-as' do
       it 'works the first time' do
-        session[:user_id] = real_user_id
+        session['user_id'] = real_user_id
         it_succeeds
       end
       it 'switches targets' do
-        session[:user_id] = '211159'
-        session[:original_user_id] = real_user_id
+        session['user_id'] = '211159'
+        session['original_user_id'] = real_user_id
         it_succeeds
       end
     end
@@ -56,8 +56,8 @@ describe ActAsController do
         allow(User::Auth).to receive(:get).with(nil).and_call_original
       end
       it 'is denied' do
-        session[:user_id] = real_user_id
-        session[:lti_authenticated_only] = true
+        session['user_id'] = real_user_id
+        session['lti_authenticated_only'] = true
         it_fails
       end
     end
@@ -65,7 +65,7 @@ describe ActAsController do
       let(:real_superuser) {false}
       let(:real_viewer) {false}
       it 'is denied' do
-        session[:user_id] = real_user_id
+        session['user_id'] = real_user_id
         it_fails
       end
     end

--- a/spec/controllers/bootstrap_controller_spec.rb
+++ b/spec/controllers/bootstrap_controller_spec.rb
@@ -12,7 +12,7 @@ describe BootstrapController do
 
   context 'when authenticated' do
     before do
-      session[:user_id] = user_id
+      session['user_id'] = user_id
     end
     it 'makes a warmup request' do
       expect(LiveUpdatesWarmer).to receive(:warmup_request).with(user_id).once
@@ -24,8 +24,8 @@ describe BootstrapController do
     let(:original_user_id) {nil}
     before do
       expect(Settings.features).to receive(:reauthentication).and_return(true)
-      session[:user_id] = user_id
-      session[:original_user_id] = original_user_id
+      session['user_id'] = user_id
+      session['original_user_id'] = original_user_id
     end
     context 'when viewing as' do
       let(:original_user_id) {random_id}

--- a/spec/controllers/cache_controller_spec.rb
+++ b/spec/controllers/cache_controller_spec.rb
@@ -4,7 +4,7 @@ describe CacheController do
 
   let (:user_id) { rand(99999).to_s }
   before do
-    session[:user_id] = user_id
+    session['user_id'] = user_id
     Rails.env.stub(:production?).and_return(true)
   end
 

--- a/spec/controllers/campus_rosters_controller_spec.rb
+++ b/spec/controllers/campus_rosters_controller_spec.rb
@@ -22,7 +22,7 @@ describe CampusRostersController do
   let(:photo_file) { {:data => '\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x01'} }
 
   before do
-    session[:user_id] = user_id
+    session['user_id'] = user_id
     allow_any_instance_of(Berkeley::CoursePolicy).to receive(:can_view_roster_photos?).and_return(true)
     allow_any_instance_of(Rosters::Campus).to receive(:get_feed).and_return(roster_feed)
   end

--- a/spec/controllers/canvas_course_add_user_controller_spec.rb
+++ b/spec/controllers/canvas_course_add_user_controller_spec.rb
@@ -36,8 +36,8 @@ describe CanvasCourseAddUserController do
   let(:canvas_course_id) {'767330'}
 
   before do
-    session[:user_id] = "12345"
-    session[:canvas_user_id] = "43232321"
+    session['user_id'] = "12345"
+    session['canvas_user_id'] = "43232321"
     allow_any_instance_of(Canvas::CourseUser).to receive(:request_course_user).and_return(canvas_course_user_hash)
     allow_any_instance_of(Canvas::Admins).to receive(:admin_user?).and_return(true)
     allow(Canvas::CourseAddUser).to receive(:course_sections_list).and_return(course_sections_list)

--- a/spec/controllers/canvas_course_grade_export_controller_spec.rb
+++ b/spec/controllers/canvas_course_grade_export_controller_spec.rb
@@ -12,9 +12,9 @@ describe CanvasCourseGradeExportController do
   end
 
   before do
-    session[:user_id] = "4868640"
-    session[:canvas_user_id] = "43232321"
-    session[:canvas_course_id] = "1164764"
+    session['user_id'] = "4868640"
+    session['canvas_user_id'] = "43232321"
+    session['canvas_course_id'] = "1164764"
     allow_any_instance_of(Canvas::CoursePolicy).to receive(:can_export_grades?).and_return(true)
     allow_any_instance_of(Canvas::CourseUsers).to receive(:course_grades).and_return(course_grades)
   end
@@ -99,7 +99,7 @@ describe CanvasCourseGradeExportController do
     end
 
     context 'when the canvas course id is not present in the session' do
-      before { session[:canvas_course_id] = nil }
+      before { session['canvas_course_id'] = nil }
       it 'returns 403 error' do
         get :download_egrades_csv, :format => :csv, :term_cd => 'D', :term_yr => '2014', :ccn => '1234'
         expect(response.status).to eq(403)
@@ -180,7 +180,7 @@ describe CanvasCourseGradeExportController do
 
   describe 'when indicating if a course site has official sections' do
     before do
-      session[:user_id] = nil
+      session['user_id'] = nil
       allow_any_instance_of(Canvas::Egrades).to receive(:is_official_course?).and_return(true)
     end
     it_should_behave_like 'an endpoint' do

--- a/spec/controllers/canvas_course_provision_controller_spec.rb
+++ b/spec/controllers/canvas_course_provision_controller_spec.rb
@@ -16,7 +16,7 @@ describe CanvasCourseProvisionController do
     }
   end
   before do
-    session[:user_id] = uid
+    session['user_id'] = uid
   end
 
   describe '#get_feed' do
@@ -50,7 +50,7 @@ describe CanvasCourseProvisionController do
 
     it 'should use canvas course id option when present as a parameter' do
       fake_course_provision_worker = double('canvas_course_provision', :get_feed => {:canvas_course => {}})
-      expect(Canvas::CourseProvision).to receive(:new).with(session[:user_id], canvas_course_id: canvas_course_id).and_return(fake_course_provision_worker)
+      expect(Canvas::CourseProvision).to receive(:new).with(session['user_id'], canvas_course_id: canvas_course_id).and_return(fake_course_provision_worker)
       get :get_feed, canvas_course_id: canvas_course_id
       assert_response :success
       json_response = JSON.parse(response.body)
@@ -163,7 +163,7 @@ describe CanvasCourseProvisionController do
     end
 
     it "returns canvas_course_id parameter if present in session" do
-      subject.session[:canvas_course_id] = canvas_course_id
+      subject.session['canvas_course_id'] = canvas_course_id
       subject.params['controller'] = 'canvas_course_provision'
       subject.params['action'] = 'get_feed'
       subject.params['admin_acting_as'] = admin_acting_as

--- a/spec/controllers/canvas_lti_controller_spec.rb
+++ b/spec/controllers/canvas_lti_controller_spec.rb
@@ -17,9 +17,9 @@ describe CanvasLtiController do
 
   shared_examples 'an LTI authentication' do
     it 'embeds all session variables' do
-      expect(session[:user_id]).to eq lti_values['canvas_user_login_id']
-      expect(session[:canvas_user_id]).to eq lti_values['canvas_user_id']
-      expect(session[:canvas_course_id]).to eq lti_values['canvas_course_id']
+      expect(session['user_id']).to eq lti_values['canvas_user_login_id']
+      expect(session['canvas_user_id']).to eq lti_values['canvas_user_id']
+      expect(session['canvas_course_id']).to eq lti_values['canvas_course_id']
     end
   end
 
@@ -30,29 +30,29 @@ describe CanvasLtiController do
       end
       it_behaves_like 'an LTI authentication'
       it 'notes that the authentication is valid only for LTI' do
-        expect(session[:lti_authenticated_only]).to be_truthy
+        expect(session['lti_authenticated_only']).to be_truthy
       end
     end
     context 'when the user is already logged into CalCentral' do
       before do
-        session[:user_id] = lti_values['canvas_user_login_id']
+        session['user_id'] = lti_values['canvas_user_login_id']
         subject.send(:authenticate_by_lti, lti)
       end
       it_behaves_like 'an LTI authentication'
       it 'does not flag the authentication' do
-        expect(session[:lti_authenticated_only]).to be_falsey
+        expect(session['lti_authenticated_only']).to be_falsey
       end
     end
     context 'when the user does not match an existing CalCentral login' do
       before do
-        session[:user_id] = random_id
-        session[:some_random_junk] = random_id
+        session['user_id'] = random_id
+        session['some_random_junk'] = random_id
         subject.send(:authenticate_by_lti, lti)
       end
       it_behaves_like 'an LTI authentication'
       it 'wipes the session first' do
-        expect(session[:some_random_junk]).to be_nil
-        expect(session[:lti_authenticated_only]).to be_truthy
+        expect(session['some_random_junk']).to be_nil
+        expect(session['lti_authenticated_only']).to be_truthy
       end
     end
   end

--- a/spec/controllers/canvas_mediacasts_controller_spec.rb
+++ b/spec/controllers/canvas_mediacasts_controller_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 shared_examples 'a protected controller' do
   let(:user_id) { rand(99999).to_s }
   before do
-    session[:user_id] = user_id
+    session['user_id'] = user_id
     allow_any_instance_of(Canvas::SisUserProfile).to receive(:get).and_return({
       'id' => user_id
     })

--- a/spec/controllers/canvas_project_provision_controller_spec.rb
+++ b/spec/controllers/canvas_project_provision_controller_spec.rb
@@ -17,7 +17,7 @@ describe CanvasProjectProvisionController do
     }
   end
   before do
-    session[:user_id] = uid
+    session['user_id'] = uid
     allow_any_instance_of(AuthenticationStatePolicy).to receive(:can_create_canvas_project_site?).and_return(true)
   end
 

--- a/spec/controllers/canvas_rosters_controller_spec.rb
+++ b/spec/controllers/canvas_rosters_controller_spec.rb
@@ -48,8 +48,8 @@ describe CanvasRostersController do
 
   before do
     # emulate user authenticated via LTI Launch from a Canvas Course
-    session[:user_id] = user_id
-    session[:canvas_course_id] = canvas_course_id
+    session['user_id'] = user_id
+    session['canvas_course_id'] = canvas_course_id
     allow_any_instance_of(Canvas::CoursePolicy).to receive(:is_canvas_course_teacher_or_assistant?).and_return(true)
     allow_any_instance_of(Canvas::CanvasRosters).to receive(:get_feed).and_return(roster_feed)
   end
@@ -65,7 +65,7 @@ describe CanvasRostersController do
     end
 
     context 'when canvas course roster csv requested via non-embedded session' do
-      before { session[:canvas_course_id] = nil }
+      before { session['canvas_course_id'] = nil }
       it 'should response with roster csv' do
         get :get_csv, canvas_course_id: canvas_course_id, :format => :csv
         assert_response :success
@@ -98,7 +98,7 @@ describe CanvasRostersController do
     end
 
     context "when canvas course id not present" do
-      before { session[:canvas_course_id] = nil }
+      before { session['canvas_course_id'] = nil }
       it "should respond with empty http 403" do
         get :get_csv, canvas_course_id: 'embedded', :format => :csv
         expect(response.status).to eq 403
@@ -119,7 +119,7 @@ describe CanvasRostersController do
     end
 
     context 'when canvas course requested via non-embedded session' do
-      before { session[:canvas_course_id] = nil }
+      before { session['canvas_course_id'] = nil }
       it 'should response with roster feed' do
         get :get_feed, canvas_course_id: canvas_course_id
         assert_response :success
@@ -157,7 +157,7 @@ describe CanvasRostersController do
     end
 
     context "when canvas course id not present" do
-      before { session[:canvas_course_id] = nil }
+      before { session['canvas_course_id'] = nil }
       it "should respond with empty http 403" do
         get :get_feed, canvas_course_id: 'embedded'
         expect(response.status).to eq 403
@@ -230,7 +230,7 @@ describe CanvasRostersController do
     end
 
     context 'when Canvas course ID is not present' do
-      before { session[:canvas_course_id] = nil }
+      before { session['canvas_course_id'] = nil }
       it 'should respond with an empty HTTP 403' do
         get :profile, canvas_course_id: 'embedded', person_id: student_id
         expect(response.status).to eq 403

--- a/spec/controllers/canvas_site_creation_controller_spec.rb
+++ b/spec/controllers/canvas_site_creation_controller_spec.rb
@@ -11,7 +11,7 @@ describe CanvasSiteCreationController do
 
   describe '#authorizations' do
     before do
-      session[:user_id] = uid
+      session['user_id'] = uid
       allow_any_instance_of(Canvas::SiteCreation).to receive(:authorizations).and_return(authorizations_hash)
     end
 

--- a/spec/controllers/canvas_user_provision_controller_spec.rb
+++ b/spec/controllers/canvas_user_provision_controller_spec.rb
@@ -6,7 +6,7 @@ describe CanvasUserProvisionController do
     let(:user_id_string)     { "1234,1235" }
 
     context "if session user not present" do
-      before { session[:user_id] = nil }
+      before { session['user_id'] = nil }
       it "returns empty hash" do
         post :user_import, user_ids: user_id_string
         expect(response.status).to eq(200)
@@ -16,7 +16,7 @@ describe CanvasUserProvisionController do
 
     context "if session user is not an admin" do
       before do
-        session[:user_id] = "2050"
+        session['user_id'] = "2050"
         User::Auth.stub(:where).and_return([User::Auth.new(uid: "2050", is_superuser: false, active: true)])
       end
 
@@ -29,7 +29,7 @@ describe CanvasUserProvisionController do
 
     context "if admin user authenticated" do
       before do
-        session[:user_id] = "2050"
+        session['user_id'] = "2050"
         User::Auth.stub(:where).and_return([User::Auth.new(uid: "2050", is_superuser: true, active: true)])
         Canvas::UserProvision.any_instance.stub(:import_users).and_return(true)
       end

--- a/spec/controllers/config_controller_spec.rb
+++ b/spec/controllers/config_controller_spec.rb
@@ -26,7 +26,7 @@ describe ConfigController do
     let(:random_id) { rand(99999).to_s }
 
     before do
-      session[:user_id] = random_id
+      session['user_id'] = random_id
 
       get :get
       @json_response = JSON.parse(response.body)

--- a/spec/controllers/google_auth_controller_spec.rb
+++ b/spec/controllers/google_auth_controller_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe GoogleAuthController do
   let(:user_id) { random_id }
   before do
-    session[:user_id] = user_id
+    session['user_id'] = user_id
   end
 
   describe '#dismiss_reminder' do
@@ -34,13 +34,13 @@ describe GoogleAuthController do
     end
     context 'viewing as' do
       before do
-        session[:original_user_id] = random_id
+        session['original_user_id'] = random_id
       end
       it { should_not be_success }
     end
     context 'LTI embedded' do
       before do
-        session[:lti_authenticated_only] = true
+        session['lti_authenticated_only'] = true
       end
       it { should_not be_success }
     end

--- a/spec/controllers/my_academics_controller_spec.rb
+++ b/spec/controllers/my_academics_controller_spec.rb
@@ -9,7 +9,7 @@ describe MyAcademicsController do
     end
 
     it "should get a non-empty feed for an authenticated (but fake) user" do
-      session[:user_id] = "0"
+      session['user_id'] = "0"
       get :get_feed
       json_response = JSON.parse(response.body)
       json_response["regblocks"]["noStudentId"].should be_truthy

--- a/spec/controllers/my_activities_controller_spec.rb
+++ b/spec/controllers/my_activities_controller_spec.rb
@@ -14,7 +14,7 @@ describe MyActivitiesController do
   end
 
   it "should be an non-empty activities feed on authenticated user" do
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     dummy = JSON.parse(File.read(Rails.root.join('public/dummy/json/activities.json')))
     MyActivities::Merged.any_instance.stub(:get_feed).and_return(dummy)
     get :get_feed
@@ -24,7 +24,7 @@ describe MyActivitiesController do
   end
 
   it "should return a valid activities feed for an authenticated user" do
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     dummy = JSON.parse(File.read(Rails.root.join('public/dummy/json/activities.json')))
     MyActivities::Merged.any_instance.stub(:get_feed).and_return(dummy)
     get :get_feed

--- a/spec/controllers/my_advising_controller_spec.rb
+++ b/spec/controllers/my_advising_controller_spec.rb
@@ -14,7 +14,7 @@ describe MyAdvisingController do
       Settings.advising_proxy.stub(:fake).and_return(true)
     end
     it 'should be an non-empty advising feed based on fake Oski recorded data' do
-      session[:user_id] = '61889'
+      session['user_id'] = '61889'
       get :get_feed
       json_response = JSON.parse(response.body)
       json_response.size.should == 8

--- a/spec/controllers/my_badges_controller_spec.rb
+++ b/spec/controllers/my_badges_controller_spec.rb
@@ -20,7 +20,7 @@ describe MyBadgesController do
     GoogleApps::Proxy.stub(:access_granted?).and_return(true)
     GoogleApps::DriveList.stub(:new).and_return(@fake_drive_list)
     GoogleApps::EventsRecentItems.stub(:new).and_return(@fake_events_list)
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     get :get_feed
     json_response = JSON.parse(response.body)
 
@@ -47,19 +47,19 @@ describe MyBadgesController do
     let(:user_id) { rand(99999).to_s }
     let(:original_user_id) { rand(99999).to_s }
     before do
-      session[:user_id] = user_id
+      session['user_id'] = user_id
       expect(Settings.google_proxy).to receive(:fake).at_least(:once).and_return(true)
       expect(Settings.app_alerts_proxy).to receive(:fake).at_least(:once).and_return(true)
       expect(Settings.bearfacts_proxy).to receive(:fake).at_least(:once).and_return(true)
     end
     it 'should not give a real user a cached censored feed' do
-      session[:original_user_id] = original_user_id
+      session['original_user_id'] = original_user_id
       get :get_feed
       feed = JSON.parse(response.body)
       ['bcal', 'bdrive', 'bmail'].each do |service|
         expect(feed['badges'][service]['count']).to eq 0
       end
-      session[:original_user_id] = nil
+      session['original_user_id'] = nil
       get :get_feed
       feed = JSON.parse(response.body)
       ['bcal', 'bdrive', 'bmail'].each do |service|
@@ -74,7 +74,7 @@ describe MyBadgesController do
       ['bcal', 'bdrive', 'bmail'].each do |service|
         expect(feed['badges'][service]['count']).to be > 0
       end
-      session[:original_user_id] = original_user_id
+      session['original_user_id'] = original_user_id
       get :get_feed
       feed = JSON.parse(response.body)
       expect(feed['alert']['title']).to be_present

--- a/spec/controllers/my_classes_controller_spec.rb
+++ b/spec/controllers/my_classes_controller_spec.rb
@@ -18,7 +18,7 @@ describe MyClassesController do
       [{course_code: "PLEO 22",
       id: "750027",
       emitter: Canvas::Proxy::APP_NAME}])
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     get :get_feed
     json_response = JSON.parse(response.body)
     json_response.size.should == 1

--- a/spec/controllers/my_events_controller_spec.rb
+++ b/spec/controllers/my_events_controller_spec.rb
@@ -30,14 +30,14 @@ describe MyEventsController do
     context 'authenticated' do
       let(:random_id) { rand(99999).to_s }
       before do
-        session[:user_id] = random_id
+        session['user_id'] = random_id
       end
 
       context "failure scenarios" do
 
         # TODO fixing this test requires rspec 3, see CLC-3565 for details.
         #context "request type HTML, authenticated" do
-        #  before(:each) { session[:user_id] = random_id }
+        #  before(:each) { session['user_id'] = random_id }
         #
         #  subject { post :create, { format: 'html'} }
         #
@@ -78,7 +78,7 @@ describe MyEventsController do
 
         context 'viewing as another user' do
           before do
-            session[:original_user_id] = rand(99999).to_s
+            session['original_user_id'] = rand(99999).to_s
             allow(GoogleApps::Proxy).to receive(:access_granted?).with(random_id).and_return(true)
           end
           subject do

--- a/spec/controllers/my_finaid_controller_spec.rb
+++ b/spec/controllers/my_finaid_controller_spec.rb
@@ -16,7 +16,7 @@ describe MyFinaidController do
   it "should be an non-empty feed on authenticated user" do
     Finaid::MyFinAid.any_instance.stub(:get_feed).and_return(
       [{summary: "foo"}])
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     get :get_feed
     json_response = JSON.parse(response.body)
     json_response.size.should == 1

--- a/spec/controllers/my_financials_controller_spec.rb
+++ b/spec/controllers/my_financials_controller_spec.rb
@@ -16,7 +16,7 @@ describe MyFinancialsController do
   it "should be an non-empty financials feed on authenticated user" do
     Financials::MyFinancials.any_instance.stub(:get_feed).and_return(
       [{summary: "foo"}])
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     get :get_feed
     json_response = JSON.parse(response.body)
     json_response.size.should == 1

--- a/spec/controllers/my_groups_controller_spec.rb
+++ b/spec/controllers/my_groups_controller_spec.rb
@@ -15,7 +15,7 @@ describe MyGroupsController do
 
   it "should check for valid fields on the my groups feed" do
     #needs to be updated afterwards
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     get :get_feed
     json_response = JSON.parse(response.body)
     json_response["groups"].is_a?(Array).should == true

--- a/spec/controllers/my_tasks_controller_spec.rb
+++ b/spec/controllers/my_tasks_controller_spec.rb
@@ -17,7 +17,7 @@ describe MyTasksController do
   end
 
   it "should be an non-empty task feed on authenticated user" do
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     get :get_feed
     json_response = JSON.parse(response.body)
     json_response.should_not == {}
@@ -28,7 +28,7 @@ describe MyTasksController do
   end
 
   it "should return a valid json object on a successful task update" do
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     hash = {"someKey" => "someValue"}
     MyTasks::Merged.any_instance.stub(:update_task).and_return(hash)
     post :update_task, {key: "value"}
@@ -38,7 +38,7 @@ describe MyTasksController do
   end
 
   it "should return a valid truthy json object when successfully clearing completed google tasks" do
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     user_payload = {"emitter" => "Google"}
     GoogleApps::Proxy.stub(:access_granted?).and_return(true)
     GoogleApps::ClearTaskList.stub(:new).and_return(@fake_google_clear_tasks_proxy)
@@ -49,7 +49,7 @@ describe MyTasksController do
   end
 
   it "should successfully delete a google task" do
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     GoogleApps::Proxy.stub(:access_granted?).and_return(true)
     GoogleApps::DeleteTask.stub(:new).and_return(@fake_google_delete_tasks_proxy)
     pre_recorded_tasklist_id = "MDkwMzQyMTI0OTE3NTY4OTU0MzY6NzAzMjk1MTk3OjA"
@@ -63,7 +63,7 @@ describe MyTasksController do
   end
 
   it "should fail on deleting a canvas task" do
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     Canvas::Proxy.stub(:access_granted?).and_return(true)
     hash = {"task_id" => "gobblygook", "emitter" => "bCourses"}
     post :delete_task, hash
@@ -72,7 +72,7 @@ describe MyTasksController do
   end
 
   it "should return a 400 error on some ArgumentError with the task model object" do
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     error_msg = "some fatal issue"
     MyTasks::Merged.any_instance.stub(:update_task).and_raise(ArgumentError, error_msg)
     post :update_task, {key: "value"}
@@ -86,17 +86,17 @@ describe MyTasksController do
     let(:user_id) { rand(99999).to_s }
     let(:original_user_id) { rand(99999).to_s }
     before do
-      session[:user_id] = user_id
+      session['user_id'] = user_id
       allow(Settings.google_proxy).to receive(:fake).at_least(:once).and_return(true)
       allow(Settings.canvas_proxy).to receive(:fake).at_least(:once).and_return(true)
     end
     context 'with real-user data cached' do
       it 'should not give a real user a cached censored feed' do
-        session[:original_user_id] = original_user_id
+        session['original_user_id'] = original_user_id
         get :get_feed
         feed = JSON.parse(response.body)
         expect(feed['tasks'].index {|t| t['emitter'] == 'Google'}).to be_nil
-        session[:original_user_id] = nil
+        session['original_user_id'] = nil
         get :get_feed
         feed = JSON.parse(response.body)
         expect(feed['tasks'].index {|t| t['emitter'] == 'Google'}).to_not be_nil
@@ -106,7 +106,7 @@ describe MyTasksController do
         feed = JSON.parse(response.body)
         expect(feed['tasks'].index {|t| t['emitter'] == 'bCourses'}).to_not be_nil
         expect(feed['tasks'].index {|t| t['emitter'] == 'Google'}).to_not be_nil
-        session[:original_user_id] = original_user_id
+        session['original_user_id'] = original_user_id
         get :get_feed
         feed = JSON.parse(response.body)
         expect(feed['tasks'].index {|t| t['emitter'] == 'bCourses'}).to_not be_nil
@@ -114,7 +114,7 @@ describe MyTasksController do
       end
     end
     it 'should not add a Google task to the real user account' do
-      session[:original_user_id] = original_user_id
+      session['original_user_id'] = original_user_id
       expect_any_instance_of(MyTasks::GoogleTasks).to receive(:insert_task).never
       hash = {
         'emitter' => 'Google',

--- a/spec/controllers/my_up_next_controller_spec.rb
+++ b/spec/controllers/my_up_next_controller_spec.rb
@@ -13,7 +13,7 @@ describe MyUpNextController do
   context 'authenticated user' do
     let(:user_id) { rand(99999).to_s }
     before do
-      session[:user_id] = user_id
+      session['user_id'] = user_id
     end
     it 'returns a non-empty feed' do
       get :get_feed
@@ -25,22 +25,22 @@ describe MyUpNextController do
     let(:user_id) { rand(99999).to_s }
     let(:original_user_id) { rand(99999).to_s }
     before do
-      session[:user_id] = user_id
+      session['user_id'] = user_id
       expect(Settings.google_proxy).to receive(:fake).at_least(:once).and_return(true)
       allow(Settings.features).to receive(:reauthentication).and_return(false)
     end
     it 'should not give a real user a cached censored feed' do
-      session[:original_user_id] = original_user_id
+      session['original_user_id'] = original_user_id
       get :get_feed
       expect(JSON.parse(response.body)['items']).to be_empty
-      session[:original_user_id] = nil
+      session['original_user_id'] = nil
       get :get_feed
       expect(JSON.parse(response.body)['items']).to be_present
     end
     it 'should not return a cached real-user feed' do
       get :get_feed
       expect(JSON.parse(response.body)['items']).to be_present
-      session[:original_user_id] = original_user_id
+      session['original_user_id'] = original_user_id
       get :get_feed
       expect(JSON.parse(response.body)['items']).to be_empty
     end

--- a/spec/controllers/photo_controller_spec.rb
+++ b/spec/controllers/photo_controller_spec.rb
@@ -19,7 +19,7 @@ describe PhotoController do
     end
 
     context "when user is not logged in" do
-      before { session[:user_id] = nil }
+      before { session['user_id'] = nil }
       it "returns 401 error with no body" do
         get :my_photo
         expect(response.status).to eq 401

--- a/spec/controllers/refresh_logging_controller_spec.rb
+++ b/spec/controllers/refresh_logging_controller_spec.rb
@@ -6,7 +6,7 @@ describe RefreshLoggingController do
   end
 
   it "should not allow non-admin users to do anything to the logging level" do
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     User::Auth.stub(:where).and_return([User::Auth.new(uid: @user_id, is_superuser: false, active: true)])
     Rails.env.stub(:production?).and_return(true)
     CalcentralLogging.should_not_receive(:refresh_logging_level)
@@ -16,7 +16,7 @@ describe RefreshLoggingController do
   end
 
   it "should not attempt to change log settings to a new bad config value" do
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     Rails.env.stub(:production?).and_return(true)
     User::Auth.stub(:where).and_return([User::Auth.new(uid: @user_id, is_superuser: true, active: true)])
     CalcentralConfig.stub(:load_settings).and_return(OpenStruct.new({logger: OpenStruct.new({level: 'fooz'})}))
@@ -28,7 +28,7 @@ describe RefreshLoggingController do
   end
 
   it "should do nothing when the log level has not changed" do
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     Rails.env.stub(:production?).and_return(true)
     User::Auth.stub(:where).and_return([User::Auth.new(uid: @user_id, is_superuser: true, active: true)])
     CalcentralConfig.stub(:load_settings).and_return(OpenStruct.new({logger: OpenStruct.new({level: Rails.logger.level})}))
@@ -37,7 +37,7 @@ describe RefreshLoggingController do
   end
 
   it "should succeed in changing the log level" do
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     Rails.env.stub(:production?).and_return(true)
     User::Auth.stub(:where).and_return([User::Auth.new(uid: @user_id, is_superuser: true, active: true)])
     Rails.logger.stub(:level).and_return(1)

--- a/spec/controllers/routes_list_controller_spec.rb
+++ b/spec/controllers/routes_list_controller_spec.rb
@@ -18,7 +18,7 @@ describe RoutesListController do
 
   it "should not list any routes for non-superusers" do
     User::Auth.stub(:where).and_return([User::Auth.new(uid: @user_id, is_superuser: false, active: true)])
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     get :smoke_test_routes
     expect(response.status).to eq(403)
     expect(response.body.blank?).to be_truthy
@@ -34,8 +34,8 @@ describe RoutesListController do
         User::Auth.new(uid: uid, is_superuser: false, active: true)
       end
     end
-    session[:user_id] = @user_id
-    session[:original_user_id] = viewer_id
+    session['user_id'] = @user_id
+    session['original_user_id'] = viewer_id
     get :smoke_test_routes
     expect(response.status).to eq(403)
     expect(response.body.blank?).to be_truthy
@@ -43,7 +43,7 @@ describe RoutesListController do
 
   it "should list some /api/ routes for superusers" do
     User::Auth.stub(:where).and_return([User::Auth.new(uid: @user_id, is_superuser: true, active: true)])
-    session[:user_id] = @user_id
+    session['user_id'] = @user_id
     get :smoke_test_routes
     assert_response :success
     json_response = JSON.parse(response.body)

--- a/spec/controllers/search_users_controller_spec.rb
+++ b/spec/controllers/search_users_controller_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe SearchUsersController do
   before do
-    session[:user_id] = "1234"
+    session['user_id'] = "1234"
     User::Auth.stub(:where).and_return([User::Auth.new(uid: "1234", is_superuser: true, active: true)])
   end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -16,8 +16,8 @@ describe SessionsController do
       expect(controller).to receive(:cookies).and_return cookie_hash
       :create_reauth_cookie
       different_user_id = "some_other_#{user_id}"
-      session[:original_user_id] = different_user_id
-      session[:user_id] = different_user_id
+      session['original_user_id'] = different_user_id
+      session['user_id'] = different_user_id
 
       get :lookup, renew: 'true'
 
@@ -28,7 +28,7 @@ describe SessionsController do
     end
     it 'will create reauth cookie if original user_id not found in session' do
       expect(controller).to receive(:cookies).and_return cookie_hash
-      session[:user_id] = user_id
+      session['user_id'] = user_id
 
       get :lookup, renew: 'true'
 
@@ -37,13 +37,13 @@ describe SessionsController do
       reauth_cookie[:value].should be_truthy
       (reauth_cookie[:expires] > Date.today).should be_truthy
       session.empty?.should be_falsey
-      session[:user_id].should eql user_id
+      session['user_id'].should eql user_id
     end
     it 'will reset session when CAS uid does not match uid in session' do
       expect(controller).to receive(:cookies).and_return cookie_hash
       :create_reauth_cookie
-      session[:original_user_id] = user_id
-      session[:user_id] = user_id
+      session['original_user_id'] = user_id
+      session['user_id'] = user_id
 
       get :lookup, renew: 'true'
 
@@ -52,12 +52,12 @@ describe SessionsController do
       reauth_cookie[:value].should be_truthy
       (reauth_cookie[:expires] > Date.today).should be_truthy
       session.empty?.should be_falsey
-      session[:user_id].should eql user_id
+      session['user_id'].should eql user_id
     end
     it 'will redirect to CAS logout, despite LTI user session, when CAS user_id is an unexpected value' do
       expect(controller).to receive(:cookies).and_return cookie_hash
-      session[:lti_authenticated_only] = true
-      session[:user_id] = "some_other_#{user_id}"
+      session['lti_authenticated_only'] = true
+      session['user_id'] = "some_other_#{user_id}"
 
       # No 'renew' param
       get :lookup

--- a/spec/controllers/stored_users_controller_spec.rb
+++ b/spec/controllers/stored_users_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe StoredUsersController do
 
   before do
-    session[:user_id] = '1234'
+    session['user_id'] = '1234'
     User::Auth.stub(:where).and_return([User::Auth.new(uid: '1234', is_superuser: true, active: true)])
   end
 

--- a/spec/controllers/user_api_controller_spec.rb
+++ b/spec/controllers/user_api_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe UserApiController do
   let (:user_id) { random_id }
   before do
-    session[:user_id] = user_id
+    session['user_id'] = user_id
     allow(CampusOracle::UserAttributes).to receive(:new).with(user_id: user_id).and_return(double(get_feed: {
       'person_name' => 'Joe Test',
       :roles => {
@@ -36,7 +36,7 @@ describe UserApiController do
       expect(json_response['uid']).to eq user_id
       expect(json_response['preferred_name']).to be_present
       expect(json_response['features']).to be_present
-      visit = User::Visit.where(:uid => session[:user_id])[0]
+      visit = User::Visit.where(:uid => session['user_id'])[0]
       expect(visit.last_visit_at).to be_present
     end
   end
@@ -64,18 +64,18 @@ describe UserApiController do
     end
     context 'when viewing as' do
       let(:original_user_id) { random_id }
-      before { session[:original_user_id] = original_user_id }
+      before { session['original_user_id'] = original_user_id }
       it { should eq original_user_id }
     end
     context 'when authenticated by LTI' do
-      before { session[:lti_authenticated_only] = true }
+      before { session['lti_authenticated_only'] = true }
       it { should eq 'Authenticated through LTI' }
     end
   end
 
   describe 'superuser status' do
     before do
-      session[:original_user_id] = original_user_id
+      session['original_user_id'] = original_user_id
       allow(User::Auth).to receive(:get) do |uid|
         case uid
           when user_id
@@ -100,7 +100,7 @@ describe UserApiController do
       end
       context 'when authenticated by LTI' do
         let(:original_user_id) { nil }
-        before { session[:lti_authenticated_only] = true }
+        before { session['lti_authenticated_only'] = true }
         it { should be_falsey }
       end
     end
@@ -117,7 +117,7 @@ describe UserApiController do
           end
           context 'when authenticated by LTI' do
             let(:original_user_id) { nil }
-            before { session[:lti_authenticated_only] = true }
+            before { session['lti_authenticated_only'] = true }
             it { should eq 403 }
           end
         end
@@ -135,7 +135,7 @@ describe UserApiController do
         end
         context 'when authenticated by LTI' do
           let(:original_user_id) { nil }
-          before { session[:lti_authenticated_only] = true }
+          before { session['lti_authenticated_only'] = true }
           it { should eq 403 }
         end
       end
@@ -152,7 +152,7 @@ describe UserApiController do
         end
         context 'when authenticated by LTI' do
           let(:original_user_id) { nil }
-          before { session[:lti_authenticated_only] = true }
+          before { session['lti_authenticated_only'] = true }
           it { should eq 403 }
         end
       end
@@ -171,7 +171,7 @@ describe UserApiController do
         end
         context 'when authenticated by LTI' do
           let(:original_user_id) { nil }
-          before { session[:lti_authenticated_only] = true }
+          before { session['lti_authenticated_only'] = true }
           it { should eq 403 }
         end
       end

--- a/spec/models/berkeley/course_policy_spec.rb
+++ b/spec/models/berkeley/course_policy_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Berkeley::CoursePolicy do
   let(:user_id)     { rand(99999).to_s }
-  let(:user)        { AuthenticationState.new(user_id: user_id) }
+  let(:user)        { AuthenticationState.new('user_id' => user_id) }
   let(:course)      { Berkeley::Course.new(:course_id => "chem-1a-2014-D") }
   let(:instructor_courses) do
     {

--- a/spec/models/canvas/course_policy_spec.rb
+++ b/spec/models/canvas/course_policy_spec.rb
@@ -3,7 +3,7 @@ require "set"
 
 describe Canvas::CoursePolicy do
   let(:user_id)             { Settings.canvas_proxy.test_user_id }
-  let(:user)                { AuthenticationState.new(user_id: user_id) }
+  let(:user)                { AuthenticationState.new('user_id' => user_id) }
   let(:super_user)          { User::Auth.new(uid: user_id, is_superuser: true, active: true) }
   let(:canvas_course_id)    { 1121 }
   let(:course)              { Canvas::Course.new(:user_id => user.user_id, :canvas_course_id => canvas_course_id) }

--- a/spec/models/user_specific_model_spec.rb
+++ b/spec/models/user_specific_model_spec.rb
@@ -4,14 +4,14 @@ describe UserSpecificModel do
 
   describe '#from_session' do
     let(:fake_session) {{
-      user_id: random_id,
-      original_user_id: random_id,
-      lti_authenticated_only: true
+      'user_id' => random_id,
+      'original_user_id' => random_id,
+      'lti_authenticated_only' => true
     }}
     it 'instantiates using session variables' do
-      expect(UserSpecificModel).to receive(:new).with(fake_session[:user_id], {
-        original_user_id: fake_session[:original_user_id],
-        lti_authenticated_only: fake_session[:lti_authenticated_only]
+      expect(UserSpecificModel).to receive(:new).with(fake_session['user_id'], {
+            'original_user_id' => fake_session['original_user_id'],
+            'lti_authenticated_only' => fake_session['lti_authenticated_only']
       })
       UserSpecificModel.from_session(fake_session)
     end
@@ -21,21 +21,21 @@ describe UserSpecificModel do
     subject {UserSpecificModel.from_session(fake_session).directly_authenticated?}
     context 'when normally authenticated' do
       let(:fake_session) {{
-        user_id: random_id
+        'user_id' => random_id
       }}
       it {should be_truthy}
     end
     context 'when viewing as' do
       let(:fake_session) {{
-        user_id: random_id,
-        original_user_id: random_id
+        'user_id' => random_id,
+        'original_user_id' => random_id
       }}
       it {should be_falsey}
     end
     context 'when only authenticated from an external app' do
       let(:fake_session) {{
-        user_id: random_id,
-        lti_authenticated_only: true
+        'user_id' => random_id,
+        'lti_authenticated_only' => true
       }}
       it {should be_falsey}
     end

--- a/spec/policies/authentication_state_policy_spec.rb
+++ b/spec/policies/authentication_state_policy_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe AuthenticationStatePolicy do
   let(:session_state) do
-    {user_id: user_id, original_user_id: original_user_id, lti_authenticated_only: lti_authenticated_only}
+    {'user_id' => user_id, 'original_user_id' => original_user_id, 'lti_authenticated_only' => lti_authenticated_only}
   end
   let(:original_user_id) {nil}
   let(:lti_authenticated_only) {nil}

--- a/spec/policies/authentication_state_spec.rb
+++ b/spec/policies/authentication_state_spec.rb
@@ -6,21 +6,21 @@ describe AuthenticationState do
     subject {AuthenticationState.new(fake_session).directly_authenticated?}
     context 'when normally authenticated' do
       let(:fake_session) {{
-        user_id: random_id
+        'user_id' => random_id
       }}
       it {should be_truthy}
     end
     context 'when viewing as' do
       let(:fake_session) {{
-        user_id: random_id,
-        original_user_id: random_id
+        'user_id' => random_id,
+        'original_user_id' => random_id
       }}
       it {should be_falsey}
     end
     context 'when only authenticated from an external app' do
       let(:fake_session) {{
-        user_id: random_id,
-        lti_authenticated_only: true
+        'user_id' => random_id,
+        'lti_authenticated_only' => true
       }}
       it {should be_falsey}
     end
@@ -35,21 +35,21 @@ describe AuthenticationState do
     subject {AuthenticationState.new(fake_session).real_user_id}
     context 'when normally authenticated' do
       let(:fake_session) {{
-        user_id: random_id
+        'user_id' => random_id
       }}
-      it {should eq fake_session[:user_id]}
+      it {should eq fake_session['user_id']}
     end
     context 'when viewing as' do
       let(:fake_session) {{
-        user_id: random_id,
-        original_user_id: random_id
+        'user_id' => random_id,
+        'original_user_id' => random_id
       }}
-      it {should eq fake_session[:original_user_id]}
+      it {should eq fake_session['original_user_id']}
     end
     context 'when only authenticated from an external app' do
       let(:fake_session) {{
-        user_id: random_id,
-        lti_authenticated_only: true
+        'user_id' => random_id,
+        'lti_authenticated_only' => true
       }}
       it {should eq AuthenticationState::LTI_AUTHENTICATED_ONLY}
     end
@@ -64,21 +64,21 @@ describe AuthenticationState do
     subject {AuthenticationState.new(fake_session).viewing_as?}
     context 'when normally authenticated' do
       let(:fake_session) {{
-        user_id: random_id
+        'user_id' => random_id
       }}
       it {should be_falsey}
     end
     context 'when viewing as' do
       let(:fake_session) {{
-        user_id: random_id,
-        original_user_id: random_id
+        'user_id' => random_id,
+        'original_user_id' => random_id
       }}
       it {should be_truthy}
     end
     context 'when only authenticated from an external app' do
       let(:fake_session) {{
-        user_id: random_id,
-        lti_authenticated_only: true
+        'user_id' => random_id,
+        'lti_authenticated_only' => true
       }}
       it {should be_falsey}
     end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -11,7 +11,7 @@
 # for the method that is being tested. For exapmle, see spec/controllers/my_academics_controller_spec.rb
 shared_examples "a user authenticated api endpoint" do
   context "when no user session present" do
-    before { session[:user_id] = nil }
+    before { session['user_id'] = nil }
     it "returns empty json hash" do
       make_request
       assert_response :success
@@ -23,7 +23,7 @@ end
 
 shared_examples "an authenticated endpoint" do
   context "when no user session present" do
-    before { session[:user_id] = nil }
+    before { session['user_id'] = nil }
     it "returns empty response" do
       make_request
       expect(response.status).to eq(401)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5004

The HTTP request-and-session variables' underlying Hash data structures (which use string keys) can leak out of Rails's HashWithIndifferentAccess abstraction, unexpectedly clashing with symbol-key-using code.

In terms of lines of code, this is my biggest PR in ages. But as you'll see, it gets a little samey...