### PR TITLE
CLC-5158: fix enrollments Selenium spec

### DIFF
--- a/spec/ui_selenium/my_academics_data_enrollment_spec.rb
+++ b/spec/ui_selenium/my_academics_data_enrollment_spec.rb
@@ -216,7 +216,6 @@ describe 'My Academics enrollments', :testui => true do
 
                       # CLASS PAGES
 
-                      # semester_courses.each do |course|
                       semester_card_courses.each do |course|
 
                         begin

--- a/spec/ui_selenium/my_academics_data_enrollment_spec.rb
+++ b/spec/ui_selenium/my_academics_data_enrollment_spec.rb
@@ -63,7 +63,7 @@ describe 'My Academics enrollments', :testui => true do
                   expect(shows_default_semesters).to be true
                 end
                 show_more_button_visible = my_academics.show_more_element.visible?
-                if all_semester_names.length > default_semester_names.length
+                if all_semester_names.length > default_semester_names.length || !academics_api_page.addl_credits.nil?
                   it "offers a 'Show More' button for UID #{uid}" do
                     expect(show_more_button_visible).to be true
                   end
@@ -85,12 +85,12 @@ describe 'My Academics enrollments', :testui => true do
                   begin
                     semester_name = academics_api_page.semester_name(semester)
                     semester_courses = academics_api_page.semester_courses(semester)
-                    semester_card_courses = academics_api_page.courses_per_transcript(semester_courses)
+                    semester_card_courses = academics_api_page.semester_card_courses(semester, semester_courses)
 
-                    api_course_codes = academics_api_page.course_codes(semester_card_courses)
+                    api_course_codes = academics_api_page.semester_card_course_codes(semester)
                     api_course_titles = academics_api_page.course_titles(semester_card_courses)
-                    api_units = academics_api_page.units_per_transcript(semester_courses)
-                    api_grades = academics_api_page.grades(semester_courses, semester)
+                    api_units = academics_api_page.units_by_transcript(semester_courses)
+                    api_grades = academics_api_page.semester_grades(semester_courses, semester)
 
                     academics_page_course_codes = my_academics.prim_sec_course_codes(driver, semester_name)
                     academics_page_course_titles = my_academics.course_titles(driver, semester_name)
@@ -113,173 +113,297 @@ describe 'My Academics enrollments', :testui => true do
                       expect(academics_page_course_grades).to eql(api_grades)
                     end
 
+                    # ADDITIONAL CREDIT
+
+                    unless academics_api_page.addl_credits.nil?
+
+                      api_addl_titles = academics_api_page.addl_credits_titles
+                      api_addl_units = academics_api_page.addl_credits_units
+
+                      academics_page_addl_titles = my_academics.addl_credit_titles
+                      academics_page_addl_units = my_academics.addl_credit_units
+
+                      it "shows the Additional Credit titles for UID #{uid}" do
+                        expect(academics_page_addl_titles).to eql(api_addl_titles)
+                      end
+                      it "shows the Additional Credit units for UID #{uid}" do
+                        expect(academics_page_addl_units).to eql(api_addl_units)
+                      end
+                    end
+
                     # SEMESTER PAGES
 
-                    my_academics.click_semester_link(driver, semester_name)
-                    semester_page = CalCentralPages::MyAcademicsPage::MyAcademicsEnrollmentsCard.new(driver)
-                    wait_list_courses = academics_api_page.wait_list_courses(semester_courses)
-                    enrolled_courses = (semester_courses - wait_list_courses)
-                    semester_page_enrolled_courses = academics_api_page.courses_per_prim_section(enrolled_courses)
+                    if academics_api_page.has_enrollment_data?(semester)
+                      my_academics.click_semester_link(driver, semester_name)
+                      semester_page = CalCentralPages::MyAcademicsPage::MyAcademicsEnrollmentsCard.new(driver)
+                      wait_list_courses = academics_api_page.wait_list_courses(semester_courses)
+                      enrolled_courses = (semester_courses - wait_list_courses)
+                      semester_page_enrolled_courses = academics_api_page.semester_page_courses(enrolled_courses)
 
-                    # ENROLLED COURSES
+                      # ENROLLED COURSES
 
-                    api_enrolled_course_codes = academics_api_page.course_codes(semester_page_enrolled_courses)
-                    api_enrolled_course_titles = academics_api_page.course_titles(semester_page_enrolled_courses)
-                    api_enrolled_grade_options = academics_api_page.course_grade_options(enrolled_courses)
-                    api_enrolled_units = academics_api_page.units_per_prim_section(enrolled_courses)
-                    api_enrolled_section_labels = academics_api_page.all_section_labels(enrolled_courses)
+                      api_enrolled_course_codes = academics_api_page.course_codes(semester_page_enrolled_courses)
+                      api_enrolled_course_titles = academics_api_page.course_titles(semester_page_enrolled_courses)
+                      api_enrolled_grade_options = academics_api_page.semester_grade_options(enrolled_courses)
+                      api_enrolled_units = academics_api_page.units_by_enrollment(enrolled_courses)
+                      api_enrolled_section_labels = academics_api_page.all_section_labels(enrolled_courses)
 
