### PR TITLE
CLC-4949 CLC-4996 Modify bCourses Official Sections authorization rules

### DIFF
--- a/app/models/canvas/course_policy.rb
+++ b/app/models/canvas/course_policy.rb
@@ -19,6 +19,14 @@ module Canvas
       is_canvas_course_teacher_or_assistant?
     end
 
+    def can_edit_official_sections?
+      is_canvas_course_teacher? && can_add_current_official_sections?
+    end
+
+    def can_view_official_sections?
+      is_canvas_course_admin? || is_canvas_account_admin?
+    end
+
     def is_canvas_user?
       if canvas_user_profile.blank?
         logger.warn "UID #{@user.user_id} not found in Canvas, attempting authorization for Canvas Course ID #{@record.canvas_course_id}"

--- a/app/policies/authentication_state_policy.rb
+++ b/app/policies/authentication_state_policy.rb
@@ -44,7 +44,11 @@ class AuthenticationStatePolicy
   end
 
   def can_create_canvas_course_site?
-    can_administrate_canvas? || Canvas::CurrentTeacher.new(@user.user_id).user_currently_teaching?
+    can_administrate_canvas? || can_add_current_official_sections?
+  end
+
+  def can_add_current_official_sections?
+    Canvas::CurrentTeacher.new(@user.user_id).user_currently_teaching?
   end
 
   def can_refresh_log_settings?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,7 +71,8 @@ Calcentral::Application.routes.draw do
   get '/api/academics/canvas/course_provision' => 'canvas_course_provision#get_feed', :as => :canvas_course_provision, :defaults => { :format => 'json' }
   get '/api/academics/canvas/course_provision_as/:admin_acting_as' => 'canvas_course_provision#get_feed', :as => :canvas_course_provision_as, :defaults => { :format => 'json' }
   post '/api/academics/canvas/course_provision/create' => 'canvas_course_provision#create_course_site', :via => :post, :as => :canvas_course_create, :defaults => { :format => 'json' }
-  post '/api/academics/canvas/course_provision/edit_sections' => 'canvas_course_provision#edit_sections', :via => :post, :as => :canvas_course_edit_sections, :defaults => { :format => 'json' }
+  get '/api/academics/canvas/course_provision/sections_feed/:canvas_course_id' => 'canvas_course_provision#get_sections_feed', :as => :canvas_course_sections_feed, :defaults => { :format => 'json' }
+  post '/api/academics/canvas/course_provision/edit_sections/:canvas_course_id' => 'canvas_course_provision#edit_sections', :via => :post, :as => :canvas_course_edit_sections, :defaults => { :format => 'json' }
   get '/api/academics/canvas/course_provision/status' => 'canvas_course_provision#job_status', :via => :get, :as => :canvas_course_job_status, :defaults => { :format => 'json' }
   post '/api/academics/canvas/project_provision/create' => 'canvas_project_provision#create_project_site', :via => :post, :as => :canvas_project_create, :defaults => { :format => 'json' }
   post '/api/academics/canvas/user_provision/user_import' => 'canvas_user_provision#user_import', :as => :canvas_user_provision_import, :defaults => { :format => 'json' }

--- a/spec/controllers/canvas_course_provision_controller_spec.rb
+++ b/spec/controllers/canvas_course_provision_controller_spec.rb
@@ -7,12 +7,12 @@ describe CanvasCourseProvisionController do
   let(:admin_term_slug) { 'spring-2014' }
   let(:admin_by_ccns) { ['76376', '76628'] }
   let(:canvas_course_id) { rand(99999).to_s }
-  let(:fake_sections_feed) do
+  let(:fake_provisioning_feed) do
     {
-      :is_admin => false,
-      :admin_acting_as => nil,
-      :admin_semesters => nil,
-      :teachingSemesters => {},
+      'is_admin' => false,
+      'admin_acting_as' => nil,
+      'admin_semesters' => nil,
+      'teachingSemesters' => {},
     }
   end
   before do
@@ -20,42 +20,123 @@ describe CanvasCourseProvisionController do
   end
 
   describe '#get_feed' do
