### PR TITLE
CLC-5127 Reorganize instructor Class Info page for multiple primaries

### DIFF
--- a/app/models/my_academics/academics_module.rb
+++ b/app/models/my_academics/academics_module.rb
@@ -153,6 +153,27 @@ module MyAcademics
       term << course_info
     end
 
+    def merge_multiple_primaries(course, course_option)
+      course[:multiplePrimaries] = true
+      course[:sections].each do |section|
+        if section[:is_primary_section]
+          section[:slug] = section_slug(section)
+          section[:url] = "#{course[:url]}/#{section[:slug]}"
+        else
+          associated_primary = course[:sections].find do |prim|
+            prim[:is_primary_section] && Berkeley::CourseOptions.nested?(course_option, prim[:section_number], section[:section_number], section[:instruction_format])
+          end
+          section[:associatedWithPrimary] = section_slug associated_primary
+        end
+      end
+    end
+
+    def section_slug(section)
+      if section
+        "#{section[:instruction_format].downcase}-#{section[:section_number]}"
+      end
+    end
+
     def decode_instruction_format(format)
       case format
         when 'CLC' then 'clinic'

--- a/app/models/my_academics/semesters.rb
+++ b/app/models/my_academics/semesters.rb
@@ -69,27 +69,6 @@ module MyAcademics
       end
     end
 
-    def merge_multiple_primaries(course, course_option)
-      course[:multiplePrimaries] = true
-      course[:sections].each do |section|
-        if section[:is_primary_section]
-          section[:slug] = section_slug(section)
-          section[:url] = "#{course[:url]}/#{section[:slug]}"
-        else
-          associated_primary = course[:sections].find do |prim|
-            prim[:is_primary_section] && Berkeley::CourseOptions.nested?(course_option, prim[:section_number], section[:section_number], section[:instruction_format])
-          end
-          section[:associatedWithPrimary] = section_slug associated_primary
-        end
-      end
-    end
-
-    def section_slug(section)
-      if section
-        "#{section[:instruction_format].downcase}-#{section[:section_number]}"
-      end
-    end
-
     def translate_notation(transcript_notations)
       return unless transcript_notations
       if transcript_notations.include? 'extension'

--- a/app/models/my_academics/teaching.rb
+++ b/app/models/my_academics/teaching.rb
@@ -27,6 +27,9 @@ module MyAcademics
         sections_data[term_key].each do |course|
           next unless ignore_roles || (course[:role] == 'Instructor')
           course_info = course_info_with_multiple_listings course
+          if course_info[:sections].count { |section| section[:is_primary_section] } > 1
+            merge_multiple_primaries(course_info, course[:course_option])
+          end
           append_with_merged_crosslistings(teaching_semester[:classes], course_info)
         end
         teaching_semesters << teaching_semester unless teaching_semester[:classes].empty?

--- a/src/assets/javascripts/angular/controllers/pages/academicsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicsController.js
@@ -96,6 +96,8 @@
         }
         $scope.selectedCourseCountInstructors = academicsService.countSectionItem($scope.selectedCourse, 'instructors');
         $scope.selectedCourseCountSchedules = academicsService.countSectionItem($scope.selectedCourse, 'schedules');
+        $scope.selectedCourseCountScheduledSections = academicsService.countSectionItem($scope.selectedCourse);
+        $scope.selectedCourseLongInstructorsList = ($scope.selectedCourseCountScheduledSections > 5) || ($scope.selectedCourseCountInstructors > 10);
       }
     };
 

--- a/src/assets/javascripts/angular/controllers/widgets/booklistController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/booklistController.js
@@ -22,10 +22,6 @@
       });
     };
 
