### PR TITLE
CLC-4748 Run our rake tasks from shell script

### DIFF
--- a/script/bamboo-tests.sh
+++ b/script/bamboo-tests.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Script to install necessary dependencies and then run testext tests, for use on Bamboo CI
+
+cd $( dirname "${BASH_SOURCE[0]}" )/..
+
+# Enable rvm and use the correct Ruby version and gem set.
+[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
+source .rvmrc
+GEMSET="$1"
+if [ -z "$1" ]; then
+  GEMSET="calcentral"
+fi
+rvm gemset use $GEMSET
+
+# get Ruby deps
+bundle install --local --retry 3 || { echo "WARNING: bundle install --local failed, running bundle install"; bundle install --retry 3 || { echo "ERROR: bundle install failed"; exit 1; } }
+bundle package --all || { echo "WARNING: bundle package failed"; exit 1; }
+
+# set up Xvfb for headless browser testing
+if [ ! -f /tmp/.X99-lock ];
+then
+    Xvfb :99 -screen 0 1440x900x16 &
+fi
+
+# set up environment
+export RAILS_ENV=testext
+export DISPLAY=":99"
+export JRUBY_OPTS="-Xcext.enabled=true -J-Xmx900m -J-XX:MaxPermSize=500m -J-Djruby.compile.mode=OFF"
+
+# run the tests
+bundle exec rake assets:clean db:reset spec:xml


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4748

Step 1 in getting rid of our archaic Ruby Bamboo plugin dependency. 

This job shows the simplification in Bamboo structure -- we get to drop 2 tasks from the rake stage: https://bamboo.ets.berkeley.edu/bamboo/build/admin/edit/editBuildTasks.action?buildKey=MYB-CLCMVPCHRIS-JOB1

