### PR TITLE
CLC-5269: Selenium test for academics teaching UI

### DIFF
--- a/spec/ui_selenium/my_academics_data_final_exams_spec.rb
+++ b/spec/ui_selenium/my_academics_data_final_exams_spec.rb
@@ -90,7 +90,7 @@ describe 'My Academics Final Exams card', :testui => true do
                 end
 
                 # EXAM SCHEDULES ON SEMESTER PAGE
-                my_academics_page.click_semester_link(driver, current_term)
+                my_academics_page.click_student_semester_link(driver, current_term)
                 my_academics_page.final_exams_card_heading_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
                 semester_exam_dates = my_academics_page.all_exam_dates
                 semester_exam_times = my_academics_page.all_exam_times

--- a/spec/ui_selenium/my_academics_data_teaching_spec.rb
+++ b/spec/ui_selenium/my_academics_data_teaching_spec.rb
@@ -1,0 +1,241 @@
+require 'spec_helper'
+require 'selenium-webdriver'
+require 'page-object'
+require 'csv'
+require 'json'
+require_relative 'util/web_driver_utils'
+require_relative 'util/user_utils'
+require_relative 'pages/cal_central_pages'
+require_relative 'pages/splash_page'
+require_relative 'pages/my_academics_page'
+require_relative 'pages/my_academics_classes_card'
+require_relative 'pages/my_academics_teaching_card'
+require_relative 'pages/my_academics_class_page'
+require_relative 'pages/api_my_status_page'
+require_relative 'pages/api_my_classes_page'
+require_relative 'pages/api_my_academics_page_semesters'
+
+describe 'My Academics teaching', :testui => true do
+
+  if ENV["UI_TEST"]
+
+    include ClassLogger
+
+    begin
+
+      driver = WebDriverUtils.launch_browser
+
+      test_users = UserUtils.load_test_users
+      test_output = UserUtils.initialize_output_csv(self)
+      testable_users = []
+
+      CSV.open(test_output, 'wb') do |user_info_csv|
+        user_info_csv << ['UID', 'GSI', 'Semester', 'Course Title', 'Listing']
+      end
+
+      test_users.each do |user|
+        if user['teaching']
+          uid = user['uid'].to_s
+          logger.info("UID is #{uid}")
+
+          begin
+            splash_page = CalCentralPages::SplashPage.new(driver)
+            splash_page.load_page(driver)
+            splash_page.basic_auth(driver, uid)
+            status_api_page = ApiMyStatusPage.new(driver)
+            status_api_page.get_json(driver)
+
+            if status_api_page.is_faculty? && status_api_page.has_academics_tab?
+              academics_api_page = ApiMyAcademicsPageSemesters.new(driver)
+              academics_api_page.get_json(driver)
+              all_semesters = academics_api_page.all_teaching_semesters
+              teaching_card = CalCentralPages::MyAcademicsTeachingCard.new(driver)
+              teaching_card.load_page(driver)
+              teaching_card.page_heading_element.when_visible(timeout=WebDriverUtils.academics_timeout)
+
+              if all_semesters.present?
+                testable_users.push(uid)
+
+                all_semester_names = academics_api_page.semester_names(all_semesters)
+                default_semesters = academics_api_page.default_semesters_in_ui(all_semesters)
+                default_semester_names = academics_api_page.semester_names(default_semesters)
+                current_semester = academics_api_page.current_semester(all_semesters)
+
+                # MY ACADEMICS CLASSES CARD
+
+                unless current_semester.nil? || status_api_page.is_student?
+                  current_semester_name = academics_api_page.semester_name(current_semester)
+                  classes_card = CalCentralPages::MyAcademicsClassesCard.new(driver)
+
+                  api_current_courses = academics_api_page.semester_courses(current_semester)
+                  api_current_listing_codes = academics_api_page.semester_listing_course_codes(current_semester)
+                  api_current_course_titles = academics_api_page.course_titles(api_current_courses)
+
+                  my_academics_semester_name = classes_card.semester_heading
+                  my_academics_course_codes = classes_card.all_teaching_course_codes
+                  my_academics_course_titles = classes_card.all_teaching_course_titles
+
+                  it "shows the current semester class card on the landing page for UID #{uid}" do
+                    expect(my_academics_semester_name).to eql(current_semester_name)
+                  end
+                  it "shows the current semester course codes on the landing page class card for UID #{uid}" do
+                    expect(my_academics_course_codes).to eql(api_current_listing_codes)
+                  end
+                  it "shows the current semester course titles on the landing page class card for UID #{uid}" do
+                    expect(my_academics_course_titles).to eql(api_current_course_titles)
+                  end
+                end
+
+                # MY ACADEMICS TEACHING CARD
+
+                shows_default_semesters = teaching_card.teaching_terms_visible?(default_semester_names)
+                it "shows future, current, and most recent past teaching semesters by default for UID #{uid}" do
+                  expect(shows_default_semesters).to be true
+                end
+                show_more_button_visible = teaching_card.show_more_element.visible?
+                if all_semesters.length > default_semesters.length
+                  it "offers a 'Show More' button for UID #{uid}" do
+                    expect(show_more_button_visible).to be true
+                  end
+                  teaching_card.show_more
+                  shows_more_semesters = teaching_card.teaching_terms_visible?(all_semester_names)
+                  it "can show all semesters for UID #{uid}" do
+                    expect(shows_more_semesters).to be true
+                  end
+                else
+                  it "offers no 'Show More' button for UID #{uid}" do
+                    expect(show_more_button_visible).to be false
+                  end
+                end
+
+                all_semesters.each do |semester|
+                  if teaching_card.show_more_element.visible?
+                    teaching_card.show_more
+                  end
+                  begin
+                    semester_name = academics_api_page.semester_name(semester)
+                    semester_courses = academics_api_page.semester_courses(semester)
+
+                    teaching_card_course_codes = teaching_card.all_semester_course_codes(driver, semester_name)
+                    teaching_card_course_titles = teaching_card.all_semester_course_titles(driver, semester_name)
+
+                    api_course_codes = academics_api_page.semester_listing_course_codes(semester)
+                    api_course_titles = academics_api_page.course_titles(semester_courses)
+
+                    it "shows the course codes for #{semester_name} on the teaching card for UID #{uid}" do
+                      expect(teaching_card_course_codes).to eql(api_course_codes)
+                    end
+                    it "shows the course titles for #{semester_name} on the teaching card for UID #{uid}" do
+                      expect(teaching_card_course_titles).to eql(api_course_titles)
+                    end
+
+                    # SEMESTER PAGES
+
+                    teaching_card.click_teaching_semester_link(driver, semester_name)
+                    semester_page = CalCentralPages::MyAcademicsClassesCard.new(driver)
+
+                    api_semester_courses = academics_api_page.semester_courses(semester)
+                    api_semester_listing_codes = academics_api_page.semester_listing_course_codes(semester)
+                    api_semester_course_titles = academics_api_page.course_titles(api_semester_courses)
+
+                    semester_page_course_codes = semester_page.all_teaching_course_codes
+                    semester_page__course_titles = semester_page.all_teaching_course_titles
+
+                    it "shows the course codes on the #{semester_name} semester page for UID #{uid}" do
+                      expect(semester_page_course_codes).to eql(api_semester_listing_codes)
+                    end
+                    it "shows the course titles on the #{semester_name} semester page for UID #{uid}" do
+                      expect(semester_page__course_titles).to eql(api_semester_course_titles)
+                    end
+
+                    # CLASS PAGES
+
+                    api_semester_courses.each do |course|
+
+                      listing_codes = academics_api_page.course_listing_course_codes(course)
+                      listing_codes.each do |course_code|
+
+                        semester_page.click_class_link_by_text(driver, course_code)
+                        class_page = CalCentralPages::MyAcademicsClassPage.new(driver)
+                        class_page.class_info_heading_element.when_visible(WebDriverUtils.page_load_timeout)
+
+                        api_course_title = academics_api_page.course_title(course)
+                        api_sections = academics_api_page.sections_by_listing(course)
+                        api_section_schedule_labels = academics_api_page.section_schedule_labels(api_sections)
+                        api_section_schedules = academics_api_page.course_section_schedules(api_sections)
+                        api_section_instructor_labels = academics_api_page.section_labels(api_sections)
+                        api_section_instructors = academics_api_page.course_instructor_names(api_sections)
+
+                        class_page_course_title = class_page.course_title
+                        class_page_cross_listings = class_page.all_cross_listings
+                        class_page_section_labels = class_page.all_section_schedule_labels
+                        class_page_section_schedules = class_page.all_teaching_section_schedules
+                        class_page_section_instructors = class_page.all_section_instructors(driver, api_section_instructor_labels)
+
+                        it "shows the course title on the #{semester_name} #{course_code} class page for UID #{uid}" do
+                          expect(class_page_course_title).to eql(api_course_title)
+                        end
+                        if listing_codes.length > 1
+                          it "shows the cross listings on the #{semester_name} #{course_code} class page for UID #{uid}" do
+                            expect(class_page_cross_listings).to eql(listing_codes)
+                          end
+                        else
+                          it "shows no cross listings on the #{semester_name} #{course_code} class page for UID #{uid}" do
+                            expect(class_page_cross_listings).to be_empty
+                          end
+                          has_cross_listing_heading = class_page.cross_listing_heading?
+                          it "shows no cross listings heading on the #{semester_name} #{course_code} class page for UID #{uid}" do
+                            expect(has_cross_listing_heading).to be false
+                          end
+                        end
+                        it "shows the section labels on the #{semester_name} #{course_code} class page for UID #{uid}" do
+                          expect(class_page_section_labels).to eql(api_section_schedule_labels)
+                        end
+                        it "shows the section schedules on the #{semester_name} #{course_code} class page for UID #{uid}" do
+                          expect(class_page_section_schedules).to eql(api_section_schedules)
+                        end
+                        it "shows the section instructors on the #{semester_name} #{course_code} class page for UID #{uid}" do
+                          expect(class_page_section_instructors).to eql(api_section_instructors)
+                        end
+
+                        if semester == academics_api_page.current_semester(all_semesters) || academics_api_page.future_semesters(all_semesters).include?(semester)
+                          CSV.open(test_output, 'a+') do |user_info_csv|
+                            user_info_csv << [uid, status_api_page.is_student?, semester_name, api_course_title, course_code]
+                          end
+                        end
+
+                        class_page.back
+
+                      end
+                    end
+
+                    teaching_card.back
+
+                  end
+                end
+              else
+                has_no_classes_msg = teaching_card.no_classes_msg?
+
+                it "shows a 'you have no courses assigned to you' message for UID #{uid}" do
+                  expect(has_no_classes_msg).to be true
+                end
+
+              end
+            end
+          rescue => e
+            logger.error e.message + "\n" + e.backtrace.join("\n ")
+          end
+        end
+      end
+
+      it 'has teaching information for at least one of the test UIDs' do
+        expect(testable_users.length).to be > 0
+      end
+
+    rescue => e
+      logger.error e.message + "\n" + e.backtrace.join("\n ")
+    ensure
+      WebDriverUtils.quit_browser(driver)
+    end
+  end
+end

