### PR TITLE
CLC-2246 CLC-5008 Allow tasks from any source to display links

### DIFF
--- a/app/models/my_tasks/canvas_tasks.rb
+++ b/app/models/my_tasks/canvas_tasks.rb
@@ -1,6 +1,6 @@
 module MyTasks
   class CanvasTasks
-    include MyTasks::TasksModule, HtmlSanitizer, SafeJsonParser
+    include MyTasks::TasksModule, ClassLogger, HtmlSanitizer, SafeJsonParser
 
     def initialize(uid, starting_date)
       @uid = uid
@@ -10,114 +10,100 @@ module MyTasks
 
     def fetch_tasks
       # Track assignment IDs to filter duplicates.
+      @assignments = Set.new
+      @course_code_map = initialize_course_code_map
       tasks = []
-      assignments = Set.new
-      user_courses = Canvas::UserCourses.new(user_id: @uid).courses
-      course_id_to_code_map = {}
-      user_courses.each do |course|
-        course_id_to_code_map[course["id"]] = course["course_code"]
-      end
-      fetch_canvas_todo!(Canvas::Todo.new(:user_id => @uid), tasks, assignments, course_id_to_code_map)
-      fetch_canvas_upcoming_events!(Canvas::UpcomingEvents.new(:user_id => @uid), tasks, assignments, course_id_to_code_map)
+
+      canvas_todo = Canvas::Todo.new(user_id: @uid).todo
+      todo_results = collect_results(canvas_todo) { |result| format_todo result }
+      tasks.concat todo_results.compact if todo_results
+
+      canvas_upcoming_events = Canvas::UpcomingEvents.new(user_id: @uid).upcoming_events
+      upcoming_event_results = collect_results(canvas_upcoming_events) { |result| format_upcoming_event result }
+      tasks.concat upcoming_event_results.compact if upcoming_event_results
+
       tasks
     end
 
     private
 
-    def fetch_canvas_todo!(canvas_proxy, tasks, assignments, course_id_to_code_map)
-      response = canvas_proxy.todo
-      if response && (response.status == 200)
-        results = safe_json response.body
-        if results
-          Rails.logger.info "#{self.class.name} Sorting Canvas todo feed into buckets with starting_date #{@starting_date}; #{results}"
-          results.each do |result|
-            if (result["assignment"] != nil) && new_assignment?(result["assignment"], assignments)
-              # Skip a teacher's "overdue for grading" assignments since they don't call for a red alert.
-              if 'grading' != result['type']
-                formatted_entry = {
-                  "type" => "assignment",
-                  "title" => result["assignment"]["name"],
-                  "emitter" => Canvas::Proxy::APP_NAME,
-                  "linkUrl" => result["assignment"]["html_url"],
-                  "sourceUrl" => result["assignment"]["html_url"],
-                  "status" => "inprogress"
-                }
-                formatted_entry['notes'] = sanitize_html(result['assignment']['description']) if result['assignment']['description'].present?
-
-                due_date = convert_date(result["assignment"]["due_at"])
-                format_date_into_entry!(due_date, formatted_entry, "dueDate")
-                bucket = determine_bucket(due_date, formatted_entry, @now_time, @starting_date)
-                formatted_entry["bucket"] = bucket
-
-                if formatted_entry['bucket'] == 'Unscheduled'
-                  updated_date = convert_date(result['assignment']['updated_at'] || result['assignment']['created_at'])
-                  format_date_into_entry!(updated_date, formatted_entry, 'updatedDate')
-                end
-
-                if course_id_to_code_map
-                  formatted_entry["course_code"] = course_id_to_code_map[result["course_id"]]
-                end
-
-                # All scheduled assignments come back from Canvas with a timestamp, even if none selected. Ferret out untimed assignments.
-                if due_date
-                  if due_date.hour == 0 && due_date.minute == 0 && due_date.second == 0
-                    formatted_entry["dueDate"]["hasTime"] = false
-                  else
-                    formatted_entry["dueDate"]["hasTime"] = true
-                  end
-                end
-
-                Rails.logger.debug "#{self.class.name} Putting Canvas todo with due_date #{formatted_entry["due_date"]} in #{bucket} bucket: #{formatted_entry}"
-                tasks.push(formatted_entry)
-              end
-            end
+    def collect_results(response)
+      if response && (response.status == 200) && (results = safe_json response.body)
+        logger.info "Sorting Canvas feed into buckets with starting_date #{@starting_date}; #{results}"
+        results.collect do |result|
+          if (formatted_entry = yield result)
+            logger.debug "Adding Canvas task with dueDate: #{formatted_entry['dueDate']} in bucket '#{formatted_entry['bucket']}': #{formatted_entry}"
+            formatted_entry
           end
         end
       end
     end
 
