### PR TITLE
CLC-5170 Add all CalMail API calls needed for Mailman mailing lists

### DIFF
--- a/app/models/calmail/add_list_member.rb
+++ b/app/models/calmail/add_list_member.rb
@@ -1,0 +1,46 @@
+module Calmail
+  class AddListMember < Proxy
+    include ClassLogger
+    include ResponseWrapper
+
+    ALREADY_A_MEMBER = 'APIv1 addMember: already a member'
+
+    def add_member(list_name, email_address, full_name)
+      handling_exceptions(list_name) do
+        response = request('addMember', {
+          body: {
+            localpart: list_name,
+            sub_address: email_address,
+            notify_owner: false,
+            send_welcome: false,
+            fullname: full_name
+          },
+          on_error: {rescue_status: 500}
+        })
+        if response.code == 200
+          added = true
+        elsif response.code == 500 && response.parsed_response['message'] == ALREADY_A_MEMBER
+          added = false
+        else
+          raise Errors::ProxyError.new("Error adding member #{email_address} to #{list_name}: #{response.body}", {response: response})
+        end
+        {
+          email_address: email_address,
+          added: added
+        }
+      end
+    end
+
+    def mock_json
+      '{"tg_flash": null}'
+    end
+
+    def mock_response_already_a_member
+      mock_response.merge(
+        status: 500,
+        body: "{\"tg_flash\": null, \"message\": \"#{ALREADY_A_MEMBER}\"}"
+      )
+    end
+
+  end
+end

--- a/app/models/calmail/check_namespace.rb
+++ b/app/models/calmail/check_namespace.rb
@@ -31,14 +31,12 @@ module Calmail
     def mock_response_list_name_exists
       mock_response.merge(
         status: 500,
-        body: '{"tg_flash": null, "message": "Invalid: localpart: A mailing list by that name already exists"}'
+        body: "{\"tg_flash\": null, \"message\": \"#{MAILING_LIST_EXISTS}\"}"
       )
     end
 
-    def mock_response_list_name_available
-      mock_response.merge(
-        body: '{"available": true, "tg_flash": null}'
-      )
+    def mock_json
+      '{"available": true, "tg_flash": null}'
     end
 
   end

