### PR TITLE
CLC-5253: misc fixes for Selenium tests

### DIFF
--- a/spec/ui_selenium/my_academics_data_advising_appts_spec.rb
+++ b/spec/ui_selenium/my_academics_data_advising_appts_spec.rb
@@ -19,7 +19,7 @@ describe 'My Academics L&S Advising card', :testui => true do
     include ClassLogger
 
     begin
-      driver = WebDriverUtils.driver
+      driver = WebDriverUtils.launch_browser
       test_users = UserUtils.load_test_users
       testable_users = []
       test_output = UserUtils.initialize_output_csv(self)
@@ -223,8 +223,7 @@ describe 'My Academics L&S Advising card', :testui => true do
     rescue => e
       logger.error e.message + "\n" + e.backtrace.join("\n")
     ensure
-      logger.info 'Quitting the browser'
-      driver.quit
+      WebDriverUtils.quit_browser(driver)
     end
   end
 end

--- a/spec/ui_selenium/my_academics_data_enrollment_spec.rb
+++ b/spec/ui_selenium/my_academics_data_enrollment_spec.rb
@@ -22,7 +22,7 @@ describe 'My Academics enrollments', :testui => true do
 
     begin
 
-      driver = WebDriverUtils.driver
+      driver = WebDriverUtils.launch_browser
 
       test_users = UserUtils.load_test_users
       test_output = UserUtils.initialize_output_csv(self)
@@ -424,8 +424,7 @@ describe 'My Academics enrollments', :testui => true do
     rescue => e
       logger.error e.message + "\n" + e.backtrace.join("\n ")
     ensure
-      logger.info('Quitting the browser')
-      driver.quit
+      WebDriverUtils.quit_browser(driver)
     end
   end
 end

--- a/spec/ui_selenium/my_academics_data_final_exams_spec.rb
+++ b/spec/ui_selenium/my_academics_data_final_exams_spec.rb
@@ -19,7 +19,7 @@ describe 'My Academics Final Exams card', :testui => true do
     include ClassLogger
 
     begin
-      driver = WebDriverUtils.driver
+      driver = WebDriverUtils.launch_browser
       test_users = UserUtils.load_test_users
       testable_users = []
       test_output = UserUtils.initialize_output_csv(self)
@@ -132,8 +132,7 @@ describe 'My Academics Final Exams card', :testui => true do
     rescue => e
       logger.error e.message + "\n" + e.backtrace.join("\n")
     ensure
-      logger.info 'Quitting the browser'
-      driver.quit
+      WebDriverUtils.quit_browser(driver)
     end
   end
 end

--- a/spec/ui_selenium/my_academics_data_status_blocks_spec.rb
+++ b/spec/ui_selenium/my_academics_data_status_blocks_spec.rb
@@ -19,7 +19,7 @@ describe 'My Academics Status and Blocks', :testui => true do
     include ClassLogger
 
     begin
-      driver = WebDriverUtils.driver
+      driver = WebDriverUtils.launch_browser
       test_output = UserUtils.initialize_output_csv(self)
       test_users = UserUtils.load_test_users
 
@@ -262,8 +262,7 @@ describe 'My Academics Status and Blocks', :testui => true do
     rescue => e
       logger.error e.message + "\n" + e.backtrace.join("\n ")
     ensure
-      logger.info('Quitting the browser')
-      driver.quit
+      WebDriverUtils.quit_browser(driver)
     end
   end
 end

--- a/spec/ui_selenium/my_academics_data_telebears_spec.rb
+++ b/spec/ui_selenium/my_academics_data_telebears_spec.rb
@@ -17,7 +17,7 @@ describe 'My Academics Tele-BEARS card', :testui => true do
     include ClassLogger
 
     begin
-      driver = WebDriverUtils.driver
+      driver = WebDriverUtils.launch_browser
       test_users = UserUtils.load_test_users
       testable_users = []
       test_output = UserUtils.initialize_output_csv(self)
