### PR TITLE
CLC-5120: fix view-as tests again

### DIFF
--- a/spec/ui_selenium/my_dashboard_google_live_updates_spec.rb
+++ b/spec/ui_selenium/my_dashboard_google_live_updates_spec.rb
@@ -36,7 +36,7 @@ describe 'My Dashboard bConnected live updates', :testui => true do
       cal_net_auth_page.login(UserUtils.qa_username, UserUtils.qa_password)
       settings_page = CalCentralPages::SettingsPage.new(@driver)
       settings_page.load_page(@driver)
-      settings_page.disconnect_bconnected(@driver)
+      settings_page.disconnect_bconnected
 
       @google = GooglePage.new(@driver)
       @google.connect_calcentral_to_google(@driver, UserUtils.qa_gmail_username, UserUtils.qa_gmail_password)

--- a/spec/ui_selenium/my_dashboard_google_tasks_spec.rb
+++ b/spec/ui_selenium/my_dashboard_google_tasks_spec.rb
@@ -36,7 +36,7 @@ describe 'The My Dashboard task manager', :testui => true do
       cal_net_auth_page.login(UserUtils.qa_username, UserUtils.qa_password)
       settings_page = CalCentralPages::SettingsPage.new(@driver)
       settings_page.load_page(@driver)
-      settings_page.disconnect_bconnected(@driver)
+      settings_page.disconnect_bconnected
       google_page = GooglePage.new(@driver)
       google_page.connect_calcentral_to_google(@driver, UserUtils.qa_gmail_username, UserUtils.qa_gmail_password)
       @to_do_card = CalCentralPages::MyDashboardPage::MyDashboardToDoCard.new(@driver)

--- a/spec/ui_selenium/my_dashboard_google_up_next_spec.rb
+++ b/spec/ui_selenium/my_dashboard_google_up_next_spec.rb
@@ -36,7 +36,7 @@ describe 'My Dashboard Up Next card', :testui => true do
       cal_net_auth_page.login(UserUtils.qa_username, UserUtils.qa_password)
       settings_page = CalCentralPages::SettingsPage.new(@driver)
       settings_page.load_page(@driver)
-      settings_page.disconnect_bconnected(@driver)
+      settings_page.disconnect_bconnected
 
       @google = GooglePage.new(@driver)
       @google.connect_calcentral_to_google(@driver, UserUtils.qa_gmail_username, UserUtils.qa_gmail_password)

--- a/spec/ui_selenium/pages/settings_page.rb
+++ b/spec/ui_selenium/pages/settings_page.rb
@@ -20,29 +20,29 @@ module CalCentralPages
     button(:disconnect_no_button, :xpath => '//button[@data-ng-click="showValidation = false"]')
     button(:connect_button, :xpath => '//button[@data-ng-click="api.user.enableOAuth(service)"]')
 
-    # Student Lookup
-    button(:search_tab, :xpath => '//button[@data-ng-click="admin.switchSelectedOption(selectOption)"][text()="Search"]')
-    button(:saved_tab, :xpath => '//button[@data-ng-click="admin.switchSelectedOption(selectOption)"][text()="Saved"]')
-    button(:recent_tab, :xpath => '//button[@data-ng-click="admin.switchSelectedOption(selectOption)"][text()="Recent"]')
-    text_area(:uid_sid_input, :id => 'cc-widget-student-lookup-search')
-    button(:search_button, :xpath => '//button[@type="submit"]')
-    table(:search_results_table, :xpath => '//div[@data-ng-repeat="tab in admin.tabs"][1]//table')
-    table(:saved_users_table, :xpath => '//div[@data-ng-repeat="tab in admin.tabs"][2]//table')
-    table(:recent_users_table, :xpath => '//div[@data-ng-repeat="tab in admin.tabs"][3]//table')
-    elements(:uid_result, :td, :xpath => '//td[@data-ng-bind="user.ldap_uid || \'none\'"]')
-    button(:uid_link, :xpath => '//button[@data-ng-click="admin.changeIDType(\'UID\')"]')
-    elements(:sid_result, :td, :xpath => '//td[@data-ng-bind="user.student_id || \'none\'"]')
-    button(:sid_link, :xpath => '//button[@data-ng-click="admin.changeIDType(\'SID\')"]')
-    button(:view_as_link, :xpath => '//button[@data-ng-click="admin.actAsUser(user)"]')
-    button(:save_user_toggle, :xpath => '//button[@data-ng-click="admin.toggleSaveState(user)"]')
-    elements(:user_saved, :image, :xpath => '//i[@class="fa fa-star-o"]')
+    # View As
+    text_area(:view_as_input, :id => 'cc-settings-act-as-uid')
+    button(:view_as_submit_button, :xpath => '//button[text()="Submit"]')
+    div(:saved_users, :xpath => '//div[@class="row cc-settings-recent-uids ng-scope"][1]')
+    button(:clear_saved_users_button, :xpath => '//span[text()="Saved Users"]/following-sibling::button[text()="clear all"]')
+    elements(:saved_user_view_as_button, :div, :xpath => '//div[@class="row cc-settings-recent-uids ng-scope"][1]//button[@data-ng-click="admin.updateIDField(user.ldap_uid)"]')
+    elements(:saved_user_delete_button, :button, :xpath => '//button[text()="delete"]')
+    div(:recent_users, :xpath => '//div[@class="row cc-settings-recent-uids ng-scope"][2]')
+    button(:clear_recent_users_button, :xpath => '//span[text()="Recent Users"]/following-sibling::button[text()="clear all"]')
+    elements(:recent_user_view_as_button, :div, :xpath => '//div[@class="row cc-settings-recent-uids ng-scope"][2]//button[@data-ng-click="admin.updateIDField(user.ldap_uid)"]')
+    elements(:recent_user_save_button, :button, :xpath => '//button[text()="save"]')
+
+    # UID/SID Lookup
+    text_area(:lookup_input, :id => 'cc-settings-id')
+    button(:lookup_button, :xpath => '//button[text()="Look Up"]')
+    table(:lookup_results_table, :class => 'cc-settings-table')
 
     def load_page(driver)
       logger.info('Loading settings page')
