### PR TITLE
CLC-5202 First two CalGroups proxies

### DIFF
--- a/app/models/cal_groups/find_groups.rb
+++ b/app/models/cal_groups/find_groups.rb
@@ -1,0 +1,44 @@
+module CalGroups
+  class FindGroups < Proxy
+    include ClassLogger
+    include ResponseWrapper
+
+    def name_available?(name)
+      qualified_name = qualify name
+      handling_exceptions(qualified_name) do
+        find_group_by_name(qualified_name).empty?
+      end
+    end
+
+    def find_group_by_name(qualified_name)
+      response = request({
+          body: {
+            wsLiteObjectType: 'WsRestFindGroupsLiteRequest',
+            queryFilterType: 'FIND_BY_GROUP_NAME_EXACT',
+            groupName: qualified_name
+          },
+          method: :post
+        })
+      if response['WsFindGroupsResults']
+        response['WsFindGroupsResults']['groupResults'] || []
+      else
+        raise Errors::ProxyError.new('Could not parse results from CalGroups', {response: response})
+      end
+    end
+
+    private
+
+    def mock_json
+      read_file('fixtures', 'json', 'cal_groups_find_groups.json')
+    end
+
+    def mock_request
+      super.merge(method: :post)
+    end
+
+    def request_path
+      'groups'
+    end
+
+  end
+end

--- a/app/models/cal_groups/get_members.rb
+++ b/app/models/cal_groups/get_members.rb
@@ -1,0 +1,35 @@
+module CalGroups
+  class GetMembers < Proxy
+    include ClassLogger
+    include ResponseWrapper
+
+    def initialize(options = {})
+      @group_name = options[:group_name]
+      super(options)
+    end
+
+    def get_members
+      handling_exceptions(qualify @group_name) do
+        response = request
+        if response['WsGetMembersLiteResult']
+          {
+            members: (response['WsGetMembersLiteResult']['wsSubjects'] || [])
+          }
+        else
+          raise Errors::ProxyError.new('Could not parse results from CalGroups', {response: response})
+        end
+      end
+    end
+
+    private
+
+    def request_path
+      "groups/#{URI.escape(qualify @group_name)}/members"
+    end
+
+    def mock_json
+      read_file('fixtures', 'json', 'cal_groups_get_members.json')
+    end
+
+  end
+end

--- a/app/models/cal_groups/proxy.rb
+++ b/app/models/cal_groups/proxy.rb
@@ -1,0 +1,60 @@
+module CalGroups
+  class Proxy < BaseProxy
+    include Proxies::Mockable
+
+    def initialize(options = {})
+      super(Settings.cal_groups_proxy, options)
+      @stem_name = options[:stem_name]
+      initialize_mocks if @fake
+    end
+
+    private
+
+    # Tell HTTParty that the 'text/x-json' content type used by Calgroups should be parsed as JSON.
+    class LegacyJsonParser < HTTParty::Parser
+      SupportedFormats.merge!('text/x-json' => :json)
+    end
+
+    def mock_request
+      super.merge(uri_matching: request_url)
+    end
+
+    def qualify(name)
+      [@stem_name, name].join(':')
+    end
+
+    def request(options={})
+      request_options = {
+        basic_auth: {
+          username: @settings.username,
+          password: @settings.password
+        },
+        parser: LegacyJsonParser
+      }.merge(options)
+
+      logger.info "Fake = #{@fake}; Making request to #{request_url}"
+      response = get_response(request_url, request_options)
+      logger.debug "Remote server status #{response.code}, Body = #{response.body}"
+
+      if success?(response)
+        response.parsed_response
+      else
+        raise Errors::ProxyError.new('Failure response from CalGroups', {response: response})
+      end
+    end
+
+    def request_url
+      [@settings.base_url, request_path].join('/')
+    end
+
+    def success?(response)
+      if response && response.parsed_response && response.parsed_response.values
+        results = response.parsed_response.values.first
+        if (metadata = results['resultMetadata'])
+          metadata['success'] == 'T'
+        end
+      end
+    end
+
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -117,6 +117,12 @@ bearfacts_proxy:
   app_key: ''
   base_url: "https://apis-dev.berkeley.edu/bearfacts-apis"
 
