### PR TITLE
CLC-5052 Expanding the functionality of Mockable

### DIFF
--- a/app/models/cal1card/my_cal1card.rb
+++ b/app/models/cal1card/my_cal1card.rb
@@ -2,12 +2,14 @@ module Cal1card
   class MyCal1card < UserSpecificModel
     include Cache::LiveUpdatesEnabled
     include Cache::FeedExceptionsHandled
+    include Proxies::MockableXml
     include HttpRequester
 
     def initialize(uid, options={})
       super(uid, options)
       @settings = Settings.cal1card_proxy
       @fake = (options[:fake] != nil) ? options[:fake] : @settings.fake
+      initialize_mocks if @fake
     end
 
     def default_message_on_exception
@@ -23,23 +25,23 @@ module Cal1card
     end
 
     def get_converted_xml
-      if @fake
-        logger.info "Fake = #{@fake}, getting data from XML fixture file; user #{@uid}; cache expiration #{self.class.expires_in}"
-        feed = MultiXml.parse File.read(Rails.root.join('fixtures', 'xml', 'cal1card_feed.xml').to_s)
-      else
-        url = "#{@settings.feed_url}?uid=#{@uid}"
-        logger.info "Internal_get: Fake = #{@fake}; Making request to #{url} on behalf of user #{@uid}; cache expiration #{self.class.expires_in}"
-        response = get_response(
-          url,
-          basic_auth: {username: @settings.username, password: @settings.password}
-        )
-        feed = response.parsed_response
-        logger.debug "Cal1Card remote response: #{response.inspect}"
-      end
+      url = "#{@settings.base_url}?uid=#{@uid}"
+      logger.info "Internal_get: Fake = #{@fake}; Making request to #{url} on behalf of user #{@uid}; cache expiration #{self.class.expires_in}"
+      response = get_response(
+        url,
+        basic_auth: {username: @settings.username, password: @settings.password}
+      )
+      feed = response.parsed_response
+      logger.debug "Cal1Card remote response: #{response.inspect}"
+
       camelized = HashConverter.camelize feed
       camelized[:cal1card].merge({
         statusCode: 200
       })
+    end
+
+    def mock_xml
+      File.read(Rails.root.join('fixtures', 'xml', 'cal1card_feed.xml'))
     end
 
   end

--- a/app/models/cal1card/my_cal1card.rb
+++ b/app/models/cal1card/my_cal1card.rb
@@ -41,7 +41,7 @@ module Cal1card
     end
 
     def mock_xml
-      File.read(Rails.root.join('fixtures', 'xml', 'cal1card_feed.xml'))
+      read_file('fixtures', 'xml', 'cal1card_feed.xml')
     end
 
   end

--- a/app/models/ets_blog/release_notes.rb
+++ b/app/models/ets_blog/release_notes.rb
@@ -1,7 +1,8 @@
 module EtsBlog
   class ReleaseNotes < BaseProxy
 
-    include ClassLogger, HtmlSanitizer
+    include ClassLogger
+    include HtmlSanitizer
     include Proxies::MockableXml
     include HttpRequester
 
@@ -45,7 +46,7 @@ module EtsBlog
     end
 
     def mock_xml
-      File.read(Rails.root.join('fixtures', 'xml', 'release_notes_feed.xml'))
+      read_file('fixtures', 'xml', 'release_notes_feed.xml')
     end
 
   end

--- a/app/models/regstatus/proxy.rb
+++ b/app/models/regstatus/proxy.rb
@@ -61,7 +61,7 @@ module Regstatus
     end
 
     def mock_json
-      File.read(Rails.root.join('fixtures', 'json', 'regstatus.json'))
+      read_file('fixtures', 'json', 'regstatus.json')
     end
 
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -162,7 +162,7 @@ blog_latest_release_notes_feed_proxy:
 
 app_alerts_proxy:
   fake: false
-  feed_url: "http://ets.berkeley.edu/calcentral-alerts/feed"
+  base_url: "http://ets.berkeley.edu/calcentral-alerts/feed"
 
 cal1card_proxy:
   fake: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -166,7 +166,7 @@ app_alerts_proxy:
 
 cal1card_proxy:
   fake: false
