### PR TITLE
CLC-5003 Remove large size for GPA

### DIFF
--- a/src/assets/stylesheets/_profile.scss
+++ b/src/assets/stylesheets/_profile.scss
@@ -6,9 +6,11 @@
     margin-left: 87px;
     padding-bottom: 10px;
   }
+  .cc-widget-profile-content-fullname {
+    font-size: 16px;
+  }
   .cc-widget-profile-content-gpa {
-    font-size: 18px;
-    padding: 8px 0;
+    padding: 18px 0 0;
   }
   .cc-widget-profile-picture-not-available {
     background: $cc-color-shadow-color;

--- a/src/assets/templates/academics_student_profile.html
+++ b/src/assets/templates/academics_student_profile.html
@@ -59,7 +59,7 @@
     </div>
 
     <div class="cc-widget-profile-content">
-      <div>
+      <div class="cc-widget-profile-content-fullname">
         <strong data-ng-bind="api.user.profile.fullName"></strong>
       </div>
 


### PR DESCRIPTION
Revived from https://github.com/ets-berkeley-edu/calcentral/pull/3487 for @szhu -- please see the earlier PR for comments.

Most students visit the Academics tab to check things other than GPA,
so there's no particular reason for GPA to be larger.

In addition, many students visit CalCentral in public settings and
would prefer to have their GPA less visible to people around them.

This is a temporary solution, but a "show GPA" checkbox might be more
appropriate in the future.