### PR TITLE
[QA] CLC-5172 - E-Grades Export: empty CSVs

### DIFF
--- a/src/assets/javascripts/angular/controllers/pages/canvasCourseGradeExportController.js
+++ b/src/assets/javascripts/angular/controllers/pages/canvasCourseGradeExportController.js
@@ -167,11 +167,11 @@
           loadSectionTerms(data.sectionTerms);
         }
         if ($scope.appState !== 'error') {
-          handleGradingStandardState(data.gradingStandardEnabled);
-          handleMutedAssignments(data.mutedAssignments);
+          loadOfficialSections(data.officialSections);
         }
         if ($scope.appState !== 'error') {
-          loadOfficialSections(data.officialSections);
+          handleGradingStandardState(data.gradingStandardEnabled);
+          handleMutedAssignments(data.mutedAssignments);
         }
         if ($scope.appState !== 'error') {
           $scope.preloadGrades();


### PR DESCRIPTION
See #3641 for Development branch

https://jira.ets.berkeley.edu/jira/browse/CLC-5172

Switched order of error checking and validation to ensure sections are loaded before validating course state