--- a/spec/ui_selenium/my_academics_data_teaching_spec.rb
+++ b/spec/ui_selenium/my_academics_data_teaching_spec.rb
@@ -209,7 +209,7 @@ describe 'My Academics teaching', :testui => true do
                       end
                     end
 
-                    teaching_card.back
+                    semester_page.back
 
                   end
                 end

--- a/spec/ui_selenium/pages/my_academics_class_page.rb
+++ b/spec/ui_selenium/pages/my_academics_class_page.rb
@@ -3,7 +3,6 @@ require 'selenium-webdriver'
 require 'page-object'
 require_relative 'cal_central_pages'
 require_relative 'my_academics_page'
-require_relative '../util/web_driver_utils'
 
 module CalCentralPages
 
@@ -11,7 +10,6 @@ module CalCentralPages
 
     include PageObject
     include CalCentralPages
-    include ClassLogger
 
     span(:class_breadcrumb, :xpath => '//h1/span[@data-ng-bind="selectedCourse.course_code"]')
     span(:section_breadcrumb, :xpath => '//h1/span[@data-ng-bind="selectedSection"]')
@@ -25,7 +23,12 @@ module CalCentralPages
     elements(:section_units, :td, :xpath => '//h3[text()="Class Info"]/following-sibling::div[@data-ng-if="!isInstructorOrGsi"]//td[@data-ng-if="section.units"]')
     elements(:section_grade_option, :td, :xpath => '//h4[text()="Course Offering"]/following-sibling::div[@data-ng-if="!isInstructorOrGsi"]//td[@data-ng-bind="section.gradeOption"]')
     elements(:section_schedule_label, :div, :xpath => '//div[@data-ng-repeat="section in selectedCourse.sections"]/div[@data-ng-bind="section.section_label"]')