--- a/app/models/calmail/domain_mailing_lists.rb
+++ b/app/models/calmail/domain_mailing_lists.rb
@@ -1,0 +1,24 @@
+module Calmail
+  class DomainMailingLists < Proxy
+    include ClassLogger
+    include ResponseWrapper
+
+    def get_list_names
+      handling_exceptions(@settings.domain) do
+        list_names = []
+        response_hash = request('getDomainLists').parsed_response
+        response_hash.each do |address, description|
+          if (list_name = /([^@]+)@#{@settings.domain}/.match(address))
+            list_names << list_name[1]
+          end
+        end
+        {lists: list_names}
+      end
+    end
+
+    def mock_json
+      '{"test-mailing-list@bcourses-lists.berkeley.edu": "", "tg_flash": null, "raytest@bcourses-lists.berkeley.edu": "Test mailing list for bCourses development"}'
+    end
+
+  end
+end

--- a/app/models/calmail/remove_list_member.rb
+++ b/app/models/calmail/remove_list_member.rb
@@ -1,0 +1,45 @@
+module Calmail
+  class RemoveListMember < Proxy
+    include ClassLogger
+    include ResponseWrapper
+
+    NOT_A_MEMBER = 'Not a member of the list'
+
+    def remove_member(list_name, email_address)
+      handling_exceptions(list_name) do
+        response = request('removeMember', {
+          body: {
+            localpart: list_name,
+            unsub_address: email_address,
+            notify_owner: false,
+            send_ack: false,
+          },
+          on_error: {rescue_status: 500}
+        })
+        if response.code == 200
+          removed = true
+        elsif response.code == 500 && response.parsed_response['message'] == NOT_A_MEMBER
+          removed = false
+        else
+          raise Errors::ProxyError.new("Error removing member #{email_address} from #{list_name}: #{response.body}", {response: response})
+        end
+        {
+          email_address: email_address,
+          removed: removed
+        }
+      end
+    end
+
+    def mock_json
+      '{"tg_flash": null}'
+    end
+
+    def mock_response_not_a_member
+      mock_response.merge(
+        status: 500,
+        body: "{\"tg_flash\": null, \"message\": \"#{NOT_A_MEMBER}\"}"
+      )
+    end
+
+  end
+end

--- a/spec/models/calmail/add_list_member_spec.rb
+++ b/spec/models/calmail/add_list_member_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Calmail::AddListMember do
+  subject { described_class.new(fake: true) }
+
+  describe '#add_member' do
+    let(:list_name) { "site-#{random_id}" }
+    let(:email_address) { "th_#{random_id}@example.com" }
+    let(:full_name) { "Thurston Howell #{random_id}" }
+    let(:result) { subject.add_member(list_name, email_address, full_name)[:response] }
+    context 'new address for list' do
+      it 'succeeds' do
+        expect(result).to eq({email_address: email_address, added: true})
+      end
+    end
+    context 'specified address is already in list' do
+      before do
+        subject.set_response(subject.mock_response_already_a_member)
+      end
+      it 'fails gracefully' do
+        expect(result).to eq({email_address: email_address, added: false})
+      end
+    end
+  end
+
+end

--- a/spec/models/calmail/check_namespace_spec.rb
+++ b/spec/models/calmail/check_namespace_spec.rb
@@ -4,7 +4,7 @@ describe Calmail::CheckNamespace do
   let(:list_name) { "site-#{random_id}" }
 
   describe '#name_available?' do
-    subject { Calmail::CheckNamespace.new(fake: true) }
+    subject { described_class.new(fake: true) }
     before do
       subject.set_response(mock_response)
     end
@@ -16,7 +16,7 @@ describe Calmail::CheckNamespace do
       end
     end
     context 'mailing list does not exist' do
-      let(:mock_response) { subject.mock_response_list_name_available }
+      let(:mock_response) { subject.mock_response }
       it 'finds nothing' do
         expect(result).to be true
       end

--- a/spec/models/calmail/domain_mailing_lists_spec.rb
+++ b/spec/models/calmail/domain_mailing_lists_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Calmail::DomainMailingLists do
+  subject { described_class.new(fake: true) }
+
+  describe '#get_list_names' do
+    let(:result) { subject.get_list_names[:response] }
+    it 'returns an array of mailing list names' do
+      mailing_lists = result[:lists]
+      expect(mailing_lists.size).to eq 2
+      expect(mailing_lists).to include('raytest')
+    end
+  end
+
+end

--- a/spec/models/calmail/list_members_spec.rb
+++ b/spec/models/calmail/list_members_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Calmail::ListMembers do
-  subject { Calmail::ListMembers.new(fake: true) }
+  subject { described_class.new(fake: true) }
   let(:list_name) { "site-#{random_id}" }
 
   describe '#list_members' do

--- a/spec/models/calmail/remove_list_member_spec.rb
+++ b/spec/models/calmail/remove_list_member_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Calmail::RemoveListMember do
+  subject { described_class.new(fake: true) }
+
+  describe '#remove_member' do
+    let(:list_name) { "site-#{random_id}" }
+    let(:email_address) { "th_#{random_id}@example.com" }
+    let(:result) { subject.remove_member(list_name, email_address)[:response] }
+    context 'address is in list' do
+      it 'succeeds' do
+        expect(result).to eq({email_address: email_address, removed: true})
+      end
+    end
+    context 'specified address is not in list' do
+      before do
+        subject.set_response(subject.mock_response_not_a_member)
+      end
+      it 'fails gracefully' do
+        expect(result).to eq({email_address: email_address, removed: false})
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5170

I believe these are all the APIs of use to the Mailman integration as currently scoped out.