### PR TITLE
CLC-5216, underlying Webcast code expects of a list of CCNs

### DIFF
--- a/app/controllers/mediacasts_controller.rb
+++ b/app/controllers/mediacasts_controller.rb
@@ -2,11 +2,20 @@ class MediacastsController < ApplicationController
 
   before_filter :api_authenticate
 
+  def initialize(options = {})
+    @options = options
+  end
+
   # GET /api/media/:year/:term_code/:dept/:catalog_id
   def get_media
-    render :json => Webcast::CourseMedia.new(
-      params['year'], params['term_code'], params['dept'], params['catalog_id']
-    ).get_feed
+    term_yr = params['year']
+    term_cd = params['term_code']
+    dept_name = params['dept']
+    catalog_id = params['catalog_id']
+    ccn_list = []
+    sections = CampusOracle::Queries.get_all_course_sections(term_yr, term_cd, dept_name, catalog_id)
+    sections.each { |section| ccn_list << section['course_cntl_num'].to_i } if sections.any?
+    render :json => Webcast::CourseMedia.new(term_yr, term_cd, ccn_list, @options).get_feed
   end
 
 end

--- a/app/models/canvas/webcast_recordings.rb
+++ b/app/models/canvas/webcast_recordings.rb
@@ -25,13 +25,12 @@ module Canvas
         if (campus_section = Canvas::Proxy.sis_section_id_to_ccn_and_term(canvas_section['sis_section_id']))
           term_yr = campus_section[:term_yr]
           term_cd = campus_section[:term_cd]
-          if (campus_course = CampusOracle::Queries.get_course_from_section(campus_section[:ccn], term_yr, term_cd))
-            dept_name = campus_course['dept_name']
-            catalog_id = campus_course['catalog_id']
-            course_id = Webcast::CourseMedia.course_id(term_yr, term_cd, dept_name, catalog_id)
+          ccn = campus_section[:ccn].to_i
+          if ccn > 0
+            course_id = Webcast::CourseMedia.id_per_ccn(term_yr, term_cd, ccn)
             unless checked_courses.include?(course_id)
               checked_courses << course_id
-              media_feed = Webcast::CourseMedia.new(term_yr, term_cd, dept_name, catalog_id).get_feed
+              media_feed = Webcast::CourseMedia.new(term_yr, term_cd, ccn).get_feed
               return media_feed unless empty_feed?(media_feed)
             end
           end

--- a/app/models/webcast/course_media.rb
+++ b/app/models/webcast/course_media.rb
@@ -1,19 +1,18 @@
 module Webcast
   class CourseMedia
 
-    def self.course_id(year, term, dept, catalog_id)
-      # allow lookups by either term_cd or term name
+    def self.id_per_ccn(year, term, ccn)
+      term.to_s.strip!
+      # Allow lookups by either term_cd or term name
       term_cd = Berkeley::TermCodes.names[term.downcase]
-      if term_cd.blank?
-        term_cd = term
-      end
-      "#{year}-#{term_cd}-#{dept}-#{catalog_id}"
+      "#{year}-#{term_cd || term.upcase}-#{ccn}"
     end
 
-    def initialize(year, term, dept, catalog_id)
-      dept = decode_slash(dept)
-      catalog_id = decode_slash(catalog_id)
-      @id = self.class.course_id(year, term, dept, catalog_id)
+    def initialize(year, term, ccn_list, options = {})
+      @year = year
+      @term = term
+      @ccn_list = ccn_list
+      @options = options
     end
 
     # Replaces '_slash_' with '/' since front-end encodes slashes. See CLC-4279.
@@ -23,31 +22,41 @@ module Webcast
     end
 
     def get_feed
-      playlist = get_playlist
-      if !playlist[:proxy_error_message].blank? || !playlist[:body].blank?
+      return {} unless Settings.features.videos
+      playlist_data_hash = get_playlist_hash
+      error_message = playlist_data_hash[:proxy_error_message]
+      unless error_message.blank? && playlist_data_hash[:body].blank?
         return {
-          :proxyErrorMessage => playlist[:proxy_error_message] || playlist[:body]
+          :proxyErrorMessage => error_message || playlist_data_hash[:body]
         }
       end