-                    semester_page_codes = semester_page.all_enrolled_course_codes
-                    semester_page_titles = semester_page.all_enrolled_course_titles
-                    semester_page_grade_options = semester_page.all_enrolled_grade_options
-                    semester_page_units = semester_page.all_enrolled_units
-                    semester_page_sections = semester_page.all_enrolled_sections
+                      semester_page_codes = semester_page.all_enrolled_course_codes
+                      semester_page_titles = semester_page.all_enrolled_course_titles
+                      semester_page_grade_options = semester_page.all_enrolled_grade_options
+                      semester_page_units = semester_page.all_enrolled_units
+                      semester_page_sections = semester_page.all_enrolled_sections
 
-                    it "shows the enrolled course codes on the #{semester_name} semester page for UID #{uid}" do
-                      expect(semester_page_codes).to eql(api_enrolled_course_codes)
-                      expect(semester_page_codes.all? &:blank?).to be false
-                    end
-                    it "shows the enrolled course titles on the #{semester_name} semester page for UID #{uid}" do
-                      expect(semester_page_titles).to eql(api_enrolled_course_titles)
-                      expect(semester_page_titles.all? &:blank?).to be false
-                    end
-                    it "shows the enrolled course grade options on the #{semester_name} semester page for UID #{uid}" do
-                      expect(semester_page_grade_options).to eql(api_enrolled_grade_options)
-                      expect(semester_page_grade_options.all? &:blank?).to be false
-                    end
-                    it "shows the enrolled course units on the #{semester_name} semester page for UID #{uid}" do
-                      expect(semester_page_units).to eql(api_enrolled_units)
-                      expect(semester_page_units.all? &:blank?).to be false
-                    end
-                    it "shows the enrolled section labels on the #{semester_name} semester page for UID #{uid}" do
-                      expect(semester_page_sections).to eql(api_enrolled_section_labels)
-                      expect(semester_page_sections.all? &:blank?).to be false
-                    end
-
-                    # WAIT LIST COURSES
-
-                    if wait_list_courses.any?
-                      api_wait_list_course_codes = academics_api_page.wait_list_course_codes(wait_list_courses)
-                      api_wait_list_course_titles = academics_api_page.wait_list_course_titles(wait_list_courses)
-                      api_wait_list_sections = academics_api_page.all_section_labels(wait_list_courses)
-                      api_wait_list_positions = academics_api_page.wait_list_positions(wait_list_courses)
-                      api_wait_list_sizes = academics_api_page.enrollment_limits(wait_list_courses)
-
-                      sem_page_wait_list_codes = semester_page.all_waitlist_course_codes
-                      sem_page_wait_list_titles = semester_page.all_waitlist_course_titles
-                      sem_page_wait_list_sections = semester_page.all_waitlist_sections
-                      sem_page_wait_list_positions = semester_page.all_waitlist_positions
-                      sem_page_wait_list_sizes = semester_page.all_waitlist_class_sizes
-
-                      it "shows the wait list course codes on the #{semester_name} semester page for UID #{uid}" do
-                        expect(sem_page_wait_list_codes).to eql(api_wait_list_course_codes)
-                        expect(sem_page_wait_list_codes.all? &:blank?).to be false
+                      it "shows the enrolled course codes on the #{semester_name} semester page for UID #{uid}" do
+                        expect(semester_page_codes).to eql(api_enrolled_course_codes)
                       end
-                      it "shows the wait list course titles on the #{semester_name} semester page for UID #{uid}" do
-                        expect(sem_page_wait_list_titles).to eql(api_wait_list_course_titles)
-                        expect(sem_page_wait_list_titles.all? &:blank?).to be false
+                      it "shows the enrolled course titles on the #{semester_name} semester page for UID #{uid}" do
+                        expect(semester_page_titles).to eql(api_enrolled_course_titles)
                       end
-                      it "shows the wait list sections on the #{semester_name} semester page for UID #{uid}" do
-                        expect(sem_page_wait_list_sections).to eql(api_wait_list_sections)
-                        expect(sem_page_wait_list_sections.all? &:blank?).to be false
+                      it "shows the enrolled course grade options on the #{semester_name} semester page for UID #{uid}" do
+                        expect(semester_page_grade_options).to eql(api_enrolled_grade_options)
                       end
