### PR TITLE
CLC-4789 Separate multiple primary section enrollments in Class Info

### DIFF
--- a/app/models/berkeley/course_options.rb
+++ b/app/models/berkeley/course_options.rb
@@ -142,15 +142,14 @@ module Berkeley
       'Z9' => [{formats: ['DIS', 'LAB']}]
     }
 
-    def nested?(course_option, primary_section_number, secondary_section)
+    def nested?(course_option, primary_section_number, secondary_section_number, secondary_instruction_format)
       mapping = MAPPING[course_option]
       return false if mapping.nil?
-      return false unless match_idx = mapping.index { |m| m[:formats].include?(secondary_section['instruction_format']) }
-      match = mapping[match_idx]
+      return false unless match = mapping.find { |m| m[:formats].include?(secondary_instruction_format) }
       return true if match[:primary].nil?
       match_string = primary_section_number[match[:primary]]
       match_string.reverse! if match[:reverse]
-      return match_string == secondary_section['section_num'][match[:secondary]]
+      return match_string == secondary_section_number[match[:secondary]]
     end
 
   end

--- a/app/models/campus_oracle/queries.rb
+++ b/app/models/campus_oracle/queries.rb
@@ -228,7 +228,7 @@ module CampusOracle
         sql = <<-SQL
       select d.dept_description, c.term_yr, c.term_cd, c.course_cntl_num, r.enroll_status, r.wait_list_seq_num, r.unit, r.pnp_flag, r.grade,
         c.course_title, c.course_title_short, c.dept_name, c.catalog_id, c.primary_secondary_cd, c.section_num, c.instruction_format,
