### PR TITLE
CLC-4916  - Find a Person to Add: Refactor authorization to respect role type rather than role

### DIFF
--- a/app/controllers/canvas_course_add_user_controller.rb
+++ b/app/controllers/canvas_course_add_user_controller.rb
@@ -18,7 +18,7 @@ class CanvasCourseAddUserController < ApplicationController
   # GET /api/academics/canvas/course_user_roles
   def course_user_roles
     profile = user_profile
-    render json: { courseId: canvas_course_id, roles: profile[:roles], grantingRoles: profile[:grantingRoles] }.to_json
+    render json: { courseId: canvas_course_id, roles: profile[:roles], roleTypes: profile[:roleTypes], grantingRoles: profile[:grantingRoles] }.to_json
   end
 
   # GET /api/academics/canvas/course_add_user/search_users.json
@@ -53,10 +53,12 @@ class CanvasCourseAddUserController < ApplicationController
 
   def user_profile
     canvas_user_profile = Canvas::SisUserProfile.new(user_id: session['user_id']).get
-    course_user_roles = Canvas::CourseUser.new(:user_id => canvas_user_profile['id'], :course_id => canvas_course_id).roles
+    course_user_worker = Canvas::CourseUser.new(:user_id => canvas_user_profile['id'], :course_id => canvas_course_id)
+    course_user_roles = course_user_worker.roles
+    course_user_role_types = course_user_worker.role_types
     global_admin = Canvas::Admins.new.admin_user?(session['user_id'])
     granting_roles = Canvas::CourseAddUser.granting_roles(course_user_roles, global_admin)
-    { roles: course_user_roles.merge({'globalAdmin' => global_admin}), grantingRoles: granting_roles }
+    { roles: course_user_roles.merge({'globalAdmin' => global_admin}), roleTypes: course_user_role_types, grantingRoles: granting_roles }
   end
 
 end

--- a/app/models/canvas/course_user.rb
+++ b/app/models/canvas/course_user.rb
@@ -67,6 +67,12 @@ module Canvas
       roles_hash
     end
 
+    def role_types
+      profile = course_user
+      return [] if profile.nil? || profile['enrollments'].nil? || profile['enrollments'].empty?
+      role_types = profile['enrollments'].collect {|enrollment| enrollment['type'] }
+    end
+
     # Do not need to log a stack trace when the user is not a course site member.
     def existence_check
       true

--- a/spec/controllers/canvas_course_add_user_controller_spec.rb
+++ b/spec/controllers/canvas_course_add_user_controller_spec.rb
@@ -77,6 +77,11 @@ describe CanvasCourseAddUserController do
             expect(roles['observer']).to be_falsey
             expect(roles['designer']).to be_falsey
             expect(roles['ta']).to be_falsey
+
+            role_types = response_json['roleTypes']
+            expect(role_types).to be_an_instance_of Array
+            expect(role_types.count).to eq 1
+            expect(role_types[0]).to eq 'StudentEnrollment'
           end
 
           it "returns no granting roles" do
@@ -107,6 +112,11 @@ describe CanvasCourseAddUserController do
             expect(roles['observer']).to be_falsey
             expect(roles['designer']).to be_falsey
             expect(roles['ta']).to be_truthy
+
+            role_types = response_json['roleTypes']
+            expect(role_types).to be_an_instance_of Array
+            expect(role_types.count).to eq 1
+            expect(role_types[0]).to eq 'TaEnrollment'
           end
 
           it "returns student and observer granting roles" do
@@ -121,7 +131,6 @@ describe CanvasCourseAddUserController do
             expect(response_json['grantingRoles']).to include({'id' => "StudentEnrollment", "name" => "Student"})
             expect(response_json['grantingRoles']).to include({'id' => "ObserverEnrollment", "name" => "Observer"})
           end
-
         end
 
         context "when user is canvas course teacher" do
@@ -144,6 +153,11 @@ describe CanvasCourseAddUserController do
             expect(roles['observer']).to be_falsey
             expect(roles['designer']).to be_falsey
             expect(roles['ta']).to be_falsey
+
+            role_types = response_json['roleTypes']
+            expect(role_types).to be_an_instance_of Array
+            expect(role_types.count).to eq 1
+            expect(role_types[0]).to eq 'TeacherEnrollment'
           end
 
           it "returns all granting roles" do
@@ -169,6 +183,7 @@ describe CanvasCourseAddUserController do
             expect(response.status).to eq(200)
             response_json = JSON.parse(response.body)
             expect(response_json['roles']).to be_an_instance_of Hash