-                      it "shows the wait list positions on the #{semester_name} semester page for UID #{uid}" do
-                        expect(sem_page_wait_list_positions).to eql(api_wait_list_positions)
-                        expect(sem_page_wait_list_positions.all? &:blank?).to be false
+                      it "shows the enrolled course units on the #{semester_name} semester page for UID #{uid}" do
+                        expect(semester_page_units).to eql(api_enrolled_units)
                       end
-                      it "shows the wait list sizes on the #{semester_name} semester page for UID #{uid}" do
-                        expect(sem_page_wait_list_sizes).to eql(api_wait_list_sizes)
-                        expect(sem_page_wait_list_sizes.all? &:blank?).to be false
+                      it "shows the enrolled section labels on the #{semester_name} semester page for UID #{uid}" do
+                        expect(semester_page_sections.sort!).to eql(api_enrolled_section_labels.sort!)
                       end
-                    end
 
-                    # CLASS PAGES
+                      if enrolled_courses.empty?
+                        has_no_enrollment_msg = semester_page.no_enrollment_message?
+                        it "shows a 'no enrollment' message on the #{semester_name} semester page for UID #{uid}" do
+                          expect(has_no_enrollment_msg).to be true
+                        end
+                      end
 
-                    semester_courses.each do |course|
-                      begin
-                        api_course_code = academics_api_page.course_code(course)
-                        api_course_title = academics_api_page.course_title(course)
-                        api_course_instructors = academics_api_page.course_instructor_names(course)
-                        api_sections = academics_api_page.sections(course)
-                        api_section_labels = academics_api_page.section_labels(course)
-                        api_section_ccns = academics_api_page.section_ccns(course)
-                        api_section_units = academics_api_page.section_units(course)
-                        api_grade_options = academics_api_page.section_grade_options(course)
-                        api_section_schedules = academics_api_page.course_section_schedules(course)
+                      # WAIT LIST COURSES
 
-                        semester_page.click_class_link(driver, api_course_code)
-                        class_page = CalCentralPages::MyAcademicsClassPage.new(driver)
-                        class_page.class_info_heading_element.when_visible(WebDriverUtils.page_load_timeout)
+                      if wait_list_courses.any?
+                        api_wait_list_course_codes = academics_api_page.wait_list_course_codes(wait_list_courses)
+                        api_wait_list_course_titles = academics_api_page.wait_list_course_titles(wait_list_courses)
+                        api_wait_list_sections = academics_api_page.all_section_labels(wait_list_courses)
+                        api_wait_list_positions = academics_api_page.wait_list_positions(wait_list_courses)
+                        api_wait_list_sizes = academics_api_page.enrollment_limits(wait_list_courses)
 
-                        class_page_breadcrumb = class_page.class_breadcrumb
-                        class_page_course_title = class_page.course_title
-                        class_page_course_role = class_page.role
-                        class_page_section_labels = class_page.all_section_schedule_labels
-                        class_page_section_ccns = class_page.all_student_section_ccns
-                        class_page_section_units = class_page.all_section_units
-                        class_page_grade_options = class_page.all_section_grade_options
-                        class_page_section_schedules = class_page.all_section_schedules
-                        class_page_course_instructors = class_page.all_course_instructors(driver, api_section_labels)
+                        sem_page_wait_list_codes = semester_page.all_waitlist_course_codes
+                        sem_page_wait_list_titles = semester_page.all_waitlist_course_titles
+                        sem_page_wait_list_sections = semester_page.all_waitlist_sections
+                        sem_page_wait_list_positions = semester_page.all_waitlist_positions
+                        sem_page_wait_list_sizes = semester_page.all_waitlist_class_sizes
 
-                        it "shows #{api_course_code} in the class page breadcrumb for #{semester_name} for UID #{uid}" do
-                          expect(class_page_breadcrumb).to eql(api_course_code)
+                        it "shows the wait list course codes on the #{semester_name} semester page for UID #{uid}" do
+                          expect(sem_page_wait_list_codes).to eql(api_wait_list_course_codes)
+                          expect(sem_page_wait_list_codes.all? &:blank?).to be false
                         end
-                        it "shows the class title on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
-                          expect(class_page_course_title).to eql(api_course_title)
-                          expect(class_page_course_title.blank?).to be false
+                        it "shows the wait list course titles on the #{semester_name} semester page for UID #{uid}" do
+                          expect(sem_page_wait_list_titles).to eql(api_wait_list_course_titles)
+                          expect(sem_page_wait_list_titles.all? &:blank?).to be false
                         end