-    it_should_behave_like "an api endpoint" do
-      before { allow_any_instance_of(Canvas::CourseProvision).to receive(:get_feed).and_raise(RuntimeError, "Something went wrong") }
-      let(:make_request) { get :get_feed }
-    end
-
     it_should_behave_like "a user authenticated api endpoint" do
       let(:make_request) { get :get_feed }
     end
-
-    it 'should respond with empty 401 response when feed request unauthorized' do
-      allow_any_instance_of(Canvas::CourseProvision).to receive(:get_feed).and_return(nil)
-      get :get_feed
-      assert_response 401
-      expect(response.body).to eq " "
+    context 'when user authenticated' do
+      before do
+        allow_any_instance_of(Canvas::CourseProvision).to receive(:get_feed).and_return(fake_provisioning_feed)
+        allow_any_instance_of(AuthenticationStatePolicy).to receive(:can_create_canvas_course_site?).and_return(fake_authorized)
+      end
+      context 'allowed to create a course site' do
+        let(:fake_authorized) {true}
+        it 'should return sections feed' do
+          get :get_feed
+          assert_response :success
+          json_response = JSON.parse(response.body)
+          expect(json_response).to eq fake_provisioning_feed
+        end
+        it 'should not accept a canvas_course_id parameter' do
+          get :get_feed, canvas_course_id: canvas_course_id
+          assert_response 500
+          json_response = JSON.parse(response.body)
+          expect(json_response['error']).to be_present
+        end
+        it_should_behave_like "an api endpoint" do
+          before { allow_any_instance_of(Canvas::CourseProvision).to receive(:get_feed).and_raise(RuntimeError, "Something went wrong") }
+          let(:make_request) { get :get_feed }
+        end
+        it 'should respond with empty 401 response when feed is empty' do
+          allow_any_instance_of(Canvas::CourseProvision).to receive(:get_feed).and_return(nil)
+          get :get_feed
+          assert_response 401
+          expect(response.body).to eq " "
+        end
+      end
+      context 'not allowed to create a course site' do
+        let(:fake_authorized) {false}
+        it 'responds with empty 403' do
+          get :get_feed
+          assert_response 403
+          expect(response.body).to be_blank
+        end
+      end
     end
+  end
 
-    it 'should return sections feed' do
-      allow_any_instance_of(Canvas::CourseProvision).to receive(:get_feed).and_return(fake_sections_feed)
-      get :get_feed
-      assert_response :success
-      json_response = JSON.parse(response.body)
-      expect(json_response).to be_an_instance_of Hash
-      expect(json_response['is_admin']).to eq false
-      expect(json_response['admin_acting_as']).to eq nil
-      expect(json_response['admin_semesters']).to eq nil
-      expect(json_response['teachingSemesters']).to be_an_instance_of Hash
+  describe '#get_sections_feed' do
+    let(:fake_sections_feed) do
+      fake_provisioning_feed.merge('canvas_course' => {'canvasCourseId' => canvas_course_id.to_i, 'canEdit' => fake_can_edit})
     end
