### PR TITLE
CLC-5134, add Canvas API call to show Webcast tab when appropriate

### DIFF
--- a/app/models/canvas/external_tools.rb
+++ b/app/models/canvas/external_tools.rb
@@ -77,7 +77,7 @@ module Canvas
     end
 
     def show_course_site_tab(tab_id)
-      update_course_site_tab_hidden(tab_id, true)
+      update_course_site_tab_hidden(tab_id, false)
     end
 
     def create_external_tool_by_xml(tool_name, xml_string)

--- a/app/models/canvas/external_tools.rb
+++ b/app/models/canvas/external_tools.rb
@@ -65,6 +65,21 @@ module Canvas
       })
     end
 
+    def find_canvas_course_tab(tool_id)
+      response = request_uncached("#{@api_root}/tabs", '_find_canvas_course_tab', { method: :get })
+      all_tabs = response && safe_json(response.body)
+      matching_tab = all_tabs && all_tabs.select { |tab| tab['id'].ends_with? "_#{tool_id}" }
+      matching_tab ? matching_tab.first : nil
+    end
+
+    def hide_course_site_tab(tab_id)
+      update_course_site_tab_hidden(tab_id, true)
+    end
+
+    def show_course_site_tab(tab_id)
+      update_course_site_tab_hidden(tab_id, true)
+    end
+
     def create_external_tool_by_xml(tool_name, xml_string)
       parameters = {
           'name' => tool_name,
@@ -105,6 +120,19 @@ module Canvas
           body: parameters
         })
       response ? safe_json(response.body) : nil
+    end
+
+    private
+
+    def update_course_site_tab_hidden(tab_id, set_to_hidden)
+      url = "#{@api_root}/tabs/#{tab_id}?hidden=#{set_to_hidden}"
+      response = request_uncached(url, '_hide_course_site_tab', { method: :put })
+      tab = response && safe_json(response.body)
+      is_tab_now_hidden = tab && tab['hidden']
+      unless is_tab_now_hidden == set_to_hidden
+        raise Errors::ProxyError.new("Failed to set hidden=#{set_to_hidden} on Canvas course site nav tab", response: response, url: url, uid: @uid)
+      end
+      tab
     end
 
   end

--- a/app/models/canvas/webcast_lti_refresh.rb
+++ b/app/models/canvas/webcast_lti_refresh.rb
@@ -31,8 +31,8 @@ module Canvas
     def update_hidden_on_webcast_tab(show_tab, tab)
       modified_tab = nil
       if tab
-        is_tab_showing = tab.has_key?('hidden') && tab['hidden']
-        if is_tab_showing == show_tab
+        is_tab_showing = !tab.has_key?('hidden') || !tab['hidden']
+        if show_tab == is_tab_showing
           Rails.logger.warn "Webcast tab on course site #{@canvas_course_id} is already hidden=#{show_tab}. Do nothing."
         else
           Rails.logger.info "Set hidden=#{show_tab} on Webcast tab in course site #{@canvas_course_id}"
@@ -57,8 +57,7 @@ module Canvas
     end
 
     def is_eligible_for_webcast?(ccn_list)
-      # TODO: implement this!!
-      true
+      Webcast::Rooms.new(@options).any_in_webcast_enabled_room? ccn_list
     end
 
   end

--- a/app/models/canvas/webcast_lti_refresh.rb
+++ b/app/models/canvas/webcast_lti_refresh.rb
@@ -3,34 +3,68 @@ module Canvas
 
     def initialize(options = {})
       @options = options
-      @course_id = options[:course_id]
+      @external_tools = Canvas::ExternalTools.new @options
+      @canvas_course_id = options[:canvas_course_id]
       @canvas_webcast_tool_id = options[:canvas_webcast_tool_id]
     end
 
     def refresh_canvas
-      course_site_log_entry = nil
-      sections = Canvas::CourseSections.new(@options).official_section_identifiers
+      is_webcast_sign_up_active = Webcast::SystemStatus.new(@options).get['is_sign_up_active']
+      # TODO: When this class operates on a list of canvas_course_site ids then tab_modified should become a hash
+      tab_after_modification = nil
+      sections = Canvas::CourseSections.new(@options.merge(course_id: @canvas_course_id)).official_section_identifiers
       if sections.any?
         term_yr = sections.first[:term_yr]
         term_cd = sections.first[:term_cd]
         ccn_list = sections.map { |section| section[:ccn] }
         recordings_per_ccn = Webcast::CourseMedia.new(term_yr, term_cd, ccn_list, @options).get_feed
         courses_with_recordings = recordings_per_ccn.select{ |course_id, media| media[:videos] || media[:video] }