-    elements(:section_schedule, :div, :xpath => '//h4[text()="Section Schedules"]/following-sibling::div[@data-ng-repeat="section in selectedCourse.sections"]//div[@data-ng-repeat="schedule in section.schedules"]')
+    elements(:student_section_schedule, :div, :xpath => '//h4[text()="Section Schedules"]/following-sibling::div[@data-ng-repeat="section in selectedCourse.sections"]//div[@data-ng-repeat="schedule in section.schedules"]')
+    elements(:teaching_section_schedule, :div, :xpath => '//h3[text()="Section Schedules"]/following-sibling::div[@data-ng-repeat="section in selectedCourse.sections"]//div[@data-ng-repeat="schedule in section.schedules"]')
+    h3(:cross_listing_heading, :xpath => '//h3[text()="Cross-listed As"]')
+    elements(:cross_listing, :span, :xpath => '//span[@data-ng-bind="listing.course_code"]')
+
+    # INSTRUCTORS
     elements(:section_instructors_heading, :h3, :xpath => '//h3[@data-ng-bind="section.section_label"]')
 
     # WEBCAST
@@ -76,9 +79,15 @@ module CalCentralPages
       labels
     end
 
-    def all_section_schedules
+    def all_student_section_schedules
       schedules = []
-      section_schedule_elements.each { |schedule| schedules.push(schedule.text) }
+      student_section_schedule_elements.each { |schedule| schedules.push(schedule.text) }
+      schedules
+    end
+
+    def all_teaching_section_schedules
+      schedules = []
+      teaching_section_schedule_elements.each { |schedule| schedules.push(schedule.text) }
       schedules
     end
 