-  feed_url: 'https://webstage.housing.berkeley.edu/c1c/dyn/csc.asp'
+  base_url: 'https://webstage.housing.berkeley.edu/c1c/dyn/csc.asp'
   username: 'secret'
   password: 'secret'
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -158,7 +158,7 @@ audio_proxy:
 
 blog_latest_release_notes_feed_proxy:
   fake: false
-  feed_url: "https://ets.berkeley.edu/taxonomy/term/788/all/feed"
+  base_url: "https://ets.berkeley.edu/taxonomy/term/788/all/feed"
 
 app_alerts_proxy:
   fake: false

--- a/lib/proxies/mock_http_interaction.rb
+++ b/lib/proxies/mock_http_interaction.rb
@@ -18,6 +18,15 @@ module Proxies
       set_response
     end
 
+    def override_xml
+      if block_given?
+        parsed_structure = MultiXml.parse @response[:body]
+        yield parsed_structure
+        @response[:body] = parsed_structure
+      end
+      set_response
+    end
+
     def set_response(options={})
       @response.merge! options
       stub = stub_request(@request[:method], @request[:uri])

--- a/lib/proxies/mockable.rb
+++ b/lib/proxies/mockable.rb
@@ -39,5 +39,9 @@ module Proxies
       ''
     end
 
+    def read_file(*args)
+      File.read(Rails.root.join(*args))
+    end
+
   end
 end

--- a/lib/proxies/mockable.rb
+++ b/lib/proxies/mockable.rb
@@ -20,9 +20,10 @@ module Proxies
     end
 
     def mock_request
+      feed_uri = URI.parse(@settings.base_url)
       {
         method: :get,
-        uri: /\A#{Regexp.quote @settings.base_url}/
+        uri: /.*#{feed_uri.hostname}#{feed_uri.path}.*/
       }
     end
 

--- a/lib/proxies/mockable_xml.rb
+++ b/lib/proxies/mockable_xml.rb
@@ -1,0 +1,33 @@
+module Proxies
+  module MockableXml
+
+    include Mockable
+
+    def initialize_mocks
+      if defined? WebMock
+        set_response
+      end
+    end
+
+    def on_request(options={})
+      MockHttpInteraction.new(mock_request.merge(options), mock_response)
+    end
+
+    def override_xml(&blk)
+      on_request.override_xml(&blk)
+    end
+
+    def mock_response
+      {
+        status: 200,
+        headers: {'Content-Type' => 'application/xml'},
+        body: mock_xml
+      }
+    end
+
+    def mock_xml
+      ''
+    end
+
+  end
+end

--- a/spec/models/cal1card/my_cal1card_spec.rb
+++ b/spec/models/cal1card/my_cal1card_spec.rb
@@ -28,7 +28,7 @@ describe Cal1card::MyCal1card do
 
   context "server errors" do
     include_context 'short-lived Live Updates cache'
-    let (:cal1card_uri) { URI.parse(Settings.cal1card_proxy.feed_url) }
+    let (:cal1card_uri) { URI.parse(Settings.cal1card_proxy.base_url) }
     before(:each) { Cal1card::MyCal1card.stub(:new).and_return(real_oski_proxy) }
     after(:each) { WebMock.reset! }
 

--- a/spec/models/ets_blog/release_notes_spec.rb
+++ b/spec/models/ets_blog/release_notes_spec.rb
@@ -4,7 +4,7 @@ describe EtsBlog::ReleaseNotes do
 
   let (:fake_proxy) { EtsBlog::ReleaseNotes.new({fake: true}) }
   let (:real_proxy) { EtsBlog::ReleaseNotes.new({fake: false}) }
-  let (:feed_uri) { URI.parse(Settings.blog_latest_release_notes_feed_proxy.feed_url) }
+  let (:feed_uri) { URI.parse(Settings.blog_latest_release_notes_feed_proxy.base_url) }
 
   context 'fetching fake data feed' do
     include_context 'it writes to the cache'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5052

3 new proxies are now on the Mockable framework. Mockable now correctly handles basic authentication. It also provides a read_file convenience method. And, you can now mock proxies that deliver XML instead of JSON. 

Note: This change requires a settings.yml configuration change: Renaming the feed_url param to base_url in 3 proxies: blog_latest_release_notes_feed_proxy, app_alerts_proxy, cal1card_proxy. Changing the setting will be part of the release notes. 