-      videos = get_videos_as_json(playlist)
-      audio = get_audio_as_json(playlist)
-      itunes = get_itunes_as_json(playlist)
-      videos.merge(audio).merge(itunes)
+      feed = {}
+      @ccn_list.each do |ccn|
+        key = Webcast::CourseMedia.id_per_ccn(@year, @term, ccn)
+        data = playlist_data_hash[ccn]
+        if data
+          videos = get_videos_as_json data
+          audio = get_audio_as_json data
+          itunes = get_itunes_as_json data
+          feed[key] = videos.merge(audio).merge(itunes)
+        else
+          feed[key] = Webcast::Recordings::ERRORS
+        end
+      end
+      feed
     end
 
-    def get_playlist
-      proxy = Webcast::Recordings.new
-      recordings = proxy.get
+    def get_playlist_hash
+      playlist_hash = {}
+      recordings = Webcast::Recordings.new(@options).get
       if recordings && recordings[:courses]
-        playlist = recordings[:courses][@id]
-        if playlist.blank?
-          Webcast::Recordings::ERRORS
-        else
-          playlist
+        @ccn_list.each do |ccn|
+          key = Webcast::CourseMedia.id_per_ccn(@year, @term, ccn)
+          playlist = recordings[:courses][key]
+          playlist_hash[ccn] = playlist unless playlist.blank?
         end
-      else
-        recordings
       end
+      playlist_hash
     end
 
     def get_itunes_url(id)
@@ -64,7 +73,7 @@ module Webcast
     end
 
     def get_videos_as_json(playlist)
-      if !Settings.features.videos || playlist[:recordings].blank? || playlist[:audio_only]
+      if playlist[:recordings].blank? || playlist[:audio_only]
         {
           :videos => []
         }
@@ -76,11 +85,12 @@ module Webcast
     end
 
     def get_audio_as_json(playlist)
-      get_audio(playlist[:audio_rss])
+      get_audio playlist[:audio_rss]
     end
 
     def get_audio(audio_rss)
-      Webcast::Audio.new({:audio_rss => audio_rss}).get
+      audio_options = @options.merge({:audio_rss => audio_rss})
+      Webcast::Audio.new(audio_options).get
     end
 
   end

--- a/app/models/webcast/merged.rb
+++ b/app/models/webcast/merged.rb
@@ -1,0 +1,26 @@
+module Webcast
+  class Merged
+
+    include Cache::CachedFeed
+
+    def initialize(year, term, ccn_list, options = {})
+      @year = year
+      @term = term
+      @ccn_list = ccn_list
+      @options = options
+    end
+
+    def get_feed_internal
+      {
+        :system_status => Webcast::SystemStatus.new(@options).get,
+        :rooms => Webcast::Rooms.new(@options).get,
+        :media => Webcast::CourseMedia.new(@year, @term, @ccn_list, @options).get_feed
+      }
+    end
+
+    def instance_key
+      Webcast::CourseMedia.id_per_ccn(@year, @term, @ccn_list.to_s)
+    end
+
+  end
+end

--- a/app/models/webcast/recordings.rb
+++ b/app/models/webcast/recordings.rb
@@ -12,13 +12,15 @@ module Webcast
     def request_internal
       return {} unless Settings.features.videos
 
-      data = get_json_data
       recordings = {
         courses: {}
       }