-
-    it 'should use canvas course id option when present as a parameter' do
-      fake_course_provision_worker = double('canvas_course_provision', :get_feed => {:canvas_course => {}})
-      expect(Canvas::CourseProvision).to receive(:new).with(session['user_id'], canvas_course_id: canvas_course_id).and_return(fake_course_provision_worker)
-      get :get_feed, canvas_course_id: canvas_course_id
-      assert_response :success
-      json_response = JSON.parse(response.body)
-      expect(json_response).to be_an_instance_of Hash
-      expect(json_response['canvas_course']).to be_an_instance_of Hash
+    let(:fake_can_edit) { false }
+    let(:fake_course_provision) { instance_double(Canvas::CourseProvision, get_feed: fake_sections_feed) }
+    let(:fake_policy) { instance_double(Canvas::CoursePolicy) }
+    it_should_behave_like 'a user authenticated api endpoint' do
+      let(:make_request) { get :get_sections_feed, canvas_course_id: canvas_course_id }
+    end
+    context 'when user authenticated' do
+      before do
+        allow(Canvas::CourseProvision).to receive(:new) do |uid_arg, options|
+          if (uid_arg == uid) && (options[:canvas_course_id] == canvas_course_id.to_i)
+            fake_course_provision
+          end
+        end
+        allow(Canvas::CoursePolicy).to receive(:new).and_return(fake_policy)
+        allow(fake_policy).to receive(:can_view_official_sections?).and_return(fake_authorized)
+        allow(fake_policy).to receive(:can_edit_official_sections?).and_return(fake_can_edit)
+      end
+      context 'allowed to view course site official sections' do
+        let(:fake_authorized) { true }
+        it 'should return sections feed' do
+          get :get_sections_feed, canvas_course_id: canvas_course_id
+          assert_response :success
+          expect(JSON.parse(response.body)).to eq fake_sections_feed
+        end
+        context 'in LTI context' do
+          before do
+            session['canvas_course_id'] = canvas_course_id
+          end
+          it 'uses the session-stored course ID' do
+            get :get_sections_feed, canvas_course_id: 'embedded'
+            assert_response :success
+            expect(JSON.parse(response.body)).to eq fake_sections_feed
+          end
+        end
+        context 'allowed to edit official sections' do
+          let(:fake_can_edit) { true }
+          it 'should return sections feed' do
+            get :get_sections_feed, canvas_course_id: canvas_course_id
+            assert_response :success
+            expect(JSON.parse(response.body)).to eq fake_sections_feed
+          end
+        end
+        it 'requires a canvas_course_id parameter' do
+          get :get_sections_feed, canvas_course_id: ''
+          assert_response 500
+          json_response = JSON.parse(response.body)
+          expect(json_response['error']).to be_present
+        end
+        it_should_behave_like "an api endpoint" do
+          before { allow(fake_course_provision).to receive(:get_feed).and_raise(RuntimeError, "Something went wrong") }
+          let(:make_request) { get :get_sections_feed, canvas_course_id: canvas_course_id }
+        end
+        context 'when feed is empty' do
+          let(:fake_sections_feed) {nil}
+          it 'should respond with empty 401' do
+            get :get_sections_feed, canvas_course_id: canvas_course_id
+            assert_response 401
+            expect(response.body).to eq " "
+          end
+        end
+      end
+      context 'not allowed to view official sections' do
+        let(:fake_authorized) {false}
+        it 'responds with empty 403' do
+          get :get_sections_feed, canvas_course_id: canvas_course_id
+          assert_response 403
+          expect(response.body).to be_blank
+        end
+      end
     end
   end
 
@@ -63,6 +144,9 @@ describe CanvasCourseProvisionController do
     let(:instructor_id) { '1234' }      # represents UID for instructor / teacher creating courses
     let(:ccns) { ['12345', '12348'] }   # represents the course control numbers associated with each course section
     let(:term_slug) { 'fall-2014' }     # represents the term for the course being created
+    before do
+      allow_any_instance_of(AuthenticationStatePolicy).to receive(:can_create_canvas_course_site?).and_return(true)
+    end
 
     it_should_behave_like "an api endpoint" do
       before { allow_any_instance_of(Canvas::CourseProvision).to receive(:create_course_site).and_raise(RuntimeError, "Something went wrong") }
@@ -80,7 +164,7 @@ describe CanvasCourseProvisionController do
       expect(json_response['error']).to eq "Conflicting request parameters sent to Canvas Course Provision"
     end
 
-    it 'responds with success when course provisioning job is created successful' do
+    it 'responds with success when course provisioning job is created' do
       allow_any_instance_of(Canvas::CourseProvision).to receive(:create_course_site).and_return('canvas.courseprovision.12345.1383330151057')
       post :create_course_site, ccns: @ccns, admin_acting_as: @instructor_id, term_slug: @term_slug
       assert_response :success
@@ -91,22 +175,39 @@ describe CanvasCourseProvisionController do
   end
 
   describe '#edit_sections' do