-                        it "shows the student role on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
-                          expect(class_page_course_role).to eql('Student')
+                        it "shows the wait list sections on the #{semester_name} semester page for UID #{uid}" do
+                          expect(sem_page_wait_list_sections).to eql(api_wait_list_sections)
+                          expect(sem_page_wait_list_sections.all? &:blank?).to be false
                         end
-                        if api_section_labels.length == api_section_schedules.length
-                          it "shows the enrolled section labels on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
-                            expect(class_page_section_labels).to eql(api_section_labels)
-                            expect(class_page_section_labels.all? &:blank?).to be false
-                          end
-                        elsif api_section_labels.length < api_section_schedules.length
-                          it "shows no duplicate enrolled section labels on #{semester_name} #{api_course_code} class page for UID #{uid}" do
-                            expect(class_page_section_labels.length).to be < class_page_section_schedules.length
-                            expect(class_page_section_labels).to eql(class_page_section_labels.uniq)
-                          end
-                        else
-                          it "shows no enrolled section labels without schedules on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
-                            expect(class_page_section_labels.length).to eql(class_page_section_schedules.length)
-                          end
+                        it "shows the wait list positions on the #{semester_name} semester page for UID #{uid}" do
+                          expect(sem_page_wait_list_positions).to eql(api_wait_list_positions)
+                          expect(sem_page_wait_list_positions.all? &:blank?).to be false
                         end
-                        it "shows the enrolled section CCNs on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
-                          expect(class_page_section_ccns).to eql(api_section_ccns)
-                          expect(class_page_section_ccns.all? &:blank?).to be false
+                        it "shows the wait list sizes on the #{semester_name} semester page for UID #{uid}" do
+                          expect(sem_page_wait_list_sizes).to eql(api_wait_list_sizes)
+                          expect(sem_page_wait_list_sizes.all? &:blank?).to be false
                         end
-                        it "shows the section units on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
-                          expect(class_page_section_units).to eql(api_section_units)
-                          expect(class_page_section_units.all? &:blank?).to be false
-                        end
-                        it "shows the section grade options on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
-                          expect(class_page_grade_options).to eql(api_grade_options)
-                          expect(class_page_grade_options.all? &:blank?).to be false
-                        end
-                        it "shows the section schedules on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
-                          expect(class_page_section_schedules).to eql(api_section_schedules)
-                        end
-                        it "shows the section instructors on the #{semester_name} #{api_course_code} class page for UID #{uid}" do
-                          expect(class_page_course_instructors).to eql(api_course_instructors)
-                        end
+                      end
 