@@ -135,8 +135,7 @@ describe 'My Academics Tele-BEARS card', :testui => true do
     rescue => e
       logger.error e.message + "\n" + e.backtrace.join("\n")
     ensure
-      logger.info 'Quitting the browser'
-      driver.quit
+      WebDriverUtils.quit_browser(driver)
     end
   end
 end

--- a/spec/ui_selenium/my_academics_data_webcasts_spec.rb
+++ b/spec/ui_selenium/my_academics_data_webcasts_spec.rb
@@ -17,7 +17,7 @@ describe 'My Academics webcasts card', :testui => true do
 
     begin
 
-      driver = WebDriverUtils.driver
+      driver = WebDriverUtils.launch_browser
 
       test_users = UserUtils.load_test_users
       testable_users = []
@@ -137,8 +137,7 @@ describe 'My Academics webcasts card', :testui => true do
     rescue => e
       logger.error e.message + "\n" + e.backtrace.join("\n ")
     ensure
-      logger.info('Quitting the browser')
-      driver.quit
+      WebDriverUtils.quit_browser(driver)
     end
   end
 end

--- a/spec/ui_selenium/my_dashboard_google_live_updates_spec.rb
+++ b/spec/ui_selenium/my_dashboard_google_live_updates_spec.rb
@@ -21,11 +21,11 @@ describe 'My Dashboard bConnected live updates', :testui => true do
     id = today.to_i.to_s
 
     before(:all) do
-      @driver = WebDriverUtils.driver
+      @driver = WebDriverUtils.launch_browser
     end
 
     after(:all) do
-      @driver.quit
+      WebDriverUtils.quit_browser(@driver)
     end
 
     before(:context) do

--- a/spec/ui_selenium/my_dashboard_google_tasks_spec.rb
+++ b/spec/ui_selenium/my_dashboard_google_tasks_spec.rb
@@ -21,11 +21,11 @@ describe 'The My Dashboard task manager', :testui => true do
     wait_for_task = Selenium::WebDriver::Wait.new(:timeout => WebDriverUtils.google_task_timeout)
 
     before(:all) do
-      @driver = WebDriverUtils.driver
+      @driver = WebDriverUtils.launch_browser
     end
 
     after(:all) do
-      @driver.quit
+      WebDriverUtils.quit_browser(@driver)
     end
 
     before(:context) do

--- a/spec/ui_selenium/my_dashboard_google_up_next_spec.rb
+++ b/spec/ui_selenium/my_dashboard_google_up_next_spec.rb
@@ -21,11 +21,11 @@ describe 'My Dashboard Up Next card', :testui => true do
     id = today.to_i.to_s
 
     before(:all) do
-      @driver = WebDriverUtils.driver
+      @driver = WebDriverUtils.launch_browser
     end
 
     after(:all) do
-      @driver.quit
+      WebDriverUtils.quit_browser(@driver)
     end
 
     before(:context) do

--- a/spec/ui_selenium/my_finances_data_acct_summary_spec.rb
+++ b/spec/ui_selenium/my_finances_data_acct_summary_spec.rb
@@ -19,7 +19,7 @@ describe 'My Finances Billing Summary', :testui => true do
     include ClassLogger
 
     begin
-      driver = WebDriverUtils.driver
+      driver = WebDriverUtils.launch_browser
       test_output = UserUtils.initialize_output_csv(self)
       test_users = UserUtils.load_test_users
       testable_users = []
@@ -205,8 +205,7 @@ describe 'My Finances Billing Summary', :testui => true do
     rescue => e
       logger.error e.message + "\n" + e.backtrace.join("\n ")
     ensure
-      logger.info('Quitting the browser')
-      driver.quit
+      WebDriverUtils.quit_browser(driver)
     end
   end
 end