-        c.catalog_root, c.catalog_prefix, c.catalog_suffix_1, c.catalog_suffix_2, c.enroll_limit, c.cred_cd
+        c.catalog_root, c.catalog_prefix, c.catalog_suffix_1, c.catalog_suffix_2, c.enroll_limit, c.cred_cd, c.course_option
       from calcentral_class_roster_vw r
       join calcentral_course_info_vw c on (
         c.term_yr = r.term_yr

--- a/app/models/campus_oracle/user_courses/base.rb
+++ b/app/models/campus_oracle/user_courses/base.rb
@@ -66,7 +66,7 @@ module CampusOracle
                   primaries.each do |prim|
                     secondaries.each do |sec|
                       if explicit_secondaries.include?(sec['course_cntl_num']) ||
-                        Berkeley::CourseOptions.nested?(course[:course_option], prim[:section_number], sec)
+                        Berkeley::CourseOptions.nested?(course[:course_option], prim[:section_number], sec['section_num'], sec['instruction_format'])
                         nested_secondaries[sec['course_cntl_num']] = row_to_section_data(sec)
                       end
                     end
@@ -109,24 +109,20 @@ module CampusOracle
           nil
         else
           course_name = row['course_title'].present? ? row['course_title'] : row['course_title_short']
-          course_item.merge!({
+          course_item.merge({
                                term_yr: row['term_yr'],
                                term_cd: row['term_cd'],
                                dept: row['dept_name'],
                                dept_desc: row['dept_description'],
                                catid: row['catalog_id'],
                                course_catalog: row['catalog_id'],
+                               course_option: row['course_option'],
                                emitter: 'Campus',
                                name: course_name,
                                sections: [
                                  row_to_section_data(row)
                                ]
                              })
-          # This only applies to instructors and will be skipped for students.
-          if (course_option = row['course_option'])
-            course_item[:course_option] = course_option
-          end
-          course_item
         end
       end
 

--- a/app/models/my_academics/canvas_sites.rb
+++ b/app/models/my_academics/canvas_sites.rb
@@ -40,7 +40,17 @@ module MyAcademics
               campus_courses.each do |course|
                 linked_ccns = []
                 course[:sections].each do |s|
-                  linked_ccns << {ccn: s[:ccn]} if site_ccns.include?(s[:ccn].to_i)
+                  if site_ccns.include? s[:ccn].to_i
+                    linked_ccns << {ccn: s[:ccn]}
+                    # In the case of multiple primaries, expose the minimum data needed to make a section association.
+                    if course[:multiplePrimaries]
+                      primary_to_associate = s[:is_primary_section] ? s : course[:sections].find { |prim| prim[:slug] == s[:associatedWithPrimary] }
+                      if primary_to_associate
+                        primary_to_associate[:siteIds] ||= []
+                        primary_to_associate[:siteIds] << course_site[:id]
+                      end
+                    end
+                  end
                 end
                 if linked_ccns.present?
                   course[:class_sites] ||= []

--- a/app/models/my_classes/campus.rb
+++ b/app/models/my_classes/campus.rb
@@ -33,35 +33,37 @@ module MyClasses
       end
       # If a student is enrolled or waitlisted in multiple primary sections with the
       # same department and catalog ID, show them as separate "classes" on the dashboard.
-      # In very rare cases (notably a student who is waitlisted for multiple primary
-      # sections of a large course offering with secondary sections), the sections list
-      # of the split class will be somewhat arbitrary. This has no visible effect in
-      # the current UX, however.
-      split_primaries = multiple_primaries?(campus_course)
-      working_course = nil
-      campus_course[:sections].each do |section|
-        if section[:is_primary_section]
-          working_course = campus_course.deep_dup
-          if split_primaries
-            working_course[:listings].each do |listing|
-              listing[:id] = "#{listing[:id]}-#{section[:section_number]}"
-            end
-            working_course[:listings].first[:courseCodeSection] = "#{section[:instruction_format]} #{section[:section_number]}"
-          end
-          if section[:waitlistPosition] && section[:waitlistPosition] > 0
-            working_course[:enroll_limit] = section[:enroll_limit]
-            working_course[:waitlistPosition] = section[:waitlistPosition]
-          end
-          working_course[:sections] = [section]
-          class_list << working_course
-        else
-          working_course[:sections] << section
-        end
-      end
-    end
+      # In a case such as a student who is waitlisted for multiple primary
+      # sections of a large course offering with secondary sections, we'll try our best
+      # to associate primaries and secondaries based on the course_option value, but
+      # success is not guaranteed.
+      primary_sections, secondary_sections = campus_course[:sections].partition {|section| section[:is_primary_section]}
 
-    def multiple_primaries?(campus_course)
-      (campus_course[:sections].select {|section| section[:is_primary_section]}).size > 1
+      primary_sections.each do |section|
+        working_course = campus_course.deep_dup
+        if primary_sections.count > 1
+          working_course[:listings].each do |listing|
+            listing[:id] = "#{listing[:id]}-#{section[:section_number]}"
+          end
+          working_course[:listings].first[:courseCodeSection] = "#{section[:instruction_format]} #{section[:section_number]}"
+        end
+        if section[:waitlistPosition] && section[:waitlistPosition] > 0
+          working_course[:enroll_limit] = section[:enroll_limit]
+          working_course[:waitlistPosition] = section[:waitlistPosition]
+        end
+        working_course[:sections] = [section]
+        working_course[:site_url] << "/#{section[:instruction_format].downcase}-#{section[:section_number]}"
+        working_course.delete :course_option
+        class_list << working_course
+      end
+
+      secondary_sections.each do |sec|
+        primary = primary_sections.find { |prim| Berkeley::CourseOptions.nested?(campus_course[:course_option], prim[:section_number], sec[:section_number], sec[:instruction_format]) }
+        # Fallback if we can't find anything nested
+        primary ||= primary_sections.first
+        primary_in_class_list = class_list.find { |course| course[:sections].first[:ccn] == primary[:ccn]}
+        primary_in_class_list[:sections] << sec
+      end
     end
 
   end

--- a/public/dummy/json/academics.json
+++ b/public/dummy/json/academics.json
@@ -703,7 +703,7 @@
               "is_primary_section": false,
               "section_label": "IND 201",
               "section_number": "201",
-              "associatedWithPrimary": "72910",
+              "associatedWithPrimary": "lab-002",
               "schedules": [],
               "instructors": [
                 {

--- a/spec/models/berkeley/course_options_spec.rb
+++ b/spec/models/berkeley/course_options_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe Berkeley::CourseOptions do
-  subject { Berkeley::CourseOptions.nested?(primary['course_option'], primary['section_num'], secondary) }
+  subject { Berkeley::CourseOptions.nested?(primary['course_option'], primary['section_num'], secondary['section_num'], secondary['instruction_format']) }
 
   context 'when no nesting defined' do
     let(:primary) { {'course_option' => 'UNKN', 'section_num' => '001'} }

--- a/spec/models/campus_oracle/queries_spec.rb
+++ b/spec/models/campus_oracle/queries_spec.rb
@@ -140,9 +140,14 @@ describe CampusOracle::Queries do
 
   context "#get_enrolled_sections", if: Sakai::SakaiData.test_data? do
     subject { CampusOracle::Queries.get_enrolled_sections('300939') }
-
-    it { should_not be_blank }
-    it { subject.all? { |section| section.has_key?("cred_cd") } }
+    it 'should include requested columns' do
+      expect(subject).to be_present
+      %w(dept_description term_yr term_cd course_cntl_num enroll_status wait_list_seq_num unit pnp_flag grade
+         course_title course_title_short dept_name catalog_id primary_secondary_cd section_num instruction_format
+         catalog_root catalog_prefix catalog_suffix_1 catalog_suffix_2 enroll_limit cred_cd course_option).each do |column|
+        expect(subject).to all(include column)
+      end
+    end
   end
 
   it 'finds cross-listed course data', if: Sakai::SakaiData.test_data? do

--- a/spec/models/campus_oracle/user_courses/base_spec.rb
+++ b/spec/models/campus_oracle/user_courses/base_spec.rb
@@ -56,6 +56,7 @@ describe CampusOracle::UserCourses::Base do
       it 'includes only course info at the course level' do
         course = subject.first
         expect(course[:course_code]).to eq "#{base_enrollment['dept_name']} #{base_enrollment['catalog_id']}"
+        expect(course[:course_option]).to eq base_enrollment['course_option']
         expect(course[:catid]).to eq base_enrollment['catalog_id']
         expect(course[:cred_cd]).to be_nil
         expect(course[:pnp_flag]).to be_nil

--- a/spec/models/my_academics/canvas_sites_spec.rb
+++ b/spec/models/my_academics/canvas_sites_spec.rb
@@ -13,6 +13,17 @@ describe MyAcademics::CanvasSites do
       class_sites: []
     }
   end
+  let(:campus_course_multiple_primaries_base) do
+    {
+      slug: course_id,
+      multiplePrimaries: true,
+      sections: [
+        {ccn: ccn.to_s},
+        {ccn: (ccn+1).to_s}
+      ],
+      class_sites: []
+    }
+  end
   let(:fake_term_yr) {2013}
   let(:fake_term_cd) {'D'}
   let(:student_classes) {[]}
@@ -136,6 +147,18 @@ describe MyAcademics::CanvasSites do
           end
         end
 
+        context 'when campus courses include multiple primaries' do
+          let(:student_classes) {[campus_course_multiple_primaries_base]}
+          it 'includes the site in the campus class item' do
+            it_is_a_linked_course_site_item(:semesters)
+          end
+          it 'links the site to the correct primary section' do
+            course = subject[:semesters].first[:classes].first
+            site = course[:class_sites].first
+            expect(course[:sections][0][:siteIds]).to eq [site[:id]]
+            expect(course[:sections][1][:siteIds]).to eq nil
+          end
+        end
       end
 
       context 'when the Canvas course site does not match a known campus section' do

--- a/spec/models/my_classes/campus_spec.rb
+++ b/spec/models/my_classes/campus_spec.rb
@@ -10,6 +10,7 @@ describe MyClasses::Campus do
   let(:fake_sections) {[
     {
       ccn: rand(99999),
+      instruction_format: 'LEC',
       is_primary_section: true
     }
   ]}
@@ -20,6 +21,7 @@ describe MyClasses::Campus do
     catid: catid,
     dept: 'ECON',
     course_code: course_code,
+    course_option: 'E1',
     emitter: 'Campus',
     name: 'Retire in Only 85 Years',
     role: 'Student',
@@ -77,21 +79,35 @@ describe MyClasses::Campus do
           unit: '2',
           section_number: '021',
           waitlistPosition: 2
+        },
+        {
+          ccn: '76393',
+          enroll_status: 'E',
+          instruction_format: 'DIS',
+          is_primary_section: false,
+          pnp_flag: 'N ',
+          unit: '0',
+          section_number: '200',
+          waitlistPosition: 0
         }
       ]}
       it_behaves_like 'a Classes list'
-      its(:size) {should eq fake_sections.size}
-      it 'treats them as two different classes with the same URL' do
+      its(:size) {should eq 2}
+      it 'treats them as two different classes' do
         expect(subject[0][:listings][0][:id]).to_not eq subject[1][:listings][0][:id]
-        [subject, fake_sections].transpose.each do |course, enrollment|
+        expect(subject[0][:site_url]).to_not eq subject[1][:site_url]
+        [subject, fake_sections[0..1]].transpose.each do |course, enrollment|
           expect(course[:listings].first[:courseCodeSection]).to eq "#{enrollment[:instruction_format]} #{enrollment[:section_number]}"
-          expect(course[:sections].size).to eq 1
           expect(course[:sections][0][:ccn]).to eq enrollment[:ccn]
           if (enrollment[:waitlistPosition] > 0)
             expect(course[:enroll_limit]).to eq enrollment[:enroll_limit]
             expect(course[:waitlistPosition]).to eq enrollment[:waitlistPosition]
           end
         end
+      end
+      it 'associates secondary sections based on course_option' do
+        expect(subject[0][:sections].size).to eq 2
+        expect(subject[1][:sections].size).to eq 1
       end
     end
   end

--- a/src/assets/javascripts/angular/configuration/routeConfiguration.js
+++ b/src/assets/javascripts/angular/configuration/routeConfiguration.js
@@ -24,6 +24,10 @@
       templateUrl: 'academics_classinfo.html',
       controller: 'AcademicsController'
     }).
