### PR TITLE
[QA] CLC-5026 Update path for Google Drive badge icons

### DIFF
--- a/app/models/my_badges/google_drive.rb
+++ b/app/models/my_badges/google_drive.rb
@@ -76,7 +76,7 @@ module MyBadges
         file_baseclass = File.basename(URI.parse(icon_link).path, '.png')
         raise TypeError, 'Not a png file' if file_baseclass.index('.').present?
         drive_icons_list = Rails.cache.fetch('drive_icons', expires_in: Settings.cache.maximum_expires_in) {
-          raw_list = Dir.glob(File.join(Rails.root, 'app/assets/images/drive_icons/', '*.png'))
+          raw_list = Dir.glob(File.join(Rails.root, 'src/assets/images/drive_icons/', '*.png'))
           raw_list.select! {|filename| File.basename(filename).rindex('.png').present? }
           raw_list.map {|filename| File.basename(filename, ".png")}
         }

--- a/spec/models/my_badges/my_badges_spec.rb
+++ b/spec/models/my_badges/my_badges_spec.rb
@@ -113,10 +113,29 @@ describe "MyBadges" do
     expect(badges).to be_blank
   end
 
-  it "should ignore non png icons for bdrive" do
-    proxy = MyBadges::GoogleDrive.new(@user_id)
-    icon_class_result = proxy.send(:process_icon, "http://www.google.com/lol_cat.gif")
-    icon_class_result.present?.should_not be_truthy
-  end
+  context 'css classes for bdrive icons' do
+    let (:proxy) { MyBadges::GoogleDrive.new(@user_id) }
+    let (:icon_class_result) { proxy.send(:process_icon, image_url) }
 
+    context 'when icon is an expected png file' do
+      let (:image_url) { 'https://ssl.gstatic.com/docs/doclist/images/icon_11_document_list.png' }
+      it 'should return the file basename' do
+        expect(icon_class_result).to eq 'icon_11_document_list'
+      end
+    end
+
+    context 'when icon is an unexpected png file' do
+      let (:image_url) { 'https://ssl.gstatic.com/docs/doclist/images/icon_11_cuneiform_list.png' }
+      it 'should return nothing' do
+        expect(icon_class_result).to be_blank
+      end
+    end
+
+    context 'when icon is not a png file' do
+      let (:image_url) { 'http://www.google.com/lol_cat.gif' }
+      it 'should return nothing' do
+        expect(icon_class_result).to be_blank
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5026

QA version of #3519.