-    var returnSection = function(section) {
-      return section.section_number;
-    };
-
     var addToRequests = function(semester) {
       var enrolledCourses = academicsService.getClassesSections(semester.classes, false);
       var waitlistedCourses = academicsService.getClassesSections(semester.classes, true);
@@ -34,15 +30,7 @@
       for (var c = 0; c < courses.length; c++) {
         // get textbooks for each course
         var selectedCourse = courses[c];
-        var sectionNumbers = selectedCourse.sections.map(returnSection);
-
-        var courseInfo = {
-          'sectionNumbers[]': sectionNumbers,
-          'department': selectedCourse.dept,
-          'courseCatalog': selectedCourse.courseCatalog,
-          'slug': semester.slug
-        };
-
+        var courseInfo = academicsService.textbookRequestInfo(selectedCourse, semester);
         var courseTitle = selectedCourse.course_code;
         if (selectedCourse.multiplePrimaries) {
           courseTitle = courseTitle + ' ' + selectedCourse.sections[0].section_label;

--- a/src/assets/javascripts/angular/controllers/widgets/textbookController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/textbookController.js
@@ -5,38 +5,59 @@
   /**
    * Textbook controller
    */
-  angular.module('calcentral.controllers').controller('TextbookController', function(textbookFactory, $scope) {
+  angular.module('calcentral.controllers').controller('TextbookController', function(academicsService, textbookFactory, $q, $scope) {
     /**
      * Get Textbooks for the selected course
      * @param  {Object} selectedCourse Selected Course Object
      */
-    var getTextbooks = function(selectedCourse) {
-      var sectionNumbers = selectedCourse.sections.map(function(section) {
-        return section.section_number;
-      });
+    var requests = [];
+    $scope.bookListsBySection = [];
+    $scope.textbooksCount = 0;
 
-      var courseInfo = {
-        'sectionNumbers[]': sectionNumbers,
-        'department': selectedCourse.dept,
-        'courseCatalog': selectedCourse.courseCatalog,
-        'slug': $scope.selectedSemester.slug
-      };
-
-      textbookFactory.getTextbooks({
+    var getTextbook = function(courseInfo, sectionLabel) {
+      return textbookFactory.getTextbooks({
         params: courseInfo
       })
-      .success(function(data) {
-        angular.extend($scope, data);
+        .success(function(data) {
+          data.sectionLabel = sectionLabel;
+          if (data.statusCode && data.statusCode >= 400) {
+            data.errorMessage = data.body;
+            $scope.textbookError = data;
+          }
+          if (data.books && data.books.items) {
+            $scope.textbooksCount += data.books.items.length;
+          }
+          $scope.bookListsBySection.push(data);
+          $scope.bookListsBySection.sort(function(a, b) {
+            return a.sectionLabel.localeCompare(b.sectionLabel);
+          });
+        });
+    };
 
-        if (data.statusCode && data.statusCode >= 400) {
-          $scope.textbookError = data;
+    var getCourseTextbooks = function(selectedCourse) {
+      var semester = $scope.isInstructorOrGsi ? $scope.selectedTeachingSemester : $scope.selectedStudentSemester;
+      var separatedPrimaries = academicsService.getClassesSections(semester.classes, false, selectedCourse.course_code);
+
+      for (var c = 0; c < separatedPrimaries.length; c++) {
+        // get textbooks for each primary section
+        var course = separatedPrimaries[c];
+        var courseInfo = academicsService.textbookRequestInfo(course, semester);
+        requests.push(getTextbook(courseInfo, course.sections[0].section_label));
+      }
+
+      $q.all(requests).then(function() {
+        if (!$scope.textbooksCount && $scope.bookListsBySection.length && $scope.bookListsBySection[0].books) {
+          $scope.textbookError = {
+            'body': $scope.bookListsBySection[0].books.bookUnavailableError
+          };
         }
+        $scope.isLoading = false;
       });
     };
 
     $scope.$watchCollection('[$parent.selectedCourse, api.user.profile.features.textbooks]', function(returnValues) {
       if (returnValues[0] && returnValues[1] === true) {
-        getTextbooks(returnValues[0]);
+        getCourseTextbooks(returnValues[0]);
       }
     });
   });

--- a/src/assets/javascripts/angular/services/academicsService.js
+++ b/src/assets/javascripts/angular/services/academicsService.js
@@ -27,8 +27,16 @@
     var countSectionItem = function(selectedCourse, sectionItem) {
       var count = 0;
       for (var i = 0; i < selectedCourse.sections.length; i++) {
-        if (selectedCourse.sections[i][sectionItem] && selectedCourse.sections[i][sectionItem].length) {
-          count += selectedCourse.sections[i][sectionItem].length;
+        var section = selectedCourse.sections[i];
+        // Ignore crosslistings.
+        if (section.scheduledWithCcn) {
+          continue;
+        }
+        // If called without a second argument, return a simple count of sections ignoring crosslistings.
+        if (!sectionItem) {
+          count += 1;
+        } else if (section[sectionItem] && section[sectionItem].length) {
+          count += section[sectionItem].length;
         }
       }
       return count;
@@ -86,11 +94,14 @@
       return classes;
     };
 
-    var getClassesSections = function(courses, findWaitlisted) {
+    var getClassesSections = function(courses, findWaitlisted, courseCode) {
       var classes = [];
 
       for (var i = 0; i < courses.length; i++) {
         var course = courses[i];
+        if (courseCode && course.course_code !== courseCode) {
+          continue;
+        }
         var sections = [];
         for (var j = 0; j < course.sections.length; j++) {
           var section = course.sections[j];
@@ -181,6 +192,10 @@
       return count;
     };
 
+    var returnSection = function(section) {
+      return section.section_number;
+    };
+
     var splitMultiplePrimaries = function(originalCourse, enrolledSections) {
       var classes = {};
       for (var i = 0; i < enrolledSections.length; i++) {
@@ -209,6 +224,17 @@
       return classes;
     };
 
+    var textbookRequestInfo = function(course, semester) {
+      var sectionNumbers = course.sections.map(returnSection);
+      var courseInfo = {
+        'sectionNumbers[]': sectionNumbers,
+        'department': course.dept,
+        'courseCatalog': course.courseCatalog,
+        'slug': semester.slug
+      };
+      return courseInfo;
+    };
+
     // Expose methods
     return {
       chooseDefaultSemester: chooseDefaultSemester,
@@ -221,7 +247,8 @@
       hasTeachingClasses: hasTeachingClasses,
       isLSStudent: isLSStudent,
       normalizeGradingData: normalizeGradingData,
-      pastSemestersCount: pastSemestersCount
+      pastSemestersCount: pastSemestersCount,
+      textbookRequestInfo: textbookRequestInfo
     };
   });
 }(window.angular));

--- a/src/assets/stylesheets/_academics.scss
+++ b/src/assets/stylesheets/_academics.scss
@@ -85,6 +85,13 @@
       position: relative;
     }
   }
+  .cc-academics-class-textbooks {
+    &:not(:first-of-type) {
+      border-top: 1px solid $cc-color-list-border;
+      margin-top: 15px;
+      padding-top: 15px;
+    }
+  }
   .cc-academics-column-labels {
     color: $cc-color-light-medium-grey;
     font-weight: bold;

--- a/src/assets/templates/academics_class_sites.html
+++ b/src/assets/templates/academics_class_sites.html
@@ -1,0 +1,19 @@
+<div class="cc-widget" data-ng-if="selectedCourse.class_sites.length">
+  <div class="cc-widget-title">
+    <h2>Class Sites</h2>
+  </div>
+  <div class="cc-widget-padding">
+    <ul class="cc-academics-class-sites-list">
+      <li data-ng-repeat="site in selectedCourse.class_sites" class="cc-icon-container">
+        <i class="cc-left cc-icon" data-ng-class="'cc-icon-{{site.emitter|lowercase}}'"></i>
+        <div class="cc-class-site">
+          <a data-ng-href="{{site.site_url}}"
+             data-ng-click="api.analytics.trackExternalLink('Class Sites', group.emitter, site.site_url)">
+            <strong class="cc-ellipsis" data-ng-bind="site.name"></strong>
+          </a>
+          <div data-ng-if="site.shortDescription != site.name && site.shortDescription != selectedCourse.title" data-ng-bind="site.shortDescription" class="cc-ellipsis cc-text-light"></div>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/src/assets/templates/academics_classinfo.html
+++ b/src/assets/templates/academics_classinfo.html
@@ -31,7 +31,7 @@
     <div class="medium-4 columns cc-academics-row-margin">
       <div class="cc-widget">
         <div class="cc-widget-title">
-          <h2>Class information</h2>
+          <h2>Class Information</h2>
         </div>
         <div class="cc-widget-padding">
           <h3>Class Title</h3>
@@ -64,11 +64,10 @@
             </table>
           </div>
 
-          <h3 data-ng-if="selectedCourseCountSchedules || selectedCourse.units || selectedCourse.gradeOption">Class Info</h3>
+          <h3 data-ng-if="!isInstructorOrGsi && (selectedCourseCountSchedules || selectedCourse.units || selectedCourse.gradeOption)">Class Info</h3>
 
-          <h4 data-ng-hide="isInstructorOrGsi">Course Offering</h4>
-
-          <div data-ng-hide="isInstructorOrGsi" class="cc-table">
+          <h4 data-ng-if="!isInstructorOrGsi">Course Offering</h4>
+          <div data-ng-if="!isInstructorOrGsi" class="cc-table">
             <table class="cc-academics-class-info" data-ng-repeat="section in selectedCourse.sections" data-ng-if="section.is_primary_section">
               <tbody>
                 <tr class="cc-academics-class-primary-row" data-ng-if="selectedCourse.multiplePrimaries && !selectedSection">
@@ -87,7 +86,8 @@
             </table>
           </div>
 
-          <h4 data-ng-if="selectedCourseCountSchedules">Section Schedules</h4>
+          <h3 data-ng-if="isInstructorOrGsi && selectedCourseCountSchedules">Section Schedules</h3>
+          <h4 data-ng-if="!isInstructorOrGsi && selectedCourseCountSchedules">Section Schedules</h4>
 
           <div class="row collapse" data-ng-repeat="section in selectedCourse.sections" data-ng-if="!section.scheduledWithCcn">
             <div class="small-3 columns" data-ng-if="section.schedules && section.schedules.length" data-ng-bind="section.section_label"></div>
@@ -100,6 +100,7 @@
           </div>
         </div>
       </div>
+      <div data-ng-if="selectedCourseLongInstructorsList" data-ng-include="'academics_class_sites.html'" ></div>
     </div>
 
     <div class="medium-4 columns" data-ng-if="selectedCourseCountInstructors">
@@ -122,25 +123,7 @@
           </div>
         </div>
       </div>
-      <div class="cc-widget" data-ng-if="selectedCourse.class_sites.length">
-        <div class="cc-widget-title">
-          <h2>Class Sites</h2>
-        </div>
-        <div class="cc-widget-padding">
-          <ul class="cc-academics-class-sites-list">
-            <li data-ng-repeat="site in selectedCourse.class_sites" class="cc-icon-container">
-              <i class="cc-left cc-icon" data-ng-class="'cc-icon-{{site.emitter|lowercase}}'"></i>
-              <div class="cc-class-site">
-                <a data-ng-href="{{site.site_url}}"
-                   data-ng-click="api.analytics.trackExternalLink('Class Sites', group.emitter, site.site_url)">
-                  <strong class="cc-ellipsis" data-ng-bind="site.name"></strong>
-                </a>
-                <div data-ng-if="site.shortDescription != site.name && site.shortDescription != selectedCourse.title" data-ng-bind="site.shortDescription" class="cc-ellipsis cc-text-light"></div>
-              </div>
-            </li>
-          </ul>
-        </div>
-      </div>
+      <div data-ng-if="!selectedCourseLongInstructorsList" data-ng-include="'academics_class_sites.html'" ></div>
     </div>
 
     <div class="medium-4 columns cc-column-last">
@@ -158,11 +141,14 @@
         </div>
         <div data-cc-spinner-directive>
           <div class="cc-widget-padding">
-            <div data-ng-if="books.items.length">
-              <div data-ng-include="'textbook.html'"></div>
-            </div>
-            <div class="cc-text-line-height" data-ng-if="!books.items.length" data-ng-bind="books.bookUnavailableError"></div>
-            <div class="cc-text-line-height" data-ng-if="textbookError.body" data-ng-bind="textbookError.body">
+            <div class="cc-text-line-height" data-ng-if="!textbooksCount && textbookError.body" data-ng-bind="textbookError.body"></div>
+            <div data-ng-if="textbooksCount" data-ng-repeat="sectionBookList in bookListsBySection" class="cc-academics-class-textbooks">
+              <h3 class="cc-book-title" data-ng-bind="sectionBookList.sectionLabel" data-ng-if="bookListsBySection.length > 1"></h3>
+              <div data-ng-repeat="books in sectionBookList">
+                <div data-ng-if="books.items.length" data-ng-include="'textbook.html'"></div>
+                <div class="cc-text-line-height" data-ng-if="!books.items.length" data-ng-bind="books.bookUnavailableError"></div>
+              </div>
+              <div class="cc-text-line-height" data-ng-if="textbooksCount && sectionBookList.errorMessage" data-ng-bind="sectionBookList.errorMessage"></div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5127

Multiple-primary backend code is moved from MyAcademics::Semesters to MyAcademics::AcademicsModule so that MyAcademics::Teaching can use it as well.

textbookController.js is reworked along the lines of booklistController.js to handle concurrent textbook queries for multiple primary sections when necessary. Some common code is extracted to academicsService.js.

The Class Info template is modified to fit the redesign, and the Class Sites card extracted to its own template.