### PR TITLE
CLC-4913 - Course Provisioning: As an Instructor, I want to only be added to appropriate sections when creating a course site

### DIFF
--- a/app/models/canvas/course_sections.rb
+++ b/app/models/canvas/course_sections.rb
@@ -23,6 +23,24 @@ module Canvas
       course_sections.compact
     end
 
+    def create(name, sis_section_id)
+      request_params = {
+        'course_section' => {
+          'name' => name,
+          'sis_section_id' => sis_section_id,
+          'start_at' => nil,
+          'end_at' => nil,
+          'restrict_enrollments_to_section_dates' => nil,
+        }
+      }
+      request_options = {
+        :method => :post,
+        :body => request_params,
+      }
+      response = request_uncached("courses/#{@course_id}/sections", "_course_create_section", request_options)
+      JSON.parse(response.body)
+    end
+
   end
 end
 

--- a/app/models/canvas/provide_course_site.rb
+++ b/app/models/canvas/provide_course_site.rb
@@ -208,7 +208,7 @@ module Canvas
     end
 
     def enroll_instructor
-      default_section = Canvas::CourseSections.new(:course_id => course_details['id']).create(@import_data['site_name'], '')
+      default_section = Canvas::CourseSections.new(:course_id => course_details['id']).create(@import_data['site_name'], "DEFSEC:#{course_details['id']}")
       response = Canvas::CourseAddUser.add_user_to_course_section(@uid, 'TeacherEnrollment', default_section['id'])
       if response.blank?
         logger.error("Imported course from #{@import_data['courses_csv_file']} but could not add #{@uid} as teacher to section #{default_section['id']}")