+    when('/academics/semester/:semesterSlug/class/:classSlug/:sectionSlug', {
+      templateUrl: 'academics_classinfo.html',
+      controller: 'AcademicsController'
+    }).
     when('/academics/booklist/:semesterSlug', {
       templateUrl: 'academics_booklist.html',
       controller: 'AcademicsController'

--- a/src/assets/javascripts/angular/controllers/pages/academicsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicsController.js
@@ -5,7 +5,7 @@
   /**
    * Academics controller
    */
-  angular.module('calcentral.controllers').controller('AcademicsController', function(academicsFactory, apiService, badgesFactory, $routeParams, $scope) {
+  angular.module('calcentral.controllers').controller('AcademicsController', function(academicsFactory, academicsService, apiService, badgesFactory, $routeParams, $scope) {
     apiService.util.setTitle('My Academics');
 
     var checkPageExists = function(page) {
@@ -40,200 +40,25 @@
       $scope.previousNextSemesterShow = (nextSemesterCompare || previousSemesterCompare);
     };
 
-    var findSemester = function(semesters, slug, selectedSemester) {
-      if (selectedSemester || !semesters) {
-        return selectedSemester;
-      }
-
-      for (var i = 0; i < semesters.length; i++) {
-        if (semesters[i].slug === slug) {
-          return semesters[i];
-        }
-      }
-    };
-
-    var getClassesSections = function(courses, findWaitlisted) {
-      var classes = [];
-
-      for (var i = 0; i < courses.length; i++) {
-        var course = courses[i];
-        var sections = [];
-        for (var j = 0; j < course.sections.length; j++) {
-          var section = course.sections[j];
-          if ((findWaitlisted && section.waitlistPosition) || (!findWaitlisted && !section.waitlistPosition)) {
-            sections.push(section);
-          }
-        }
-        if (sections.length) {
-          if (findWaitlisted) {
-            var courseCopy = angular.copy(course);
-            courseCopy.sections = sections;
-            classes.push(courseCopy);
-          } else {
-            classes = classes.concat(splitMultiplePrimaries(course, sections));
-          }
-        }
-      }
-
-      return classes;
-    };
-
-    var getAllClasses = function(semesters) {
-      var classes = [];
-      for (var i = 0; i < semesters.length; i++) {
-        for (var j = 0; j < semesters[i].classes.length; j++) {
-          if (semesters[i].timeBucket !== 'future') {
-            classes.push(semesters[i].classes[j]);
-          }
-        }
-      }
-
-      return classes;
-    };
-
-    var getPreviousClasses = function(semesters) {
-      var classes = [];
-      for (var i = 0; i < semesters.length; i++) {
-        for (var j = 0; j < semesters[i].classes.length; j++) {
-          if (semesters[i].timeBucket !== 'future' && semesters[i].timeBucket !== 'current') {
-            classes.push(semesters[i].classes[j]);
-          }
-        }
-      }
-
-      return classes;
-    };
-
-    // Selects the semester of most pressing interest. Choose the current semester if available.
-    // Otherwise choose the next semester in the future, if available.
-    // Otherwise,choose the most recent semester.
-    var chooseDefaultSemester = function(semesters) {
-      var oldestFutureSemester = false;
-      for (var i = 0; i < semesters.length; i++) {
-        if (semesters[i].timeBucket === 'current') {
-          return semesters[i];
-        } else if (semesters[i].timeBucket === 'future') {
-          oldestFutureSemester = semesters[i];
-        } else {
-          if (oldestFutureSemester) {
-            return oldestFutureSemester;
-          } else {
-            return semesters[i];
-          }
-        }
-      }
-      return oldestFutureSemester;
-    };
-
-    var hasTeachingClasses = function(teachingSemesters) {
-      if (teachingSemesters) {
-        for (var i = 0; i < teachingSemesters.length; i++) {
-          var semester = teachingSemesters[i];
-          if (semester.classes.length > 0) {
-            return true;
-          }
-        }
-      }
-      return false;
-    };
-
-    var countSectionItem = function(selectedCourse, sectionItem) {
-      var count = 0;
-      for (var i = 0; i < selectedCourse.sections.length; i++) {
-        if (selectedCourse.sections[i][sectionItem] && selectedCourse.sections[i][sectionItem].length) {
-          count += selectedCourse.sections[i][sectionItem].length;
-        }
-      }
-      return count;
-    };
-
-    var initMultiplePrimaries = function(course) {
-      var primariesCount = 0;
-      angular.forEach(course.sections, function(section) {
-        if (section.is_primary_section) {
-          // Copy the first section's grading information to the course for
-          // easier processing later.
-          if (primariesCount === 0) {
-            course.gradeOption = section.gradeOption;
-            course.units = section.units;
-          }
-          primariesCount++;
-        }
-      });
-      course.multiplePrimaries = (primariesCount > 1);
-    };
-
-    var splitMultiplePrimaries = function(originalCourse, enrolledSections) {
-      var classes = [];
-      var course = angular.copy(originalCourse);
-      course.sections = [];
-      var hasPrimary = false;
-      for (var i = 0; i < enrolledSections.length; i++) {
-        var section = enrolledSections[i];
-        if (section.is_primary_section) {
-          if (hasPrimary) {
-            classes.push(course);
-            course = angular.copy(originalCourse);
-            course.sections = [];
-            hasPrimary = false;
-          }
-          course.gradeOption = section.gradeOption;
-          course.units = section.units;
-          hasPrimary = true;
-        }
-        course.sections.push(section);
-      }
-      classes.push(course);
-      return classes;
-    };
-
-    var pastSemestersCount = function(semesters) {
-      var count = 0;
-
-      if (semesters && semesters.length) {
-        for (var i = 0; i < semesters.length; i++) {
-          if (semesters[i].timeBucket === 'past') {
-            semesters[i].summaryFromTranscript = true;
-            count++;
-          } else {
-            semesters[i].summaryFromTranscript = !semesters[i].hasEnrollmentData;
-          }
-        }
-      }
-      return count;
-    };
-
-    var isLSStudent = function(collegeAndLevel) {
-      if (!collegeAndLevel || !collegeAndLevel.colleges) {
-        return false;
-      }
-
-      for (var i = 0; i < collegeAndLevel.colleges.length; i++) {
-        if (collegeAndLevel.colleges[i].college === 'College of Letters & Science') {
-          return true;
-        }
-      }
-    };
-
     var fillSemesterSpecificPage = function(semesterSlug, data) {
       var isOnlyInstructor = !!$routeParams.teachingSemesterSlug;
-      var selectedStudentSemester = findSemester(data.semesters, semesterSlug, selectedStudentSemester);
-      var selectedTeachingSemester = findSemester(data.teachingSemesters, semesterSlug, selectedTeachingSemester);
+      var selectedStudentSemester = academicsService.findSemester(data.semesters, semesterSlug, selectedStudentSemester);
+      var selectedTeachingSemester = academicsService.findSemester(data.teachingSemesters, semesterSlug, selectedTeachingSemester);
       var selectedSemester = (selectedStudentSemester || selectedTeachingSemester);
       if (!checkPageExists(selectedSemester)) {
         return;
       }
-      var selectedTelebears = findSemester(data.telebears, semesterSlug, selectedTelebears);
+      var selectedTelebears = academicsService.findSemester(data.telebears, semesterSlug, selectedTelebears);
       updatePrevNextSemester([data.semesters, data.teachingSemesters], selectedSemester);
 
       $scope.selectedSemester = selectedSemester;
       if (selectedStudentSemester && !$routeParams.classSlug) {
         $scope.selectedCourses = selectedStudentSemester.classes;
         if (!isOnlyInstructor) {
-          $scope.allCourses = getAllClasses(data.semesters);
-          $scope.previousCourses = getPreviousClasses(data.semesters);
-          $scope.enrolledCourses = getClassesSections(selectedStudentSemester.classes, false);
-          $scope.waitlistedCourses = getClassesSections(selectedStudentSemester.classes, true);
+          $scope.allCourses = academicsService.getAllClasses(data.semesters);
+          $scope.previousCourses = academicsService.getPreviousClasses(data.semesters);
+          $scope.enrolledCourses = academicsService.getClassesSections(selectedStudentSemester.classes, false);
+          $scope.waitlistedCourses = academicsService.getClassesSections(selectedStudentSemester.classes, true);
         }
       }
       $scope.selectedStudentSemester = selectedStudentSemester;
@@ -252,8 +77,11 @@
         for (var i = 0; i < classSemester.classes.length; i++) {
           var course = classSemester.classes[i];
           if (course.slug === $routeParams.classSlug) {
-            initMultiplePrimaries(course);
-            $scope.selectedCourse = course;
+            if ($routeParams.sectionSlug) {
+              $scope.selectedSection = academicsService.filterBySectionSlug(course, $routeParams.sectionSlug);
+            }
+            academicsService.normalizeGradingData(course);
+            $scope.selectedCourse = (course.sections.length) ? course : null;
             if (isOnlyInstructor) {
               $scope.campusCourseId = course.listings[0].course_id;
             }
@@ -263,8 +91,11 @@
         if (!checkPageExists($scope.selectedCourse)) {
           return;
         }
-        $scope.selectedCourseCountInstructors = countSectionItem($scope.selectedCourse, 'instructors');
-        $scope.selectedCourseCountSchedules = countSectionItem($scope.selectedCourse, 'schedules');
+        if ($routeParams.sectionSlug && !checkPageExists($scope.selectedSection)) {
+          return;
+        }
+        $scope.selectedCourseCountInstructors = academicsService.countSectionItem($scope.selectedCourse, 'instructors');
+        $scope.selectedCourseCountSchedules = academicsService.countSectionItem($scope.selectedCourse, 'schedules');
       }
     };
 
@@ -274,14 +105,14 @@
       $scope.semesters = data.semesters;
 
       if (data.semesters) {
-        $scope.pastSemestersCount = pastSemestersCount(data.semesters);
+        $scope.pastSemestersCount = academicsService.pastSemestersCount(data.semesters);
         $scope.pastSemestersLimit = data.semesters.length - $scope.pastSemestersCount + 1;
         if (data.additionalCredits) {
           $scope.pastSemestersCount++;
         }
       }
 
-      $scope.isLSStudent = isLSStudent($scope.collegeAndLevel);
+      $scope.isLSStudent = academicsService.isLSStudent($scope.collegeAndLevel);
       $scope.isUndergraduate = ($scope.collegeAndLevel && $scope.collegeAndLevel.standing === 'Undergraduate');
 
       $scope.isAcademicInfoAvailable = !!(($scope.semesters && $scope.semesters.length) ||
@@ -290,9 +121,9 @@
 
       $scope.showProfileMessage = (!$scope.collegeAndLevel || !$scope.collegeAndLevel.standing || $scope.transitionRegStatus);
 
-      $scope.hasTeachingClasses = hasTeachingClasses(data.teachingSemesters);
+      $scope.hasTeachingClasses = academicsService.hasTeachingClasses(data.teachingSemesters);
       if (data.teachingSemesters) {
-        $scope.pastSemestersTeachingCount = pastSemestersCount(data.teachingSemesters);
+        $scope.pastSemestersTeachingCount = academicsService.pastSemestersCount(data.teachingSemesters);
         $scope.pastSemestersTeachingLimit = data.teachingSemesters.length - $scope.pastSemestersTeachingCount + 1;
       }
 
@@ -305,7 +136,7 @@
         if ($scope.hasTeachingClasses && (!data.semesters || (data.semesters.length === 0))) {
           // Show the current semester, or the most recent semester, since otherwise the instructor
           // landing page will be grimly bare.
-          $scope.selectedTeachingSemester = chooseDefaultSemester(data.teachingSemesters);
+          $scope.selectedTeachingSemester = academicsService.chooseDefaultSemester(data.teachingSemesters);
           $scope.widgetSemesterName = $scope.selectedTeachingSemester.name;
         }
       }

--- a/src/assets/javascripts/angular/services/academicsService.js
+++ b/src/assets/javascripts/angular/services/academicsService.js
@@ -1,0 +1,227 @@
+/* jshint camelcase: false */
+(function(angular) {
+  'use strict';
+
+  angular.module('calcentral.services').service('academicsService', function() {
+    // Selects the semester of most pressing interest. Choose the current semester if available.
+    // Otherwise choose the next semester in the future, if available.
+    // Otherwise,choose the most recent semester.
+    var chooseDefaultSemester = function(semesters) {
+      var oldestFutureSemester = false;
+      for (var i = 0; i < semesters.length; i++) {
+        if (semesters[i].timeBucket === 'current') {
+          return semesters[i];
+        } else if (semesters[i].timeBucket === 'future') {
+          oldestFutureSemester = semesters[i];
+        } else {
+          if (oldestFutureSemester) {
+            return oldestFutureSemester;
+          } else {
+            return semesters[i];
+          }
+        }
+      }
+      return oldestFutureSemester;
+    };
+
+    var countSectionItem = function(selectedCourse, sectionItem) {
+      var count = 0;
+      for (var i = 0; i < selectedCourse.sections.length; i++) {
+        if (selectedCourse.sections[i][sectionItem] && selectedCourse.sections[i][sectionItem].length) {
+          count += selectedCourse.sections[i][sectionItem].length;
+        }
+      }
+      return count;
+    };
+
+    var filterBySectionSlug = function(course, sectionSlug) {
+      if (!course.multiplePrimaries) {
+        return null;
+      }
+      var filteredSections = [];
+      var siteIds = [];
+      var sectionFromSlug = null;
+      for (var i = 0; i < course.sections.length; i++) {
+        var section = course.sections[i];
+        if (section.is_primary_section && section.slug === sectionSlug) {
+          sectionFromSlug = section;
+        } else if (section.associatedWithPrimary !== sectionSlug) {
+          continue;
+        }
+        filteredSections.push(section);
+        if (section.siteIds) {
+          siteIds = siteIds.concat(section.siteIds);
+        }
+      }
+      course.sections = filteredSections;
+      if (course.class_sites) {
+        course.class_sites = course.class_sites.filter(function(classSite) {
+          return (siteIds.indexOf(classSite.id) !== -1);
+        });
+      }
+      return sectionFromSlug;
+    };
+
+    var findSemester = function(semesters, slug, selectedSemester) {
+      if (selectedSemester || !semesters) {
+        return selectedSemester;
+      }
+
+      for (var i = 0; i < semesters.length; i++) {
+        if (semesters[i].slug === slug) {
+          return semesters[i];
+        }
+      }
+    };
+
+    var getAllClasses = function(semesters) {
+      var classes = [];
+      for (var i = 0; i < semesters.length; i++) {
+        for (var j = 0; j < semesters[i].classes.length; j++) {
+          if (semesters[i].timeBucket !== 'future') {
+            classes.push(semesters[i].classes[j]);
+          }
+        }
+      }
+      return classes;
+    };
+
+    var getClassesSections = function(courses, findWaitlisted) {
+      var classes = [];
+
+      for (var i = 0; i < courses.length; i++) {
+        var course = courses[i];
+        var sections = [];
+        for (var j = 0; j < course.sections.length; j++) {
+          var section = course.sections[j];
+          if ((findWaitlisted && section.waitlistPosition) || (!findWaitlisted && !section.waitlistPosition)) {
+            sections.push(section);
+          }
+        }
+        if (sections.length) {
+          if (findWaitlisted) {
+            var courseCopy = angular.copy(course);
+            courseCopy.sections = sections;
+            classes.push(courseCopy);
+          } else {
+            var primarySections = splitMultiplePrimaries(course, sections);
+            for (var ccn in primarySections) {
+              if (primarySections.hasOwnProperty(ccn)) {
+                classes.push(primarySections[ccn]);
+              }
+            }
+          }
+        }
+      }
+      return classes;
+    };
+
+    var getPreviousClasses = function(semesters) {
+      var classes = [];
+      for (var i = 0; i < semesters.length; i++) {
+        for (var j = 0; j < semesters[i].classes.length; j++) {
+          if (semesters[i].timeBucket !== 'future' && semesters[i].timeBucket !== 'current') {
+            classes.push(semesters[i].classes[j]);
+          }
+        }
+      }
+      return classes;
+    };
+
+    var hasTeachingClasses = function(teachingSemesters) {
+      if (teachingSemesters) {
+        for (var i = 0; i < teachingSemesters.length; i++) {
+          var semester = teachingSemesters[i];
+          if (semester.classes.length > 0) {
+            return true;
+          }
+        }
+      }
+      return false;
+    };
+
+    var isLSStudent = function(collegeAndLevel) {
+      if (!collegeAndLevel || !collegeAndLevel.colleges) {
+        return false;
+      }
+
+      for (var i = 0; i < collegeAndLevel.colleges.length; i++) {
+        if (collegeAndLevel.colleges[i].college === 'College of Letters & Science') {
+          return true;
+        }
+      }
+    };
+
+    var normalizeGradingData = function(course) {
+      for (var i = 0; i < course.sections.length; i++) {
+        var section = course.sections[i];
+        if (section.is_primary_section) {
+          // Copy the first section's grading information to the course for
+          // easier processing later.
+          course.gradeOption = section.gradeOption;
+          course.units = section.units;
+          break;
+        }
+      }
+    };
+
+    var pastSemestersCount = function(semesters) {
+      var count = 0;
+
+      if (semesters && semesters.length) {
+        for (var i = 0; i < semesters.length; i++) {
+          if (semesters[i].timeBucket === 'past') {
+            semesters[i].summaryFromTranscript = true;
+            count++;
+          } else {
+            semesters[i].summaryFromTranscript = !semesters[i].hasEnrollmentData;
+          }
+        }
+      }
+      return count;
+    };
+
+    var splitMultiplePrimaries = function(originalCourse, enrolledSections) {
+      var classes = {};
+      for (var i = 0; i < enrolledSections.length; i++) {
+        var section = enrolledSections[i];
+        var key;
+        if (section.is_primary_section) {
+          var course = angular.copy(originalCourse);
+          course.gradeOption = section.gradeOption;
+          course.units = section.units;
+          if (course.multiplePrimaries) {
+            course.url = section.url;
+          }
+          key = course.multiplePrimaries ? section.slug : 'default';
+          course.sections = classes[key] ? classes[key].sections : [];
+          course.sections.push(section);
+          classes[key] = course;
+        } else {
+          key = originalCourse.multiplePrimaries ? section.associatedWithPrimary : 'default';
+          if (!classes[key]) {
+            classes[key] = {};
+            classes[key].sections = [];
+          }
+          classes[key].sections.push(section);
+        }
+      }
+      return classes;
+    };
+
+    // Expose methods
+    return {
+      chooseDefaultSemester: chooseDefaultSemester,
+      countSectionItem: countSectionItem,
+      filterBySectionSlug: filterBySectionSlug,
+      findSemester: findSemester,
+      getAllClasses: getAllClasses,
+      getClassesSections: getClassesSections,
+      getPreviousClasses: getPreviousClasses,
+      hasTeachingClasses: hasTeachingClasses,
+      isLSStudent: isLSStudent,
+      normalizeGradingData: normalizeGradingData,
+      pastSemestersCount: pastSemestersCount
+    };
+  });
+}(window.angular));

--- a/src/assets/templates/academics_classinfo.html
+++ b/src/assets/templates/academics_classinfo.html
@@ -9,6 +9,7 @@
       <a href="/academics">My Academics</a> &raquo;
       <a data-ng-href="/academics/semester/{{selectedSemester.slug}}"><span data-ng-bind="selectedSemester.name"></span></a> &raquo;
       <span data-ng-bind="selectedCourse.course_code"></span>
+      <span data-ng-if="selectedSection" data-ng-bind-template=" &raquo; {{selectedSection.section_label}}"></span>
       <div class="cc-academics-teaching-button-group" data-ng-if="isInstructorOrGsi">
         <ul class="cc-button-group cc-even-{{selectOptions.length}}" role="tablist">
           <li data-ng-repeat="selectOption in selectOptions">
@@ -70,7 +71,7 @@
           <div data-ng-hide="isInstructorOrGsi" class="cc-table">
             <table class="cc-academics-class-info" data-ng-repeat="section in selectedCourse.sections" data-ng-if="section.is_primary_section">
               <tbody>
-                <tr class="cc-academics-class-primary-row" data-ng-if="selectedCourse.multiplePrimaries">
+                <tr class="cc-academics-class-primary-row" data-ng-if="selectedCourse.multiplePrimaries && !selectedSection">
                   <td data-ng-bind="section.section_label"></td>
                 </tr>
                 <tr>

--- a/src/assets/templates/academics_semesters.html
+++ b/src/assets/templates/academics_semesters.html
@@ -25,8 +25,10 @@
           </thead>
           <tbody data-ng-if="!semester.summaryFromTranscript" data-ng-repeat="class in semester.classes">
             <tr data-ng-repeat="section in class.sections" data-ng-if="section.is_primary_section">
-              <td data-ng-if="class.url"><a data-ng-href="{{class.url}}" data-ng-bind="class.course_code"></a>
-              <td data-ng-if="!class.url" data-ng-bind="class.course_code"></td>
+              <td data-ng-if="class.multiplePrimaries && section.url"><a data-ng-href="{{section.url}}" data-ng-bind-template="{{class.course_code}} {{section.section_label}}"></a></td>
+              <td data-ng-if="class.multiplePrimaries && !section.url" data-ng-bind-template="{{class.course_code}} {{section.section_label}}"></td>
+              <td data-ng-if="!class.multiplePrimaries && class.url"><a data-ng-href="{{class.url}}" data-ng-bind="class.course_code"></a></td>
+              <td data-ng-if="!class.multiplePrimaries && !class.url" data-ng-bind="class.course_code"></td>
               <td data-ng-bind="class.title"></td>
               <td data-ng-bind="section.units | number:1" class="cc-table-right"></td>
             </tr>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-4789

A few notes:

The `course_option` database column, which was only being queried for instructor assignments, is now queried for student enrollments as well because we need it for the edge case of assigning secondary sections among multiple primaries. The value is not included in the final My Academics or My Classes feeds.

Our policy of not exposing section associations for Canvas sites had to be very slightly relaxed in order to point Canvas sites to the correct primary section in the multiple-primaries case. These associations were already exposed in My Classes, and are now exposed in My Academics as well.

The front-end component looks much bigger than it actually is because our collection of utility functions for parsing the academics feed was moved from academicsController.js to the new academicsService.js, so that the booklist controller can use them as well.