-        if courses_with_recordings.empty?
-          Rails.logger.info "No #{term_yr}#{term_cd} Webcast recordings found where CCN in #{ccn_list.join(',')}"
+        tab = @external_tools.find_canvas_course_tab @canvas_webcast_tool_id
+        show_tab = courses_with_recordings.any? || is_webcast_sign_up_active && is_eligible_for_webcast?(ccn_list)
+        tab_after_modification = update_hidden_on_webcast_tab(show_tab, tab)
+      end
+      tab_after_modification
+    end
+
+    private
+
+    def update_hidden_on_webcast_tab(show_tab, tab)
+      modified_tab = nil
+      if tab
+        is_tab_showing = tab.has_key?('hidden') && tab['hidden']
+        if is_tab_showing == show_tab
+          Rails.logger.warn "Webcast tab on course site #{@canvas_course_id} is already hidden=#{show_tab}. Do nothing."
         else
-          record = Webcast::CourseSiteLog.find_by canvas_course_site_id: @course_id
-          if record
-            unhidden_date = record.webcast_tool_unhidden_at.strftime('%m/%d/%Y')
-            Rails.logger.warn "Do nothing to course site #{@course_id} because Webcast tool was unhidden on #{unhidden_date}."
+          Rails.logger.info "Set hidden=#{show_tab} on Webcast tab in course site #{@canvas_course_id}"
+          tab_id = tab['id']
+          if show_tab
+            modified_tab = @external_tools.show_course_site_tab tab_id
           else
-            # TODO: Use Canvas Tabs API to un-hide Webcast tool @canvas_webcast_tool_id
-            course_site_log_entry = Webcast::CourseSiteLog.create({ canvas_course_site_id: @course_id, webcast_tool_unhidden_at: Time.zone.now })
-            Rails.logger.warn "The Webcast tool has been un-hidden on course site #{@course_id}"
+            record = Webcast::CourseSiteLog.find_by canvas_course_site_id: @canvas_course_id
+            if record
+              unhidden_date = record.webcast_tool_unhidden_at.strftime('%m/%d/%Y')
+              Rails.logger.warn "Do nothing to course site #{@canvas_course_id} because Webcast tool was un-hidden on #{unhidden_date}."
+            else
+              modified_tab = @external_tools.hide_course_site_tab tab_id
+              Webcast::CourseSiteLog.create({ canvas_course_site_id: @canvas_course_id, webcast_tool_unhidden_at: Time.zone.now })
+              Rails.logger.warn "The Webcast tool has been un-hidden on course site #{@canvas_course_id}"
+            end
           end
         end
+      else
+        Rails.logger.warn "No Webcast tab, hidden or otherwise, found on course site #{@canvas_course_id}"
       end
-      course_site_log_entry
+      modified_tab
+    end
+
+    def is_eligible_for_webcast?(ccn_list)
+      # TODO: implement this!!
+      true
+    end
+
+    def is_canvas_tab_hidden?(tab)
+      # Canvas docs say the 'hidden' property is "only included if true"
+      tab.has_key? 'hidden' && tab['hidden']
     end
 
   end

--- a/app/models/webcast/rooms.rb
+++ b/app/models/webcast/rooms.rb
@@ -19,5 +19,9 @@ module Webcast
       building_map
     end
 
+    def any_in_webcast_enabled_room?(ccn_list)
+      raise RuntimeError, 'Method not implemented'
+    end
+
   end
 end

--- a/lib/tasks/canvas.rake
+++ b/lib/tasks/canvas.rake
@@ -93,7 +93,7 @@ namespace :canvas do
       else
         tool_id = webcast_tool.values.first
         Rails.logger.warn "Updating Webcast tool (id = #{tool_id}) configuration on Canvas course site #{course_id}"
-        options = ENV.merge(course_id: course_id, canvas_webcast_tool_id: tool_id)
+        options = ENV.merge(canvas_course_id: course_id, canvas_webcast_tool_id: tool_id)
         Canvas::WebcastLtiRefresh.new(options).refresh_canvas
         Rails.logger.warn "Webcast tool (id = #{tool_id}) refreshed on Canvas course site #{course_id}"
       end

--- a/spec/models/canvas/webcast_lti_refresh_spec.rb
+++ b/spec/models/canvas/webcast_lti_refresh_spec.rb
@@ -2,7 +2,8 @@ describe Canvas::WebcastLtiRefresh do
 
   let(:term_yr) { 2014 }
   let(:term_cd) { 'B' }
