### PR TITLE
CLC-5211 New DB table for bCourses site mailing lists

### DIFF
--- a/app/models/mailing_lists/site_mailing_list.rb
+++ b/app/models/mailing_lists/site_mailing_list.rb
@@ -1,0 +1,10 @@
+module MailingLists
+  class SiteMailingList < ActiveRecord::Base
+    include ActiveRecordHelper
+
+    self.table_name = 'canvas_site_mailing_lists'
+
+    attr_accessible :canvas_site_id, :list_name, :state, :populated_at
+
+  end
+end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -10,7 +10,7 @@ class Ability
       can :access, :all
       can :dashboard, :all
       if user.policy.can_administrate?
-        can :manage, [User::Auth, Finaid::FinAidYear, Calendar::User, Calendar::QueuedEntry, Calendar::LoggedEntry, Calendar::Job]
+        can :manage, [User::Auth, Finaid::FinAidYear, Calendar::User, Calendar::QueuedEntry, Calendar::LoggedEntry, Calendar::Job, MailingLists::SiteMailingList]
       end
       if user.policy.can_author?
         can :manage, [Links::Link, Links::LinkCategory, Links::LinkSection, Links::UserRole]
@@ -63,7 +63,8 @@ RailsAdmin.config do |config|
   # Include specific models (exclude the others):
   config.included_models = ['Links::Link', 'Links::LinkCategory', 'Links::LinkSection', 'Links::UserRole',
                             'Finaid::FinAidYear', 'User::Auth',
-                            'Calendar::User', 'Calendar::QueuedEntry', 'Calendar::LoggedEntry', 'Calendar::Job']
+                            'Calendar::User', 'Calendar::QueuedEntry', 'Calendar::LoggedEntry', 'Calendar::Job',
+                            'MailingLists::SiteMailingList']
 
   # Label methods for model instances:
   # config.label_methods << :description # Default is [:name, :title]
@@ -211,6 +212,10 @@ RailsAdmin.config do |config|
         end
       end
     end
+  end
+
+  config.model 'MailingLists::SiteMailingList' do
+    label 'Site Mailing List'
   end
 
   config.navigation_static_label = 'Tools'

--- a/db/migrate/20150430231721_create_canvas_site_mailing_lists.rb
+++ b/db/migrate/20150430231721_create_canvas_site_mailing_lists.rb
@@ -1,0 +1,14 @@
+class CreateCanvasSiteMailingLists < ActiveRecord::Migration
+  def change
+    create_table :canvas_site_mailing_lists do |t|
+      t.string :canvas_site_id
+      t.string :list_name
+      t.string :state
+      t.timestamp :populated_at
+
+      t.timestamps
+    end
+    add_index(:canvas_site_mailing_lists, :canvas_site_id, unique: true)
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150430222956) do
+ActiveRecord::Schema.define(version: 20150430231721) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "canvas_site_mailing_lists", force: true do |t|
+    t.string   "canvas_site_id"
+    t.string   "list_name"
+    t.string   "state"
+    t.datetime "populated_at"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "canvas_site_mailing_lists", ["canvas_site_id"], name: "index_canvas_site_mailing_lists_on_canvas_site_id", unique: true, using: :btree
 
   create_table "canvas_synchronization", force: true do |t|
     t.datetime "last_guest_user_sync"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5211
https://jira.ets.berkeley.edu/jira/browse/CLC-5212

This is a dependency for both the admin app side and the membership refresh script side of bCourses site mailing lists. Once it's in place, either side should be doable semi-independently. CCAdmin can be used to create mailing-list-associations by hand for early testing of refresh script logic.