-                        if academics_api_page.current_semester.include?(semester) || academics_api_page.future_semesters.include?(semester)
-                          api_sections.each do |section|
-                            i = api_sections.index(section)
-                            CSV.open(test_output, 'a+') do |user_info_csv|
-                              user_info_csv << [uid, semester_name, api_section_ccns[i], api_course_code, api_course_title, api_section_labels[i],
-                                                api_grade_options[i], api_section_units[i], academics_api_page.wait_list_position(section)]
+                      # CLASS PAGES
+
+                      # semester_courses.each do |course|
+                      semester_card_courses.each do |course|
+
+                        begin
+
+                          api_course_code = academics_api_page.course_code(course)
+                          api_course_title = academics_api_page.course_title(course)
+
+                          # Multiple primary sections in a course have one class page per primary section
+                          if academics_api_page.multiple_primaries?(course)
+                            academics_api_page.primary_sections(course).each do |prim_section|
+
+                              api_sections = academics_api_page.associated_sections(course, prim_section)
+                              api_section_labels = academics_api_page.section_labels(api_sections)
+                              api_section_ccns = academics_api_page.section_ccns(api_sections)
+                              api_section_instructors = academics_api_page.course_instructor_names(api_sections)
+                              api_section_units = academics_api_page.section_units(api_sections)
+                              api_section_schedules = academics_api_page.course_section_schedules(api_sections)
+                              api_grade_options = academics_api_page.section_grade_options(api_sections)
+
+                              class_page_url = academics_api_page.section_url(prim_section)
+                              semester_page.click_class_link(driver, class_page_url)
+                              class_page = CalCentralPages::MyAcademicsClassPage.new(driver)
+                              class_page.class_info_heading_element.when_visible(WebDriverUtils.page_load_timeout)
+
+                              class_page_breadcrumb = class_page.class_breadcrumb
+                              class_page_course_title = class_page.course_title
+                              class_page_course_role = class_page.role
+                              class_page_section_labels = class_page.all_section_schedule_labels
+                              class_page_section_ccns = class_page.all_student_section_ccns
+                              class_page_section_units = class_page.all_section_units
+                              class_page_grade_options = class_page.all_section_grade_options
+                              class_page_section_schedules = class_page.all_section_schedules
+                              class_page_course_instructors = class_page.all_section_instructors(driver, api_section_labels)
+
+                              it "shows #{api_course_code} in the class page breadcrumb for #{semester_name} for UID #{uid}" do
+                                expect(class_page_breadcrumb).to eql(api_course_code)
+                              end
+                              it "shows the class title on the #{semester_name} #{api_course_code} multi-primary class page for UID #{uid}" do
+                                expect(class_page_course_title).to eql(api_course_title)
+                                expect(class_page_course_title.blank?).to be false
+                              end
+                              it "shows the student role on the #{semester_name} #{api_course_code} multi-primary class page for UID #{uid}" do
+                                expect(class_page_course_role).to eql('Student')
+                              end
+                              if api_section_labels.length == api_section_schedules.length
+                                it "shows the enrolled section labels on the #{semester_name} #{api_course_code} multi-primary class page for UID #{uid}" do
+                                  expect(class_page_section_labels).to eql(api_section_labels)
+                                  expect(class_page_section_labels.all? &:blank?).to be false
+                                end
+                              elsif api_section_labels.length < api_section_schedules.length
+                                it "shows no duplicate enrolled section labels on #{semester_name} #{api_course_code} multi-primary class page for UID #{uid}" do
+                                  expect(class_page_section_labels.length).to be < class_page_section_schedules.length
+                                  expect(class_page_section_labels).to eql(class_page_section_labels.uniq)
+                                end
+                              else
+                                it "shows no enrolled section labels without schedules on the #{semester_name} #{api_course_code} multi-primary class page for UID #{uid}" do
+                                  expect(class_page_section_labels.length).to eql(class_page_section_schedules.length)
+                                end
+                              end
+                              it "shows the section instructors on the #{semester_name} #{api_course_code} multi-primary class page for UID #{uid}" do
+                                expect(class_page_course_instructors).to eql(api_section_instructors)
+                              end
+                              it "shows the enrolled section CCNs on the #{semester_name} #{api_course_code} multi-primary class page for UID #{uid}" do
+                                expect(class_page_section_ccns).to eql(api_section_ccns)
+                                expect(class_page_section_ccns.length).to eql(api_section_ccns.length)
+                                expect(class_page_section_ccns.all? &:blank?).to be false
+                              end
+                              it "shows the section units on the #{semester_name} #{api_course_code} multi-primary class page for UID #{uid}" do
+                                expect(class_page_section_units).to eql(api_section_units)
+                                expect(class_page_section_units.all? &:blank?).to be false
+                              end
+                              it "shows the section grade options on the #{semester_name} #{api_course_code} multi-primary class page for UID #{uid}" do
+                                expect(class_page_grade_options).to eql(api_grade_options)
+                                expect(class_page_grade_options.all? &:blank?).to be false
+                              end
+                              it "shows the section schedules on the #{semester_name} #{api_course_code} multi-primary class page for UID #{uid}" do
+                                expect(class_page_section_schedules).to eql(api_section_schedules)
+                              end
+
+                              if academics_api_page.current_semester.include?(semester) || academics_api_page.future_semesters.include?(semester)
+                                api_sections.each do |api_section|
+                                  i = api_sections.index(api_section)
+                                  CSV.open(test_output, 'a+') do |user_info_csv|
+                                    user_info_csv << [uid, semester_name, api_section_ccns[i], api_course_code, api_course_title, api_section_labels[i],
+                                                      api_grade_options[i], api_section_units[i], academics_api_page.wait_list_position(api_section)]
+                                  end
+                                end
+                              end
+
+                              class_page.back
                             end
