### PR TITLE
CLC-5150 Move deleteRecentUser logic to backend

### DIFF
--- a/app/controllers/act_as_controller.rb
+++ b/app/controllers/act_as_controller.rb
@@ -11,6 +11,10 @@ class ActAsController < ApplicationController
     session['original_user_id'] = session['user_id'] unless session['original_user_id']
     session['user_id'] = params['uid']
 
+    # This makes sure the most recently viewed user is at the top of the list
+    User::StoredUsers.delete_recent_uid(session['original_user_id'], params['uid'])
+    User::StoredUsers.store_recent_uid(session['original_user_id'], params['uid'])
+
     render :nothing => true, :status => 204
   end
 

--- a/app/controllers/stored_users_controller.rb
+++ b/app/controllers/stored_users_controller.rb
@@ -14,18 +14,8 @@ class StoredUsersController < ApplicationController
     render json: response.to_json
   end
 
-  def store_recent_uid
-    response = User::StoredUsers.store_recent_uid(current_user.real_user_id, params['uid'])
-    render json: response.to_json
-  end
-
   def delete_saved_uid
     response = User::StoredUsers.delete_saved_uid(current_user.real_user_id, params['uid'])
-    render json: response.to_json
-  end
-
-  def delete_recent_uid
-    response = User::StoredUsers.delete_recent_uid(current_user.real_user_id, params['uid'])
     render json: response.to_json
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,10 +121,7 @@ Calcentral::Application.routes.draw do
   post '/stop_act_as' => 'act_as#stop', :via => :post
   get '/stored_users' => 'stored_users#get', :via => :get, :defaults => { :format => 'json' }
   post '/store_user/saved' => 'stored_users#store_saved_uid', via: :post, defaults: { format: 'json' }
-  post '/store_user/recent' => 'stored_users#store_recent_uid', via: :post, defaults: { format: 'json' }
   post '/delete_user/saved' => 'stored_users#delete_saved_uid', via: :post, defaults: { format: 'json' }
-  post '/delete_user/recent' => 'stored_users#delete_recent_uid', via: :post, defaults: { format: 'json' }
-
 
   # All the other paths should use the bootstrap page
   # We need this because we use html5mode=true

--- a/spec/controllers/stored_users_controller_spec.rb
+++ b/spec/controllers/stored_users_controller_spec.rb
@@ -73,27 +73,6 @@ describe StoredUsersController do
 
   end
 
-  describe '#store_recent_uid' do
-
-    it 'should return error_response on invalid uid' do
-      post :store_recent_uid, { format: 'json', uid: 'not_numeric' }
-      expect(response.status).to eq(400)
-      json_response = JSON.parse(response.body)
-      expect(json_response['success']).to eq false
-      expect(json_response['message']).to eq 'Please provide a numeric UID.'
-    end
-
-    it 'should return success_response on valid uid' do
-      User::StoredUsers.should_receive(:store_recent_uid).with('1234', '100').and_return(success_response)
-
-      post :store_recent_uid, { format: 'json', uid: '100' }
-      expect(response.status).to eq(200)
-      json_response = JSON.parse(response.body)
-      expect(json_response['success']).to eq true
-    end
-
-  end
-
   describe '#delete_saved_uid' do
 
     it 'should return error_response on invalid uid' do
@@ -108,27 +87,6 @@ describe StoredUsersController do
       User::StoredUsers.should_receive(:delete_saved_uid).with('1234', '100').and_return(success_response)
 
       post :delete_saved_uid, { format: 'json', uid: '100' }
-      expect(response.status).to eq(200)
-      json_response = JSON.parse(response.body)
-      expect(json_response['success']).to eq true
-    end
-
-  end
-
-  describe '#delete_recent_uid' do
-
-    it 'should return error_response on invalid uid' do
-      post :delete_recent_uid, { format: 'json', uid: 'not_numeric' }
-      expect(response.status).to eq(400)
-      json_response = JSON.parse(response.body)
-      expect(json_response['success']).to eq false
-      expect(json_response['message']).to eq 'Please provide a numeric UID.'
-    end
-
-    it 'should return success_response on valid uid' do
-      User::StoredUsers.should_receive(:delete_recent_uid).with('1234', '100').and_return(success_response)
-
-      post :delete_recent_uid, { format: 'json', uid: '100' }
       expect(response.status).to eq(200)
       json_response = JSON.parse(response.body)
       expect(json_response['success']).to eq true

--- a/spec/features/act_as_user_spec.rb
+++ b/spec/features/act_as_user_spec.rb
@@ -4,32 +4,35 @@ feature "act_as_user" do
   before do
     @target_uid = "978966"
     @fake_events_list = GoogleApps::EventsList.new(fake: true)
-    User::Auth.new_or_update_superuser! "238382"
-    User::Auth.new_or_update_superuser! "2040"
+    User::Auth.new_or_update_superuser! '238382'
+    User::Auth.new_or_update_superuser! '2040'
+    User::Data.create({uid: '238382'})
+    User::Data.create({uid: '2040'})
     Settings.features.stub(:reauthentication).and_return(false)
   end
 
-  scenario "switch to another user and back while using a super-user" do
+  scenario 'switch to another user and back while using a super-user' do
     # disabling the cache_warmer while we're switching back and forth between users
     # The switching back triggers a cache invalidation, while the warming thread is still running.
     Cache::UserCacheWarmer.stub(:warm).and_return(nil)
