### PR TITLE
CLC-5102, webcast-integration in Junction programmatic term transition scheme

### DIFF
--- a/app/models/mediacasts/rooms.rb
+++ b/app/models/mediacasts/rooms.rb
@@ -1,21 +1,18 @@
 module Mediacasts
   class Rooms < Proxy
 
-    def initialize(term_yr, term_cd, options = {})
+    def initialize(options = {})
       super(options)
-      @term_yr = term_yr
-      @term_cd = term_cd.upcase
     end
 
     def get_json_path
-      "#{@term_yr}/#{@term_cd}/rooms.json"
+      'rooms.json'
     end
 
     def request_internal
       return {} unless Settings.features.videos
       data = get_json_data
-      building_map = {
-      }
+      building_map = {}
       data['webcastEnabledRooms'].each do |data_element|
         building_map[data_element['building']] = data_element['rooms']
       end

--- a/app/models/mediacasts/system_status.rb
+++ b/app/models/mediacasts/system_status.rb
@@ -1,0 +1,20 @@
+module Mediacasts
+  class SystemStatus < Proxy
+
+    def initialize(options = {})
+      super(options)
+    end
+
+    def get_json_path
+      'webcast-system-status.json'
+    end
+
+    def request_internal
+      return {} unless Settings.features.videos
+      is_active_value = get_json_data['isSignUpActive']
+      is_sign_up_active = is_active_value && is_active_value.strip.casecmp('true') == 0
+      { 'is_sign_up_active' => is_sign_up_active }
+    end
+
+  end
+end

--- a/fixtures/json/rooms.json
+++ b/fixtures/json/rooms.json
@@ -1,4 +1,3 @@
-
 {
   "webcastEnabledRooms":[
     {

--- a/fixtures/json/webcast-system-status.json
+++ b/fixtures/json/webcast-system-status.json
@@ -1,0 +1,3 @@
+{
+  "isSignUpActive": "true"
+}

--- a/spec/models/mediacasts/rooms_spec.rb
+++ b/spec/models/mediacasts/rooms_spec.rb
@@ -1,11 +1,9 @@
 describe Mediacasts::Rooms do
 
   let (:rooms_json_uri) { URI.parse "#{Settings.webcast_proxy.base_url}/rooms.json" }
-  let (:term_yr) { 2015 }
-  let (:term_cd) { 'D' }
 
   context 'a fake proxy' do
-    subject { Mediacasts::Rooms.new(term_yr, term_cd, {:fake => true}) }
+    subject { Mediacasts::Rooms.new({:fake => true}) }
 
     context 'fake data' do
       it 'should return webcast-enabled rooms' do
@@ -16,7 +14,7 @@ describe Mediacasts::Rooms do
   end
 
   context 'a real, non-fake proxy' do
-    subject { Mediacasts::Rooms.new(term_yr, term_cd) }
+    subject { Mediacasts::Rooms.new }
 
     context 'real data', :testext => true do
       it 'should return at least one building' do
@@ -35,7 +33,7 @@ describe Mediacasts::Rooms do
       after(:each) { WebMock.reset! }
       it 'should return the fetch error message' do
         buildings = subject.get
-        expect(buildings[:proxy_error_message]).to include('There was a problem')
+        expect(buildings[:proxy_error_message]).to include 'There was a problem'
       end
     end
 
@@ -46,7 +44,7 @@ describe Mediacasts::Rooms do
       after(:each) { WebMock.reset! }
       it 'should return the fetch error message' do
         buildings = subject.get
-        expect(buildings[:proxy_error_message]).to include('There was a problem')
+        expect(buildings[:proxy_error_message]).to include 'There was a problem'
       end
     end
 

--- a/spec/models/mediacasts/system_status_spec.rb
+++ b/spec/models/mediacasts/system_status_spec.rb
@@ -1,0 +1,26 @@
+describe Mediacasts::SystemStatus do
+
+  let (:system_status_json_uri) { URI.parse "#{Settings.webcast_proxy.base_url}/webcast-system-status.json" }
+
+  context 'a fake proxy' do
+    subject { Mediacasts::SystemStatus.new({:fake => true}) }
+
+    context 'fake data' do
+      it 'should return webcast-enabled rooms' do
+        expect(subject.get['is_sign_up_active']).to be_truthy
+      end
+    end
+  end
+
+  context 'a real, non-fake proxy' do
+    subject { Mediacasts::SystemStatus.new }
+
+    context 'real data', :testext => true do
+      it 'should return true or false' do
+        flag = subject.get['is_sign_up_active']
+        expect([true, false]).to include flag
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5102
Bamboo build: https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CJT43-1

Webcast provides /webcast-system-status.json which has property 'isSignUpActive'=[true | false]. This allows us to take term_yr and term_cd args out of Room class. This is a programmatic way of enabling webcast alerts without adding hard-to-maintain configs.