### PR TITLE
CLC-5256, restrict options sent to Faraday; bug fix on recordings.has_key?

### DIFF
--- a/app/models/canvas/report.rb
+++ b/app/models/canvas/report.rb
@@ -54,7 +54,9 @@ module Canvas
       if @fake
         csv = CSV.read("fixtures/pretty_vcr_recordings/Canvas_#{report_type}_report_#{object_type}_csv.csv", {headers: true})
       else
-        conn = Faraday.new(file_info["url"], @options) do |c|
+        # Faraday requires nil when options hash is empty. For now, we only allow ssl options.
+        conn_options = @options.any? && @options[:ssl].present? ? @options : nil
+        conn = Faraday.new(file_info["url"], conn_options) do |c|
           c.use FaradayMiddleware::FollowRedirects
           c.use Faraday::Adapter::NetHttp
         end

--- a/app/models/canvas/report.rb
+++ b/app/models/canvas/report.rb
@@ -54,9 +54,7 @@ module Canvas
       if @fake
         csv = CSV.read("fixtures/pretty_vcr_recordings/Canvas_#{report_type}_report_#{object_type}_csv.csv", {headers: true})
       else
-        # Faraday requires nil when options hash is empty. For now, we only allow ssl options.
-        conn_options = @options.any? && @options[:ssl].present? ? @options : nil
-        conn = Faraday.new(file_info["url"], conn_options) do |c|
+        conn = Faraday.new(file_info['url'], @options) do |c|
           c.use FaradayMiddleware::FollowRedirects
           c.use Faraday::Adapter::NetHttp
         end

--- a/app/models/canvas/sections_report.rb
+++ b/app/models/canvas/sections_report.rb
@@ -1,10 +1,6 @@
 module Canvas
   class SectionsReport < Canvas::Report
 
-    def initialize(options = {})
-      super options
-    end
-
     def get_csv(term_id)
       get_provisioning_csv('sections', term_id)
     end

--- a/app/models/canvas/webcast_eligible_courses.rb
+++ b/app/models/canvas/webcast_eligible_courses.rb
@@ -1,5 +1,6 @@
 module Canvas
   class WebcastEligibleCourses
+    include ClassLogger
 
     def initialize(sis_term_ids, options = {})
       @sis_term_ids = sis_term_ids
@@ -17,7 +18,7 @@ module Canvas
     def fetch_term_to_course_sections_hash
       courses_by_term = {}
       @sis_term_ids.each do |term_id|
-        canvas_sections = Canvas::SectionsReport.new.get_csv term_id
+        canvas_sections = Canvas::SectionsReport.new(@options).get_csv term_id
         if canvas_sections
           course_id_to_csv = canvas_sections.group_by { |row| row['canvas_course_id'] }
           course_id_to_csv.each do |canvas_course_id, csv_rows|
@@ -35,6 +36,8 @@ module Canvas
               end
             end
           end
+        else
+          logger.error "No Canvas sections found where term_id = #{term_id}"
         end
       end
       courses_by_term
@@ -51,7 +54,8 @@ module Canvas
             ccn = section[:ccn].to_s.to_i
             if ccn > 0
               section_key = "#{key[:term_yr]}-#{key[:term_cd]}-#{ccn}"
-              has_recordings = recordings_per_ccn.has_key? section_key
+              has_recordings = recordings_per_ccn.has_key? section_key && recordings_per_ccn[section_key][:videos].present?
+              logger.warn "#{section_key} has Webcast recordings (canvas_course_id = #{canvas_course_id})" if has_recordings
               in_webcast_enabled_room = webcast_enabled_room_ccn_set.include? section_key
               if has_recordings || in_webcast_enabled_room
                 section[:has_webcast_recordings] = has_recordings
@@ -69,7 +73,6 @@ module Canvas
     def extract_ccn_set(courses)
       ccn_set = Set.new
       courses.values.each do |course|
-        Rails.logger.warn "course = #{course.to_s}"
         course.map { |section| section[:ccn] }.each { |ccn| ccn_set << ccn.to_i }
       end
       ccn_set

--- a/app/models/canvas/webcast_eligible_courses.rb
+++ b/app/models/canvas/webcast_eligible_courses.rb
@@ -54,7 +54,7 @@ module Canvas
             ccn = section[:ccn].to_s.to_i
             if ccn > 0
               section_key = "#{key[:term_yr]}-#{key[:term_cd]}-#{ccn}"
-              has_recordings = recordings_per_ccn.has_key? section_key && recordings_per_ccn[section_key][:videos].present?
+              has_recordings = recordings_per_ccn.has_key?(section_key) && recordings_per_ccn[section_key][:videos].present?
               logger.warn "#{section_key} has Webcast recordings (canvas_course_id = #{canvas_course_id})" if has_recordings
               in_webcast_enabled_room = webcast_enabled_room_ccn_set.include? section_key
               if has_recordings || in_webcast_enabled_room