-      driver.get(WebDriverUtils.base_url + '/settings')
+      driver.get("#{WebDriverUtils.base_url}/settings")
     end
 
-    def disconnect_bconnected(driver)
+    def disconnect_bconnected
       logger.info('Checking if user is connected to Google')
       if disconnect_button_element.visible?
         logger.info('User is connected, so disconnecting from Google')
@@ -60,66 +60,47 @@ module CalCentralPages
 
     # VIEW-AS
 
-    def search_for_user(id)
-      search_tab_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
-      search_tab
-      uid_sid_input_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
-      self.uid_sid_input = id
-      search_button
-    end
-
     def view_as_user(id)
-      search_for_user(id)
-      search_results_table_element.when_present(timeout=WebDriverUtils.page_event_timeout)
-      wait_until(timeout=WebDriverUtils.page_event_timeout) { search_results_table_element[1][0].text == id }
-      view_as_link_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
-      view_as_link
+      view_as_input_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
+      self.view_as_input = id
+      view_as_submit_button
     end
 
-    def save_first_user_in_list
-      save_user_toggle_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
-      save_user_toggle
-      user_saved_elements[0].when_present(timeout=WebDriverUtils.page_event_timeout)
-    end
-
-    def click_saved_users_tab
-      saved_tab_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
-      saved_tab
-    end
-
-    def all_saved_uids
-      uids = []
-      saved_users_table_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
-      saved_users_table_element.each { |row| uids << row[0].text }
-      uids.drop(1)
-    end
-
-    def all_saved_names
-      names = []
-      saved_users_table_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
-      saved_users_table_element.each { |row| names << row[1].text }
-      names.drop(1)
-    end
-
-    def un_save_all_saved_users
-      click_saved_users_tab
-      while saved_users_table?
-        row_one = save_user_toggle_element
-        row_one.click
-        row_one.when_not_present(timeout=WebDriverUtils.page_event_timeout)
+    def clear_all_saved_users
+      saved_users_element.when_present(timeout=WebDriverUtils.page_load_timeout)
+      if clear_saved_users_button?
+        clear_saved_users_button
       end
     end
 
-    def show_uid
-      if uid_link_element.visible?
-        uid_link
+    def view_as_first_saved_user
+      wait_until(timeout=WebDriverUtils.page_load_timeout) { saved_user_view_as_button_elements.any? }
+      saved_user_view_as_button_elements[0].click
+    end
+
+    def clear_all_recent_users
+      recent_users_element.when_present(timeout=WebDriverUtils.page_load_timeout)
+      if clear_recent_users_button?
+        clear_recent_users_button
       end
     end
 
-    def show_sid
-      if sid_link_element.visible?
-        sid_link
-      end
+    def view_as_first_recent_user
+      wait_until(timeout=WebDriverUtils.page_load_timeout) { recent_user_view_as_button_elements.any? }
+      recent_user_view_as_button_elements[0].click
+    end
+
+    def save_first_recent_user
+      wait_until(timeout=WebDriverUtils.page_load_timeout) { recent_user_save_button_elements.any? }
+      recent_user_save_button_elements[0].click
+    end
+
+    # LOOK UP USER
+
+    def look_up_user(id)
+      lookup_input_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
+      self.lookup_input = id
+      lookup_button
     end
   end
 end

