### PR TITLE
[QA] CLC-5169 - E-Grades Export: Apply 2nd iteration UX changes to error display

### DIFF
--- a/src/assets/javascripts/angular/controllers/pages/canvasCourseGradeExportController.js
+++ b/src/assets/javascripts/angular/controllers/pages/canvasCourseGradeExportController.js
@@ -87,6 +87,27 @@
       });
     };
 
+    $scope.getExportOptions = function() {
+      canvasCourseGradeExportFactory.exportOptions($scope.canvasCourseId).success(function(data) {
+        if ($scope.appState !== 'error') {
+          loadSectionTerms(data.sectionTerms);
+        }
+        if ($scope.appState !== 'error') {
+          loadOfficialSections(data.officialSections);
+        }
+        if ($scope.appState !== 'error') {
+          validateCourseState(data.gradingStandardEnabled, data.mutedAssignments);
+        }
+        if ($scope.appState !== 'error') {
+          $scope.preloadGrades();
+        }
+      }).error(function() {
+        $scope.appState = 'error';
+        $scope.contactSupport = true;
+        $scope.errorStatus = 'Unable to obtain course settings.';
+      });
+    };
+
     /**
      * Performs authorization check on user to control interface presentation
      */
@@ -98,7 +119,7 @@
 
         $scope.userAuthorized = userIsAuthorized($scope.courseUserRoles);
         if ($scope.userAuthorized) {
-          getExportOptions();
+          $scope.getExportOptions();
         } else {
           $scope.appState = 'error';
           $scope.errorStatus = 'You must be a teacher in this bCourses course to export to E-Grades CSV.';
@@ -132,17 +153,13 @@
       }
     };
 
