### PR TITLE
CLC-5042 Do not display email links for Google tasks

### DIFF
--- a/app/models/my_tasks/google_tasks.rb
+++ b/app/models/my_tasks/google_tasks.rb
@@ -110,13 +110,6 @@ module MyTasks
         format_date_into_entry!(convert_date(entry['completed']), formatted_entry, 'completedDate')
       end
 
-      if entry['links'].present?
-        formatted_entry['linkUrl'] = entry['links'][0]['link']
-        if entry['links'][0]['type'] == 'email'
-          formatted_entry['linkDescription'] = 'View related email'
-        end
-      end
-
       due_date = if entry['due']
         # Google task datetimes have misleading datetime accuracy. There is no way to record a specific due time
         # for tasks (through the UI), thus the reported time+tz is always 00:00:00+0000. Calling convert_datetime_or_date

--- a/spec/models/my_tasks/my_tasks_spec.rb
+++ b/spec/models/my_tasks/my_tasks_spec.rb
@@ -76,16 +76,6 @@ describe "MyTasks" do
         expect(task['linkUrl']).to start_with('https://ucberkeley.instructure.com/courses/')
         expect(task['sourceUrl']).to eq task['linkUrl']
       end
-
-      google_tasks = tasks.select { |task| task['emitter'] == GoogleApps::Proxy::APP_ID }
-      email_tasks = google_tasks.select { |task| task['linkDescription'] == 'View related email'}
-      expect(email_tasks.count).to eq 1
-      expect(email_tasks[0]['linkUrl']).to start_with('https://mail.google.com/mail/#all/')
-
-      (google_tasks - email_tasks).each do |task|
-        expect(task['linkDescription']).to be_nil
-        expect(task['linkUrl']).to be_nil
-      end
     end
 
   end


### PR DESCRIPTION
In light of https://jira.ets.berkeley.edu/jira/browse/CLC-5042, removes the link information added in #3503 without reverting the associated code cleanup.