### PR TITLE
CLC-5017 Restore "section already in use" for Create Course Site

### DIFF
--- a/src/assets/javascripts/angular/factories/canvasCourseProvisionFactory.js
+++ b/src/assets/javascripts/angular/factories/canvasCourseProvisionFactory.js
@@ -38,7 +38,7 @@
     /*
      * Initializes selected and course site association states in semesters feed
      */
-    var fillCourseSites = function(semestersFeed) {
+    var fillCourseSites = function(semestersFeed, canvasCourseId) {
       angular.forEach(semestersFeed, function(semester) {
         angular.forEach(semester.classes, function(course) {
           course.collapsed = !course.containsCourseSections;
@@ -48,13 +48,15 @@
           var ccnToSites = {};
           angular.forEach(course.class_sites, function(site) {
             if (site.emitter === 'bCourses') {
-              angular.forEach(site.sections, function(siteSection) {
-                hasSites = true;
-                if (!ccnToSites[siteSection.ccn]) {
-                  ccnToSites[siteSection.ccn] = [];
-                }
-                ccnToSites[siteSection.ccn].push(site);
-              });
+              if (site.id !== canvasCourseId) {
+                angular.forEach(site.sections, function(siteSection) {
+                  hasSites = true;
+                  if (!ccnToSites[siteSection.ccn]) {
+                    ccnToSites[siteSection.ccn] = [];
+                  }
+                  ccnToSites[siteSection.ccn].push(site);
+                });
+              }
             }
           });
           if (hasSites) {
@@ -106,7 +108,13 @@
         return feedResponse;
       }
       feedResponse.data.usersClassCount = classCount(feedResponse.data.teachingSemesters);
-      fillCourseSites(feedResponse.data.teachingSemesters);
+      var canvasCourseId;
+      if (feedResponse.data.canvas_course) {
+        canvasCourseId = '' + feedResponse.data.canvas_course.canvasCourseId;
+      } else {
+        canvasCourseId = '';
+      }
+      fillCourseSites(feedResponse.data.teachingSemesters, canvasCourseId);
       return feedResponse;
     };
 

--- a/src/assets/templates/canvas_embedded/_shared/sections_table.html
+++ b/src/assets/templates/canvas_embedded/_shared/sections_table.html
@@ -65,7 +65,7 @@
           </div>
         </td>
       </tr>
-      <tr data-ng-if="(listMode === 'availableStaging' && section.sites)">
+      <tr data-ng-if="(listMode !== 'preview' && listMode !== 'currentStaging' && section.sites)">
         <td colspan="7" class="cc-template-sections-table-sites-cell">
           <div data-ng-repeat="site in section.sites" class="cc-template-sections-table-sites-container">
             <i class="fa fa-info-circle cc-template-sections-table-sited-icon"></i>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5017

Also removes distracting "section already in use" when it's only being used by the current course site in Official Sections.