+
+                          # Single primary section in a course has a single class page
+                          else
+                            api_sections = academics_api_page.sections(course)
+                            api_section_labels = academics_api_page.section_labels(api_sections)
+                            api_section_ccns = academics_api_page.section_ccns(api_sections)
+                            api_section_instructors = academics_api_page.course_instructor_names(api_sections)
+                            api_section_units = academics_api_page.section_units(api_sections)
+                            api_section_schedules = academics_api_page.course_section_schedules(api_sections)
+                            api_grade_options = academics_api_page.section_grade_options(api_sections)
+
+                            class_page_url = academics_api_page.course_url(course)
+                            semester_page.click_class_link(driver, class_page_url)
+                            class_page = CalCentralPages::MyAcademicsClassPage.new(driver)
+                            class_page.class_info_heading_element.when_visible(WebDriverUtils.page_load_timeout)
+
+                            class_page_breadcrumb = class_page.class_breadcrumb
+                            class_page_course_title = class_page.course_title
+                            class_page_course_role = class_page.role
+                            class_page_section_labels = class_page.all_section_schedule_labels
+                            class_page_section_ccns = class_page.all_student_section_ccns
+                            class_page_section_units = class_page.all_section_units
+                            class_page_grade_options = class_page.all_section_grade_options
+                            class_page_section_schedules = class_page.all_section_schedules
+                            class_page_course_instructors = class_page.all_section_instructors(driver, api_section_labels)
+
+                            it "shows #{api_course_code} in the class page breadcrumb for #{semester_name} for UID #{uid}" do
+                              expect(class_page_breadcrumb).to eql(api_course_code)
+                            end
+                            it "shows the class title on the #{semester_name} #{api_course_code} single primary class page for UID #{uid}" do
+                              expect(class_page_course_title).to eql(api_course_title)
+                              expect(class_page_course_title.blank?).to be false
+                            end
+                            it "shows the student role on the #{semester_name} #{api_course_code} single primary class page for UID #{uid}" do
+                              expect(class_page_course_role).to eql('Student')
+                            end
+                            if api_section_labels.length == api_section_schedules.length
+                              it "shows the enrolled section labels on the #{semester_name} #{api_course_code} single primary class page for UID #{uid}" do
+                                expect(class_page_section_labels).to eql(api_section_labels)
+                                expect(class_page_section_labels.all? &:blank?).to be false
+                              end
+                            elsif api_section_labels.length < api_section_schedules.length
+                              it "shows no duplicate enrolled section labels on #{semester_name} #{api_course_code} single primary class page for UID #{uid}" do
+                                expect(class_page_section_labels.length).to be < class_page_section_schedules.length
+                                expect(class_page_section_labels).to eql(class_page_section_labels.uniq)
+                              end
+                            else
+                              it "shows no enrolled section labels without schedules on the #{semester_name} #{api_course_code} single primary class page for UID #{uid}" do
+                                expect(class_page_section_labels.length).to eql(class_page_section_schedules.length)
+                              end
+                            end
+                            it "shows the section instructors on the #{semester_name} #{api_course_code} single primary class page for UID #{uid}" do
+                              expect(class_page_course_instructors).to eql(api_section_instructors)
+                            end
+                            it "shows the enrolled section CCNs on the #{semester_name} #{api_course_code} single primary class page for UID #{uid}" do
+                              expect(class_page_section_ccns).to eql(api_section_ccns)
+                              expect(class_page_section_ccns.length).to eql(api_section_ccns.length)
+                              expect(class_page_section_ccns.all? &:blank?).to be false
+                            end
+                            it "shows the section units on the #{semester_name} #{api_course_code} single primary class page for UID #{uid}" do
+                              expect(class_page_section_units).to eql(api_section_units)
+                              expect(class_page_section_units.all? &:blank?).to be false
+                            end
+                            it "shows the section grade options on the #{semester_name} #{api_course_code} single primary class page for UID #{uid}" do
+                              expect(class_page_grade_options).to eql(api_grade_options)
+                              expect(class_page_grade_options.all? &:blank?).to be false
+                            end
+                            it "shows the section schedules on the #{semester_name} #{api_course_code} single primary class page for UID #{uid}" do
+                              expect(class_page_section_schedules).to eql(api_section_schedules)
+                            end
+
+                            if academics_api_page.current_semester.include?(semester) || academics_api_page.future_semesters.include?(semester)
+                              api_sections.each do |api_section|
+                                i = api_sections.index(api_section)
+                                CSV.open(test_output, 'a+') do |user_info_csv|
+                                  user_info_csv << [uid, semester_name, api_section_ccns[i], api_course_code, api_course_title, api_section_labels[i],
+                                                    api_grade_options[i], api_section_units[i], academics_api_page.wait_list_position(api_section)]
+                                end
+                              end
+                            end
+
+                            class_page.back
+
                           end
                         end
+                      end
 
-                        class_page.back
+                      semester_page.back
+
+                    elsif academics_api_page.current_semester.include?(semester) || academics_api_page.future_semesters.include?(semester)
+                      logger.info "Found non-official enrollments for #{semester_name}"
+                      semester_card_courses.each do |course|
+                        i = semester_card_courses.index(course)
+                        CSV.open(test_output, 'a+') << [uid, semester_name, nil, api_course_codes[i], api_course_titles[i], nil, nil, api_units[i], nil]
                       end
                     end
-
-                    semester_page.back
                   end
                 end
               else
@@ -288,15 +412,14 @@ describe 'My Academics enrollments', :testui => true do
                 end
               end
             end
-
           rescue => e
             logger.error e.message + "\n" + e.backtrace.join("\n ")
           end
         end
+      end
 
-        it 'has enrollment information for at least one of the test UIDs' do
-          expect(testable_users.length).to be > 0
-        end
+      it 'has enrollment information for at least one of the test UIDs' do
+        expect(testable_users.length).to be > 0
       end
 
     rescue => e