--- a/lib/tasks/canvas.rake
+++ b/lib/tasks/canvas.rake
@@ -82,18 +82,19 @@ namespace :canvas do
 
   desc 'Manage Webcast tool placement across all Canvas course sites'
   task :webcast_lti_refresh => :environment do
+    Rails.logger.warn "Begin Webcast LTI refresh on #{Settings.canvas_proxy.url_root} (Canvas)"
     global_tools = Canvas::ExternalTools.public_list[:globalTools]
     webcast_tool = global_tools && global_tools.select{ |tool, id| tool =~ /webcast/i }
     if webcast_tool.empty?
       Rails.logger.error 'Webcast tool not found within Canvas globalTools set'
     elsif webcast_tool.length > 1
-      Rails.logger.error 'Why did we find multiple Webcast tools within Canvas globalTools set?! Abort!'
+      Rails.logger.error "Why did we find multiple Webcast tools (#{webcast_tool.to_s}) within Canvas globalTools set?! Abort!"
     else
       tool_id = webcast_tool.values.first
-      Rails.logger.warn "Updating Webcast tool (id = #{tool_id}) configuration on Canvas course site" # {course_id}
-      options = ENV.merge(canvas_webcast_tool_id: tool_id)
-      Canvas::WebcastLtiRefresh.new(Canvas::Proxy.current_sis_term_ids, tool_id, options).refresh_canvas
-      Rails.logger.warn "Webcast tool (id = #{tool_id}) refreshed on Canvas course site" # {course_id}
+      Rails.logger.warn "Updating Webcast tool (id = #{tool_id}) configs on all Canvas course sites"
+      sis_term_ids = Canvas::Proxy.current_sis_term_ids
+      refresh = Canvas::WebcastLtiRefresh.new(sis_term_ids, tool_id, options).refresh_canvas
+      Rails.logger.warn "Webcast tool (id = #{tool_id}) refreshed on #{refresh.length} Canvas course sites"
     end
   end
 

--- a/spec/models/canvas/webcast_eligible_courses_spec.rb
+++ b/spec/models/canvas/webcast_eligible_courses_spec.rb
@@ -2,7 +2,7 @@ describe Canvas::WebcastEligibleCourses do
 
   context 'fake data' do
 
-    subject { Canvas::WebcastEligibleCourses.new(%w(TERM:2014-B TERM:2014-D) ,{:user_id => @user_id}).fetch }
+    subject { Canvas::WebcastEligibleCourses.new(%w(TERM:2014-B TERM:2014-D) ,{:user_id => @user_id, fake: true}).fetch }
 
     context 'csv files exist' do
       before do

--- a/spec/models/canvas/webcast_lti_refresh_spec.rb
+++ b/spec/models/canvas/webcast_lti_refresh_spec.rb
@@ -31,7 +31,7 @@ describe Canvas::WebcastLtiRefresh do
       it 'should show the Webcast tool because it has videos' do
         allow_any_instance_of(Webcast::Rooms).to receive(:any_in_webcast_enabled_room?).and_return false
         allow_any_instance_of(Canvas::ExternalTools).to receive(:find_canvas_course_tab).and_return({ 'id' => 1, 'hidden' => true })
-        expect(Webcast::CourseSiteLog).to receive(:find_by).with(anything).exactly(4).times.and_return nil
+        expect(Webcast::CourseSiteLog).to receive(:find_by).with(anything).and_return nil
         allow_any_instance_of(Canvas::ExternalTools).to receive(:show_course_site_tab).and_return :return
         modified_tab_hash = subject.refresh_canvas
         expect(modified_tab_hash.has_key? '1336653').to be true
@@ -40,7 +40,7 @@ describe Canvas::WebcastLtiRefresh do
       it 'should not un-hide the Webcast tool because it was previously un-hidden' do
         allow_any_instance_of(Webcast::Rooms).to receive(:any_in_webcast_enabled_room?).and_return true
         log_entry = Webcast::CourseSiteLog.new(webcast_tool_unhidden_at: Time.zone.yesterday)
-        expect(Webcast::CourseSiteLog).to receive(:find_by).with(anything).exactly(4).times.and_return log_entry
+        expect(Webcast::CourseSiteLog).to receive(:find_by).with(anything).and_return log_entry
         # Canvas docs say 'hidden' property not present when value is false
         allow_any_instance_of(Canvas::ExternalTools).to receive(:find_canvas_course_tab).and_return({ 'id' => 1, 'hidden' => true })
         expect(subject.refresh_canvas).to be_empty


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5256
Changes / fixes:
* Only allow ssl override to Faraday; otherwise nil
* check for 'has Webcast recordings' needs explicit [:videos] check
* clean up logger statements

Waiting on Bamboo, too: https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CJT51-22