### PR TITLE
CLC-5134, ExternalTools : update_canvas_course_site_tab needs proper method PUT

### DIFF
--- a/app/models/canvas/external_tools.rb
+++ b/app/models/canvas/external_tools.rb
@@ -125,14 +125,22 @@ module Canvas
     private
 
     def update_course_site_tab_hidden(tab_id, set_to_hidden)
-      url = "#{@api_root}/tabs/#{tab_id}?hidden=#{set_to_hidden}"
-      response = request_uncached(url, '_hide_course_site_tab', { method: :put })
-      tab = response && safe_json(response.body)
-      is_tab_now_hidden = tab && tab['hidden']
-      unless is_tab_now_hidden == set_to_hidden
-        raise Errors::ProxyError.new("Failed to set hidden=#{set_to_hidden} on Canvas course site nav tab", response: response, url: url, uid: @uid)
+      begin
+        options = {
+          :method => :put,
+          :body => { 'hidden' => set_to_hidden },
+        }
+        response = request_uncached("#{@api_root}/tabs/#{tab_id}", '_update_course_site_tab_hidden', options)
+        tab = response && safe_json(response.body)
+        is_tab_now_hidden = tab && tab['hidden']
+        unless is_tab_now_hidden == set_to_hidden
+          raise Errors::ProxyError.new("Failed to set hidden=#{set_to_hidden} on Canvas course site nav tab", response: response, url: url, uid: @uid)
+        end
+        tab
+      rescue => exception
+        logger.error "#{self.class.name} Problem updating hidden=#{set_to_hidden} on tab #{tab_id} of Canvas #{@api_root}. Abort!"
+        raise exception
       end
-      tab
     end
 
   end

--- a/app/models/canvas/report.rb
+++ b/app/models/canvas/report.rb
@@ -3,6 +3,11 @@ module Canvas
     require 'csv'
     include ClassLogger, SafeJsonParser
 
+    def initialize(options = {})
+      super options
+      @options = options
+    end
+
     def get_sis_export_csv(object_type, term_id = nil)
       get_account_csv('sis_export', object_type, term_id)
     end
@@ -49,7 +54,7 @@ module Canvas
       if @fake
         csv = CSV.read("fixtures/pretty_vcr_recordings/Canvas_#{report_type}_report_#{object_type}_csv.csv", {headers: true})
       else
-        conn = Faraday.new(file_info["url"]) do |c|
+        conn = Faraday.new(file_info["url"], @options) do |c|
           c.use FaradayMiddleware::FollowRedirects
           c.use Faraday::Adapter::NetHttp
         end

--- a/app/models/canvas/sections_report.rb
+++ b/app/models/canvas/sections_report.rb
@@ -1,6 +1,10 @@
 module Canvas
   class SectionsReport < Canvas::Report
 
+    def initialize(options = {})
+      super options
+    end
+
     def get_csv(term_id)
       get_provisioning_csv('sections', term_id)
     end

--- a/spec/models/webcast/audio_spec.rb
+++ b/spec/models/webcast/audio_spec.rb
@@ -1,77 +1,76 @@
-require "spec_helper"
-require "json"
+require 'json'
 
 describe Webcast::Audio do
 
-  context "real data", :textext => true do
+  context 'real data', :textext => true do
 
     let (:audio_base_url) { URI.parse(Settings.audio_proxy.base_url) }
     let (:rss_url) { "#{audio_base_url}/media/common/courses/spring_2014/rss/english_117s_001_audio.rss"; }
     let (:proxy) { Webcast::Audio.new({:audio_rss => rss_url}) }
 
-    it "should get real audio data" do
+    it 'should get real audio data' do
       proxy_response = proxy.get
-      expect(proxy_response[:audio].count).to eq 26
+      expect(proxy_response[:audio]).to have(26).items
     end
 
-    it "should get good playUrls" do
+    it 'should get valid play URLs' do
       proxy_response = proxy.get
       play_url = "#{audio_base_url}/media/common/courses/spring_2014/media/english_117s_001/3c7be589-95d0-4a94-80b5-836b9f73e668_audio.mp3"
       expect(proxy_response[:audio][0][:playUrl]).to eq play_url
     end
 
-    it "should get correct downloadUrls" do
+    it 'should get correct download URLs' do
       proxy_response = proxy.get
       download_url = "#{audio_base_url}/download/common/courses/spring_2014/media/english_117s_001/3c7be589-95d0-4a94-80b5-836b9f73e668_audio.mp3"
       expect(proxy_response[:audio][0][:downloadUrl]).to eq download_url
     end
 
-    it "should get correct titles" do
+    it 'should get correct titles' do
       proxy_response = proxy.get
-      expect(proxy_response[:audio][0][:title]).to eq "English 117S - 2014-05-01: Audio begins min 06:58 & ends min 51:22"
+      expect(proxy_response[:audio][0][:title]).to eq 'English 117S - 2014-05-01: Audio begins min 06:58 & ends min 51:22'
     end
 
-    context "on remote server errors" do
+    context 'on remote server errors' do
       let! (:body) { 'An unknown error occurred.' }
       let! (:status) { 506 }
       include_context 'expecting logs from server errors'
       before(:each) {
         stub_request(:any, rss_url).to_return(status: status, body: body)
       }
-      it "should return a 503 status code" do
+      it 'should return a 503 status code' do
         proxy_response = proxy.get
         expect(proxy_response[:statusCode]).to eq 503
       end
     end
 
-    context "when xml formatting fails" do
+    context 'when xml formatting fails' do
       before(:each) {
-        stub_request(:any, rss_url).to_return(status: 200, body: "bogus xml")
+        stub_request(:any, rss_url).to_return(status: 200, body: 'bogus xml')
       }
-      it "should return a 503 status code" do
+      it 'should return a 503 status code' do
         proxy_response = proxy.get
         expect(proxy_response[:statusCode]).to eq 503
       end
     end
 
-    context "on connection errors" do
+    context 'on connection errors' do
       before(:each) {
         stub_request(:any, /.#{audio_base_url.hostname}./).to_raise(Errno::ECONNREFUSED)
       }
 
-      it "should return a 503 status code" do
+      it 'should return a 503 status code' do
         proxy_response = proxy.get
         expect(proxy_response[:statusCode]).to eq 503
       end
     end
   end
 
-  context "empty RSS feed" do
-    let (:proxy) { Webcast::Audio.new({:audio_rss => ""}) }
+  context 'empty RSS feed' do
+    let (:proxy) { Webcast::Audio.new({:audio_rss => ''}) }
 
-    it "should return an empty audio array" do
+    it 'should return an empty audio array' do
       proxy_response = proxy.get
-      expect(proxy_response[:audio].count).to eq 0
+      expect(proxy_response[:audio]).to have(0).items
     end
   end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5242
Bamboo build: https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CJT51-19

Few related changes in this PR:
* class that pulls from Webcast audio RSS must tolerate 404s
* optional options hash to Faraday connection so you can config in dev (e.g., ssl verify: false)
* ExternalTools needs proper method-PUT syntax in update_canvas_course_site_tab