+cal_groups_proxy:
+  fake: false
+  username: 'secret'
+  password: 'secret'
+  base_url: 'https://group-test.berkeley.edu/gws/servicesRest/json/v2_2_100'
+
 calmail_proxy:
   fake: false
   api_key: '99999'

--- a/fixtures/json/cal_groups_find_groups.json
+++ b/fixtures/json/cal_groups_find_groups.json
@@ -1,0 +1,24 @@
+{
+  "WsFindGroupsResults": {
+    "groupResults": [
+      {
+        "displayExtension": "testgroup",
+        "displayName": "edu:berkeley:app:bCourses:testgroup",
+        "extension": "testgroup",
+        "idIndex": "19235",
+        "name": "edu:berkeley:app:bcourses:testgroup",
+        "typeOfGroup": "group",
+        "uuid": "1cc4398e7aa246af945be1157f448561"
+      }
+    ],
+    "responseMetadata": {
+      "millis": "69",
+      "serverVersion": "2.2.1"
+    },
+    "resultMetadata": {
+      "resultCode": "SUCCESS",
+      "resultMessage": "Success for: clientVersion: 2.2.100, wsQueryFilter: WsQueryFilter[queryFilterType=FIND_BY_GROUP_NAME_EXACT,groupName=edu:berkeley:app:bcourses:testgroup]\n, includeGroupDetail: false, actAsSubject: null, paramNames: \n, params: null\n, wsGroupLookups: null",
+      "success": "T"
+    }
+  }
+}

--- a/fixtures/json/cal_groups_get_members.json
+++ b/fixtures/json/cal_groups_get_members.json
@@ -1,0 +1,36 @@
+{
+  "WsGetMembersLiteResult": {
+    "responseMetadata": {
+      "millis": "99",
+      "serverVersion": "2.2.1"
+    },
+    "resultMetadata": {
+      "resultCode": "SUCCESS",
+      "resultMessage": "Success for: clientVersion: 2.2.100, wsGroupLookups: Array size: 1: [0]: WsGroupLookup[pitGroups=[],groupName=edu:berkeley:app:bcourses:testgroup]\n\n, memberFilter: All, includeSubjectDetail: false, actAsSubject: null, fieldName: null, subjectAttributeNames: null\n, paramNames: \n, params: null\n, sourceIds: null\n, pointInTimeFrom: null, pointInTimeTo: null, pageSize: null, pageNumber: null, sortString: null, ascending: null",
+      "success": "T"
+    },
+    "wsGroup": {
+      "displayExtension": "testgroup",
+      "displayName": "edu:berkeley:app:bCourses:testgroup",
+      "extension": "testgroup",
+      "idIndex": "19235",
+      "name": "edu:berkeley:app:bcourses:testgroup",
+      "typeOfGroup": "group",
+      "uuid": "1cc4398e7aa246af945be1157f448561"
+    },
+    "wsSubjects": [
+      {
+        "id": "242881",
+        "resultCode": "SUCCESS",
+        "sourceId": "ldap",
+        "success": "T"
+      },
+      {
+        "id": "211159",
+        "resultCode": "SUCCESS",
+        "sourceId": "ldap",
+        "success": "T"
+      }
+    ]
+  }
+}