--- a/spec/ui_selenium/user_authorizations_spec.rb
+++ b/spec/ui_selenium/user_authorizations_spec.rb
@@ -13,6 +13,8 @@ describe 'User authorization', :testui => true do
 
   if ENV["UI_TEST"]
 
+    timeout = WebDriverUtils.page_load_timeout
+
     before(:each) do
       @driver = WebDriverUtils.launch_browser
     end
@@ -23,31 +25,73 @@ describe 'User authorization', :testui => true do
 
     describe 'View-as' do
 
-      context 'when an admin' do
+      context 'when an admin has viewed-as' do
+
         before(:example) do
           splash_page = CalCentralPages::SplashPage.new(@driver)
           splash_page.load_page(@driver)
           splash_page.basic_auth(@driver, UserUtils.admin_uid)
           @settings_page = CalCentralPages::SettingsPage.new(@driver)
           @settings_page.load_page(@driver)
+          @settings_page.clear_all_saved_users
+          @settings_page.clear_all_recent_users
           @settings_page.view_as_user('61889')
-          @cal_net_auth_page = CalNetAuthPage.new(@driver)
+          cal_net_auth_page = CalNetAuthPage.new(@driver)
+          cal_net_auth_page.login(UserUtils.oski_username, UserUtils.oski_password)
+          cal_net_auth_page.wait_until(timeout) { cal_net_auth_page.logout_conf_heading_element.visible? }
+          splash_page.load_page(@driver)
+          splash_page.basic_auth(@driver, UserUtils.admin_uid)
+          @settings_page.load_page(@driver)
         end
-        context 'enters unauthorized re-auth credentials' do
-          it 'logs the admin out of CalCentral' do
-            @cal_net_auth_page.login(UserUtils.oski_username, UserUtils.oski_password)
-            @cal_net_auth_page.wait_until(timeout=WebDriverUtils.page_load_timeout) { @cal_net_auth_page.logout_conf_heading_element.visible? }
-          end
+        it 'allows the admin to see recently viewed users' do
+          @settings_page.recent_users_element.when_present(timeout)
+          expect(@settings_page.recent_user_view_as_button_elements[0].text == '61889')
         end
-        context 'enters invalid re-auth credentials' do
-          it 'locks the admin out of CalCentral' do
-            @cal_net_auth_page.login('blah', 'blah')
-            @cal_net_auth_page.wait_until(timeout=WebDriverUtils.page_load_timeout) { @cal_net_auth_page.password.blank? }
-            @dashboard_page = CalCentralPages::MyDashboardPage.new(@driver)
-            @dashboard_page.load_page(@driver)
-            @cal_net_auth_page.wait_until(timeout=WebDriverUtils.page_load_timeout) { @cal_net_auth_page.username.blank? }
-            @cal_net_auth_page.wait_until(timeout=WebDriverUtils.page_load_timeout) { @cal_net_auth_page.password.blank? }
-          end
+        it 'allows the admin to save recently viewed users' do
+          @settings_page.recent_users_element.when_present(timeout)
+          @settings_page.save_first_recent_user
+          @settings_page.wait_until(timeout=WebDriverUtils.page_event_timeout) { @settings_page.clear_saved_users_button? }
+          expect(@settings_page.saved_user_view_as_button_elements[0].text == '61889')
+        end
+      end
+
+      context 'when an admin enters unauthorized re-auth credentials' do
+        before(:example) do
+          splash_page = CalCentralPages::SplashPage.new(@driver)
+          splash_page.load_page(@driver)
+          splash_page.basic_auth(@driver, UserUtils.admin_uid)
+          settings_page = CalCentralPages::SettingsPage.new(@driver)
+          settings_page.load_page(@driver)
+          settings_page.clear_all_saved_users
+          settings_page.clear_all_recent_users
+          settings_page.view_as_user('61889')
+        end
+        it 'logs the admin out of CalCentral' do
+          cal_net_auth_page = CalNetAuthPage.new(@driver)
+          cal_net_auth_page.login(UserUtils.oski_username, UserUtils.oski_password)
+          cal_net_auth_page.wait_until(timeout) { cal_net_auth_page.logout_conf_heading_element.visible? }
+        end
+      end
+
+      context 'when an admin enters invalid re-auth credentials' do
+        before(:example) do
+          splash_page = CalCentralPages::SplashPage.new(@driver)
+          splash_page.load_page(@driver)
+          splash_page.basic_auth(@driver, UserUtils.admin_uid)
+          settings_page = CalCentralPages::SettingsPage.new(@driver)
+          settings_page.load_page(@driver)
+          settings_page.clear_all_saved_users
+          settings_page.clear_all_recent_users
+          settings_page.view_as_user('61889')
+        end
+        it 'locks the admin out of CalCentral' do
+          cal_net_auth_page = CalNetAuthPage.new(@driver)
+          cal_net_auth_page.login('blah', 'blah')
+          cal_net_auth_page.wait_until(timeout) { cal_net_auth_page.password.blank? }
+          dashboard_page = CalCentralPages::MyDashboardPage.new(@driver)
+          dashboard_page.load_page(@driver)
+          cal_net_auth_page.wait_until(timeout) { cal_net_auth_page.username.blank? }
+          cal_net_auth_page.wait_until(timeout) { cal_net_auth_page.password.blank? }
         end
       end
 