@@ -97,6 +106,12 @@ module CalCentralPages
         instructors.push(all_section_instructors(driver, section))
       end
       instructors
+    end
+
+    def all_cross_listings
+      listings = []
+      cross_listing_elements.each { |listing| listings.push(listing.text) }
+      listings
     end
 
     def wait_for_webcasts

--- a/spec/ui_selenium/pages/my_academics_classes_card.rb
+++ b/spec/ui_selenium/pages/my_academics_classes_card.rb
@@ -3,15 +3,15 @@ require 'selenium-webdriver'
 require 'page-object'
 require_relative 'cal_central_pages'
 require_relative 'my_academics_page'
-require_relative '../util/web_driver_utils'
 
 module CalCentralPages
 
-  class MyAcademicsEnrollmentsCard < MyAcademicsPage
+  class MyAcademicsClassesCard < MyAcademicsPage
 
     include PageObject
     include CalCentralPages
-    include ClassLogger
+
+    span(:semester_heading, :xpath => '//span[@data-ng-bind="widgetSemesterName"]')
 
     elements(:enrolled_course_codes, :link, :xpath => '//tbody[@data-ng-repeat="course in enrolledCourses"]//a[@data-ng-bind="course.course_code"]')
     elements(:enrolled_course_titles, :td, :xpath => '//tbody[@data-ng-repeat="course in enrolledCourses"]//td[@data-ng-bind="course.title"]')
