### PR TITLE
Revert "CLC-5190 Make sure spec:xml is always defined"

### DIFF
--- a/lib/tasks/output_xml_results.rake
+++ b/lib/tasks/output_xml_results.rake
@@ -1,8 +1,10 @@
 namespace :spec do
-  desc 'Runs rake spec, but pipes the output to xml using the rspec_junit_formatter gem'
-  RSpec::Core::RakeTask.new(:xml) do |t|
-    # Because most of us aren't perfect, but we'd still want the out pipe to show us why.
-    t.fail_on_error = false
-    t.rspec_opts = ['--format documentation --format RspecJunitFormatter --out coverage/rspec.xml']
+  if %w(test testext).include? Rails.env
+    desc "Runs rake spec, but pipes the output to xml using the rspec_junit_formatter gem"
+    RSpec::Core::RakeTask.new(:xml) do |t|
+      # Because most of us aren't perfect, but we'd still want the out pipe to show us why.
+      t.fail_on_error = false
+      t.rspec_opts = ['--format documentation --format RspecJunitFormatter --out coverage/rspec.xml']
+    end
   end
 end


### PR DESCRIPTION
This reverts commit d689e18448f056e43b3ff67d19f01dda278781b2 which doesn't fix the issue, and will break people's torquebox knob building step. 