--- a/spec/ui_selenium/pages/my_academics_class_page.rb
+++ b/spec/ui_selenium/pages/my_academics_class_page.rb
@@ -14,15 +14,16 @@ module CalCentralPages
     include ClassLogger
 
     span(:class_breadcrumb, :xpath => '//h1/span[@data-ng-bind="selectedCourse.course_code"]')
+    span(:section_breadcrumb, :xpath => '//h1/span[@data-ng-bind="selectedSection"]')
 
     # CLASS INFO
-    h1(:class_info_heading, :xpath => '//h2[text()="Class information"]')
+    h2(:class_info_heading, :xpath => '//h2[text()="Class Information"]')
     div(:course_title, :xpath => '//h3[text()="Class Title"]/following-sibling::div[@data-ng-bind="selectedCourse.title"]')
     div(:role, :xpath => '//h3[text()="My Role"]/following-sibling::div[@data-ng-bind="selectedCourse.role"]')
     elements(:student_section_label, :td, :xpath => '//h3[text()="My Enrollment"]/following-sibling::div[@data-ng-if="selectedCourse.sections.length && !isInstructorOrGsi"]//td[@data-ng-bind="sec.section_label"]')
     elements(:student_section_ccn, :td, :xpath => '//h3[text()="My Enrollment"]/following-sibling::div[@data-ng-if="selectedCourse.sections.length && !isInstructorOrGsi"]//td[@data-ng-bind="sec.ccn"]')
-    elements(:section_units, :td, :xpath => '//h3[text()="Class Info"]/following-sibling::div[@data-ng-hide="isInstructorOrGsi"]//td[@data-ng-if="section.units"]')
-    elements(:section_grade_option, :td, :xpath => '//h4[text()="Course Offering"]/following-sibling::div[@data-ng-hide="isInstructorOrGsi"]//td[@data-ng-bind="section.gradeOption"]')
+    elements(:section_units, :td, :xpath => '//h3[text()="Class Info"]/following-sibling::div[@data-ng-if="!isInstructorOrGsi"]//td[@data-ng-if="section.units"]')
+    elements(:section_grade_option, :td, :xpath => '//h4[text()="Course Offering"]/following-sibling::div[@data-ng-if="!isInstructorOrGsi"]//td[@data-ng-bind="section.gradeOption"]')
     elements(:section_schedule_label, :div, :xpath => '//div[@data-ng-repeat="section in selectedCourse.sections"]/div[@data-ng-bind="section.section_label"]')
     elements(:section_schedule, :div, :xpath => '//h4[text()="Section Schedules"]/following-sibling::div[@data-ng-repeat="section in selectedCourse.sections"]//div[@data-ng-repeat="schedule in section.schedules"]')
     elements(:section_instructors_heading, :h3, :xpath => '//h3[@data-ng-bind="section.section_label"]')
@@ -81,10 +82,12 @@ module CalCentralPages
       schedules
     end
 
-    def all_section_instructors(driver, section_label)
+    def all_section_instructors(driver, section_labels)
       instructors = []
-      instructor_elements = driver.find_elements(:xpath => "//h3[text()='#{section_label}']/following-sibling::ul/li[@data-ng-repeat='instructor in section.instructors']/a")
-      instructor_elements.each { |instructor| instructors.push((instructor.text).gsub("\n- opens in new window", '')) }
+      section_labels.each do |section|
+        instructor_elements = driver.find_elements(:xpath => "//h3[text()='#{section}']/following-sibling::ul//a[@data-ng-bind='instructor.name']")
+        instructor_elements.each { |instructor| instructors.push((instructor.text).gsub("\n- opens in new window", '')) }
+      end
       instructors
     end
 

--- a/spec/ui_selenium/pages/my_academics_enrollments_card.rb
+++ b/spec/ui_selenium/pages/my_academics_enrollments_card.rb
@@ -18,6 +18,7 @@ module CalCentralPages
     elements(:enrolled_grade_options, :td, :xpath => '//tbody[@data-ng-repeat="course in enrolledCourses"]//td[@data-ng-bind="course.gradeOption"]')
     elements(:enrolled_units, :td, :xpath => '//tbody[@data-ng-repeat="course in enrolledCourses"]//td[@data-ng-bind="course.units | number:1"]')
     elements(:enrolled_sections, :span, :xpath => '//tbody[@data-ng-repeat="course in enrolledCourses"]//div[@data-ng-repeat="section in course.sections"]/span[@data-ng-bind="section.section_label"]')