-      data['courses'].each do |course|
-        if course['year'] && course['semester'] && course['deptName'] && course['catalogId']
-          key = Webcast::CourseMedia.course_id(course['year'], course['semester'], course['deptName'], course['catalogId'])
+      get_json_data['courses'].each do |course|
+        year = course['year']
+        semester = course['semester']
+        ccn = course['ccn']
+        if year && semester && ccn
+          key = Webcast::CourseMedia.id_per_ccn(year, semester, course['ccn'])
           recordings[:courses][key] = {
             audio_only: course['audioOnly'],
             audio_rss: course['audioRSS'].to_s,
@@ -33,4 +35,3 @@ module Webcast
 
   end
 end
-

--- a/spec/controllers/mediacasts_controller_spec.rb
+++ b/spec/controllers/mediacasts_controller_spec.rb
@@ -1,0 +1,73 @@
+describe MediacastsController do
+
+  before { session['user_id'] = rand(99999).to_s }
+
+  # Single digit CCNs have no webcast recordings
+  let(:law_2723) { {:dept_name => 'LAW', :catalog_id => '2723', :term_yr => '2008', :term_cd => 'D', :ccn_set => [1, 49688, 2]} }
+  let(:chem_101) { {:dept_name => 'CHEM', :catalog_id => '101', :term_yr => '2014', :term_cd => 'B', :ccn_set => [1, 2, 3]} }
+  let(:malay_100A) { {:dept_name => 'MALAY/I', :catalog_id => '100A', :term_yr => '2014', :term_cd => 'D', :ccn_set => [85006]} }
+
+  describe 'when serving webcast recordings' do
+    context 'when Webcast feature flag is false' do
+      before { Settings.features.videos = false }
+      after { Settings.features.videos = true }
+      it 'should return no videos' do
+        json = post_course law_2723
+        expect(json[:videos]).to be_nil
+      end
+    end
+
+    context 'fetching fake data' do
+      before do
+        expect(Settings.webcast_proxy).to receive(:fake).and_return(true)
+      end
+
+      context 'when no Webcast recordings found' do
+        it 'should campus_db query results are empty' do
+          term_yr = '2014', term_cd = 'D', dept_name = 'ECON', catalog_id = '101'
+          CampusOracle::Queries.should_receive(:get_all_course_sections).with(term_yr, term_cd, dept_name, catalog_id).and_return []
+          post :get_media, year: term_yr, term_code: term_cd, dept: dept_name, catalog_id: catalog_id
+          expect(response.status).to eq 200
+          expect(JSON.parse response.body).to eq({})
+        end
+      end
+
+      context 'when no Webcast recordings found' do
+        it 'should pay attention to term code' do
+          json = post_course chem_101
+          expect(json[:videos]).to be_nil
+        end
+      end
+
+      context 'when Webcast recordings found' do
+        it 'should escape special characters in dept name' do
+          json = post_course malay_100A
+          # This course happens to have zero YouTube videos
+          course = json['2014-D-85006']
+          expect(course['videos']).to be_empty
+          itunes = course['itunes']
+          expect(itunes['audio']).to be_nil
+          expect(itunes['video']).to include('819827828')
+        end
+      end
+    end
+  end
+
+  private
+
+  def post_course(course)
+    # :year/:term_code/:dept/:catalog_id
+    term_yr = course[:term_yr]
+    term_cd = course[:term_cd]
+    dept_name = course[:dept_name]
+    catalog_id = course[:catalog_id]
+    # Add leading zero to CCN to verify proper handling
+    query_results = []
+    course[:ccn_set].each {|ccn| query_results << { 'course_cntl_num' => "0#{ccn}" }}
+    CampusOracle::Queries.should_receive(:get_all_course_sections).with(term_yr, term_cd, dept_name, catalog_id).and_return query_results
+    post :get_media, year: term_yr, term_code: term_cd, dept: dept_name, catalog_id: catalog_id
+    expect(response.status).to eq 200
+    JSON.parse response.body
+  end
+
+end

--- a/spec/models/canvas/webcast_recordings_spec.rb
+++ b/spec/models/canvas/webcast_recordings_spec.rb
@@ -19,14 +19,13 @@ describe Canvas::WebcastRecordings do
         ]
       end
       before do
-        expect(Webcast::CourseMedia).to receive(:new).at_least(:once) do |yr, cd, dept, catid|
-          expect((yr == '2013' && cd == 'B' && dept == 'BIOLOGY' && catid == '1A') ||
-            (yr == '2012' && cd == 'B' && dept == 'COG SCI')).to be_truthy
+        expect(Webcast::CourseMedia).to receive(:new).at_least(:once) do |yr, cd, ccn|
+          expect((yr == '2013' && cd == 'B' && ccn == 7366) || (yr == '2012' && cd == 'B' && ccn == 16171)).to be_truthy
           # 2013-B-7366