@@ -19,11 +19,16 @@ module CalCentralPages
     elements(:enrolled_units, :td, :xpath => '//tbody[@data-ng-repeat="course in enrolledCourses"]//td[@data-ng-bind="course.units | number:1"]')
     elements(:enrolled_sections, :span, :xpath => '//tbody[@data-ng-repeat="course in enrolledCourses"]//div[@data-ng-repeat="section in course.sections"]/span[@data-ng-bind="section.section_label"]')
     div(:no_enrollment_message, :xpath => '//div[contains(text(),"You are not currently enrolled in any courses")]')
+
     elements(:waitlist_course_codes, :link, :xpath => '//h3[text()="Wait Lists"]/following-sibling::div//a[@data-ng-bind="course.course_code"]')
     elements(:waitlist_sections, :span, :xpath => '//h3[text()="Wait Lists"]/following-sibling::div//span[@data-ng-bind="section.section_label"]')
     elements(:waitlist_course_titles, :td, :xpath => '//h3[text()="Wait Lists"]/following-sibling::div//td[@data-ng-bind="course.title"]')
     elements(:waitlist_positions, :td, :xpath => '//h3[text()="Wait Lists"]/following-sibling::div//strong[@data-ng-bind="section.waitlistPosition"]')
     elements(:waitlist_class_size, :td, :xpath => '//h3[text()="Wait Lists"]/following-sibling::div//strong[@data-ng-bind="section.enroll_limit"]')
+
+    elements(:teaching_course_code, :link, :xpath => '//tbody[@data-ng-repeat="course in selectedTeachingSemester.classes"]//a[@data-ng-bind="listing.course_code"]')
+    elements(:teaching_course_title, :td, :xpath => '//tbody[@data-ng-repeat="course in selectedTeachingSemester.classes"]//td[@data-ng-bind="course.title"]')
+    elements(:teaching_course_section, :div, :xpath => '//div[@data-ng-repeat="scheduledSection in course.scheduledSections"]')
 
     def all_enrolled_course_codes
       codes = []
@@ -85,8 +90,23 @@ module CalCentralPages
       sizes
     end
 
-    def click_course_code(driver, code)
-      driver.find_element(:link_text => code).click
+    def all_teaching_course_codes
+      codes = []
+      teaching_course_code_elements.each { |code| codes.push(code.text) }
+      codes
     end
+
+    def all_teaching_course_titles
+      titles = []
+      teaching_course_title_elements.each { |title| titles.push(title.text) }
+      titles
+    end
+
+    def all_teaching_course_sections
+      sections = []
+      teaching_course_section_elements.each { |section| sections.push(section.text) }
+      sections
+    end
+
   end
 end

--- a/spec/ui_selenium/pages/my_academics_page.rb
+++ b/spec/ui_selenium/pages/my_academics_page.rb
@@ -13,7 +13,6 @@ module CalCentralPages
     wait_for_expected_title('My Academics | CalCentral')
 
     h1(:page_heading, :xpath => '//h1[contains(.,"My Academics")]')
-    link(:first_student_semester_link, :xpath => '//div[@class="cc-academics-semesters"]//a')
 
     def load_page(driver)
       logger.info('Loading My Academics page')
@@ -41,16 +40,25 @@ module CalCentralPages
       end
     end
 
-    def click_semester_link(driver, semester_name)
+    def click_student_semester_link(driver, semester_name)
       logger.info("Clicking link for #{semester_name}")
