### PR TITLE
CLC-5234 Remove obsolete 'token' from MyFinAid proxy

### DIFF
--- a/app/models/finaid/proxy.rb
+++ b/app/models/finaid/proxy.rb
@@ -34,10 +34,9 @@ module Finaid
         return nil
       else
         logger.info "Fake = #{@fake}; Making request to #{request_url} on behalf of user #{@uid}, student_id = #{@student_id}, aidYear = #{@term_year}; cache expiration #{self.class.expires_in}"
-        request_options = {query: {
-          token: @settings.token,
-          aidYear: @term_year
-        }}
+        request_options = {
+          query: {aidYear: @term_year}
+        }
         if (@settings.app_id.present? && @settings.app_key.present?)
           request_options[:headers] = {
             'app_id' => @settings.app_id,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -138,7 +138,6 @@ regstatus_proxy:
 
 myfinaid_proxy:
   fake: false
-  token: secret set per deployment layer
   app_id: ''
   app_key: ''
   base_url: "https://apis-qa.berkeley.edu/myfinaid"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5234

Finaid tests pass on Bamboo with token removed from code.