### PR TITLE
CLC-5130, active-record class for webcast_preferences table

### DIFF
--- a/app/models/webcast/preferences.rb
+++ b/app/models/webcast/preferences.rb
@@ -5,16 +5,5 @@ module Webcast
 
     attr_accessible :year, :term_cd, :ccn, :opt_out
 
-    def self.lookup(year, term_cd, ccn)
-      result_set = Preferences.limit(1).where(
-        'year = :year AND term_cd = :term_cd AND ccn = :ccn',
-        {
-          year: year,
-          term_cd: term_cd,
-          ccn: ccn
-        })
-      result_set[0]
-    end
-
   end
 end

--- a/app/models/webcast/preferences.rb
+++ b/app/models/webcast/preferences.rb
@@ -1,0 +1,20 @@
+module Webcast
+  class Preferences < ActiveRecord::Base
+
+    self.table_name = 'webcast_preferences'
+
+    attr_accessible :year, :term_cd, :ccn, :opt_out
+
+    def self.lookup(year, term_cd, ccn)
+      result_set = Preferences.limit(1).where(
+        'year = :year AND term_cd = :term_cd AND ccn = :ccn',
+        {
+          year: year,
+          term_cd: term_cd,
+          ccn: ccn
+        })
+      result_set[0]
+    end
+
+  end
+end

--- a/spec/models/webcast/preferences_spec.rb
+++ b/spec/models/webcast/preferences_spec.rb
@@ -2,39 +2,32 @@ describe Webcast::Preferences do
 
   describe '#lookup' do
     before do
-      Webcast::Preferences.create(
-        {
-          year: 2015,
-          term_cd: 'D',
-          ccn: 1234,
-          opt_out: true})
-      Webcast::Preferences.create(
-        {
-          year: 2016,
-          term_cd: 'B',
-          ccn: 5678,
-          opt_out: false})
+      Webcast::Preferences.create params(2015, 'D', 1234, true)
+      Webcast::Preferences.create params(2016, 'B', 5678, false)
     end
 
     it 'should deny per uniqueness constraint' do
-      expect {
-        Webcast::Preferences.create(
-          {
-            year: 2016,
-            term_cd: 'B',
-            ccn: 5678,
-            opt_out: true})
-      }.to raise_error NameError
+      expect { Webcast::Preferences.create params(2016, 'B', 5678, true) }.to raise_error NameError
     end
 
     it 'should not find matching record' do
-      expect(Webcast::Preferences.lookup(2015, 'B', 1234)).to be_nil
+      expect(Webcast::Preferences.find_by({ year: 2015, term_cd: 'B', ccn: 1234 })).to be_nil
     end
 
     it 'should return record with opt_out equal false' do
-      record = Webcast::Preferences.lookup(2015, 'D', 1234)
+      record = Webcast::Preferences.find_by({ year: 2015, term_cd: 'D', ccn: 1234 })
       expect(record).to_not be_nil
+      expect(record.year).to eq 2015
+      expect(record.term_cd).to eq 'D'
+      expect(record.ccn).to eq 1234
       expect(record.opt_out).to be true
     end
   end
+
+  private
+
+  def params(year, term_cd, ccn, opt_out)
+    { year: year, term_cd: term_cd, ccn: ccn, opt_out: opt_out }
+  end
+
 end

--- a/spec/models/webcast/preferences_spec.rb
+++ b/spec/models/webcast/preferences_spec.rb
@@ -1,0 +1,40 @@
+describe Webcast::Preferences do
+
+  describe '#lookup' do
+    before do
+      Webcast::Preferences.create(
+        {
+          year: 2015,
+          term_cd: 'D',
+          ccn: 1234,
+          opt_out: true})
+      Webcast::Preferences.create(
+        {
+          year: 2016,
+          term_cd: 'B',
+          ccn: 5678,
+          opt_out: false})
+    end
+
+    it 'should deny per uniqueness constraint' do
+      expect {
+        Webcast::Preferences.create(
+          {
+            year: 2016,
+            term_cd: 'B',
+            ccn: 5678,
+            opt_out: true})
+      }.to raise_error NameError
+    end
+
+    it 'should not find matching record' do
+      expect(Webcast::Preferences.lookup(2015, 'B', 1234)).to be_nil
+    end
+
+    it 'should return record with opt_out equal false' do
+      record = Webcast::Preferences.lookup(2015, 'D', 1234)
+      expect(record).to_not be_nil
+      expect(record.opt_out).to be true
+    end
+  end
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5130

Preferences class bound to db table 'webcast_preferences' with spec