-    /* Load and initialize application based on grading standard state for course */
-    var handleGradingStandardState = function(gradingStandardEnabled) {
+    /* Load and initialize application based on grading standard and muted assignment states for course */
+    var validateCourseState = function(gradingStandardEnabled, mutedAssignments) {
+      $scope.mutedAssignments = mutedAssignments;
       if (!gradingStandardEnabled) {
         $scope.appState = 'error';
         $scope.noGradingStandardEnabled = true;
       }
-    };
-
-    /* Load and initialize application based on muted Assignments */
-    var handleMutedAssignments = function(mutedAssignments) {
-      $scope.mutedAssignments = mutedAssignments;
       if (mutedAssignments.length > 0) {
         $scope.appState = 'error';
         $scope.mutedAssignmentsPresent = true;
@@ -159,28 +176,6 @@
         $scope.errorStatus = 'None of the sections within this course site are associated with UC Berkeley course catalog sections.';
         $scope.contactSupport = true;
       }
-    };
-
-    var getExportOptions = function() {
-      canvasCourseGradeExportFactory.exportOptions($scope.canvasCourseId).success(function(data) {
-        if ($scope.appState !== 'error') {
-          loadSectionTerms(data.sectionTerms);
-        }
-        if ($scope.appState !== 'error') {
-          loadOfficialSections(data.officialSections);
-        }
-        if ($scope.appState !== 'error') {
-          handleGradingStandardState(data.gradingStandardEnabled);
-          handleMutedAssignments(data.mutedAssignments);
-        }
-        if ($scope.appState !== 'error') {
-          $scope.preloadGrades();
-        }
-      }).error(function() {
-        $scope.appState = 'error';
-        $scope.contactSupport = true;
-        $scope.errorStatus = 'Unable to obtain course settings.';
-      });
     };
 
     var userIsAuthorized = function(courseUserRoles) {

--- a/src/assets/stylesheets/_canvas_base.scss
+++ b/src/assets/stylesheets/_canvas_base.scss
@@ -1,3 +1,65 @@
+// Canvas Fonts
+$bc-header-font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+
+// Canvas Tables
+// https://canvas.instructure.com/styleguide#tables
+.bc-table {
+  border: 1px solid $bc-color-table-border-grey;
+  border-collapse: separate;
+  border-radius: 5px;
+  border-spacing: 0;
+  font-weight: 300;
+  margin-bottom: 0;
+  max-width: 100%;
+  width: 100%;
+
+  th, td {
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
+    line-height: 1.3;
+    padding: 14px 7px;
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  thead {
+    background-color: transparent;
+  }
+
+  th {
+    background-color: transparent;
+    border-bottom-color: $bc-color-table-header-border-grey;
+    font-weight: bold;
+    padding-bottom: 7px;
+  }
+
+  tr:last-child td {
+    border-bottom: 0;
+
+    &:first-child {
+      border-bottom-left-radius: 5px;
+    }
+    &:last-child {
+      border-bottom-right-radius: 5px;
+    }
+  }
+
+  td {
+    border-bottom-color: $bc-color-table-cell-border-grey;
+  }
+
+  &.bc-table-striped {
+    tbody {
+      tr:nth-child(odd) {
+        background-color: $bc-color-table-cell-bg-grey;
+      }
+      tr:nth-of-type(even) {
+        background-color: $bc-color-white;
+      }
+    }
+  }
+}
+
 .cc-page-form {
   background: transparent;
   border: 0;
@@ -50,6 +112,16 @@
 // ***********************************
 // bCourses Shared Template Styles
 // ***********************************
+
+.cc-template-back-icon {
+  color: $bc-color-link-blue;
+  font-size: 15px;
+}
+
+.cc-template-back-link {
+  font-family: $bc-header-font-family;
+  font-size: 14px;
+}
 
 // Error display for remote background jobs
 .cc-template-background-job-error {

--- a/src/assets/stylesheets/_canvas_buttons.scss
+++ b/src/assets/stylesheets/_canvas_buttons.scss
@@ -24,10 +24,11 @@ $bc-canvas-button-selected-color: #fff;
   overflow: hidden;
   padding: 8px 14px;
   transition: background-color .2s ease-in-out;
-  &:hover, &:active, &:focus, &:link {
+  &:hover, &:active, &:focus {
     background: $bc-canvas-button-hover-background;
     border-color: $bc-canvas-button-hover-border;
     color: $bc-color-grey-text;
+    text-decoration: none;
   }
   &[disabled] {
     color: $bc-color-grey-text;
@@ -47,7 +48,7 @@ $bc-canvas-button-selected-color: #fff;
   background: $bc-canvas-button-primary-background;
   border: 1px solid $bc-canvas-button-primary-border;
   color: $bc-color-white;
-  &:hover, &:active, &:focus, &:link {
+  &:hover, &:active, &:focus {
     background: $bc-canvas-button-primary-hover-background;
     border-color: $bc-canvas-button-primary-hover-border;
     box-shadow: none;

--- a/src/assets/stylesheets/_canvas_colors.scss
+++ b/src/assets/stylesheets/_canvas_colors.scss
@@ -65,3 +65,9 @@ $bc-color-warning-foreground-selected: #a07f46;
 $bc-color-white: #fff;
 $bc-color-yellow-row-highlighted: #fefae4;
 $bc-color-gold: #f1a91e;
+
+$bc-color-link-blue: #2683bc;
+$bc-color-table-border-grey: #d3dbe0;
+$bc-color-table-header-border-grey: #ababab;
+$bc-color-table-cell-border-grey: #d6d6d6;
+$bc-color-table-cell-bg-grey: #f5f5f5;

--- a/src/assets/stylesheets/_canvas_course_grade_export.scss
+++ b/src/assets/stylesheets/_canvas_course_grade_export.scss
@@ -1,23 +1,39 @@
 .cc-page-course-grade-export {
   background-color: $bc-color-white;
-  padding: 13px;
+  font-family: $bc-header-font-family;
+  font-size: 14px;
+  font-weight: 300;
+  padding: 15px 25px;
 
   // Reset to avoid default Foundation form styling
   p {
+    font-family: $bc-header-font-family;
+    font-size: 14px;
+    font-weight: 300;
     margin-bottom: 10px;
   }
 
+  .cc-page-course-grade-export-back-link {
+    margin-bottom: 5px;
+  }
+
   .cc-page-course-grade-export-header {
-    margin: 15px 0;
+    font-size: 23px;
+    font-weight: 400;
+    margin: 20px 0 15px;
     text-transform: capitalize;
   }
 
   .cc-page-course-grade-export-sub-header {
-    margin: 15px 0;
+    font-size: 20px;
+    font-weight: 400;
+    margin: 20px 0 15px;
   }
 
   .cc-page-course-grading-export-error-notice {
-    margin: 10px 0;
+    font-size: 14px;
+    font-weight: normal;
+    margin: 3px 0;
   }
 
   .cc-page-course-grade-export-error-notice-icon {
@@ -33,28 +49,29 @@
     margin: 10px;
   }
 
-  a.cc-page-course-grade-export-download-button {
-    display: block;
-    margin: 10px;
-    padding: 10px 22px;
-    text-align: center;
-  }
-
   .cc-page-course-grade-export-download-description {
-    padding: 4px 10px;
+    line-height: 16px;
+    margin-bottom: 20px;
+    padding: 4px 0;
   }
 
   .cc-page-course-grade-export-download-header {
-    margin-top: 10px;
-    padding: 4px 10px;
+    font-size: 20px;
+    font-weight: 400;
+    margin-top: 24px;
+    padding: 12px 0;
   }
 
   .cc-page-course-grade-export-more-info-container {
-    margin: 20px 10px;
+    margin-top: 40px;
+  }
+
+  .cc-page-course-grade-export-more-info {
+    margin: 20px 0;
   }
 
   .cc-page-course-grade-export-section {
-    margin: 10px;
+    margin: 10px 0;
   }
 
   .cc-page-course-grade-export-section-select {
@@ -66,8 +83,32 @@
   }
 
   .cc-page-course-grading-export-muted-assignments-table-header {
+    margin: 15px 0 5px;
+  }
+
+  .cc-page-course-grading-export-muted-assignments-table-container {
+    border: $bc-color-table-border-grey 1px solid;
+    border-radius: 5px;
+  }
+
+  .cc-page-course-grading-export-muted-assignments-table {
+    margin-bottom: 35px;
+    th, td {
+      padding: 14px 20px;
+    }
+  }
+
+  .cc-page-course-grade-export-gradebook-button {
+    font-family: $bc-header-font-family;
     font-size: 14px;
-    margin: 15px 0 10px;
+  }
+
+  .cc-page-course-grading-export-assignments-name-column {
+    width: 150px;
+  }
+
+  .cc-page-course-grading-export-assignments-due-at-column {
+    width: 170px;
   }
 
   .cc-page-course-grading-export-error {
@@ -78,6 +119,10 @@
     margin: 15px 0;
   }
 
+  .cc-page-course-grade-export-error-description {
+    line-height: 17px;
+  }
+
   .cc-page-course-grading-export-back-link {
     margin-right: 12px;
   }
@@ -86,5 +131,19 @@
     font-size: 11px;
     padding: 1px 5px;
     text-decoration: none;
+  }
+
+  .cc-page-course-grading-export-enable-grading-scheme-checkbox-container {
+    float: left;
+    padding: 2px;
+  }
+
+  .cc-page-course-grading-export-enable-grading-scheme-label-container {
+    float: left;
+    padding: 2px;
+  }
+
+  .cc-page-course-grading-export-enable-grading-scheme-label {
+    font-weight: bold;
   }
 }

--- a/src/assets/stylesheets/_canvas_emulated.scss
+++ b/src/assets/stylesheets/_canvas_emulated.scss
@@ -1,2 +1,0 @@
-// Canvas Fonts
-$bc-header-font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;

--- a/src/assets/stylesheets/calcentral.scss
+++ b/src/assets/stylesheets/calcentral.scss
@@ -73,8 +73,8 @@
 
 // Canvas external apps
 @import "canvas_colors";
+@import "canvas_base";
 @import "canvas_embedded";
-@import "canvas_emulated";
 @import "canvas_buttons";
 @import "canvas_course_add_user";
 @import "canvas_course_grade_export";
@@ -83,7 +83,6 @@
 @import "canvas_create_project_site";
 @import "canvas_user_provision";
 @import "canvas_roster";
-@import "canvas_shared";
 @import "canvas_site_creation";
 
 // My Finances

--- a/src/assets/templates/canvas_embedded/_shared/back_to_gradebook_link.html
+++ b/src/assets/templates/canvas_embedded/_shared/back_to_gradebook_link.html
@@ -1,0 +1,2 @@
+<i class="fa fa-angle-left cc-template-back-icon"></i>&nbsp;
+<a class="cc-template-back-link" data-ng-click="goToGradebook()">Back to Gradebook</a>

--- a/src/assets/templates/canvas_embedded/course_grade_export.html
+++ b/src/assets/templates/canvas_embedded/course_grade_export.html
@@ -28,8 +28,7 @@
   <div data-ng-if="appState === 'ready'">
     <div class="row collapse">
       <div class="medium-12 columns">
-        <i class="fa fa-long-arrow-left"></i>
-        <button class="cc-button-link" data-ng-click="goToGradebook()">Back to Gradebook</button>
+        <div data-ng-include src="'canvas_embedded/_shared/back_to_gradebook_link.html'"></div>
       </div>
     </div>
 
@@ -61,7 +60,7 @@
           Current grades download ignores unsubmitted assignments when calculating grades.
           Use this download when you want to excuse unsubmitted assignments.
         </p>
-        <a data-ng-href="/api/academics/canvas/egrade_export/download/{{canvasCourseId}}.csv?ccn={{selectedSection.course_cntl_num}}&term_cd={{selectedSection.term_cd}}&term_yr={{selectedSection.term_yr}}&type=current" target="_self" class="cc-button cc-page-course-grade-export-download-button">Download Current Grades</a>
+        <a data-ng-href="/api/academics/canvas/egrade_export/download/{{canvasCourseId}}.csv?ccn={{selectedSection.course_cntl_num}}&term_cd={{selectedSection.term_cd}}&term_yr={{selectedSection.term_yr}}&type=current" target="_self" class="bc-canvas-button bc-canvas-button-primary">Download Current Grades</a>
       </div>
     </div>
 
@@ -72,22 +71,24 @@
           Final grades download counts unsubmitted assignments as zeroes when calculating grades.
           Use this download when you want to include all unsubmitted assignments as part of the grade.
         </p>
-        <a data-ng-href="/api/academics/canvas/egrade_export/download/{{canvasCourseId}}.csv?ccn={{selectedSection.course_cntl_num}}&term_cd={{selectedSection.term_cd}}&term_yr={{selectedSection.term_yr}}&type=final" target="_self" class="cc-button cc-page-course-grade-export-download-button">Download Final Grades</a>
+        <a data-ng-href="/api/academics/canvas/egrade_export/download/{{canvasCourseId}}.csv?ccn={{selectedSection.course_cntl_num}}&term_cd={{selectedSection.term_cd}}&term_yr={{selectedSection.term_yr}}&type=final" target="_self" class="bc-canvas-button bc-canvas-button-primary">Download Final Grades</a>
       </div>
     </div>
 
     <div class="row collapse">
       <div class="medium-12 columns">
-        <p class="cc-page-course-grade-export-more-info-container">
-          For more information, see <a href="http://ets.berkeley.edu/bcourses/how-do-i-submit-grades-e-grades-bcourses">How do I Submit Grades to E-Grades from bCourses?</a>
-        </p>
-        <p class="cc-page-course-grade-export-more-info-container">
-          Updated Gradebook?
-          <button class="bc-canvas-button cc-page-course-grade-export-refresh-button" data-ng-click="preloadGrades()">
-            <i class="fa fa-refresh"></i>
-            Refresh Prepared Grades
-          </button>
-        </p>
+        <div class="cc-page-course-grade-export-more-info-container">
+          <p class="cc-page-course-grade-export-more-info">
+            For more information, see <a href="http://ets.berkeley.edu/bcourses/how-do-i-submit-grades-e-grades-bcourses">How do I Submit Grades to E-Grades from bCourses?</a>
+          </p>
+          <p class="cc-page-course-grade-export-more-info">
+            Updated Gradebook?
+            <button class="bc-canvas-button cc-page-course-grade-export-refresh-button" data-ng-click="getExportOptions()">
+              <i class="fa fa-refresh"></i>
+              Refresh Prepared Grades
+            </button>
+          </p>
+        </div>
       </div>
     </div>
 
@@ -115,8 +116,9 @@
 
       <div class="row collapse">
         <div class="medium-12 columns">
-          <i class="fa fa-long-arrow-left"></i>
-          <button class="cc-button-link" data-ng-click="goToGradebook()">Back to Gradebook</button>
+          <div class="cc-page-course-grade-export-back-link">
+            <div data-ng-include src="'canvas_embedded/_shared/back_to_gradebook_link.html'"></div>
+          </div>
         </div>
       </div>
 
@@ -126,53 +128,8 @@
         </div>
       </div>
 
-      <div data-ng-show="noGradingStandardEnabled" class="cc-page-course-grading-export-error">
-        <div class="row collapse">
-          <div class="medium-12 columns">
-
-            <div class="cc-notice-box cc-notice-warning cc-radius cc-page-course-grading-export-error-notice">
-              <div class="cc-left cc-page-course-grading-export-error-notice-cell">
-                <i class="fa fa-exclamation-triangle cc-icon-yellow cc-page-course-grade-export-error-notice-icon"></i>
-              </div>
-              <div class="cc-page-course-grading-export-error-notice-cell">
-                In order to download E-Grades, a grading scheme must be enabled.
-              </div>
-              <div class="cc-clearfix"></div>
-            </div>
-
-            <h2 class="cc-page-course-grade-export-sub-header">Set Grading Scheme</h2>
-
-            <p>A grading scheme must be enabled to calculate student letter grades. You can choose to enable the
-            default grading scheme, or manually enable a custom grading scheme.</p>
-
-            <h3 class="cc-page-course-grade-export-error-grading-scheme-header">Default Grading Scheme</h3>
-
-            <p class="cc-page-course-grading-export-error-notice">
-              Select to enable and use the default 'Letter Grades +/-' grading scheme below and then click on 'Continue' below.
-            </p>
-            <div>
-              <input id="cc-page-course-grading-export-enable-grading-scheme" type="checkbox"
-              data-ng-model="enableDefaultGradingScheme">
-              <label for="cc-page-course-grading-export-enable-grading-scheme">Enable and use default Letter Grades +/- grading scheme with E-Grades Download</label>
-            </div>
-
-            <h3 class="cc-page-course-grade-export-error-grading-scheme-header">Custom Grading Scheme</h3>
-
-            <p>
-              If you need to choose an alternative grading scheme for your course site other than the default scheme,
-              please edit and enable the grading scheme in the
-              <button class="cc-button-link" data-ng-click="goToCourseSettings()">course settings</button> page for this course site.
-              Once this step is completed, return here and try again.
-            </p>
-            <p>
-              For more information see <a href="http://guides.instructure.com/m/4152/l/57089-how-do-i-enable-a-grading-scheme-for-my-course">How do I enable a grading scheme for my course?</a>
-            </p>
-
-          </div>
-        </div>
-      </div>
-
       <div data-ng-if="mutedAssignmentsPresent" class="cc-page-course-grading-export-error">
+
         <div class="row collapse">
           <div class="medium-12 columns">
 
@@ -181,30 +138,22 @@
                 <i class="fa fa-exclamation-triangle cc-icon-yellow cc-page-course-grade-export-error-notice-icon"></i>
               </div>
               <div class="cc-page-course-grading-export-error-notice-cell">
-                In order to download E-Grades, all assignments need to be unmuted.
+                In order to download E-Grades, all <strong>assignments</strong> must be <strong>unmuted</strong>.
               </div>
               <div class="cc-clearfix"></div>
             </div>
 
-            <h2 class="cc-page-course-grade-export-sub-header">Unmute Assignments</h2>
-
-            <p>
-              E-Grade exports cannot be properly calculated when assignments within the Gradebook are muted.
-              Please unmute all assignments within the <button class="cc-button-link" data-ng-click="goToGradebook()">Gradebook</button>. Once this step is completed, return here and try again.
-            </p>
-            <p>
-              For more information see the 'Unmute Assignment' section of <a href="http://guides.instructure.com/m/4152/l/45130-how-do-i-mute-an-assignment-in-the-gradebook#UnmuteAssignment">How do I mute an assignment in the Gradebook?</a>
+            <h2 class="cc-page-course-grade-export-sub-header">Unmute All Assignments</h2>
+            <p class="cc-page-course-grade-export-error-description">
+              E-Grade.csv exports cannot be properly calculated when assignments within the Gradebook are muted.<br>
+              <a href="http://guides.instructure.com/m/4152/l/45130-how-do-i-mute-an-assignment-in-the-gradebook#UnmuteAssignment">How to mute assignments in Gradebook</a>
             </p>
 
-            <h3 class="cc-page-course-grading-export-muted-assignments-table-header">
-              <span data-ng-pluralize count="mutedAssignments.length" when="{'one': '1 Muted Assignment', 'other': '{{mutedAssignments.length}} Muted Assignments'}"></span>
-            </h3>
-
-            <table role="grid">
+            <table class="bc-table bc-table-striped cc-page-course-grading-export-muted-assignments-table" role="grid">
               <thead>
                 <tr>
-                  <th scope="col">Name</th>
-                  <th scope="col">Due At</th>
+                  <th scope="col">Assignment</th>
+                  <th scope="col">Due Date</th>
                   <th scope="col">Points Possible</th>
                 </tr>
               </thead>
@@ -224,15 +173,51 @@
               </tbody>
             </table>
 
+            <div class="cc-text-right">
+              <button class="bc-canvas-button cc-page-course-grading-export-back-link" type="button" data-ng-click="goToGradebook()" type="button" aria-label="Go Back to Gradebook">Cancel</button>
+              <button class="bc-canvas-button bc-canvas-button-primary cc-page-course-grade-export-gradebook-button" data-ng-click="goToGradebook()">Change in Gradebook</button>
+            </div>
+
           </div>
         </div>
       </div>
 
-      <div class="row collapse">
-        <div class="medium-12 columns end">
-          <div class="cc-text-right">
-            <button class="cc-button-link cc-page-button-grey cc-page-course-grading-export-back-link" type="button" data-ng-click="goToGradebook()" type="button" aria-label="Go Back to Gradebook">Back</button>
-            <button data-ng-click="preloadGrades()" data-ng-disabled="!enableDefaultGradingScheme" class="bc-canvas-button bc-canvas-button-primary" type="submit">Continue</button>
+      <div data-ng-show="noGradingStandardEnabled && !mutedAssignmentsPresent" class="cc-page-course-grading-export-error">
+        <div class="row collapse">
+          <div class="medium-12 columns">
+
+            <div class="cc-notice-box cc-notice-warning cc-radius cc-page-course-grading-export-error-notice">
+              <div class="cc-left cc-page-course-grading-export-error-notice-cell">
+                <i class="fa fa-exclamation-triangle cc-icon-yellow cc-page-course-grade-export-error-notice-icon"></i>
+              </div>
+              <div class="cc-page-course-grading-export-error-notice-cell">
+                In order to download E-Grades, a <strong>grading scheme</strong> must be <strong>enabled</strong>.
+              </div>
+              <div class="cc-clearfix"></div>
+            </div>
+
+            <h2 class="cc-page-course-grade-export-sub-header">Set Grading Scheme</h2>
+            <p class="cc-page-course-grade-export-error-description">
+              A grading scheme must be set before student letter grades can be calculated.<br>
+              <a href="http://guides.instructure.com/m/4152/l/57089-how-do-i-enable-a-grading-scheme-for-my-course">How to set a Grading Scheme</a>
+            </p>
+            <div>
+              <div class="cc-page-course-grading-export-enable-grading-scheme-checkbox-container">
+                <input id="cc-page-course-grading-export-enable-grading-scheme" type="checkbox"
+                data-ng-model="enableDefaultGradingScheme">
+              </div>
+              <div class="cc-page-course-grading-export-enable-grading-scheme-label-container">
+                <label for="cc-page-course-grading-export-enable-grading-scheme" class="cc-page-course-grading-export-enable-grading-scheme-label">Enable the default Letter Grades +/- grading scheme</label><br>
+                <strong>or</strong> set a custom grading scheme in <button class="cc-button-link" data-ng-click="goToCourseSettings()">Course Settings</button> and return here once completed.
+              </div>
+              <div class="cc-clearfix"></div>
+            </div>
+
+            <div class="cc-text-right">
+              <button class="bc-canvas-button cc-page-course-grading-export-back-link" type="button" data-ng-click="goToGradebook()" type="button" aria-label="Go Back to Gradebook">Cancel</button>
+              <button data-ng-click="preloadGrades()" data-ng-disabled="!enableDefaultGradingScheme" class="bc-canvas-button bc-canvas-button-primary" type="button">Continue</button>
+            </div>
+
           </div>
         </div>
       </div>


### PR DESCRIPTION
CLC-5169 - E-Grades Export: Apply 2nd iteration UX changes to error display
https://jira.ets.berkeley.edu/jira/browse/CLC-5169

CLC-5187 - E-Grades Export: "refresh" doesn't re-validate grading scheme or muted assignments
https://jira.ets.berkeley.edu/jira/browse/CLC-5187

See 'master' PR #3646 for un-squashed development branch version.