-      wait = Selenium::WebDriver::Wait.new(:timeout => WebDriverUtils.page_load_timeout)
-      wait.until { driver.find_element(:link_text => semester_name) }
+      wait_until(timeout=WebDriverUtils.page_load_timeout) { driver.find_element(:xpath => "//div[@data-ng-if='api.user.profile.hasStudentHistory && semesters.length']//a[text()='#{semester_name}']") }
       driver.find_element(:link_text => semester_name).click
     end
 
-    def click_class_link(driver, url)
-      wait = Selenium::WebDriver::Wait.new(:timeout => WebDriverUtils.page_load_timeout)
-      wait.until { driver.find_element(:xpath => "//a[@href='#{url}']") }
+    def click_teaching_semester_link(driver, semester_name)
+      logger.info("Clicking link for #{semester_name}")
+      wait_until(timeout=WebDriverUtils.page_load_timeout) { driver.find_element(:xpath => "//div[@data-ng-if='hasTeachingClasses']//a[text()='#{semester_name}']") }
+      driver.find_element(:xpath => "//div[@data-ng-if='hasTeachingClasses']//a[text()='#{semester_name}']").click
+    end
+
+    def click_class_link_by_text(driver, link_text)
+      wait_until(timeout=WebDriverUtils.page_load_timeout) { driver.find_element(:link_text => link_text) }
+      driver.find_element(:link_text => link_text).click
+    end
+
+    def click_class_link_by_url(driver, url)
+      wait_until(timeout=WebDriverUtils.page_load_timeout) { driver.find_element(:xpath => "//a[@href='#{url}']") }
       driver.find_element(:xpath => "//a[@href='#{url}']").click
     end
   end

--- a/spec/ui_selenium/pages/my_academics_teaching_card.rb
+++ b/spec/ui_selenium/pages/my_academics_teaching_card.rb
@@ -1,0 +1,42 @@
+require 'selenium-webdriver'
+require 'page-object'
+require_relative 'cal_central_pages'
+require_relative '../util/web_driver_utils'
+
+module CalCentralPages
+  class MyAcademicsTeachingCard < MyAcademicsPage
+
+    include PageObject
+    include CalCentralPages
+
+    elements(:semester_link, :link, :xpath => '//div[@data-ng-if="hasTeachingClasses"]//a[@data-ng-bind="semester.name"]')
+    elements(:course_code, :link, :xpath => '//a[@data-ng-bind="listing.course_code"]')
+    button(:show_more, :xpath => '//button[@data-ng-if="pastSemestersTeachingCount > 1"]/span[text()="Show More"]')
+    button(:show_less, :xpath => '//button[@data-ng-if="pastSemestersTeachingCount > 1"]/span[text()="Show Less"]')
+    paragraph(:no_classes_msg, :xpath => '//p[contains(text(),"You are officially an instructor at UC Berkeley, but no courses assigned to you are currently available through campus services.")]')
+
+    def teaching_terms_visible?(term_names)
+      terms_in_ui = []
+      semester_link_elements.each { |link| terms_in_ui.push(link.text) }
+      if terms_in_ui.sort == term_names.sort
+        true
+      else
+        false
+      end
+    end
+
+    def all_semester_course_codes(driver, semester_name)
+      codes = []
+      code_elements = driver.find_elements(:xpath, "//div[@data-ng-if='hasTeachingClasses']//a[text()='#{semester_name}']/../following-sibling::div//a[@data-ng-bind='listing.course_code']")
+      code_elements.each { |element| codes.push(element.text) }
+      codes
+    end
+
+    def all_semester_course_titles(driver, semester_name)
+      titles = []
+      title_elements = driver.find_elements(:xpath => "//div[@data-ng-if='hasTeachingClasses']//a[text()='#{semester_name}']/../following-sibling::div//div[@data-ng-bind='class.title']")
+      title_elements.each { |element| titles.push(element.text) }
+      titles
+    end
+  end
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5269

This is a new test to cover what instructors see in the Academics UI.  The test iterates through UIDs, checking the teaching semester information that appears in the Academics landing page, semester pages, and class pages.

There is also some minor refactoring and reorganizing of code already used by the student academics test, since there is much overlap with this new test.