+
             roles = response_json['roles']
             expect(roles).to be_an_instance_of Hash
             expect(roles['globalAdmin']).to be_truthy
@@ -177,6 +192,9 @@ describe CanvasCourseAddUserController do
             expect(roles['observer']).to be_falsey
             expect(roles['designer']).to be_falsey
             expect(roles['ta']).to be_falsey
+
+            role_types = response_json['roleTypes']
+            expect(role_types).to eq []
           end
 
           it "returns all granting roles" do

--- a/spec/models/canvas/course_user_spec.rb
+++ b/spec/models/canvas/course_user_spec.rb
@@ -246,4 +246,38 @@ describe Canvas::CourseUser do
     end
   end
 
+  context "when returning course user role types" do
+    before { allow(subject).to receive(:course_user).and_return(canvas_course_user) }
+    context 'when profile not available' do
+      before { allow(subject).to receive(:course_user).and_return(nil) }
+      it 'returns empty array' do
+        course_user_role_types = subject.role_types
+        expect(course_user_role_types).to eq []
+      end
+    end
+
+    context 'when enrollments not available in profile' do
+      before { canvas_course_user['enrollments'] = nil }
+      it 'returns empty array' do
+        course_user_role_types = subject.role_types
+        expect(course_user_role_types).to eq []
+      end
+    end
+
+    context 'when no enrollments present' do
+      before { canvas_course_user['enrollments'] = [] }
+      it 'returns empty array' do
+        course_user_role_types = subject.role_types
+        expect(course_user_role_types).to eq []
+      end
+    end
+
+    it 'returns array of role types' do
+      course_user_role_types = subject.role_types
+      expect(course_user_role_types).to be_an_instance_of Array
+      expect(course_user_role_types[0]).to eq 'StudentEnrollment'
+      expect(course_user_role_types[1]).to eq 'ObserverEnrollment'
+    end
+  end
+
 end

--- a/src/assets/javascripts/angular/controllers/pages/canvasCourseAddUserController.js
+++ b/src/assets/javascripts/angular/controllers/pages/canvasCourseAddUserController.js
@@ -144,10 +144,11 @@
     var checkAuthorization = function() {
       canvasCourseAddUserFactory.courseUserRoles($scope.canvasCourseId).success(function(data) {
         $scope.courseUserRoles = data.roles;
+        $scope.courseUserRoleTypes = data.roleTypes;
         $scope.grantingRoles = data.grantingRoles;
         $scope.selectedRole = $scope.grantingRoles[0];
 
-        $scope.userAuthorized = userIsAuthorized($scope.courseUserRoles);
+        $scope.userAuthorized = userIsAuthorized($scope.courseUserRoleTypes);
         if ($scope.userAuthorized) {
           getCourseSections();
           $scope.showSearchForm = true;
@@ -180,11 +181,11 @@
       });
     };
 
-    var userIsAuthorized = function(courseUserRoles) {
-      if (courseUserRoles.globalAdmin || courseUserRoles.teacher || courseUserRoles.ta || courseUserRoles.designer || courseUserRoles.owner || courseUserRoles.maintainer) {
-        return true;
-      }
-      return false;
+    var userIsAuthorized = function(courseUserRoleTypes) {
+      var authorizedTypes = ['TeacherEnrollment', 'TaEnrollment'];
+      return authorizedTypes.some(function(authorizedType) {
+        return courseUserRoleTypes.indexOf(authorizedType) > -1;
+      });
     };
 
     apiService.util.iframeUpdateHeight();

--- a/src/assets/javascripts/angular/controllers/pages/canvasCourseAddUserController.js
+++ b/src/assets/javascripts/angular/controllers/pages/canvasCourseAddUserController.js
@@ -148,7 +148,7 @@
         $scope.grantingRoles = data.grantingRoles;
         $scope.selectedRole = $scope.grantingRoles[0];
 
-        $scope.userAuthorized = userIsAuthorized($scope.courseUserRoleTypes);
+        $scope.userAuthorized = userIsAuthorized($scope.courseUserRoleTypes) || $scope.courseUserRoles.globalAdmin;
         if ($scope.userAuthorized) {
           getCourseSections();
           $scope.showSearchForm = true;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4916

Updates the Course User Roles API end-point to include the users role types for authorization in addition to the actual roles. Removes custom roles from the roles hash that were added to temporarily authorize access to the 'Find a Person to Add' tool for the Owner, Maintainer, and Member roles that were introduced to the 'Projects' account.