### PR TITLE
CLC-4949 Show bCourses site Official Sections without instructor access

### DIFF
--- a/app/models/campus_oracle/user_courses/all.rb
+++ b/app/models/campus_oracle/user_courses/all.rb
@@ -21,18 +21,7 @@ module CampusOracle
 
           # Merge each section's schedule, location, and instructor list.
           # TODO Is this information useful for non-current terms?
-          campus_classes.values.each do |semester|
-            semester.each do |course|
-              # Remove any duplicates from campus data.
-              course[:sections].uniq!
-              course[:sections].each do |section|
-                proxy = CampusOracle::CourseSections.new({term_yr: course[:term_yr],
-                                                          term_cd: course[:term_cd],
-                                                          ccn: section[:ccn]})
-                section.merge!(proxy.get_section_data)
-              end
-            end
-          end
+          merge_detailed_section_data(campus_classes)
 
           campus_classes
         end

--- a/app/models/campus_oracle/user_courses/base.rb
+++ b/app/models/campus_oracle/user_courses/base.rb
@@ -180,6 +180,21 @@ module CampusOracle
         section_data
       end
 
+      def merge_detailed_section_data(campus_classes)
+        campus_classes.values.each do |semester|
+          semester.each do |course|
+            # Remove any duplicates from campus data.
+            course[:sections].uniq!
+            course[:sections].each do |section|
+              proxy = CampusOracle::CourseSections.new({term_yr: course[:term_yr],
+                  term_cd: course[:term_cd],
+                  ccn: section[:ccn]})
+              section.merge!(proxy.get_section_data)
+            end
+          end
+        end
+      end
+
     end
   end
 end

--- a/app/models/campus_oracle/user_courses/selected_sections.rb
+++ b/app/models/campus_oracle/user_courses/selected_sections.rb
@@ -3,6 +3,8 @@ module CampusOracle
     class SelectedSections < Base
 
       def get_selected_sections(term_yr, term_cd, ccns)
+        # Sort to get canonical cache key.
+        ccns = ccns.sort
         self.class.fetch_from_cache "selected_sections-#{term_yr}-#{term_cd}-#{ccns.join(',')}" do
           campus_classes = {}
           sections = CampusOracle::Queries.get_sections_from_ccns(term_yr, term_cd, ccns)
@@ -15,6 +17,7 @@ module CampusOracle
               previous_item = item
             end
           end
+          merge_detailed_section_data(campus_classes)
           campus_classes
         end
       end

--- a/app/models/my_academics/teaching.rb
+++ b/app/models/my_academics/teaching.rb
@@ -5,23 +5,34 @@ module MyAcademics
     def merge(data)
       proxy = CampusOracle::UserCourses::All.new({user_id: @uid})
       feed = proxy.get_all_campus_courses
+      teaching_semesters = format_teaching_semesters(feed)
+      if teaching_semesters.present?
+        data[:teachingSemesters] = teaching_semesters
+      end
+    end
 
+    # Our bCourses Canvas integration occasionally needs to create an Academics Teaching Semesters
+    # list based on an explicit set of CCNs.
+    def courses_list_from_ccns(term_yr, term_code, ccns)
+      proxy = CampusOracle::UserCourses::SelectedSections.new({user_id: @uid})
+      feed = proxy.get_selected_sections(term_yr, term_code, ccns)
+      format_teaching_semesters(feed, true)
+    end
+
+    def format_teaching_semesters(sections_data, ignore_roles = false)
       teaching_semesters = []
-
-      # The campus courses feed is organized by semesters, with course offerings under them.
-      feed.keys.each do |term_key|
+      # The campus courses data is organized by semesters, with course offerings under them.
+      sections_data.keys.each do |term_key|
         teaching_semester = semester_info term_key
-        feed[term_key].each do |course|
-          next unless course[:role] == 'Instructor'
+        sections_data[term_key].each do |course|
+          next unless ignore_roles || (course[:role] == 'Instructor')
           course_info = course_info_with_multiple_listings course
           append_with_merged_crosslistings(teaching_semester[:classes], course_info)
         end
         teaching_semesters << teaching_semester unless teaching_semester[:classes].empty?
       end
-
-      if teaching_semesters.present?
-        data[:teachingSemesters] = teaching_semesters
-      end
+      teaching_semesters
     end
+
   end
 end

--- a/spec/models/campus_oracle/user_courses/selected_sections_spec.rb
+++ b/spec/models/campus_oracle/user_courses/selected_sections_spec.rb
@@ -2,12 +2,13 @@ require 'spec_helper'
 
 describe CampusOracle::UserCourses::SelectedSections do
 
-  it 'prefixes short CCNs with zeroes', :if => CampusOracle::Connection.test_data? do
+  it 'mimics normal My Academics feed', :if => CampusOracle::Connection.test_data? do
     client = CampusOracle::UserCourses::SelectedSections.new({user_id: '238382'})
     courses = client.get_selected_sections(2013, 'D', [7309])
     sections = courses['2013-D'].first[:sections]
     expect(sections.size).to eq 1
     expect(sections.first[:ccn]).to eq '07309'
+    expect(sections.first[:schedules].size).to eq 2
   end
 
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4949

Centralize My-Academics-style formatting of arbitrary section lists. (The Canvas-copy-and-paste version had already gone stale.)
Merge arbitrary section data into the normal available-for-course-provisioning feed.
TODO: Standardizing the order of the merged sections.
TODO: RSpec for merge_non_teaching_site_sections.