-  let(:course_id) { 1289865 }
+  let(:canvas_course_id) { 1289865 }
+  let(:canvas_webcast_tool_id) { 1234 }
   let(:ccn_with_webcast) { 87432 }
   let(:ccn_without_webcast) { 99999 }
   let(:course_with_webcast) {[
@@ -15,22 +16,30 @@ describe Canvas::WebcastLtiRefresh do
 
   # Refresh Webcast LTI configuration on Canvas course sites
   context 'a fake proxy' do
-    subject { Canvas::WebcastLtiRefresh.new({course_id: course_id, fake: true}) }
+    subject { Canvas::WebcastLtiRefresh.new({canvas_course_id: canvas_course_id, canvas_webcast_tool_id: canvas_webcast_tool_id, fake: true}) }
 
     context 'course site has webcast' do
       before do
         allow_any_instance_of(Canvas::CourseSections).to receive(:official_section_identifiers).and_return course_with_webcast
       end
-      it 'should show the Webcast tool' do
-        expect(Webcast::CourseSiteLog).to receive(:find_by).with({ canvas_course_site_id: course_id }).and_return nil
-        expect(Webcast::CourseSiteLog).to receive(:create).with({ canvas_course_site_id: course_id, webcast_tool_unhidden_at: anything }).and_return(:return_value)
-        allow_any_instance_of(Canvas::WebcastLtiRefresh).to receive(:show_webcast_tool_on_course_site).and_return true
+
+      it 'should show the Webcast tool because it has videos' do
+        allow_any_instance_of(Canvas::ExternalTools).to receive(:find_canvas_course_tab).and_return({ 'id' => 1 })
+        expect(Webcast::CourseSiteLog).to receive(:find_by).with({ canvas_course_site_id: canvas_course_id }).and_return nil
+        allow_any_instance_of(Canvas::ExternalTools).to receive(:show_course_site_tab).and_return(:return_value)
         expect(subject.refresh_canvas).to eq(:return_value)
       end
 
-      it 'should not unhide the Webcast tool because it was previously unhidden' do
+      it 'should not un-hide the Webcast tool because it was previously un-hidden' do
         log_entry = Webcast::CourseSiteLog.new(webcast_tool_unhidden_at: Time.zone.yesterday)
-        expect(Webcast::CourseSiteLog).to receive(:find_by).with({ canvas_course_site_id: course_id }).and_return log_entry
+        expect(Webcast::CourseSiteLog).to receive(:find_by).with(anything).and_return log_entry
+        # Canvas docs say 'hidden' property not present when value is false
+        allow_any_instance_of(Canvas::ExternalTools).to receive(:find_canvas_course_tab).and_return({ 'id' => 1 })
+        expect(subject.refresh_canvas).to be_nil
+      end
+
+      it 'should not un-hide the Webcast tool because it is already un-hidden' do
+        allow_any_instance_of(Canvas::ExternalTools).to receive(:find_canvas_course_tab).and_return({ 'id' => 1, 'hidden' => true })
         expect(subject.refresh_canvas).to be_nil
       end
     end
@@ -41,6 +50,19 @@ describe Canvas::WebcastLtiRefresh do
       end
       it 'should skip course sites that have no webcast recordings' do
         expect(subject.refresh_canvas).to be_nil
+      end
+    end
+
+    context 'course site has no webcast but course is eligible and sign up is active' do
+      before do
+        allow_any_instance_of(Canvas::CourseSections).to receive(:official_section_identifiers).and_return course_without_webcast
+      end
+      it 'should un-hide Webcast tool because course is in eligible room' do
+        allow_any_instance_of(Canvas::WebcastLtiRefresh).to receive(:is_canvas_tab_hidden?).and_return true
+        allow_any_instance_of(Canvas::ExternalTools).to receive(:find_canvas_course_tab).and_return({ 'id' => 1 })
+        expect(Webcast::CourseSiteLog).to receive(:find_by).with({ canvas_course_site_id: canvas_course_id }).and_return nil
+        allow_any_instance_of(Canvas::ExternalTools).to receive(:show_course_site_tab).and_return(:return_value)
+        expect(subject.refresh_canvas).to eq(:return_value)
       end
     end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5134
Bamboo build: https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CJT51-10

Method in Webcast::Rooms need implementation:
```
    def any_in_webcast_enabled_room?(ccn_list)
      raise RuntimeError, 'Method not implemented'
    end
``` 
That said, the GET/PUT calls to Canvas tabs API are done. Please let me know if they need work.
