### PR TITLE
CLC-5050, bug fix in webcast.json feed gives us more exact start times

### DIFF
--- a/spec/models/mediacasts/course_media_spec.rb
+++ b/spec/models/mediacasts/course_media_spec.rb
@@ -186,7 +186,7 @@ describe Mediacasts::CourseMedia do
           expect(recording).to be_an_instance_of Hash
           expect(recording['youTubeId']).to eq 'VvOGnqMCbKE'
           expect(recording['lecture']).to eq '2014-01-24: Introduction, safety, observations and notebook skills, How the nose knows'
-          expect(recording['recordingStartUTC']).to eq '2014-01-24T00:00:00-08:00'
+          expect(recording['recordingStartUTC']).to eq '2014-01-24T12:07:00-08:00'
           # audioOnly
         end
       end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5050

Expected recordingStart date needed change according to a bug fix on the Webcast side. 

Bamboo build against this branch (CLC-5050) was a success: 
https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CJT41-1