--- a/spec/ui_selenium/my_finances_data_cal1card_spec.rb
+++ b/spec/ui_selenium/my_finances_data_cal1card_spec.rb
@@ -19,7 +19,7 @@ describe 'My Finances Cal1Card', :testui => true do
     include ClassLogger
 
     begin
-      driver = WebDriverUtils.driver
+      driver = WebDriverUtils.launch_browser
       test_users = UserUtils.load_test_users
       testable_users = []
       test_output = UserUtils.initialize_output_csv(self)
@@ -156,8 +156,7 @@ describe 'My Finances Cal1Card', :testui => true do
     rescue => e
       logger.error e.message + "\n" + e.backtrace.join("\n ")
     ensure
-      logger.info('Quitting the browser')
-      driver.quit
+      WebDriverUtils.quit_browser(driver)
     end
   end
 end

--- a/spec/ui_selenium/my_finances_data_finaid_spec.rb
+++ b/spec/ui_selenium/my_finances_data_finaid_spec.rb
@@ -19,7 +19,7 @@ describe 'My Finances financial aid messages', :testui => true do
     include ClassLogger
 
     begin
-      driver = WebDriverUtils.driver
+      driver = WebDriverUtils.launch_browser
       test_output = UserUtils.initialize_output_csv(self)
       test_users = UserUtils.load_test_users
 
@@ -183,8 +183,7 @@ describe 'My Finances financial aid messages', :testui => true do
     rescue => e
       logger.error e.message + "\n" + e.backtrace.join("\n ")
     ensure
-      logger.info('Quitting the browser')
-      driver.quit
+      WebDriverUtils.quit_browser(driver)
     end
   end
 end

--- a/spec/ui_selenium/my_finances_data_transaction_detail_spec.rb
+++ b/spec/ui_selenium/my_finances_data_transaction_detail_spec.rb
@@ -18,7 +18,7 @@ describe 'My Finances activity details', :testui => true do
     include ClassLogger
 
     begin
-      driver = WebDriverUtils.driver
+      driver = WebDriverUtils.launch_browser
       test_output = UserUtils.initialize_output_csv(self)
       test_users = UserUtils.load_test_users
 
@@ -561,8 +561,7 @@ describe 'My Finances activity details', :testui => true do
     rescue => e
       logger.error e.message + "\n" + e.backtrace.join("\n ")
     ensure
-      logger.info('Quitting the browser')
-      driver.quit
+      WebDriverUtils.quit_browser(driver)
     end
   end
 end

--- a/spec/ui_selenium/my_finances_ui_details_page_spec.rb
+++ b/spec/ui_selenium/my_finances_ui_details_page_spec.rb
@@ -20,11 +20,11 @@ describe 'My Finances details page', :testui => true do
     wait = Selenium::WebDriver::Wait.new(:timeout => WebDriverUtils.page_event_timeout)
 
     before(:all) do
-      @driver = WebDriverUtils.driver
+      @driver = WebDriverUtils.launch_browser
     end
 
     after(:all) do
-      @driver.quit
+      WebDriverUtils.quit_browser(@driver)
     end
 
     before(:context) do

--- a/spec/ui_selenium/my_finances_ui_landing_page_spec.rb
+++ b/spec/ui_selenium/my_finances_ui_landing_page_spec.rb
@@ -17,11 +17,11 @@ describe 'My Finances landing page', :testui => true do
   if ENV["UI_TEST"] && Settings.ui_selenium.layer != 'production'
 
     before(:all) do
-      @driver = WebDriverUtils.driver
+      @driver = WebDriverUtils.launch_browser
     end
 
     after(:all) do
-      @driver.quit
+      WebDriverUtils.quit_browser(@driver)
     end
 
     before(:context) do

--- a/spec/ui_selenium/pages/my_finances_details_page.rb
+++ b/spec/ui_selenium/pages/my_finances_details_page.rb
@@ -35,7 +35,7 @@ module CalCentralPages
       image(:sort_ascending, :xpath => '//i[@class="fa fa-chevron-up"]')
 
       table(:transaction_table, :xpath => '//div[@class="cc-table cc-table-sortable cc-page-myfinances-table cc-table-finances"]/table')
