### PR TITLE
CLC-5063 Do not query an empty list of UIDs from Canvas Refresh

### DIFF
--- a/app/models/canvas/maintain_users.rb
+++ b/app/models/canvas/maintain_users.rb
@@ -91,7 +91,7 @@ module Canvas
             accounts_batch = []
           end
         end
-        compare_to_campus(accounts_batch)
+        compare_to_campus(accounts_batch) if accounts_batch.present?
       end
     end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5063

Multiples of a thousand led to an empty SQL query clause and sudden script termination.