### PR TITLE
NOJIRA - Add space before 'E-Grades' button text, after icon

### DIFF
--- a/public/canvas/canvas-customization.js
+++ b/public/canvas/canvas-customization.js
@@ -251,7 +251,7 @@
                 var egradesItem = [
                   '<a class="ui-button" id="download_csv" href="' + linkUrl + '">',
                   '<i class="icon-export"></i>',
-                  'E-Grades',
+                  ' E-Grades',
                   '</a>'
                 ].join('');
                 $gradebookToolbarMenuButtons.append(egradesItem);


### PR DESCRIPTION
@jonmhays noticed a space missing between the download icon and the 'E-Grades' text in the label that we add to the Gradebook. This is a fix for that.

See #3652 for QA PR