### PR TITLE
CLC-5156 - Deprecation warning with establish_connection: use symbol for campusdb

### DIFF
--- a/app/models/campus_oracle/connection.rb
+++ b/app/models/campus_oracle/connection.rb
@@ -2,7 +2,7 @@ module CampusOracle
   class Connection < ActiveRecord::Base
     # WARNING: Default Rails SQL query caching (done for the lifetime of a controller action) apparently does not apply
     # to anything but the primary DB connection. Any Oracle query caching needs to be handled explicitly.
-    establish_connection "campusdb"
+    establish_connection :campusdb
 
     def self.test_data?
       Settings.campusdb.adapter == "h2"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5156

**NOTE**: Wait till after the QA branch has been cut.
This is for 56, not 55.