-    it_should_behave_like "an api endpoint" do
-      before { allow(Canvas::CourseProvision).to receive(:new).and_raise(RuntimeError, "Something went wrong") }
-      let(:make_request) { post :edit_sections, canvas_course_id: canvas_course_id, ccns_to_remove: ['16171', '16109', '10287'], ccns_to_add: ['16167', '16168', '16169'] }
+    let(:fake_can_edit) { false }
+    let(:ccns_to_remove) { ['16171', '16109', '10287'] }
+    let(:ccns_to_add) { ['16167', '16168', '16169'] }
+    it_should_behave_like 'a user authenticated api endpoint' do
+      let(:make_request) { post :edit_sections, canvas_course_id: canvas_course_id, ccns_to_remove: ccns_to_remove, ccns_to_add:  ccns_to_add }
     end
-
-    it_should_behave_like "a user authenticated api endpoint" do
-      let(:make_request) { post :edit_sections, canvas_course_id: canvas_course_id, ccns_to_remove: ['16171', '16109', '10287'], ccns_to_add: ['16167', '16168', '16169'] }
-    end
-
-    it 'responds with success when section removal job is created successful' do
-      allow_any_instance_of(Canvas::CourseProvision).to receive(:edit_sections).and_return('canvas.courseprovision.12345.1383330151057')
-      post :edit_sections, canvas_course_id: canvas_course_id, ccns_to_remove: ['16171', '16109', '10287'], ccns_to_add: ['16167', '16168', '16169']
-      assert_response :success
-      json_response = JSON.parse(response.body)
-      json_response['job_request_status'].should == 'Success'
-      json_response['job_id'].should == 'canvas.courseprovision.12345.1383330151057'
+    context 'when user authenticated' do
+      before do
+        allow_any_instance_of(Canvas::CourseProvision).to receive(:edit_sections).and_return('canvas.courseprovision.12345.1383330151057')
+        allow_any_instance_of(Canvas::CoursePolicy).to receive(:can_edit_official_sections?).and_return(fake_can_edit)
+      end
+      context 'allowed to edit official sections' do
+        let(:fake_can_edit) { true }
+        it 'responds with success when section removal job is created' do
+          post :edit_sections, canvas_course_id: canvas_course_id, ccns_to_remove: ccns_to_remove, ccns_to_add:  ccns_to_add
+          assert_response :success
+          json_response = JSON.parse(response.body)
+          json_response['job_request_status'].should == 'Success'
+          json_response['job_id'].should == 'canvas.courseprovision.12345.1383330151057'
+        end
+        it_should_behave_like 'an api endpoint' do
+          before { allow_any_instance_of(Canvas::CourseProvision).to receive(:edit_sections).and_raise(RuntimeError, "Something went wrong") }
+          let(:make_request) { post :edit_sections, canvas_course_id: canvas_course_id, ccns_to_remove: ccns_to_remove, ccns_to_add:  ccns_to_add }
+        end
+      end
+      context 'not allowed to edit official sections' do
+        let(:fake_can_edit) {false}
+        it 'responds with empty 403' do
+          post :edit_sections, canvas_course_id: canvas_course_id, ccns_to_remove: ccns_to_remove, ccns_to_add:  ccns_to_add
+          assert_response 403
+          expect(response.body).to be_blank
+        end
+      end
     end
   end
 
@@ -159,11 +260,12 @@ describe CanvasCourseProvisionController do
       expect(result[:admin_by_ccns].count).to eq 2
       expect(result[:admin_by_ccns][0]).to eq admin_by_ccns[0]
       expect(result[:admin_term_slug]).to eq admin_term_slug
-      expect(result[:canvas_course_id]).to eq canvas_course_id
+      expect(result[:canvas_course_id]).to eq canvas_course_id.to_i
     end
 
-    it "returns canvas_course_id parameter if present in session" do
+    it 'returns canvas_course_id session variable if LTI embedded' do
       subject.session['canvas_course_id'] = canvas_course_id
+      subject.params['canvas_course_id'] = 'embedded'
       subject.params['controller'] = 'canvas_course_provision'
       subject.params['action'] = 'get_feed'
       subject.params['admin_acting_as'] = admin_acting_as