@@ -60,8 +104,7 @@ describe 'User authorization', :testui => true do
           @settings_page.load_page(@driver)
         end
         it 'offers no view-as interface' do
-          expect(@settings_page.search_tab_element.visible?).to be false
-          expect(@settings_page.uid_sid_input_element.visible?).to be false
+          expect(@settings_page.view_as_input_element.visible?).to be false
         end
       end
     end
@@ -77,24 +120,16 @@ describe 'User authorization', :testui => true do
           @settings_page.load_page(@driver)
         end
         it 'allows conversion of UID to SID' do
-          @settings_page.search_for_user('61889')
-          @settings_page.view_as_link_element.when_present(timeout=WebDriverUtils.page_event_timeout)
-          @settings_page.show_sid
-          @settings_page.wait_until(timeout=WebDriverUtils.page_event_timeout) { @settings_page.sid_result_elements[0].text == '11667051' }
+          @settings_page.look_up_user('61889')
+          @settings_page.wait_until(timeout) { @settings_page.lookup_results_table? }
+          expect(@settings_page.lookup_results_table_element[1][0].text).to eql('61889')
+          expect(@settings_page.lookup_results_table_element[1][1].text).to eql('11667051')
         end
         it 'allows conversion of SID to UID' do
-          @settings_page.search_for_user('11667051')
-          @settings_page.show_uid
-          @settings_page.wait_until(timeout=WebDriverUtils.page_event_timeout) { @settings_page.uid_result_elements[0].text == '61889' }
-        end
-        it 'allows the admin to save and un-save searched users' do
-          @settings_page.un_save_all_saved_users
-          @settings_page.search_for_user('61889')
-          @settings_page.show_uid
-          @settings_page.save_first_user_in_list
-          @settings_page.click_saved_users_tab
-          expect(@settings_page.all_saved_uids[0]).to eql('61889')
-          expect(@settings_page.all_saved_names[0]).to eql('OSKI BEAR')
+          @settings_page.look_up_user('11667051')
+          @settings_page.wait_until(timeout) { @settings_page.lookup_results_table? }
+          expect(@settings_page.lookup_results_table_element[1][0].text).to eql('61889')
+          expect(@settings_page.lookup_results_table_element[1][1].text).to eql('11667051')
         end
       end
 
@@ -107,7 +142,7 @@ describe 'User authorization', :testui => true do
           @settings_page.load_page(@driver)
         end
         it 'offers no UID/SID conversion interface' do
-          expect(@settings_page.uid_sid_input_element.visible?).to be false
+          expect(@settings_page.lookup_input_element.visible?).to be false
         end
       end
     end
@@ -120,24 +155,25 @@ describe 'User authorization', :testui => true do
           splash_page.load_page(@driver)
           splash_page.basic_auth(@driver, UserUtils.admin_uid)
           @driver.get("#{WebDriverUtils.base_url}/ccadmin")
-          @cal_net_auth_page = CalNetAuthPage.new(@driver)
         end
         context 'enters unauthorized re-auth credentials' do
           it 'blocks access to CC admin' do
-            @cal_net_auth_page.login(UserUtils.oski_username, UserUtils.oski_password)
-            @cal_net_auth_page.wait_until(timeout=WebDriverUtils.page_load_timeout) { @cal_net_auth_page.password.blank? }
-            @dashboard_page = CalCentralPages::MyDashboardPage.new(@driver)
-            @dashboard_page.load_page(@driver)
-            @dashboard_page.wait_for_expected_title?
+            cal_net_auth_page = CalNetAuthPage.new(@driver)
+            cal_net_auth_page.login(UserUtils.oski_username, UserUtils.oski_password)
+            cal_net_auth_page.wait_until(timeout) { cal_net_auth_page.password.blank? }
+            dashboard_page = CalCentralPages::MyDashboardPage.new(@driver)
+            dashboard_page.load_page(@driver)
+            dashboard_page.wait_for_expected_title?
           end
         end
         context 'enters invalid re-auth credentials' do
           it 'blocks access to CC admin' do
