### PR TITLE
CLC-5135, remove_index only reversible if given a :column option

### DIFF
--- a/db/migrate/20150430222956_alter_webcast_preferences_table.rb
+++ b/db/migrate/20150430222956_alter_webcast_preferences_table.rb
@@ -2,6 +2,9 @@ class AlterWebcastPreferencesTable < ActiveRecord::Migration
   def change
 
     remove_index(:webcast_preferences, {name: 'webcast_preferences_unique_index'})
+    remove_index(:webcast_preferences, :year)
+    remove_index(:webcast_preferences, :term_cd)
+    remove_index(:webcast_preferences, :ccn)
     drop_table :webcast_preferences
 
     create_table :webcast_course_site_log do |t|


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5135

Index was on a composite key so remove_index per three columns. No new migrate file here. 