+    div(:no_enrollment_message, :xpath => '//div[contains(text(),"You are not currently enrolled in any courses")]')
     elements(:waitlist_course_codes, :link, :xpath => '//h3[text()="Wait Lists"]/following-sibling::div//a[@data-ng-bind="course.course_code"]')
     elements(:waitlist_sections, :span, :xpath => '//h3[text()="Wait Lists"]/following-sibling::div//span[@data-ng-bind="section.section_label"]')
     elements(:waitlist_course_titles, :td, :xpath => '//h3[text()="Wait Lists"]/following-sibling::div//td[@data-ng-bind="course.title"]')

--- a/spec/ui_selenium/pages/my_academics_page.rb
+++ b/spec/ui_selenium/pages/my_academics_page.rb
@@ -48,10 +48,10 @@ module CalCentralPages
       driver.find_element(:link_text => semester_name).click
     end
 
-    def click_class_link(driver, course_code)
+    def click_class_link(driver, url)
       wait = Selenium::WebDriver::Wait.new(:timeout => WebDriverUtils.page_load_timeout)
-      wait.until { driver.find_element(:link_text => course_code) }
-      driver.find_element(:link_text => course_code).click
+      wait.until { driver.find_element(:xpath => "//a[@href='#{url}']") }
+      driver.find_element(:xpath => "//a[@href='#{url}']").click
     end
   end
 end

--- a/spec/ui_selenium/pages/my_academics_semesters_card.rb
+++ b/spec/ui_selenium/pages/my_academics_semesters_card.rb
@@ -14,14 +14,19 @@ module CalCentralPages
     include ClassLogger
 
     elements(:semester_links, :link, :xpath => '//h2[text()="Semesters"]/../following-sibling::div//a[@data-ng-bind="semester.name"]')
+    elements(:no_enrollment_semester_h3, :h3, :xpath => '//h2[text()="Semesters"]/../following-sibling::div//h3[@data-ng-if="!semester.hasEnrollmentData"]')
     link(:order_transcripts_link, :xpath => '//h2[text()="Semesters"]/following-sibling::a[contains(.,"Order Transcripts")]')
     button(:show_more, :xpath => '//button[@data-ng-if="pastSemestersCount > 1"]/span[text()="Show More"]')
     button(:show_less, :xpath => '//button[@data-ng-if="pastSemestersCount > 1"]/span[text()="Show Less"]')
 
+    elements(:addl_credit_title, :td, :xpath => '//td[@data-ng-bind="additionalCredit.title"]')
+    elements(:addl_credit_units, :td, :xpath => '//td[@data-ng-bind="additionalCredit.units | number:1"]')
+
     def student_terms_visible?(term_names)
-      links = []
-      semester_links_elements.each { |link| links.push(link.text) }
-      if links.sort == term_names.sort
+      terms_in_ui = []
+      semester_links_elements.each { |link| terms_in_ui.push(link.text) }
+      no_enrollment_semester_h3_elements.each { |heading| terms_in_ui.push(heading.text) }
+      if terms_in_ui.sort == term_names.sort
         true
       else
         false
@@ -30,8 +35,10 @@ module CalCentralPages
 
     def prim_sec_course_codes(driver, semester_name)
       codes = []
-      code_elements = driver.find_elements(:xpath => "//h3[contains(.,'#{semester_name}')]/following-sibling::table//a[@data-ng-bind='class.course_code']")
-      code_elements.each { |element| codes.push(element.text) }
+      course_code_link_elements = driver.find_elements(:xpath => "//h3[contains(.,'#{semester_name}')]/following-sibling::table//a")
+      course_code_link_elements.each { |element| codes.push(element.text) }
+      course_code_no_link_elements = driver.find_elements(:xpath => "//h3[contains(.,'#{semester_name}')]/following-sibling::table//td[@data-ng-if='!class.url']")
+      course_code_no_link_elements.each { |element| codes.push(element.text) }
       codes
     end
 
@@ -54,6 +61,18 @@ module CalCentralPages
       grades_elements = driver.find_elements(:xpath => "//h3[contains(.,'#{semester_name}')]/following-sibling::table//td[4]")
       grades_elements.each { |element| grades.push(element.text) }
       grades
+    end
+
+    def addl_credit_titles
+      titles = []
+      addl_credit_title_elements.each { |title| titles.push(title.text) }
+      titles
+    end
+
+    def addl_credit_units
+      units = []
+      addl_credit_units_elements.each { |unit| units.push(unit.text) }
+      units
     end
   end
 end


### PR DESCRIPTION
Test updated to include coverage for the following:
* Multiple primary sections:
  * On semester cards, appending section codes to course codes under the right circumstances
  * Offering multiple class pages for multiple primary sections, also under the right circumstances
* EAP and additional credit
  * Verifying the content of cards with transcript data but no enrollment data

The test changes have been verified with the full set of ~180 test user accounts.