-            @cal_net_auth_page.login('blah', 'blah')
-            @cal_net_auth_page.wait_until(timeout=WebDriverUtils.page_load_timeout) { @cal_net_auth_page.password.blank? }
-            @dashboard_page = CalCentralPages::MyDashboardPage.new(@driver)
-            @dashboard_page.load_page(@driver)
-            @dashboard_page.wait_for_expected_title?
+            cal_net_auth_page = CalNetAuthPage.new(@driver)
+            cal_net_auth_page.login('blah', 'blah')
+            cal_net_auth_page.wait_until(timeout) { cal_net_auth_page.password.blank? }
+            dashboard_page = CalCentralPages::MyDashboardPage.new(@driver)
+            dashboard_page.load_page(@driver)
+            dashboard_page.wait_for_expected_title?
           end
         end
       end
@@ -148,22 +184,23 @@ describe 'User authorization', :testui => true do
           splash_page.load_page(@driver)
           splash_page.basic_auth(@driver, '61889')
           @driver.get("#{WebDriverUtils.base_url}/ccadmin")
-          @cal_net_auth_page = CalNetAuthPage.new(@driver)
         end
         context 'enters unauthorized re-auth credentials' do
           it 'redirects the user to My Dashboard' do
-            @cal_net_auth_page.login(UserUtils.oski_username, UserUtils.oski_password)
-            @dashboard_page = CalCentralPages::MyDashboardPage.new(@driver)
-            @dashboard_page.wait_for_expected_title?
+            cal_net_auth_page = CalNetAuthPage.new(@driver)
+            cal_net_auth_page.login(UserUtils.oski_username, UserUtils.oski_password)
+            dashboard_page = CalCentralPages::MyDashboardPage.new(@driver)
+            dashboard_page.wait_for_expected_title?
           end
         end
         context 'enters invalid re-auth credentials' do
           it 'blocks access to CC admin' do
-            @cal_net_auth_page.login('blah', 'blah')
-            @cal_net_auth_page.wait_until(timeout=WebDriverUtils.page_load_timeout) { @cal_net_auth_page.password.blank? }
-            @dashboard_page = CalCentralPages::MyDashboardPage.new(@driver)
-            @dashboard_page.load_page(@driver)
-            @dashboard_page.wait_for_expected_title?
+            cal_net_auth_page = CalNetAuthPage.new(@driver)
+            cal_net_auth_page.login('blah', 'blah')
+            cal_net_auth_page.wait_until(timeout) { cal_net_auth_page.password.blank? }
+            dashboard_page = CalCentralPages::MyDashboardPage.new(@driver)
+            dashboard_page.load_page(@driver)
+            dashboard_page.wait_for_expected_title?
           end
         end
       end

--- a/spec/ui_selenium/user_google_connection_spec.rb
+++ b/spec/ui_selenium/user_google_connection_spec.rb
@@ -32,7 +32,7 @@ describe 'Google apps', :testui => true do
         @cal_net.login(UserUtils.qa_username, UserUtils.qa_password)
         @settings_page = CalCentralPages::SettingsPage.new(@driver)
         @settings_page.load_page(@driver)
-        @settings_page.disconnect_bconnected(@driver)
+        @settings_page.disconnect_bconnected
         google = GooglePage.new(@driver)
         google.connect_calcentral_to_google(@driver, UserUtils.qa_gmail_username, UserUtils.qa_gmail_password)
       end
@@ -113,7 +113,7 @@ describe 'Google apps', :testui => true do
           cal_net.login(UserUtils.oski_username, UserUtils.oski_password)
           @settings_page = CalCentralPages::SettingsPage.new(@driver)
           @settings_page.load_page(@driver)
-          @settings_page.disconnect_bconnected(@driver)
+          @settings_page.disconnect_bconnected
           google = GooglePage.new(@driver)
           google.connect_calcentral_to_google(@driver, UserUtils.oski_gmail_username, UserUtils.oski_gmail_password)
         end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5120

These changes restore the view-as and look-up portions of the User Authorizations spec to the former UI (see CLC-5203), also removing supporting code that pertained to the formerly-new UI.