-      link(:transaction_table_row_one, :xpath => '//div[@class="cc-table cc-table-sortable cc-page-myfinances-table"]/table/tbody')
+      link(:transaction_table_row_one, :xpath => '//div[@class="cc-table cc-table-sortable cc-page-myfinances-table cc-table-finances"]/table/tbody')
 
       span(:trans_date, :xpath => '//span[@data-ng-bind="item.transDate | date:\'MM/dd/yy\'"]')
       div(:trans_desc, :xpath => '//div[@data-ng-bind="item.transDesc"]')

--- a/spec/ui_selenium/user_authentication_spec.rb
+++ b/spec/ui_selenium/user_authentication_spec.rb
@@ -22,11 +22,11 @@ describe 'User authentication', :testui => true do
   if ENV["UI_TEST"]
 
     before(:each) do
-      @driver = WebDriverUtils.driver
+      @driver = WebDriverUtils.launch_browser
     end
 
     after(:each) do
-      @driver.quit
+      WebDriverUtils.quit_browser(@driver)
     end
 
     before(:example) do

--- a/spec/ui_selenium/user_authorizations_spec.rb
+++ b/spec/ui_selenium/user_authorizations_spec.rb
@@ -14,11 +14,11 @@ describe 'User authorization', :testui => true do
   if ENV["UI_TEST"]
 
     before(:each) do
-      @driver = WebDriverUtils.driver
+      @driver = WebDriverUtils.launch_browser
     end
 
     after(:each) do
-      @driver.quit
+      WebDriverUtils.quit_browser(@driver)
     end
 
     describe 'View-as' do

--- a/spec/ui_selenium/user_google_connection_spec.rb
+++ b/spec/ui_selenium/user_google_connection_spec.rb
@@ -15,11 +15,11 @@ describe 'Google apps', :testui => true do
   if ENV["UI_TEST"]
 
     before(:each) do
-      @driver = WebDriverUtils.driver
+      @driver = WebDriverUtils.launch_browser
     end
 
     after(:each) do
-      @driver.quit
+      WebDriverUtils.quit_browser(@driver)
     end
 
     context 'as any user' do

--- a/spec/ui_selenium/util/web_driver_utils.rb
+++ b/spec/ui_selenium/util/web_driver_utils.rb
@@ -4,7 +4,7 @@ class WebDriverUtils
 
   include ClassLogger
 
-  def self.driver
+  def self.launch_browser
     if Settings.ui_selenium.webDriver == 'firefox'
       Rails.logger.info('Browser is Firefox')
       Selenium::WebDriver.for :firefox
@@ -18,6 +18,14 @@ class WebDriverUtils
   rescue => e
     Rails.logger.error('Unable to initialize the designated WebDriver')
     Rails.logger.error e.message + "\n" + e.backtrace.join("\n")
+  end
+
+  def self.quit_browser(driver)
+    logger.info 'Quitting the browser'
+    # If the browser did not start successfully, the quit method will fail.
+    driver.quit rescue NoMethodError
+    # Pause after quitting the browser to make sure it shuts down completely before the next test relaunches it
+    sleep(3)
   end
 
   def self.base_url


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5253

Includes the following changes:
* New util method for quitting the browser, which tolerates errors:  this is to overcome situations where the browser hasn't instantiated in the first place.  The subsequent NoMethodError kills the remaining test suite.  Also renamed the command to launch the browser, to better distinguish it from the quit method.
* A hardcoded pause after quitting the browser: this is another experiment to avoid the RuntimeError occasionally encountered when launching the browser.  When one test quits and another launches, the browser instances might be tripping over one another.  In any case, these sporadic errors cause regular build failures.
* Fixed a broken XPath for the finances details test.