@@ -171,7 +273,7 @@ describe CanvasCourseProvisionController do
       expect(result.keys.count).to eq 2
       expect(result).to be_an_instance_of Hash
       expect(result[:admin_acting_as]).to eq admin_acting_as
-      expect(result[:canvas_course_id]).to eq canvas_course_id
+      expect(result[:canvas_course_id]).to eq canvas_course_id.to_i
     end
   end
 end

--- a/src/assets/javascripts/angular/controllers/pages/canvasCourseManageOfficialSectionsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/canvasCourseManageOfficialSectionsController.js
@@ -189,14 +189,7 @@
      */
     var fetchFeed = function() {
       $scope.isLoading = true;
-      var feedRequestOptions = {
-        isAdmin: false,
-        adminMode: false,
-        adminActingAs: false,
-        adminByCcns: [],
-        currentAdminSemester: false
-      };
-      canvasCourseProvisionFactory.getSections(feedRequestOptions).then(function(sectionsFeed) {
+      canvasCourseProvisionFactory.getCourseSections($scope.canvasCourseId).then(function(sectionsFeed) {
         if (sectionsFeed.status !== 200) {
           $scope.isLoading = false;
           $scope.displayError = 'failure';
@@ -205,17 +198,9 @@
           if (sectionsFeed.data) {
             if (sectionsFeed.data && sectionsFeed.data.canvas_course) {
               $scope.canvasCourse = sectionsFeed.data.canvas_course;
-              // get user course roles feed for authorization
-              canvasCourseAddUserFactory.courseUserRoles($scope.canvasCourse.canvasCourseId).then(function(rolesFeed) {
-                if (rolesFeed.data.roles.teacher) {
-                  $scope.isTeacher = true;
-                }
-                refreshFromFeed(sectionsFeed.data);
-                apiService.util.iframeUpdateHeight();
-                if (!$scope.isCourseCreator) {
-                  $scope.displayError = 'unauthorized';
-                }
-              });
+              $scope.isTeacher = $scope.canvasCourse.canEdit;
+              refreshFromFeed(sectionsFeed.data);
+              apiService.util.iframeUpdateHeight();
             } else {
               $scope.displayError = 'failure';
             }

--- a/src/assets/javascripts/angular/factories/canvasCourseProvisionFactory.js
+++ b/src/assets/javascripts/angular/factories/canvasCourseProvisionFactory.js
@@ -70,6 +70,13 @@
       });
     };
 
+    var getCourseSections = function(canvasCourseId) {
+      var feedUrl = '/api/academics/canvas/course_provision/sections_feed/' + canvasCourseId;
+      return $http.get(feedUrl).then(function(response) {
+        return parseSectionsFeed(response);
+      }).catch(errorResponseHandler);
+    };
+
     var getSections = function(feedRequestOptions) {
       var feedUrl = '/api/academics/canvas/course_provision';
       var feedParams = {};
@@ -107,8 +114,7 @@
      * Sends request to add and/or delete sections from existing course site
      */
     var updateSections = function(canvasCourseId, addCcns, deleteCcns) {
-      return $http.post('/api/academics/canvas/course_provision/edit_sections', {
-        canvas_course_id: canvasCourseId,
+      return $http.post('/api/academics/canvas/course_provision/edit_sections/' + canvasCourseId, {
         ccns_to_remove: deleteCcns,
         ccns_to_add: addCcns
       });
@@ -117,6 +123,7 @@
     return {
       courseCreate: courseCreate,
       courseProvisionJobStatus: courseProvisionJobStatus,
+      getCourseSections: getCourseSections,
       getSections: getSections,
       updateSections: updateSections
     };


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4949
https://jira.ets.berkeley.edu/jira/browse/CLC-4996

Changing authorization touched enough places that it seemed best to submit this PR separately. Next step is to fill in more course section data in the feed, but that part of the task should have fewer chances of merge conflicts.

* Authorization rules have been changed, made explicit, & moved to the controller.
* A "canEdit" property has been added to the feed to let the front-end know whether to show the Edit button.
* Two API paths were changed to make the authz checks easier and follow existing conventions.
* The Official Sections app can now be run outside an embedded iframe.

TO DO: Add not-an-instructor site section data.