-    User::Data.stub(:where, :uid => '2040').and_return("tricking the first login check")
-    login_with_cas "238382"
+    login_with_cas '238382'
     suppress_rails_logging {
-      act_as_user "2040"
+      act_as_user '2040'
     }
-    User::Data.unstub(:where)
-    visit "/api/my/status"
+    visit '/api/my/status'
     response = JSON.parse(page.body)
-    response["isLoggedIn"].should be_truthy
-    response["uid"].should == "2040"
+    response['isLoggedIn'].should be_truthy
+    response['uid'].should == '2040'
     suppress_rails_logging {
      stop_act_as_user
     }
-    visit "/api/my/status"
+    visit '/api/my/status'
     response = JSON.parse(page.body)
-    response["isLoggedIn"].should be_truthy
-    response["uid"].should == "238382"
+    response['isLoggedIn'].should be_truthy
+    response['uid'].should == '238382'
+    visit '/stored_users'
+    response = JSON.parse(page.body)
+    response['users']['recent'][0]['ldap_uid'].should == '2040'
   end
 
   scenario "make sure admin users can act as a user who has never signed in before" do
@@ -71,7 +74,6 @@ feature "act_as_user" do
 
     # you don't want the admin user to delete an existing "viewed as" user's data row
     viewed_user_uid = "2040"
-    fake_user = User::Data.create(:uid=>viewed_user_uid)
     User::Data.where(:uid=>viewed_user_uid).should_not be_empty
     suppress_rails_logging {
       act_as_user "2040"
@@ -179,7 +181,6 @@ feature "act_as_user" do
     Cache::UserCacheWarmer.stub(:warm).and_return(nil)
     GoogleApps::Proxy.stub(:access_granted?).and_return(true)
     GoogleApps::EventsList.stub(:new).and_return(@fake_events_list)
-    User::Data.stub(:where, :uid => '2040').and_return("tricking the first login check")
     %w(238382 2040 11002820).each do |user|
       login_with_cas user
       visit "/api/my/up_next"

--- a/src/assets/javascripts/angular/controllers/widgets/studentLookupController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/studentLookupController.js
@@ -98,37 +98,16 @@
       });
     };
 
-    /**
-     * Store recent/saved user
-     */
-    $scope.admin.storeRecentUser = function(user) {
-      // Make sure the most recently viewed user is at the top of the list
-      return $scope.admin.deleteRecentUser(user).success(function() {
-        return adminFactory.storeUser({
-          uid: user.ldap_uid
-        }, 'recent');
-      });
-    };
-
     $scope.admin.storeSavedUser = function(user) {
       adminFactory.storeUser({
         uid: user.ldap_uid
-      }, 'saved').success(getStoredUsersUncached);
-    };
-
-    /**
-     * Delete recent/saved user
-     */
-    $scope.admin.deleteRecentUser = function(user) {
-      return adminFactory.deleteUser({
-        uid: user.ldap_uid
-      }, 'recent').success(getStoredUsersUncached);
+      }).success(getStoredUsersUncached);
     };
 
     $scope.admin.deleteSavedUser = function(user) {
       adminFactory.deleteUser({
         uid: user.ldap_uid
-      }, 'saved').success(getStoredUsersUncached);
+      }).success(getStoredUsersUncached);
     };
 
     /**
@@ -211,11 +190,9 @@
      * Act as another user
      */
     $scope.admin.actAsUser = function(user) {
-      $scope.admin.storeRecentUser(user).then(function() {
-        return adminFactory.actAs({
-          uid: user.ldap_uid
-        }).success(apiService.util.redirectToSettings);
-      });
+      return adminFactory.actAs({
+        uid: user.ldap_uid
+      }).success(apiService.util.redirectToSettings);
     };
 
     var establishTabs = function() {

--- a/src/assets/javascripts/angular/factories/adminFactory.js
+++ b/src/assets/javascripts/angular/factories/adminFactory.js
@@ -11,9 +11,7 @@
     var searchUsersByUidUrl = '/api/search_users/uid/';
     var storedUsersUrl = '/stored_users';
     var storeSavedUserUrl = '/store_user/saved';
-    var storeRecentUserUrl = '/store_user/recent';
     var deleteSavedUserUrl = '/delete_user/saved';
-    var deleteRecentUserUrl = '/delete_user/recent';
 
     var actAs = function(user) {
       return $http.post(actAsUrl, user);
@@ -35,20 +33,12 @@
       return apiService.http.request(options, storedUsersUrl);
     };
 
-    var storeUser = function(options, type) {
-      if (type === 'recent') {
-        return $http.post(storeRecentUserUrl, options);
-      } else if (type === 'saved') {
-        return $http.post(storeSavedUserUrl, options);
-      }
+    var storeUser = function(options) {
+      return $http.post(storeSavedUserUrl, options);
     };
 
-    var deleteUser = function(options, type) {
-      if (type === 'recent') {
-        return $http.post(deleteRecentUserUrl, options);
-      } else if (type === 'saved') {
-        return $http.post(deleteSavedUserUrl, options);
-      }
+    var deleteUser = function(options) {
+      return $http.post(deleteSavedUserUrl, options);
     };
 
     return {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5150

This saves a couple of Ajax requests (and a bunch of code) by consolidating the recentUser save into the act-as controller code. 

This PR is a little risky (although it is covered by the changes to the act_as_user_spec). If we're feeling conservative for 55, please consider holding off on merge until after tomorrow's QA branch. 