### PR TITLE
CLC-5118, rename all_playlists to recordings (webcast terminology)

### DIFF
--- a/app/models/webcast/course_media.rb
+++ b/app/models/webcast/course_media.rb
@@ -36,17 +36,17 @@ module Webcast
     end
 
     def get_playlist
-      proxy = Webcast::AllPlaylists.new
-      all_playlists = proxy.get
-      if all_playlists && all_playlists[:courses]
-        playlist = all_playlists[:courses][@id]
+      proxy = Webcast::Recordings.new
+      recordings = proxy.get
+      if recordings && recordings[:courses]
+        playlist = recordings[:courses][@id]
         if playlist.blank?
-          Webcast::AllPlaylists::ERRORS
+          Webcast::Recordings::ERRORS
         else
           playlist
         end
       else
-        all_playlists
+        recordings
       end
     end
 

--- a/app/models/webcast/recordings.rb
+++ b/app/models/webcast/recordings.rb
@@ -1,5 +1,5 @@
 module Webcast
-  class AllPlaylists < Proxy
+  class Recordings < Proxy
 
     def initialize(options = {})
       super(options)

--- a/spec/models/webcast/course_media_spec.rb
+++ b/spec/models/webcast/course_media_spec.rb
@@ -160,7 +160,7 @@ describe Webcast::CourseMedia do
       subject { Webcast::CourseMedia.new(2008, 'D', 'LAW', '2723') }
 
       before do
-        allow(Webcast::AllPlaylists).to receive(:new).and_return Webcast::AllPlaylists.new({fake: true})
+        allow(Webcast::Recordings).to receive(:new).and_return Webcast::Recordings.new({fake: true})
       end
 
       context 'a normal return of fake data' do

--- a/spec/models/webcast/recordings_spec.rb
+++ b/spec/models/webcast/recordings_spec.rb
@@ -1,9 +1,9 @@
-describe Webcast::AllPlaylists do
+describe Webcast::Recordings do
 
   let (:webcast_uri) { URI.parse "#{Settings.webcast_proxy.base_url}/webcast.json" }
 
   context 'a fake proxy' do
-    subject { Webcast::AllPlaylists.new({:fake => true}) }
+    subject { Webcast::Recordings.new({:fake => true}) }
 
     context 'a normal return of fake data' do
       it 'should return a lot of playlists' do
@@ -14,7 +14,7 @@ describe Webcast::AllPlaylists do
   end
 
   context 'a real, non-fake proxy' do
-    subject { Webcast::AllPlaylists.new }
+    subject { Webcast::Recordings.new }
 
     context 'normal return of real data', :testext => true do
       it 'should return a bunch of playlists' do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5118

This is the last refactor. The name 'recordings' is succinct and it fits with webcast terminology and the naming in the feed.