--- a/spec/models/cal_groups/find_groups_spec.rb
+++ b/spec/models/cal_groups/find_groups_spec.rb
@@ -1,0 +1,82 @@
+describe CalGroups::FindGroups do
+  let(:stem_name) { 'edu:berkeley:app:bcourses' }
+  let(:group_name) { "site-#{random_id}" }
+  let(:qualified_group_name) { [stem_name, group_name].join(':') }
+
+  let(:proxy) { CalGroups::FindGroups.new(stem_name: stem_name, fake: fake) }
+
+  let(:find_group) { proxy.find_group_by_name qualified_group_name }
+  let(:name_available_response) { proxy.name_available?(group_name)[:response]  }
+
+  after(:each) { WebMock.reset! }
+
+  shared_examples 'group found' do
+    it 'returns data for a single group' do
+      expect(find_group).to have(1).item
+      %w(displayExtension displayName extension idIndex name typeOfGroup uuid).each do |key|
+        expect(find_group.first[key]).to be_present
+      end
+    end
+
+    it 'reports group name as unavailable' do
+      expect(name_available_response).to eq false
+    end
+  end
+
+  shared_examples 'group not found' do
+    it 'finds nothing' do
+      expect(find_group).to be_empty
+    end
+
+    it 'reports group name as available' do
+      expect(name_available_response).to eq true
+    end
+  end
+
+  context 'using fake data feed' do
+    let(:fake) { true }
+
+    context 'default fake group' do
+      include_examples 'group found'
+    end
+
+    context 'when group does not exist' do
+      before do
+        proxy.override_json do |json|
+          json['WsFindGroupsResults'].delete 'groupResults'
+        end
+      end
+      include_examples 'group not found'
+    end
+
+    context 'when response metadata reports failure' do
+      before do
+        proxy.override_json do |json|
+          json['WsFindGroupsResults']['resultMetadata']['success'] = 'F'
+        end
+      end
+      it 'should return an error' do
+        expect(name_available_response[:statusCode]).to eq 503
+      end
+    end
+  end
+
+  context 'using real data feed', testext: true do
+    let(:fake) { false }
+
+    context 'a known test group' do
+      let(:group_name) { 'testgroup' }
+      include_examples 'group found'
+    end
+
+    context 'a nonexistent group' do
+      let(:group_name) { 'pleasedonotcreateagroupwiththisname' }
+      include_examples 'group not found'
+    end
+
+    it_should_behave_like 'a proxy logging errors' do
+      subject { name_available_response }
+    end
+  end
+
+end

--- a/spec/models/cal_groups/get_members_spec.rb
+++ b/spec/models/cal_groups/get_members_spec.rb
@@ -1,0 +1,75 @@
+describe CalGroups::GetMembers do
+  let(:stem_name) { 'edu:berkeley:app:bcourses' }
+  let(:group_name) { "site-#{random_id}" }
+
+  let(:proxy) { CalGroups::GetMembers.new(stem_name: stem_name, group_name: group_name, fake: fake) }
+  let(:result) { proxy.get_members[:response] }
+
+  after(:each) { WebMock.reset! }
+
+  shared_examples 'members found' do
+    it 'returns data for multiple members' do
+      expect(result[:members]).to_not be_empty
+      result[:members].each do |member|
+        expect(member['id']).to be_present
+        expect(member['resultCode']).to eq 'SUCCESS'
+        expect(member['sourceId']).to eq 'ldap'
+        expect(member['success']).to eq 'T'
+      end
+    end
+  end
+
+  shared_examples 'no members found' do
+    it 'returns an empty dataset' do
+      expect(result[:members]).to be_empty
+    end
+  end
+
+  shared_examples 'group not found' do
+    it 'returns an error' do
+      expect(result[:statusCode]).to eq 503
+    end
+  end
+
+  context 'using fake data feed' do
+    let(:fake) { true }
+
+    context 'populated mailing list' do
+      include_examples 'members found'
+    end
+
+    context 'empty mailing list' do
+      before do
+        proxy.override_json do |json|
+          json['WsGetMembersLiteResult'].delete 'wsSubjects'
+        end
+      end
+      include_examples 'no members found'
+    end
+
+    context 'a nonexistent group' do
+      before do
+        proxy.set_response({
+          status: 404,
+          body: '{"WsGetMembersLiteResult":{"resultMetadata":{"resultCode":"GROUP_NOT_FOUND","success":"F"}}}'
+        })
+      end
+      include_examples 'group not found'
+    end
+  end
+
+  context 'using real data feed', testext: true do
+    let(:fake) { false }
+
+    context 'a known test group' do
+      let(:group_name) { 'testgroup' }
+      include_examples 'members found'
+    end
+
+    context 'a nonexistent group' do
+      let(:group_name) { 'pleasedonotcreateagroupwiththisname' }
+      include_examples 'group not found'
+    end
+  end
+
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5202
https://jira.ets.berkeley.edu/jira/browse/CLC-5180

NB: New cal_groups_proxy local settings have been added to calcentral-dev. These should be copied over to ets-dev prior to merge, or Bamboo will fail.

Otherwise, trying to hew close to the logic in #3671 for consistency's sake. Like those proxies, these don't currently contemplate caching, but the calls could take a cache wrapper straightforwardly enough.