-    def fetch_canvas_upcoming_events!(canvas_proxy, tasks, assignments, course_id_to_code_map)
-      response = canvas_proxy.upcoming_events
-      if response && (response.status == 200)
-        results = safe_json response.body
-        if results
-          Rails.logger.info "#{self.class.name} Sorting Canvas upcoming_events feed into buckets with starting_date #{@starting_date}"
-          results.each do |result|
-            type = result['assignment'] ? 'assignment' : 'event'
-            Rails.logger.debug "Upcoming event = #{result["html_url"]}, type = #{type}"
-            # Skip calendar events which are not associated with assignments.
-            if (type == "assignment") && new_assignment?(result, assignments)
-              # Skip assignments shown to graders (as opposed to students).
-              if result['assignment']['needs_grading_count'].nil?
-                formatted_entry = {
-                  "type" => type,
-                  "title" => result["title"],
-                  "emitter" => Canvas::Proxy::APP_NAME,
-                  "linkUrl" => result["html_url"],
-                  "sourceUrl" => result["html_url"],
-                  "status" => "inprogress"
-                }
-                due_date = convert_date(result["start_at"])
-                format_date_into_entry!(due_date, formatted_entry, "dueDate")
-                bucket = determine_bucket(due_date, formatted_entry, @now_time, @starting_date)
-                formatted_entry["bucket"] = bucket
+    def entry_from_result(result, title, course_id)
+      {
+        'course_code' => @course_code_map[course_id],
+        'emitter' => Canvas::Proxy::APP_NAME,
+        'linkDescription' => "View in #{Canvas::Proxy::APP_NAME}",
+        'linkUrl' => result['html_url'],
+        'sourceUrl' => result['html_url'],
+        'status' => 'inprogress',
+        'title' => title,
+        'type' => 'assignment'
+      }
+    end
 
-                if course_id_to_code_map
-                  formatted_entry["course_code"] = course_id_to_code_map[result["assignment"]["course_id"]]
-                end
+    def format_date_and_bucket(formatted_entry, date)
+      format_date_into_entry!(date, formatted_entry, 'dueDate')
+      formatted_entry['bucket'] = determine_bucket(date, formatted_entry, @now_time, @starting_date)
+    end
 
-                Rails.logger.debug "#{self.class.name} Putting Canvas upcoming_events event with dueDate #{formatted_entry["dueDate"]} in #{bucket} bucket: #{formatted_entry}"
-                tasks.push(formatted_entry)
-              end
-            end
+    def format_todo(result)
+      logger.debug "Todo URL: #{result['html_url']}, is assignment: #{result['assignment'].present?}"
+      if result['assignment'] && new_assignment?(result['assignment'])
+        # Skip a teacher's "overdue for grading" assignments since they don't call for a red alert.
+        if result['type'] != 'grading'
+          formatted_entry = entry_from_result(result['assignment'], result['assignment']['name'], result['course_id'])
+          formatted_entry['notes'] = sanitize_html(result['assignment']['description']) if result['assignment']['description'].present?
+
+          due_date = convert_date result['assignment']['due_at']
+          format_date_and_bucket(formatted_entry, due_date)
+          # All scheduled assignments come back from Canvas with a timestamp, even if none selected. Ferret out untimed assignments.
+          if due_date
+            formatted_entry['dueDate']['hasTime'] = !(due_date.hour.zero? && due_date.minute.zero? && due_date.second.zero?)
           end
