### PR TITLE
CLC-5177 Mock request matcher can now handle ports or no ports

### DIFF
--- a/lib/proxies/mockable.rb
+++ b/lib/proxies/mockable.rb
@@ -23,7 +23,7 @@ module Proxies
       feed_uri = URI.parse(@settings.base_url)
       {
         method: :get,
-        uri: /.*#{feed_uri.hostname}#{feed_uri.path}.*/
+        uri: /.*#{feed_uri.hostname}.*#{feed_uri.path}.*/
       }
     end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5177

The use case for this only exists in the sis-master branch at the moment, but I think it's good to get into master. 