### PR TITLE
CLC-4910 Merge Regstatus into My Academics feed during term transitions

### DIFF
--- a/app/models/my_academics/college_and_level.rb
+++ b/app/models/my_academics/college_and_level.rb
@@ -87,12 +87,15 @@ module MyAcademics
         end
       end
 
+      termName = "#{feed['studentProfile']['termName'].to_text} #{feed['studentProfile']['termYear'].to_text}"
+
       {
         standing: standing,
         level: level,
         nonApLevel: nonAPLevel,
         futureTelebearsLevel: futureTBLevel,
-        colleges: colleges
+        colleges: colleges,
+        termName: termName
       }
     end
   end

--- a/app/models/my_academics/merged.rb
+++ b/app/models/my_academics/merged.rb
@@ -11,6 +11,7 @@ module MyAcademics
       # be merged before course sites.
       [
         CollegeAndLevel,
+        TransitionRegStatus,
         GpaUnits,
         Requirements,
         Regblocks,

--- a/app/models/my_academics/transition_reg_status.rb
+++ b/app/models/my_academics/transition_reg_status.rb
@@ -1,0 +1,28 @@
+module MyAcademics
+  class TransitionRegStatus
+    include AcademicsModule, ClassLogger
+
+    def merge(data)
+      college_and_level = data[:collegeAndLevel]
+      return if !college_and_level || college_and_level[:empty] || college_and_level[:noStudentId]
+
+      current_term = Berkeley::Terms.fetch.current
+      if college_and_level[:termName] != current_term.to_english
+        data[:transitionRegStatus] = reg_status_from_feed
+      else
+        data[:transitionRegStatus] = nil
+      end
+    end
+
+    def reg_status_from_feed
+      response = Regstatus::Proxy.new(user_id: @uid).get
+      if response && response[:feed] && (reg_status = response[:feed]['regStatus'])
+        {
+          termName: "#{reg_status['termName']} #{reg_status['termYear']}",
+          registered: reg_status['isRegistered']
+        }
+      end
+    end
+
+  end
+end

--- a/public/dummy/json/academics_transition_no_profile.json
+++ b/public/dummy/json/academics_transition_no_profile.json
@@ -1,0 +1,554 @@
+{
+  "collegeAndLevel": {
+    "empty": true
+  },
+  "gpaUnits": {
+    "cumulativeGpa": null,
+    "totalUnits": null,
+    "totalUnitsAttempted": null
+  },
+  "requirements": [],
+  "regblocks": {
+    "errored": false,
+    "activeBlocks": [
+      {
+        "status": "Active",
+        "type": "FINAN",
+        "blockedDate": {
+          "epoch": 1366614000,
+          "dateTime": "2013-04-22T00:00:00-07:00",
+          "dateString": "4/22/2013"
+        },
+        "clearedDate": {
+          "epoch": null,
+          "dateTime": null,
+          "dateString": null
+        },
+        "reason": "CARS",
+        "office": "BPS"
+      }
+    ],
+    "inactiveBlocks": [
+      {
+        "status": "Released",
+        "type": "ACAD",
+        "blockedDate": {
+          "epoch": 1366527600,
+          "dateTime": "2013-04-21T00:00:00-07:00",
+          "dateString": "4/21/2013"
+        },
+        "clearedDate": {
+          "epoch": 1366614000,
+          "dateTime": "2013-04-22T00:00:00-07:00",
+          "dateString": "4/22/2013"
+        },
+        "reason": "",
+        "office": "LNS"
+      },
+      {
+        "status": "Released",
+        "type": "ADMIN",
+        "blockedDate": {
+          "epoch": 1332201600,
+          "dateTime": "2012-03-20T00:00:00+00:00",
+          "dateString": "3/20/2012"
+        },
+        "clearedDate": {
+          "epoch": 1332201600,
+          "dateTime": "2012-03-20T00:00:00+00:00",
+          "dateString": "3/20/2012"
+        },
+        "reason": "STAT LAPSE",
+        "office": "OR"
+      },
+      {
+        "status": "Released",
+        "type": "ADMIN",
+        "blockedDate": {
+          "epoch": 1296691200,
+          "dateTime": "2011-02-03T00:00:00+00:00",
+          "dateString": "2/03/2011"
+        },
+        "clearedDate": {
+          "epoch": 1296691200,
+          "dateTime": "2011-02-03T00:00:00+00:00",
+          "dateString": "2/03/2011"
+        },
+        "reason": "MISC",
+        "office": "OR"
+      },
+      {
+        "status": "Released",
+        "type": "FINAN",
+        "blockedDate": {
+          "epoch": 1296000000,
+          "dateTime": "2011-01-26T00:00:00+00:00",
+          "dateString": "1/26/2011"
+        },
+        "clearedDate": {
+          "epoch": 1296000000,
+          "dateTime": "2011-01-26T00:00:00+00:00",
+          "dateString": "1/26/2011"
+        },
+        "reason": "LIBRARY",
+        "office": ""
+      },
+      {
+        "status": "Released",
+        "type": "ACAD",
+        "blockedDate": {
+          "epoch": 1245110400,
+          "dateTime": "2009-06-16T00:00:00+00:00",
+          "dateString": "6/16/2009"
+        },
+        "clearedDate": {
+          "epoch": 1245110400,
+          "dateTime": "2009-06-16T00:00:00+00:00",
+          "dateString": "6/16/2009"
+        },
+        "reason": "",
+        "office": "LNS"
+      },
+      {
+        "status": "Released",
+        "type": "ACAD",
+        "blockedDate": {
+          "epoch": 1231891200,
+          "dateTime": "2009-01-14T00:00:00+00:00",
+          "dateString": "1/14/2009"
+        },
+        "clearedDate": {
+          "epoch": 1231891200,
+          "dateTime": "2009-01-14T00:00:00+00:00",
+          "dateString": "1/14/2009"
+        },
+        "reason": "",
+        "office": "LNS"
+      },
+      {
+        "status": "Released",
+        "type": "ACAD",
+        "blockedDate": {
+          "epoch": 1173139200,
+          "dateTime": "2007-03-06T00:00:00+00:00",
+          "dateString": "3/06/2007"
+        },
+        "clearedDate": {
+          "epoch": 1173139200,
+          "dateTime": "2007-03-06T00:00:00+00:00",
+          "dateString": "3/06/2007"
+        },
+        "reason": "",
+        "office": "LNS"
+      },
+      {
+        "status": "Released",
+        "type": "ACAD",
+        "blockedDate": {
+          "epoch": 1134345600,
+          "dateTime": "2005-12-12T00:00:00+00:00",
+          "dateString": "12/12/2005"
+        },
+        "clearedDate": {
+          "epoch": 1134345600,
+          "dateTime": "2005-12-12T00:00:00+00:00",
+          "dateString": "12/12/2005"
+        },
+        "reason": "ACADEMIC",
+        "office": "LNS"
+      },
+      {
+        "status": "Released",
+        "type": "ACAD",
+        "blockedDate": {
+          "epoch": 1133827200,
+          "dateTime": "2005-12-06T00:00:00+00:00",
+          "dateString": "12/06/2005"
+        },
+        "clearedDate": {
+          "epoch": 1133827200,
+          "dateTime": "2005-12-06T00:00:00+00:00",
+          "dateString": "12/06/2005"
+        },
+        "reason": "",
+        "office": "LNS"
+      },
+      {
+        "status": "Released",
+        "type": "ACAD",
+        "blockedDate": {
+          "epoch": 1133222400,
+          "dateTime": "2005-11-29T00:00:00+00:00",
+          "dateString": "11/29/2005"
+        },
+        "clearedDate": {
+          "epoch": 1133222400,
+          "dateTime": "2005-11-29T00:00:00+00:00",
+          "dateString": "11/29/2005"
+        },
+        "reason": "",
+        "office": "LNS"
+      },
+      {
+        "status": "Released",
+        "type": "ACAD",
+        "blockedDate": {
+          "epoch": 1133222400,
+          "dateTime": "2005-11-29T00:00:00+00:00",
+          "dateString": "11/29/2005"
+        },
+        "clearedDate": {
+          "epoch": 1133222400,
+          "dateTime": "2005-11-29T00:00:00+00:00",
+          "dateString": "11/29/2005"
+        },
+        "reason": "",
+        "office": "LNS"
+      },
+      {
+        "status": "Released",
+        "type": "FINAN",
+        "blockedDate": {
+          "epoch": 1083801600,
+          "dateTime": "2004-05-06T00:00:00+00:00",
+          "dateString": "5/06/2004"
+        },
+        "clearedDate": {
+          "epoch": 1083801600,
+          "dateTime": "2004-05-06T00:00:00+00:00",
+          "dateString": "5/06/2004"
+        },
+        "reason": "CARS",
+        "office": "BPS"
+      },
+      {
+        "status": "Released",
+        "type": "ADMIN",
+        "blockedDate": {
+          "epoch": 1074038400,
+          "dateTime": "2004-01-14T00:00:00+00:00",
+          "dateString": "1/14/2004"
+        },
+        "clearedDate": {
+          "epoch": 1074038400,
+          "dateTime": "2004-01-14T00:00:00+00:00",
+          "dateString": "1/14/2004"
+        },
+        "reason": "MISCONDUCT",
+        "office": "OR"
+      },
+      {
+        "status": "Released",
+        "type": "ACAD",
+        "blockedDate": {
+          "epoch": 1073606400,
+          "dateTime": "2004-01-09T00:00:00+00:00",
+          "dateString": "1/09/2004"
+        },
+        "clearedDate": {
+          "epoch": 1073606400,
+          "dateTime": "2004-01-09T00:00:00+00:00",
+          "dateString": "1/09/2004"
+        },
+        "reason": "ACADEMIC",
+        "office": "LNS"
+      },
+      {
+        "status": "Released",
+        "type": "ACAD",
+        "blockedDate": {
+          "epoch": 1073606400,
+          "dateTime": "2004-01-09T00:00:00+00:00",
+          "dateString": "1/09/2004"
+        },
+        "clearedDate": {
+          "epoch": 1073606400,
+          "dateTime": "2004-01-09T00:00:00+00:00",
+          "dateString": "1/09/2004"
+        },
+        "reason": "ACADEMIC",
+        "office": "LNS"
+      },
+      {
+        "status": "Released",
+        "type": "ADMIN",
+        "blockedDate": {
+          "epoch": 1021852800,
+          "dateTime": "2002-05-20T00:00:00+00:00",
+          "dateString": "5/20/2002"
+        },
+        "clearedDate": {
+          "epoch": 1022112000,
+          "dateTime": "2002-05-23T00:00:00+00:00",
+          "dateString": "5/23/2002"
+        },
+        "reason": "MISC",
+        "office": "OR"
+      },
+      {
+        "status": "Released",
+        "type": "ADMIN",
+        "blockedDate": {
+          "epoch": 1021852800,
+          "dateTime": "2002-05-20T00:00:00+00:00",
+          "dateString": "5/20/2002"
+        },
+        "clearedDate": {
+          "epoch": 1021852800,
+          "dateTime": "2002-05-20T00:00:00+00:00",
+          "dateString": "5/20/2002"
+        },
+        "reason": "STAT LAPSE",
+        "office": "OR"
+      },
+      {
+        "status": "Released",
+        "type": "ACAD",
+        "blockedDate": {
+          "epoch": 955497600,
+          "dateTime": "2000-04-12T00:00:00+00:00",
+          "dateString": "4/12/2000"
+        },
+        "clearedDate": {
+          "epoch": 955584000,
+          "dateTime": "2000-04-13T00:00:00+00:00",
+          "dateString": "4/13/2000"
+        },
+        "reason": "ACADEMIC",
+        "office": "LNS"
+      },
+      {
+        "status": "Released",
+        "type": "ACAD",
+        "blockedDate": {
+          "epoch": 922233600,
+          "dateTime": "1999-03-24T00:00:00+00:00",
+          "dateString": "3/24/1999"
+        },
+        "clearedDate": {
+          "epoch": 945648000,
+          "dateTime": "1999-12-20T00:00:00+00:00",
+          "dateString": "12/20/1999"
+        },
+        "reason": "ACADEMIC",
+        "office": "LNS"
+      },
+      {
+        "status": "Released",
+        "type": "ACAD",
+        "blockedDate": {
+          "epoch": 922233600,
+          "dateTime": "1999-03-24T00:00:00+00:00",
+          "dateString": "3/24/1999"
+        },
+        "clearedDate": {
+          "epoch": 922233600,
+          "dateTime": "1999-03-24T00:00:00+00:00",
+          "dateString": "3/24/1999"
+        },
+        "reason": "ACADEMIC",
+        "office": "LNS"
+      },
+      {
+        "status": "Released",
+        "type": "ACAD",
+        "blockedDate": {
+          "epoch": 921801600,
+          "dateTime": "1999-03-19T00:00:00+00:00",
+          "dateString": "3/19/1999"
+        },
+        "clearedDate": {
+          "epoch": 955324800,
+          "dateTime": "2000-04-10T00:00:00+00:00",
+          "dateString": "4/10/2000"
+        },
+        "reason": "ACADEMIC",
+        "office": "LNS"
+      },
+      {
+        "status": "Released",
+        "type": "FINAN",
+        "blockedDate": {
+          "epoch": 918086400,
+          "dateTime": "1999-02-04T00:00:00+00:00",
+          "dateString": "2/04/1999"
+        },
+        "clearedDate": {
+          "epoch": 919123200,
+          "dateTime": "1999-02-16T00:00:00+00:00",
+          "dateString": "2/16/1999"
+        },
+        "reason": "CUBS",
+        "office": "BPS"
+      },
+      {
+        "status": "Released",
+        "type": "ADMIN",
+        "blockedDate": {
+          "epoch": 916963200,
+          "dateTime": "1999-01-22T00:00:00+00:00",
+          "dateString": "1/22/1999"
+        },
+        "clearedDate": {
+          "epoch": 916963200,
+          "dateTime": "1999-01-22T00:00:00+00:00",
+          "dateString": "1/22/1999"
+        },
+        "reason": "STAT LAPSE",
+        "office": "OR"
+      },
+      {
+        "status": "Released",
+        "type": "ADMIN",
+        "blockedDate": {
+          "epoch": 881020800,
+          "dateTime": "1997-12-02T00:00:00+00:00",
+          "dateString": "12/02/1997"
+        },
+        "clearedDate": {
+          "epoch": 884044800,
+          "dateTime": "1998-01-06T00:00:00+00:00",
+          "dateString": "1/06/1998"
+        },
+        "reason": "MISC",
+        "office": "OR"
+      },
+      {
+        "status": "Released",
+        "type": "ADMIN",
+        "blockedDate": {
+          "epoch": 853891200,
+          "dateTime": "1997-01-22T00:00:00+00:00",
+          "dateString": "1/22/1997"
+        },
+        "clearedDate": {
+          "epoch": 856396800,
+          "dateTime": "1997-02-20T00:00:00+00:00",
+          "dateString": "2/20/1997"
+        },
+        "reason": "STAT LAPSE",
+        "office": "OR"
+      }
+    ]
+  },
+  "semesters": [],
+  "otherSiteMemberships": [
+    {
+      "name": "Summer 2013",
+      "slug": "summer-2013",
+      "termCode": "C",
+      "termYear": "2013",
+      "sites": [
+        {
+          "id": "1093166",
+          "shortDescription": "Psych GSI hangout",
+          "name": "Monitor Psych 1A",
+          "emitter": "bCourses",
+          "site_url": "https://ucberkeley.beta.instructure.com/courses/1093166"
+        }
+      ]
+    }
+  ],
+  "exam_schedule": [
+    {
+      "date": {
+        "epoch": 1387324800,
+        "dateTime": "2013-12-18T00:00:00+00:00",
+        "dateString": "Wed December 18"
+      },
+      "time": "8:00A",
+      "location": {
+        "rawLocation": "390 HEARST MIN",
+        "display": "Hearst Memorial Mining Building",
+        "lat": "37.874459999999999",
+        "lon": "-122.25727000000001",
+        "roomNumber": "390"
+      },
+      "course_code": "Psychology C120"
+    },
+    {
+      "date": {
+        "epoch": 1387324800,
+        "dateTime": "2013-12-18T00:00:00+00:00",
+        "dateString": "Wed December 18"
+      },
+      "time": "3:00P",
+      "location": {
+        "rawLocation": "100 GPB",
+        "display": "Genetics & Plant Biology Building",
+        "lat": "37.873429999999999",
+        "lon": "-122.26473",
+        "roomNumber": "100"
+      },
+      "course_code": "Psychology 133"
+    },
+    {
+      "date": {
+        "epoch": 1387324800,
+        "dateTime": "2013-12-18T00:00:00+00:00",
+        "dateString": "Wed December 18"
+      },
+      "time": "3:00P",
+      "location": {
+        "rawLocation": "2060 VALLEY LSB",
+        "display": "Valley Life Sciences Building",
+        "lat": "37.871479999999998",
+        "lon": "-122.26211000000001",
+        "roomNumber": "2060"
+      },
+      "course_code": "Education 140"
+    }
+  ],
+  "telebears": [
+    {
+      "term": "Spring",
+      "year": 2014,
+      "slug": "spring-2014",
+      "adviserCodeRequired": {
+        "required": true,
+        "type": "revoked"
+      },
+      "phases": [
+        {
+          "period": "Tele-BEARS Phase I",
+          "startTime": {
+            "epoch": 1365442200,
+            "dateTime": "2013-10-13T09:30:00-08:00",
+            "dateString": "10/13"
+          },
+          "endTime": {
+            "epoch": 1365528600,
+            "dateTime": "2013-10-14T09:30:00-08:00",
+            "dateString": "10/14"
+          }
+        },
+        {
+          "period": "Tele-BEARS Phase II",
+          "startTime": {
+            "epoch": 1373389200,
+            "dateTime": "2014-02-09T09:00:00-08:00",
+            "dateString": "2/09"
+          },
+          "endTime": {
+            "epoch": 1373475600,
+            "dateTime": "2014-02-10T09:00:00-08:00",
+            "dateString": "2/10"
+          }
+        }
+      ],
+      "url": "http://registrar.berkeley.edu/tbfaqs.html"
+    }
+  ],
+  "transitionRegStatus": {
+    "termName": "Spring 2014",
+    "registered": true
+  },
+  "lastModified": {
+    "hash": "af8f7132a5d2efdf8bd3d88c2d1fa5d37086c389",
+    "timestamp": {
+      "epoch": 1383947240,
+      "dateTime": "2013-11-08T13:47:20-08:00",
+      "dateString": "11/08"
+    }
+  }
+}

--- a/public/dummy/json/academics_transition_not_registered.json
+++ b/public/dummy/json/academics_transition_not_registered.json
@@ -1,18 +1,4 @@
 {
-  "additionalCredits": [
-    {
-      "title": "AP ENGL C/L, 05-10",
-      "units": "5.3"
-    },
-    {
-      "title": "AP BIO, 05-11",
-      "units": "5.3"
-    },
-    {
-      "title": "AP MATH AB, 05-10",
-      "units": "2.7"
-    }
-  ],
   "collegeAndLevel": {
     "colleges": [
       {
@@ -481,14 +467,10 @@
       "termCode": "B",
       "termYear": "2014",
       "timeBucket": "future",
-      "hasEnrollmentData": true,
       "classes": [
         {
-          "courseCatalog": "1A",
           "course_code": "BIOLOGY 1A",
-          "course_id": "biology-1a-2014-B",
           "dept": "BIOLOGY",
-          "dept_desc": "Biology",
           "slug": "biology-1a",
           "title": "General Biology Lecture",
           "sections": [
@@ -536,14 +518,10 @@
       "termCode": "D",
       "termYear": "2013",
       "timeBucket": "current",
-      "hasEnrollmentData": true,
       "classes": [
         {
-          "courseCatalog": "1A",
           "course_code": "BIOLOGY 1A",
-          "course_id": "biology-1a-2013-D",
           "dept": "BIOLOGY",
-          "dept_desc": "Biology",
           "slug": "biology-1a",
           "title": "General Biology Lecture",
           "sections": [
@@ -598,11 +576,8 @@
           "url": "/academics/semester/fall-2013/class/biology-1a"
         },
         {
-          "courseCatalog": "C147",
           "course_code": "COG SCI C147",
-          "course_id": "cog_sci-c147-2013-D",
           "dept": "COG SCI",
-          "dept_desc": "Cognitive Science",
           "slug": "cog_sci-c147",
           "title": "Language Disorders",
           "sections": [
@@ -637,11 +612,8 @@
           "url": "/academics/semester/fall-2013/class/cog_sci-c147"
         },
         {
-          "courseCatalog": "1",
           "course_code": "PHYS ED 1",
-          "course_id": "phys_ed-1-2013-d",
           "dept": "PHYS ED",
-          "dept_desc": "Physical Education",
           "slug": "phys_ed-1",
           "title": "Physical Education Activities",
           "sections": [
@@ -696,66 +668,15 @@
       ]
     },
     {
-      "name": "Spring 2013",
-      "notation": "Education Abroad",
-      "slug": "spring-2013",
-      "termCode": "B",
-      "termYear": "2013",
-      "timeBucket": "past",
-      "hasEnrollmentData": false,
-      "classes": [
-        {
-          "courseCatalog": "105",
-          "course_code": "EGYPT 105",
-          "dept": "EGYPT",
-          "title": "MIDDLE KINGDOM HIST & CULT",
-          "transcript": [
-            {
-              "units": "5.0",
-              "grade": "A-"
-            }
-          ]
-        },
-        {
-          "courseCatalog": "50B",
-          "course_code": "ARABIC 50B",
-          "dept": "ARABIC",
-          "title": "INT MOD ARABIC",
-          "transcript": [
-            {
-              "units": "4.5",
-              "grade": "A"
-            }
-          ]
-        },
-        {
-          "courseCatalog": "399",
-          "course_code": "ARCH 399",
-          "dept": "ARCH",
-          "title": "FIELD EXCAVATION",
-          "transcript": [
-            {
-              "units": "3.9",
-              "grade": "P"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "name": "Spring 2012",
       "slug": "spring-2012",
       "termCode": "B",
       "termYear": "2012",
       "timeBucket": "past",
-      "hasEnrollmentData": true,
       "classes": [
         {
-          "courseCatalog": "1A",
           "course_code": "BIOLOGY 1A",
-          "course_id": "biology-1a-2012-B",
           "dept": "BIOLOGY",
-          "dept_desc": "Biology",
           "slug": "biology-1a",
           "title": "General Biology Lecture",
           "class_sites": [
@@ -800,11 +721,8 @@
           "url": "/academics/semester/spring-2012/class/biology-1a"
         },
         {
-          "courseCatalog": "C147",
           "course_code": "COG SCI C147",
-          "course_id": "cog_sci-c147-2012-B",
           "dept": "COG SCI",
-          "dept_desc": "Cognitive Science",
           "slug": "cog_sci-c147",
           "title": "Language Disorders",
           "sections": [
@@ -834,11 +752,8 @@
           "url": "/academics/semester/spring-2012/class/cog_sci-c147"
         },
         {
-          "courseCatalog": "297",
           "course_code": "PB HLTH 297",
-          "course_id": "pb_hlth-297-2012-B",
           "dept": "PB HLTH",
-          "dept_desc": "Public Health",
           "slug": "pb_hlth-297",
           "title": "Field Study in Public Health",
           "sections": [
@@ -1255,7 +1170,10 @@
       "url": "http://registrar.berkeley.edu/tbfaqs.html"
     }
   ],
-  "transitionRegStatus": null,
+  "transitionRegStatus": {
+    "termName": "Spring 2014",
+    "registered": false
+  },
   "lastModified": {
     "hash": "af8f7132a5d2efdf8bd3d88c2d1fa5d37086c389",
     "timestamp": {

--- a/public/dummy/json/academics_transition_registered.json
+++ b/public/dummy/json/academics_transition_registered.json
@@ -1,18 +1,4 @@
 {
-  "additionalCredits": [
-    {
-      "title": "AP ENGL C/L, 05-10",
-      "units": "5.3"
-    },
-    {
-      "title": "AP BIO, 05-11",
-      "units": "5.3"
-    },
-    {
-      "title": "AP MATH AB, 05-10",
-      "units": "2.7"
-    }
-  ],
   "collegeAndLevel": {
     "colleges": [
       {
@@ -481,14 +467,10 @@
       "termCode": "B",
       "termYear": "2014",
       "timeBucket": "future",
-      "hasEnrollmentData": true,
       "classes": [
         {
-          "courseCatalog": "1A",
           "course_code": "BIOLOGY 1A",
-          "course_id": "biology-1a-2014-B",
           "dept": "BIOLOGY",
-          "dept_desc": "Biology",
           "slug": "biology-1a",
           "title": "General Biology Lecture",
           "sections": [
@@ -536,14 +518,10 @@
       "termCode": "D",
       "termYear": "2013",
       "timeBucket": "current",
-      "hasEnrollmentData": true,
       "classes": [
         {
-          "courseCatalog": "1A",
           "course_code": "BIOLOGY 1A",
-          "course_id": "biology-1a-2013-D",
           "dept": "BIOLOGY",
-          "dept_desc": "Biology",
           "slug": "biology-1a",
           "title": "General Biology Lecture",
           "sections": [
@@ -598,11 +576,8 @@
           "url": "/academics/semester/fall-2013/class/biology-1a"
         },
         {
-          "courseCatalog": "C147",
           "course_code": "COG SCI C147",
-          "course_id": "cog_sci-c147-2013-D",
           "dept": "COG SCI",
-          "dept_desc": "Cognitive Science",
           "slug": "cog_sci-c147",
           "title": "Language Disorders",
           "sections": [
@@ -637,11 +612,8 @@
           "url": "/academics/semester/fall-2013/class/cog_sci-c147"
         },
         {
-          "courseCatalog": "1",
           "course_code": "PHYS ED 1",
-          "course_id": "phys_ed-1-2013-d",
           "dept": "PHYS ED",
-          "dept_desc": "Physical Education",
           "slug": "phys_ed-1",
           "title": "Physical Education Activities",
           "sections": [
@@ -696,66 +668,15 @@
       ]
     },
     {
-      "name": "Spring 2013",
-      "notation": "Education Abroad",
-      "slug": "spring-2013",
-      "termCode": "B",
-      "termYear": "2013",
-      "timeBucket": "past",
-      "hasEnrollmentData": false,
-      "classes": [
-        {
-          "courseCatalog": "105",
-          "course_code": "EGYPT 105",
-          "dept": "EGYPT",
-          "title": "MIDDLE KINGDOM HIST & CULT",
-          "transcript": [
-            {
-              "units": "5.0",
-              "grade": "A-"
-            }
-          ]
-        },
-        {
-          "courseCatalog": "50B",
-          "course_code": "ARABIC 50B",
-          "dept": "ARABIC",
-          "title": "INT MOD ARABIC",
-          "transcript": [
-            {
-              "units": "4.5",
-              "grade": "A"
-            }
-          ]
-        },
-        {
-          "courseCatalog": "399",
-          "course_code": "ARCH 399",
-          "dept": "ARCH",
-          "title": "FIELD EXCAVATION",
-          "transcript": [
-            {
-              "units": "3.9",
-              "grade": "P"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "name": "Spring 2012",
       "slug": "spring-2012",
       "termCode": "B",
       "termYear": "2012",
       "timeBucket": "past",
-      "hasEnrollmentData": true,
       "classes": [
         {
-          "courseCatalog": "1A",
           "course_code": "BIOLOGY 1A",
-          "course_id": "biology-1a-2012-B",
           "dept": "BIOLOGY",
-          "dept_desc": "Biology",
           "slug": "biology-1a",
           "title": "General Biology Lecture",
           "class_sites": [
@@ -800,11 +721,8 @@
           "url": "/academics/semester/spring-2012/class/biology-1a"
         },
         {
-          "courseCatalog": "C147",
           "course_code": "COG SCI C147",
-          "course_id": "cog_sci-c147-2012-B",
           "dept": "COG SCI",
-          "dept_desc": "Cognitive Science",
           "slug": "cog_sci-c147",
           "title": "Language Disorders",
           "sections": [
@@ -834,11 +752,8 @@
           "url": "/academics/semester/spring-2012/class/cog_sci-c147"
         },
         {
-          "courseCatalog": "297",
           "course_code": "PB HLTH 297",
-          "course_id": "pb_hlth-297-2012-B",
           "dept": "PB HLTH",
-          "dept_desc": "Public Health",
           "slug": "pb_hlth-297",
           "title": "Field Study in Public Health",
           "sections": [
@@ -1148,73 +1063,6 @@
       ]
     }
   ],
-  "otherSiteMemberships": [
-    {
-      "name": "Summer 2013",
-      "slug": "summer-2013",
-      "termCode": "C",
-      "termYear": "2013",
-      "sites": [
-        {
-          "id": "1093166",
-          "shortDescription": "Psych GSI hangout",
-          "name": "Monitor Psych 1A",
-          "emitter": "bCourses",
-          "site_url": "https://ucberkeley.beta.instructure.com/courses/1093166"
-        }
-      ]
-    }
-  ],
-  "exam_schedule": [
-    {
-      "date": {
-        "epoch": 1387324800,
-        "dateTime": "2013-12-18T00:00:00+00:00",
-        "dateString": "Wed December 18"
-      },
-      "time": "8:00A",
-      "location": {
-        "rawLocation": "390 HEARST MIN",
-        "display": "Hearst Memorial Mining Building",
-        "lat": "37.874459999999999",
-        "lon": "-122.25727000000001",
-        "roomNumber": "390"
-      },
-      "course_code": "Psychology C120"
-    },
-    {
-      "date": {
-        "epoch": 1387324800,
-        "dateTime": "2013-12-18T00:00:00+00:00",
-        "dateString": "Wed December 18"
-      },
-      "time": "3:00P",
-      "location": {
-        "rawLocation": "100 GPB",
-        "display": "Genetics & Plant Biology Building",
-        "lat": "37.873429999999999",
-        "lon": "-122.26473",
-        "roomNumber": "100"
-      },
-      "course_code": "Psychology 133"
-    },
-    {
-      "date": {
-        "epoch": 1387324800,
-        "dateTime": "2013-12-18T00:00:00+00:00",
-        "dateString": "Wed December 18"
-      },
-      "time": "3:00P",
-      "location": {
-        "rawLocation": "2060 VALLEY LSB",
-        "display": "Valley Life Sciences Building",
-        "lat": "37.871479999999998",
-        "lon": "-122.26211000000001",
-        "roomNumber": "2060"
-      },
-      "course_code": "Education 140"
-    }
-  ],
   "telebears": [
     {
       "term": "Spring",
@@ -1255,7 +1103,10 @@
       "url": "http://registrar.berkeley.edu/tbfaqs.html"
     }
   ],
-  "transitionRegStatus": null,
+  "transitionRegStatus": {
+    "termName": "Spring 2014",
+    "registered": true
+  },
   "lastModified": {
     "hash": "af8f7132a5d2efdf8bd3d88c2d1fa5d37086c389",
     "timestamp": {

--- a/public/dummy/json/badges_transition.json
+++ b/public/dummy/json/badges_transition.json
@@ -1,0 +1,559 @@
+{
+  "alert": {
+    "title": "CalCentral Scheduled Maintenance 3/17",
+    "teaser": "CalCentral v32 release at 6 - 7am",
+    "url": "http://ets-dev.berkeley.edu/calcentral-scheduled-maintenance-317",
+    "timestamp": {
+      "epoch": 1393495946,
+      "dateTime": "2014-02-27T02:12:26-08:00",
+      "dateString": "2/27"
+    }
+  },
+  "badges": {
+    "bcal": {
+      "items": [
+        {
+          "link": "https://www.google.com/calendar/event?eid=X2VkaG1ncGI0ZWxtNmFiOW42Z3AzNmM5ZDc1MDZzcWJlZDlnbTZycmxlOXBtYXNwZWNkbm1xXzIwMTMwNDE3VDE2MDAwMFogdGFtbWkuY2hhbmcuY2xjQG0",
+          "title": "EE 20N Discussion",
+          "startTime": {
+            "epoch": 1366214400,
+            "dateTime": "2013-04-17T09:00:00-07:00",
+            "dateString": "4/17",
+            "allDayEvent": true
+          },
+          "endTime": {
+            "epoch": 1366218000,
+            "dateTime": "2013-04-17T10:00:00-07:00",
+            "dateString": "4/17",
+            "allDayEvent": true
+          },
+          "modifiedTime": {
+            "epoch": 1365631878,
+            "dateTime": "2013-04-10T22:11:18+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=X2VkaG1ncGI0ZWxtNmFiOW42Z3AzNmM5ZDc1MDZzcWJlZDlnbTZycmxlOXBtYXNwZWNkbm1xXzIwMTMwNDI0VDE2MDAwMFogdGFtbWkuY2hhbmcuY2xjQG0",
+          "title": "EE 20N Discussion",
+          "startTime": {
+            "epoch": 1366819200,
+            "dateTime": "2013-04-24T09:00:00-07:00",
+            "dateString": "4/24",
+            "allDayEvent": true
+          },
+          "endTime": {
+            "epoch": 1367168400,
+            "dateTime": "2013-04-28T10:00:00-07:00",
+            "dateString": "4/28",
+            "allDayEvent": true
+          },
+          "modifiedTime": {
+            "epoch": 1365631878,
+            "dateTime": "2013-04-10T22:11:18+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=X2VkaG1ncGI0ZWxtNmFiOW42b3NqMGI5aDgxbjZpcmphYzVobXV0YmllZGluNmJqM2R0bWdfMjAxMzA0MTdUMTcwMDAwWiB0YW1taS5jaGFuZy5jbGNAbQ",
+          "title": "ETH STD 21AC DIS 101",
+          "startTime": {
+            "epoch": 1366218000,
+            "dateTime": "2013-04-17T10:00:00-07:00",
+            "dateString": "4/17"
+          },
+          "endTime": {
+            "epoch": 1366221600,
+            "dateTime": "2013-04-17T11:00:00-07:00",
+            "dateString": "4/17"
+          },
+          "modifiedTime": {
+            "epoch": 1365631861,
+            "dateTime": "2013-04-10T22:11:01+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "new",
+          "editor": "Spongebob overly-squre Squarepants"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=X2VkaG1ncGI0ZWxtNmFiOW42b3NqMGI5aDgxbjZpcmphYzVobXV0YmllZGluNmJqM2R0bWdfMjAxMzA0MjRUMTcwMDAwWiB0YW1taS5jaGFuZy5jbGNAbQ",
+          "title": "ETH STD 21AC DIS 101",
+          "startTime": {
+            "epoch": 1366822800,
+            "dateTime": "2013-04-24T10:00:00-07:00",
+            "dateString": "4/24"
+          },
+          "endTime": {
+            "epoch": 1366826400,
+            "dateTime": "2013-04-24T11:00:00-07:00",
+            "dateString": "4/24"
+          },
+          "modifiedTime": {
+            "epoch": 1365631861,
+            "dateTime": "2013-04-10T22:11:01+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=X2VkaG1ncGI0ZWxtNmFiOW42b3FqaWQ5ZDZ0MDZzcWJlZDlnbTZycmxlOXBtYXNwZWNkbm1xXzIwMTMwNDE5VDIwMDAwMFogdGFtbWkuY2hhbmcuY2xjQG0",
+          "title": "MATH 53 Discussion",
+          "startTime": {
+            "epoch": 1366401600,
+            "dateTime": "2013-04-19T13:00:00-07:00",
+            "dateString": "4/19"
+          },
+          "endTime": {
+            "epoch": 1366405200,
+            "dateTime": "2013-04-19T14:00:00-07:00",
+            "dateString": "4/19"
+          },
+          "modifiedTime": {
+            "epoch": 1365631738,
+            "dateTime": "2013-04-10T22:08:58+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=X2VkaG1ncGI0ZWxtNmFiOW42b3FqaWQ5ZDZ0MDZzcWJlZDlnbTZycmxlOXBtYXNwZWNkbm1xXzIwMTMwNDIyVDIwMDAwMFogdGFtbWkuY2hhbmcuY2xjQG0",
+          "title": "MATH 53 Discussion",
+          "startTime": {
+            "epoch": 1366660800,
+            "dateTime": "2013-04-22T13:00:00-07:00",
+            "dateString": "4/22"
+          },
+          "endTime": {
+            "epoch": 1366664400,
+            "dateTime": "2013-04-22T14:00:00-07:00",
+            "dateString": "4/22"
+          },
+          "modifiedTime": {
+            "epoch": 1365631738,
+            "dateTime": "2013-04-10T22:08:58+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=X2VkaG1ncGI0ZWxtNmFiOW42b3FqaWQ5ZDZ0MDZzcWJlZDlnbTZycmxlOXBtYXNwZWNkbm1xXzIwMTMwNDE3VDIwMDAwMFogdGFtbWkuY2hhbmcuY2xjQG0",
+          "title": "MATH 53 Discussion",
+          "startTime": {
+            "epoch": 1366228800,
+            "dateTime": "2013-04-17T13:00:00-07:00",
+            "dateString": "4/17"
+          },
+          "endTime": {
+            "epoch": 1366232400,
+            "dateTime": "2013-04-17T14:00:00-07:00",
+            "dateString": "4/17"
+          },
+          "modifiedTime": {
+            "epoch": 1365631738,
+            "dateTime": "2013-04-10T22:08:58+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=X2VkaG1ncGI0ZWxtNmFiOW42b3FqaWQ5ZDZ0MDZzcWJlZDlnbTZycmxlOXBtYXNwZWNkbm1xXzIwMTMwNDI0VDIwMDAwMFogdGFtbWkuY2hhbmcuY2xjQG0",
+          "title": "MATH 53 Discussion",
+          "startTime": {
+            "epoch": 1366833600,
+            "dateTime": "2013-04-24T13:00:00-07:00",
+            "dateString": "4/24"
+          },
+          "endTime": {
+            "epoch": 1366837200,
+            "dateTime": "2013-04-24T14:00:00-07:00",
+            "dateString": "4/24"
+          },
+          "modifiedTime": {
+            "epoch": 1365631738,
+            "dateTime": "2013-04-10T22:08:58+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=X2VkaG1ncGI0ZWxtNmFiOW42b3MzaWI5aTgxbjZpcmphYzVobXV0YmllZGluNmJqM2R0bWdfMjAxMzA0MThUMjEwMDAwWiB0YW1taS5jaGFuZy5jbGNAbQ",
+          "title": "ETH STD 21AC",
+          "startTime": {
+            "epoch": 1366318800,
+            "dateTime": "2013-04-18T14:00:00-07:00",
+            "dateString": "4/18"
+          },
+          "endTime": {
+            "epoch": 1366324200,
+            "dateTime": "2013-04-18T15:30:00-07:00",
+            "dateString": "4/18"
+          },
+          "modifiedTime": {
+            "epoch": 1365631715,
+            "dateTime": "2013-04-10T22:08:35+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=X2VkaG1ncGI0ZWxtNmFiOW42b3MzaWI5aTgxbjZpcmphYzVobXV0YmllZGluNmJqM2R0bWdfMjAxMzA0MjNUMjEwMDAwWiB0YW1taS5jaGFuZy5jbGNAbQ",
+          "title": "ETH STD 21AC",
+          "startTime": {
+            "epoch": 1366750800,
+            "dateTime": "2013-04-23T14:00:00-07:00",
+            "dateString": "4/23"
+          },
+          "endTime": {
+            "epoch": 1366756200,
+            "dateTime": "2013-04-23T15:30:00-07:00",
+            "dateString": "4/23"
+          },
+          "modifiedTime": {
+            "epoch": 1365631715,
+            "dateTime": "2013-04-10T22:08:35+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=X2VkaG1ncGI0ZWxtNmFiOW42b3MzaWI5aTgxbjZpcmphYzVobXV0YmllZGluNmJqM2R0bWdfMjAxMzA0MTZUMjEwMDAwWiB0YW1taS5jaGFuZy5jbGNAbQ",
+          "title": "ETH STD 21AC",
+          "startTime": {
+            "epoch": 1366146000,
+            "dateTime": "2013-04-16T14:00:00-07:00",
+            "dateString": "4/16"
+          },
+          "endTime": {
+            "epoch": 1366151400,
+            "dateTime": "2013-04-16T15:30:00-07:00",
+            "dateString": "4/16"
+          },
+          "modifiedTime": {
+            "epoch": 1365631715,
+            "dateTime": "2013-04-10T22:08:35+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=X2VkaG1ncGI0ZWxtNmFiOW42b3MzaWI5aTgxbjZpcmphYzVobXV0YmllZGluNmJqM2R0bWdfMjAxMzA0MjVUMjEwMDAwWiB0YW1taS5jaGFuZy5jbGNAbQ",
+          "title": "ETH STD 21AC",
+          "startTime": {
+            "epoch": 1366923600,
+            "dateTime": "2013-04-25T14:00:00-07:00",
+            "dateString": "4/25"
+          },
+          "endTime": {
+            "epoch": 1366929000,
+            "dateTime": "2013-04-25T15:30:00-07:00",
+            "dateString": "4/25"
+          },
+          "modifiedTime": {
+            "epoch": 1365631715,
+            "dateTime": "2013-04-10T22:08:35+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=dnRjZ3QyNzQ1ZWRua3VhN2hvZ2pnMmRtMmdfMjAxMzA0MTlUMTgwMDAwWiB0YW1taS5jaGFuZy5jbGNAbQ",
+          "title": "PHYSICS 7B Lecture",
+          "startTime": {
+            "epoch": 1366394400,
+            "dateTime": "2013-04-19T11:00:00-07:00",
+            "dateString": "4/19"
+          },
+          "endTime": {
+            "epoch": 1366398000,
+            "dateTime": "2013-04-19T12:00:00-07:00",
+            "dateString": "4/19"
+          },
+          "modifiedTime": {
+            "epoch": 1365631665,
+            "dateTime": "2013-04-10T22:07:45+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=dnRjZ3QyNzQ1ZWRua3VhN2hvZ2pnMmRtMmdfMjAxMzA0MjJUMTgwMDAwWiB0YW1taS5jaGFuZy5jbGNAbQ",
+          "title": "PHYSICS 7B Lecture",
+          "startTime": {
+            "epoch": 1366653600,
+            "dateTime": "2013-04-22T11:00:00-07:00",
+            "dateString": "4/22"
+          },
+          "endTime": {
+            "epoch": 1366657200,
+            "dateTime": "2013-04-22T12:00:00-07:00",
+            "dateString": "4/22"
+          },
+          "modifiedTime": {
+            "epoch": 1365631665,
+            "dateTime": "2013-04-10T22:07:45+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=dnRjZ3QyNzQ1ZWRua3VhN2hvZ2pnMmRtMmdfMjAxMzA0MTdUMTgwMDAwWiB0YW1taS5jaGFuZy5jbGNAbQ",
+          "title": "PHYSICS 7B Lecture",
+          "startTime": {
+            "epoch": 1366221600,
+            "dateTime": "2013-04-17T11:00:00-07:00",
+            "dateString": "4/17"
+          },
+          "endTime": {
+            "epoch": 1366225200,
+            "dateTime": "2013-04-17T12:00:00-07:00",
+            "dateString": "4/17"
+          },
+          "modifiedTime": {
+            "epoch": 1365631665,
+            "dateTime": "2013-04-10T22:07:45+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=dnRjZ3QyNzQ1ZWRua3VhN2hvZ2pnMmRtMmdfMjAxMzA0MjRUMTgwMDAwWiB0YW1taS5jaGFuZy5jbGNAbQ",
+          "title": "PHYSICS 7B Lecture",
+          "startTime": {
+            "epoch": 1366826400,
+            "dateTime": "2013-04-24T11:00:00-07:00",
+            "dateString": "4/24"
+          },
+          "endTime": {
+            "epoch": 1366830000,
+            "dateTime": "2013-04-24T12:00:00-07:00",
+            "dateString": "4/24"
+          },
+          "modifiedTime": {
+            "epoch": 1365631665,
+            "dateTime": "2013-04-10T22:07:45+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=X2VkaG1ncGI0ZWxtNmFiOW42Z3AzNGMxZDcxMDZzcWJlZDlnbTZycmxlOXBtYXNwZWNkbm1xXzIwMTMwNDE4VDE5MzAwMFogdGFtbWkuY2hhbmcuY2xjQG0",
+          "title": "EE 20N Lecture",
+          "startTime": {
+            "epoch": 1366313400,
+            "dateTime": "2013-04-18T12:30:00-07:00",
+            "dateString": "4/18"
+          },
+          "endTime": {
+            "epoch": 1366318800,
+            "dateTime": "2013-04-18T14:00:00-07:00",
+            "dateString": "4/18"
+          },
+          "modifiedTime": {
+            "epoch": 1365631634,
+            "dateTime": "2013-04-10T22:07:14+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=X2VkaG1ncGI0ZWxtNmFiOW42Z3AzNGMxZDcxMDZzcWJlZDlnbTZycmxlOXBtYXNwZWNkbm1xXzIwMTMwNDIzVDE5MzAwMFogdGFtbWkuY2hhbmcuY2xjQG0",
+          "title": "EE 20N Lecture",
+          "startTime": {
+            "epoch": 1366745400,
+            "dateTime": "2013-04-23T12:30:00-07:00",
+            "dateString": "4/23"
+          },
+          "endTime": {
+            "epoch": 1366750800,
+            "dateTime": "2013-04-23T14:00:00-07:00",
+            "dateString": "4/23"
+          },
+          "modifiedTime": {
+            "epoch": 1365631634,
+            "dateTime": "2013-04-10T22:07:14+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=X2VkaG1ncGI0ZWxtNmFiOW42Z3AzNGMxZDcxMDZzcWJlZDlnbTZycmxlOXBtYXNwZWNkbm1xXzIwMTMwNDE2VDE5MzAwMFogdGFtbWkuY2hhbmcuY2xjQG0",
+          "title": "EE 20N Lecture",
+          "startTime": {
+            "epoch": 1366140600,
+            "dateTime": "2013-04-16T12:30:00-07:00",
+            "dateString": "4/16"
+          },
+          "endTime": {
+            "epoch": 1366146000,
+            "dateTime": "2013-04-16T14:00:00-07:00",
+            "dateString": "4/16"
+          },
+          "modifiedTime": {
+            "epoch": 1365631634,
+            "dateTime": "2013-04-10T22:07:14+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        },
+        {
+          "link": "https://www.google.com/calendar/event?eid=X2VkaG1ncGI0ZWxtNmFiOW42Z3AzNGMxZDcxMDZzcWJlZDlnbTZycmxlOXBtYXNwZWNkbm1xXzIwMTMwNDI1VDE5MzAwMFogdGFtbWkuY2hhbmcuY2xjQG0",
+          "title": "EE 20N Lecture",
+          "startTime": {
+            "epoch": 1366918200,
+            "dateTime": "2013-04-25T12:30:00-07:00",
+            "dateString": "4/25"
+          },
+          "endTime": {
+            "epoch": 1366923600,
+            "dateTime": "2013-04-25T14:00:00-07:00",
+            "dateString": "4/25"
+          },
+          "modifiedTime": {
+            "epoch": 1365631634,
+            "dateTime": "2013-04-10T22:07:14+00:00",
+            "dateString": "4/10"
+          },
+          "changeState": "updated"
+        }
+      ],
+      "count": 20
+    },
+    "bdrive": {
+      "count": 2,
+      "items": [
+        {
+          "title": "Assignment #1? or Assignment #2? or Assignment #3? or Assignment #4? or Assignment #5?",
+          "link": "https://www.googleapis.com/drive/v2/files/1CRO3fkWnQrqm_-8M1pO5cB6opxXB7HWxUN4IPDqdzrI",
+          "modifiedTime": {
+            "epoch": 1363798261,
+            "dateTime": "2013-03-20T16:51:01+00:00",
+            "dateString": "3/20"
+          },
+          "editor": "Sage Adams",
+          "changeState": "modified"
+        },
+        {
+          "title": "Group Work #1",
+          "link": "https://www.googleapis.com/drive/v2/files/1PJExieJtoo5xf945FvmWbxJZaltkmtcqPzEcFs2o2P8",
+          "modifiedTime": {
+            "epoch": 1363715337,
+            "dateTime": "2013-03-19T17:48:57+00:00",
+            "dateString": "3/19"
+          },
+          "editor": "Sage Adams",
+          "changeState": "modified"
+        },
+        {
+          "title": "Assignment #1",
+          "link": "https://www.googleapis.com/drive/v2/files/1CRO3fkWnQrqm_-8M1pO5cB6opxXB7HWxUN4IPDqdzrI",
+          "modifiedTime": {
+            "epoch": 1363798261,
+            "dateTime": "2013-03-20T16:51:01+00:00",
+            "dateString": "3/20"
+          },
+          "editor": "Sage Adams",
+          "changeState": "modified"
+        },
+        {
+          "title": "Group Work #1",
+          "link": "https://www.googleapis.com/drive/v2/files/1PJExieJtoo5xf945FvmWbxJZaltkmtcqPzEcFs2o2P8",
+          "modifiedTime": {
+            "epoch": 1363715337,
+            "dateTime": "2013-03-19T17:48:57+00:00",
+            "dateString": "3/19"
+          },
+          "editor": "Sage Adams",
+          "changeState": "modified"
+        }
+      ]
+    },
+    "bmail": {
+      "count": 928,
+      "items": [
+        {
+          "title": "Hospitals Profit From Surgical Errors, Study Finds: Course Name Example",
+          "summary": "Since insurers pay more for patients with surgical complications, some hospitals",
+          "modifiedTime": {
+            "epoch": 1366151767,
+            "dateTime": "2013-04-16T22:36:07+00:00",
+            "dateString": "4/16"
+          },
+          "link": "http://mail.google.com/mail?account_id=tammi.chang.clc@gmail.com&message_id=13e14fda5e01d126&view=conv&extsrc=atom",
+          "editor": "Instructure Canvas"
+        },
+        {
+          "title": "F.D.A. Was Lax on Compounding, Its Leader Says: Course Name Example",
+          "summary": "Asking Congress for more authority, Dr. Margaret A. Hamburg said her agency should",
+          "modifiedTime": {
+            "epoch": 1366151766,
+            "dateTime": "2013-04-16T22:36:06+00:00",
+            "dateString": "4/16"
+          },
+          "link": "http://mail.google.com/mail?account_id=tammi.chang.clc@gmail.com&message_id=13e14fda2c441a9a&view=conv&extsrc=atom",
+          "editor": "Instructure Canvas"
+        },
+        {
+          "title": "The Lede: Neighbors Mourn Loss of 8-Year-Old: Course Name Example",
+          "summary": "Bill Richard, the father of the 8-year-old boy who was killed Monday, offered thanks",
+          "modifiedTime": {
+            "epoch": 1366151766,
+            "dateTime": "2013-04-16T22:36:06+00:00",
+            "dateString": "4/16"
+          },
+          "link": "http://mail.google.com/mail?account_id=tammi.chang.clc@gmail.com&message_id=13e14fda191e34df&view=conv&extsrc=atom",
+          "editor": "Instructure Canvas"
+        },
+        {
+          "title": "Investigation Under Way in Boston: Course Name Example",
+          "summary": "Authorities were trying to identify suspects and a motive behind an attack that",
+          "modifiedTime": {
+            "epoch": 1366151765,
+            "dateTime": "2013-04-16T22:36:05+00:00",
+            "dateString": "4/16"
+          },
+          "link": "http://mail.google.com/mail?account_id=tammi.chang.clc@gmail.com&message_id=13e14fd9e5ff01bc&view=conv&extsrc=atom",
+          "editor": "Instructure Canvas"
+        },
+        {
+          "title": "Justices Hear Case of Adopted Indian Child: Course Name Example",
+          "summary": "The Supreme Court considered whether a 3-year-old should remain with her biological",
+          "modifiedTime": {
+            "epoch": 1366151765,
+            "dateTime": "2013-04-16T22:36:05+00:00",
+            "dateString": "4/16"
+          },
+          "link": "http://mail.google.com/mail?account_id=tammi.chang.clc@gmail.com&message_id=13e14fd9e21bc151&view=conv&extsrc=atom",
+          "editor": "Instructure Canvas"
+        }
+      ]
+    }
+  },
+  "studentInfo": {
+    "californiaResidency": {
+      "summary": null,
+      "explanation": null,
+      "needsAction": false
+    },
+    "regStatus": {
+      "code": null,
+      "summary": null,
+      "explanation": null,
+      "needsAction": null
+    },
+    "regBlock": {
+      "errored": null,
+      "needsAction": false,
+      "activeBlocks": 0
+    }
+  },
+  "lastModified": {
+    "hash": "af8f7132a5d2efdf8bd3d88c2d1fa5d37086c389",
+    "timestamp": {
+      "epoch": 1383947240,
+      "dateTime": "2013-11-08T13:47:20-08:00",
+      "dateString": "11/08"
+    }
+  }
+}

--- a/spec/models/my_academics/college_and_level_spec.rb
+++ b/spec/models/my_academics/college_and_level_spec.rb
@@ -20,6 +20,7 @@ describe "MyAcademics::CollegeAndLevel" do
     oski_college[:colleges][1][:major].should == "Rhetoric"
     oski_college[:colleges][2][:major].should == "Business Administration"
     oski_college[:standing].should == "Undergraduate"
+    expect(oski_college[:termName]).to eq 'Summer 2013'
   end
 
   it "should get test-300940's multiple college enrollments" do

--- a/spec/models/my_academics/transition_reg_status_spec.rb
+++ b/spec/models/my_academics/transition_reg_status_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+describe MyAcademics::TransitionRegStatus do
+  let(:oski_uid) { '61889' }
+  let(:feed) { {collegeAndLevel: college_and_level_data} }
+  let(:merged_feed) { MyAcademics::TransitionRegStatus.new(oski_uid).merge(feed); feed }
+
+  shared_examples 'should not merge' do
+    it { expect(merged_feed.has_key? :transitionRegStatus).to eq false }
+  end
+
+  shared_examples 'should return nil status' do
+    it { expect(merged_feed[:transitionRegStatus]).to be_nil }
+  end
+
+  context 'when collegeAndLevel is missing' do
+    let(:feed) { {} }
+    include_examples 'should not merge'
+  end
+
+  context 'when collegeAndLevel is empty' do
+    let(:college_and_level_data) { {empty: true} }
+    include_examples 'should not merge'
+  end
+
+  context 'when collegeAndLevel reports no student ID' do
+    let(:college_and_level_data) { {noStudentId: true} }
+    include_examples 'should not merge'
+  end
+
+  context 'when collegeAndLevel contains profile information for the term' do
+    let(:fake) { true }
+    let(:regstatus_proxy) { Regstatus::Proxy.new(user_id: oski_uid, fake: fake) }
+    let(:profile_proxy) { profile_proxy = Bearfacts::Profile.new(user_id: oski_uid, fake: fake) }
+
+    before do
+      allow(Regstatus::Proxy).to receive(:new).and_return(regstatus_proxy)
+      allow(Bearfacts::Profile).to receive(:new).and_return(profile_proxy)
+    end
+
+    let(:college_and_level_data) do
+      data = {}
+      MyAcademics::CollegeAndLevel.new(oski_uid).merge(data)
+      data[:collegeAndLevel].merge(termName: term_name)
+    end
+
+    context 'when collegeAndLevel term is the CalCentral current term' do
+      let(:term_name) { Berkeley::Terms.fetch.current.to_english }
+      include_examples 'should return nil status'
+    end
+
+    context 'when collegeAndLevel term is not the CalCentral current term' do
+      let(:term_name) { Berkeley::Terms.fetch.next.to_english }
+      it 'returns transition status for the CalCentral current term' do
+        expect(merged_feed[:transitionRegStatus][:termName]).to eq Berkeley::Terms.fetch.current.to_english
+      end
+
+      context 'when student is registered' do
+        before do
+          regstatus_proxy.override_json { |json| json['regStatus']['isRegistered'] = true }
+        end
+        it 'should return true registration' do
+          expect(merged_feed[:transitionRegStatus][:registered]).to eq true
+        end
+      end
+
+      context 'when student is not registered' do
+        before do
+          regstatus_proxy.override_json { |json| json['regStatus']['isRegistered'] = false }
+        end
+        it 'should return false registration' do
+          expect(merged_feed[:transitionRegStatus][:registered]).to eq false
+        end
+      end
+
+      context 'when proxy returns an error' do
+        before { allow_any_instance_of(Regstatus::Proxy).to receive(:get).and_return({errored: true}) }
+        include_examples 'should return nil status'
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4910

Merges in registration data only during transitions (as determined by whether the term in the Bearfacts profile matches the current term in CalCentral).

Dummy JSON feeds for different scenarios are also included. In addition to registration-related changes, the `collegeAndLevel` data in the dummies has been made consistent with our current feed structure.