+
+          if formatted_entry['bucket'] == 'Unscheduled'
+            updated_date = convert_date(result['assignment']['updated_at'] || result['assignment']['created_at'])
+            format_date_into_entry!(updated_date, formatted_entry, 'updatedDate')
+          end
+
+          formatted_entry
         end
       end
     end
 
-    def new_assignment?(assignment, assignments)
-      id = assignment["html_url"]
-      assignments.add?(id)
+    def format_upcoming_event(result)
+      logger.debug "Upcoming event URL: #{result['html_url']}, is assignment: #{result['assignment'].present?}"
+      # Skip calendar events which are not associated with assignments.
+      if result['assignment'] && new_assignment?(result)
+        # Skip assignments shown to graders (as opposed to students).
+        if result['assignment']['needs_grading_count'].nil?
+          formatted_entry = entry_from_result(result, result['title'], result['assignment']['course_id'])
+          format_date_and_bucket(formatted_entry, convert_date(result['start_at']))
+          formatted_entry
+        end
+      end
     end
+
+    def initialize_course_code_map
+      user_courses = Canvas::UserCourses.new(user_id: @uid).courses
+      user_courses.inject({}) { |map, course| map[course['id']] = course['course_code']; map }
+    end
+
+    def new_assignment?(assignment)
+      id = assignment['html_url']
+      @assignments.add? id
+    end
+
   end
 end

--- a/fixtures/pretty_vcr_recordings/Google_tasks.json
+++ b/fixtures/pretty_vcr_recordings/Google_tasks.json
@@ -127,7 +127,14 @@
                 "updated": "2012-11-30T08:59:46.000Z",
                 "selfLink": "https://www.googleapis.com/tasks/v1/lists/MDM3NDMyMTM2NzUwNzM1MDg0MTc6MDow/tasks/MDM3NDMyMTM2NzUwNzM1MDg0MTc6MDoxNDAxOTIxNjM1",
                 "position": "00000000001073741823",
-                "status": "needsAction"
+                "status": "needsAction",
+                "links": [
+                  {
+                    "type": "email",
+                    "description": "CLARIFICATION: No one gets near the sodium without goggles",
+                    "link": "https://mail.google.com/mail/#all/14c471d405b7b"
+                  }
+                ]
               },
               {
                 "kind": "tasks#task",

--- a/src/assets/templates/dashboard_task_loop.html
+++ b/src/assets/templates/dashboard_task_loop.html
@@ -73,10 +73,10 @@
 
       <div class="cc-clearfix">
         <a class="cc-button"
-        data-ng-show="task.emitter=='bCourses'"
+        data-ng-show="task.linkDescription"
         data-ng-click="api.util.preventBubble($event);api.analytics.trackExternalLink('Tasks', task.emitter, task.linkUrl)"
         data-ng-href="{{task.linkUrl}}">
-          View in {{task.emitter}}
+          <span data-ng-bind="task.linkDescription">
           <span class="cc-visuallyhidden" data-ng-bind-template="- {{ task.title }}"></span>
         </a>
 


### PR DESCRIPTION
Include optional email links in Google tasks, per https://jira.ets.berkeley.edu/jira/browse/CLC-5008 . Google tasks have their hard-coded `linkUrl` property replaced with an optional informative value. The front end is made agnostic about task source and will display links for any task with a `linkDescription` property.

On the back end, reworking the task logic provided a good opening for the refactor long requested in https://jira.ets.berkeley.edu/jira/browse/CLC-2246 .