-          if yr == '2013' && cd == 'B' && dept == 'BIOLOGY' && catid == '1A'
+          if yr == '2013' && cd == 'B' && ccn == 7366
             double(get_feed: media_feed_empty)
           # 2012-B-16171
-          elsif yr == '2012' && cd == 'B' && dept == 'COG SCI'
+          elsif yr == '2012' && cd == 'B' && ccn == 16171
             double(get_feed: media_feed_full)
           end
         end

--- a/spec/models/webcast/merged_spec.rb
+++ b/spec/models/webcast/merged_spec.rb
@@ -1,0 +1,46 @@
+describe Webcast::Merged do
+
+  let(:options) { {:fake => true} }
+
+  context '#authenticated' do
+
+    context 'no matching course' do
+      let(:feed) do
+        Webcast::Merged.new(2014, 'B', [1], options).get_feed
+      end
+
+      it 'returns system status when authenticated' do
+        expect(feed[:system_status]['is_sign_up_active']).to be true
+        expect(feed[:rooms]).to have(26).items
+        expect(feed[:rooms]['VALLEY LSB']).to contain_exactly('2040', '2050', '2060')
+        course = feed[:media]['2014-B-1']
+        expect(course).to eq Webcast::Recordings::ERRORS
+        expect(course[:videos]).to be_nil
+        expect(course[:audio]).to be_nil
+      end
+    end
+
+    context 'one matching course' do
+      let(:feed) do
+        Webcast::Merged.new(2014, 'B', [1, 87432], options).get_feed
+      end
+      it 'returns course media' do
+        expect(feed[:media]['2014-B-1']).to eq Webcast::Recordings::ERRORS
+        expect(feed[:media]['2014-B-87432'][:videos]).to have(31).items
+      end
+    end
+
+    context 'two matching course' do
+      let(:feed) do
+        Webcast::Merged.new(2014, 'B', [1, 87432, 2, 76207], options).get_feed
+      end
+      it 'returns course media' do
+        expect(feed[:media]['2014-B-1']).to eq Webcast::Recordings::ERRORS
+        expect(feed[:media]['2014-B-87432'][:videos]).to have(31).items
+        expect(feed[:media]['2014-B-2']).to eq Webcast::Recordings::ERRORS
+        expect(feed[:media]['2014-B-76207'][:videos]).to have(35).items
+      end
+    end
+
+  end
+end

--- a/spec/models/webcast/recordings_spec.rb
+++ b/spec/models/webcast/recordings_spec.rb
@@ -3,12 +3,13 @@ describe Webcast::Recordings do
   let (:webcast_uri) { URI.parse "#{Settings.webcast_proxy.base_url}/webcast.json" }
 
   context 'a fake proxy' do
-    subject { Webcast::Recordings.new({:fake => true}) }
-
-    context 'a normal return of fake data' do
+    context 'data organized by ccn' do
+      let(:recordings) { Webcast::Recordings.new({:fake => true}).get }
       it 'should return a lot of playlists' do
-        result = subject.get
-        expect(result[:courses].keys.length).to eq 17
+        expect(recordings[:courses].keys.length).to eq 19
+        law_2723 = recordings[:courses]['2008-D-49688']
+        expect(law_2723).to_not be_nil
+        expect(law_2723[:recordings]).to have(12).items
       end
     end
   end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5216
Bamboo, too: https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CJT50-6

Previously, the underlying Webcast code would expect dept_name and catalog_id then return the matching set of recordings from the feed. Now, we (1) query for all course sections that relate to dept_name and catalog_id, (2) pass the list of CCNs to webcast code and (3) return multiple sets of recordings. In the case of Canvas integration, we use the set of sis_section_ids (associated with a course site) to generate the necessary list of CCNs.

I also increased test coverage (e.g., controller). When this PR is in I will focus on the front-end code that consumes this newly organized feed. 