### PR TITLE
CLC-5036 Initialize current list of Official Sections when empty

### DIFF
--- a/src/assets/javascripts/angular/controllers/pages/canvasCourseManageOfficialSectionsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/canvasCourseManageOfficialSectionsController.js
@@ -24,6 +24,7 @@
      */
     var initState = function() {
       // initialize maintenance notice settings
+      $scope.existingCourseSections = [];
       $scope.allSections = [];
       $scope.courseActionVerb = 'site is updated';
       $scope.maintenanceCollapsed = true;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5036

For admins, the "teachingSemesters" part of the initial feed is filled in from the course site sections. When the site has no sections, there are no "teachingSemesters" in the feed. And that meant the front-end never reached the critical initialization code for "$scope.existingCourseSections": https://github.com/ets-berkeley-edu/calcentral/blob/973056b210423b0e74670349d28351ca67045898/src/assets/javascripts/angular/controllers/pages/canvasCourseManageOfficialSectionsController.js#L68

Since "$scope.existingCourseSections" is key to enabling expected behavior, we should ensure that it's always defined.