--- a/fixtures/pretty_vcr_recordings/Canvas_course_create_section.json
+++ b/fixtures/pretty_vcr_recordings/Canvas_course_create_section.json
@@ -1,0 +1,100 @@
+{
+  "http_interactions": [
+    {
+      "request": {
+        "method": "post",
+        "uri": "http://ucb.beta.example.com/api/v1/courses/5/sections",
+        "body": {
+          "encoding": "US-ASCII",
+          "string": "course_section%5Bend_at%5D=&course_section%5Bname%5D=Data+Structures&course_section%5Brestrict_enrollments_to_section_dates%5D=&course_section%5Bsis_section_id%5D=&course_section%5Bstart_at%5D="
+        },
+        "headers": {
+          "Authorization": [
+            ""
+          ],
+          "Cache-Control": [
+            "no-store"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "x-sakai-token": [
+
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": null
+        },
+        "headers": {
+          "x-canvas-user-id": [
+            "10000000000002"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "content-type": [
+            "application/json; charset=utf-8"
+          ],
+          "x-ua-compatible": [
+            "IE=Edge"
+          ],
+          "etag": [
+            "\"b3e553d4d3a4e1d8ff7fa08f59b014a4\""
+          ],
+          "cache-control": [
+            "max-age=0, private, must-revalidate"
+          ],
+          "set-cookie": [
+            "_csrf_token=mWxsTV3T02ceABG9cjOkm9nea%2BG9VQP0t1liXz%2BY%2Bg7BDQE3GamZF250Ju85dOnqtJsyjtkkaoXaLToScPGRVg%3D%3D; path=/, _normandy_session=-u9Xyke-HRDCS66Zr0-j4A+C-XrYcEElxV3kSsUzk6G46YRi2CyBYBoTTi-oKfgzMSh8zkWzirnx0tCnBwcrREet6ZtAcRAX296WgXKs-wjmMREienO5jiCge8AMTKDn-rZoJbLdjn6_PcgVqIgR6c05LRkxSVB6H-1Fit9EeIxJXWWOE3fDyI13Uuq0UtDSUS3dZzFZTLdqLapxDU5vuDevjTL6ZycC4BeK1fIoA1sfeepgntGrnjVfKDUBcRwA4zIc68NqORXuGMr1efTv46STuZBRGwBhYm2XYEURsnfJw.NXvYeD9YMNQcRdLCIhaYNhRD98s.VQn5pA; path=/; HttpOnly"
+          ],
+          "x-session-id": [
+            "6683b3ec97fa3ffe148acbf66f131184"
+          ],
+          "x-request-context-id": [
+            "957a5050-afea-0132-8e62-685b358d5fc5"
+          ],
+          "x-canvas-meta": [
+            "b=375092;m=399032;u=1.53;y=0.06;d=0.35;"
+          ],
+          "x-runtime": [
+            "1.965004"
+          ],
+          "connection": [
+            "close"
+          ],
+          "server": [
+            "thin"
+          ],
+          "Authorization": [
+            ""
+          ],
+          "x-sakai-token": [
+
+          ]
+        },
+        "body": {
+          "encoding": "US-ASCII",
+          "string": "",
+          "debug_json": {
+            "course_id": 5,
+            "end_at": null,
+            "id": 160,
+            "name": "Data Structures",
+            "nonxlist_course_id": null,
+            "start_at": null,
+            "sis_section_id": null,
+            "sis_course_id": "CRS:COMPSCI-61B-2014-D",
+            "integration_id": null,
+            "sis_import_id": null
+          }
+        },
+        "http_version": null
+      },
+      "recorded_at": "Wed, 18 Mar 2015 22:18:12 GMT"
+    }
+  ],
+  "recorded_with": "VCR 2.9.3"
+}

--- a/spec/models/canvas/course_sections_spec.rb
+++ b/spec/models/canvas/course_sections_spec.rb
@@ -42,7 +42,6 @@ describe Canvas::CourseSections do
     end
   end
 
-
   context 'when providing official section identifiers existing within course' do
     let(:course_sections) do
       [
@@ -87,6 +86,23 @@ describe Canvas::CourseSections do
         end
       end
 
+    end
+  end
+
+  context 'when creating new section within course' do
+    it 'returns section details with id' do
+      result = subject.create('Data Structures', '')
+      expect(result).to be_an_instance_of Hash
+      expect(result['id']).to eq 160
+      expect(result['course_id']).to eq 5
+      expect(result['name']).to eq 'Data Structures'
+      expect(result['sis_course_id']).to eq "CRS:COMPSCI-61B-2014-D"
+      expect(result['sis_section_id']).to eq nil
+      expect(result['start_at']).to eq nil
+      expect(result['end_at']).to eq nil
+      expect(result['integration_id']).to eq nil
+      expect(result['sis_import_id']).to eq nil
+      expect(result['nonxlist_course_id']).to eq nil
     end
   end
 

--- a/spec/models/canvas/provide_course_site_spec.rb
+++ b/spec/models/canvas/provide_course_site_spec.rb
@@ -46,7 +46,7 @@ describe Canvas::ProvideCourseSite do
   }
   let(:section_details_hash) {
     {
-      "id"=>1253733,
+      "id"=>119433,
       "sis_section_id"=>nil,
       "name"=>"Data Structures",
       "course_id"=>5,
@@ -506,12 +506,15 @@ describe Canvas::ProvideCourseSite do
 
   describe '#enroll_instructor' do
     before do
+      course_site_name = site_name
+      subject.instance_eval { @import_data['site_name'] = course_site_name }
       allow(subject).to receive(:course_details).and_return(course_details_hash)
-      allow_any_instance_of(Canvas::CourseSections).to receive(:create).and_return(section_details_hash)
+      allow_any_instance_of(Canvas::CourseSections).to receive(:create).with(site_name, "DEFSEC:#{course_details_hash['id']}").and_return(section_details_hash)
       allow(Canvas::CourseAddUser).to receive(:add_user_to_course_section).with(uid, 'TeacherEnrollment', section_details_hash['id']).and_return(true)
     end
-    it 'establishes a default section' do
-      expect_any_instance_of(Canvas::CourseSections).to receive(:create).and_return(section_details_hash)
+
+    it 'establishes a default section with SIS Section ID' do
+      expect_any_instance_of(Canvas::CourseSections).to receive(:create).with(site_name, "DEFSEC:#{course_details_hash['id']}").and_return(section_details_hash)
       subject.enroll_instructor
     end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4913

Establishes API based method for creation of a course section. Updates Canvas::ProvideCourseSite to use this method to automatically create a default course section and enroll the site creator as a 'Teacher' in that section. The exception to this is when the course site is created by CCN.