### PR TITLE
CLC-5299, Webcasts: recordings duplicated on cross-listed course

### DIFF
--- a/app/models/webcast/merged.rb
+++ b/app/models/webcast/merged.rb
@@ -35,12 +35,12 @@ module Webcast
 
     def merge(course, media_type)
       return [] if course.empty?
-      all_recordings = []
+      all_recordings = Set.new
       course.values.each do |section|
         recordings = section[media_type]
         recordings.each { |r| all_recordings << r } if recordings
       end
-      all_recordings
+      all_recordings.to_a
     end
 
     def merge_itunes(course)

--- a/app/models/webcast/recordings.rb
+++ b/app/models/webcast/recordings.rb
@@ -1,10 +1,6 @@
 module Webcast
   class Recordings < Proxy
 
-    def initialize(options = {})
-      super(options)
-    end
-
     def get_json_path
       'webcast.json'
     end

--- a/app/models/webcast/rooms.rb
+++ b/app/models/webcast/rooms.rb
@@ -1,10 +1,6 @@
 module Webcast
   class Rooms < Proxy
 
-    def initialize(options = {})
-      super(options)
-    end
-
     def get_json_path
       'rooms.json'
     end

--- a/app/models/webcast/sign_up_eligible.rb
+++ b/app/models/webcast/sign_up_eligible.rb
@@ -1,0 +1,20 @@
+module Webcast
+  class SignUpEligible < Proxy
+
+    def get_json_path
+      'eligible-for-webcast.json'
+    end
+
+    def request_internal
+      return {} unless Settings.features.videos
+      ccn_set_by_term = {}
+      data = get_json_data
+      data['semesters'].each do |term|
+        slug = "#{term['year']}-#{term['semester'].downcase}"
+        ccn_set_by_term[slug] = term['ccnSet'].to_a
+      end
+      ccn_set_by_term
+    end
+
+  end
+end

--- a/app/models/webcast/system_status.rb
+++ b/app/models/webcast/system_status.rb
@@ -1,10 +1,6 @@
 module Webcast
   class SystemStatus < Proxy
 
-    def initialize(options = {})
-      super(options)
-    end
-
     def get_json_path
       'webcast-system-status.json'
     end

--- a/fixtures/webcast/eligible-for-webcast.json
+++ b/fixtures/webcast/eligible-for-webcast.json
@@ -1,0 +1,25 @@
+{
+  "semesters": [
+    {
+      "year": 2015,
+      "semester": "Spring",
+      "ccnSet": [
+        5916,
+        51991
+      ]
+    },
+    {
+      "year": 2015,
+      "semester": "Fall",
+      "ccnSet": [
+        5917,
+        51992
+      ]
+    },
+    {
+      "year": 2016,
+      "semester": "Spring",
+      "ccnSet": []
+    }
+  ]
+}

--- a/fixtures/webcast/webcast.json
+++ b/fixtures/webcast/webcast.json
@@ -1729,6 +1729,314 @@
       "youTubePlaylist": "PL-XXv-cvA_iDy-rACIy-kh40XJJDp3Y0X",
       "iTunesVideo": 819827828,
       "videoRSS": "http://wbe-itunes.berkeley.edu/media/common/courses/spring_2014/rss/statistics_131a_001_screen.rss"
+    },
+    {
+      "year": 2015,
+      "semester": "Spring",
+      "ccn": 51990,
+      "deptName": "L & S",
+      "catalogId": "C70U",
+      "public": false,
+      "youTubePlaylist": "PL-XXv-cvA_iAn6Qt6B7D-phRT0Ld1GOUV",
+      "audioRSS": "http://wbe-itunes.berkeley.edu/media/common/courses/2015B/rss/5915_audio.rss",
+      "screenRSS": "http://wbe-itunes.berkeley.edu/media/common/courses/2015B/rss/5915_screen.rss",
+      "recordings": [
+        {
+          "lecture": "2015-01-21: A Grand Tour of the Cosmos",
+          "youTubeId": "E8WBr8u7YoI",
+          "recordingStartUTC": "2015-01-21T15:07:00-08:00"
+        },
+        {
+          "lecture": "2015-01-23: Journey Through Space and Time",
+          "youTubeId": "hoLFZNm3lsk",
+          "recordingStartUTC": "2015-01-23T15:07:00-08:00"
+        },
+        {
+          "lecture": "2015-01-26: Light â€“ The Supreme Informant",
+          "youTubeId": "a5arg3cSFeg",
+          "recordingStartUTC": "2015-01-26T15:07:00-08:00"
+        },
+        {
+          "lecture": "2015-01-28: The Fingerprints of Atoms",
+          "youTubeId": "ibG9xrcKs2g",
+          "recordingStartUTC": "2015-01-28T15:07:00-08:00"
+        },
+        {
+          "lecture": "2015-01-30: Thermal Radiation; Doppler Effect",
+          "youTubeId": "MGUFdWgjEyU",
+          "recordingStartUTC": "2015-01-30T15:07:00-08:00"
+        },
+        {
+          "lecture": "2015-01-30: Telescopes: Tools of the Trade",
+          "youTubeId": "OX2fKZNIXLA",
+          "recordingStartUTC": "2015-01-30T16:07:00-08:00"
+        },
+        {
+          "lecture": "2015-02-02: Telescopes; Twinkling; Lunar Phases",
+          "youTubeId": "5LF4QaTTR80",
+          "recordingStartUTC": "2015-02-02T15:07:00-08:00"
+        },
+        {
+          "lecture": "2015-02-04: Glorious Total Solar Eclipses",
+          "youTubeId": "IEK2sThtnB8",
+          "recordingStartUTC": "2015-02-04T15:07:00-08:00"
+        },
+        {
+          "lecture": "2015-02-06: Eclipses; Celestial Phenomena",
+          "youTubeId": "cISHdRPoml8",
+          "recordingStartUTC": "2015-02-06T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-02-09: Seasons; The Copernican Revolution",
+          "youTubeId": "CB-FypT3TwY",
+          "recordingStartUTC": "2015-02-09T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-02-11: On the Shoulders of Giants",
+          "youTubeId": "zE6PuqmEgIo",
+          "recordingStartUTC": "2015-02-11T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-02-18: Newton; Origin of Solar System; Earth",
+          "youTubeId": "aPs816-AzLg",
+          "recordingStartUTC": "2015-02-18T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-02-20: (Part 1) The Moon, Mercury, Venus, Mars",
+          "youTubeId": "Sb7_aZlZXjk",
+          "recordingStartUTC": "2015-02-20T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-02-20: (Part 2) Mars, Jupiter, Saturn",
+          "youTubeId": "LYUuTlcAgUk",
+          "recordingStartUTC": "2015-02-20T16:06:00-08:00"
+        },
+        {
+          "lecture": "2015-02-23: Uranus, Neptune, Pluto",
+          "youTubeId": "piwH4DTIx2Q",
+          "recordingStartUTC": "2015-02-23T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-02-25: Comets, Space Debris, Collisions",
+          "youTubeId": "1r3d3uq1gKQ",
+          "recordingStartUTC": "2015-02-25T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-02-27: Collisions; Exoplanets",
+          "youTubeId": "ZaRnqiMPzuE",
+          "recordingStartUTC": "2015-02-27T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-03-02: Other Worlds",
+          "youTubeId": "Dr3y8TNoWvs",
+          "recordingStartUTC": "2015-03-02T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-03-04: Our Sun and other Stars",
+          "youTubeId": "jq-1XmLFkMI",
+          "recordingStartUTC": "2015-03-04T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-03-06: (Part 1) Social Stars: Binaries and Clusters",
+          "youTubeId": "XEJvZ1H0BcU",
+          "recordingStartUTC": "2015-03-06T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-03-06: (Part 2) How Stars Shine: Cosmic Furnaces",
+          "youTubeId": "oPIOnqW1b1k",
+          "recordingStartUTC": "2015-03-06T16:06:00-08:00"
+        },
+        {
+          "lecture": "2015-03-09: The Fate of Our Sun: Stellar Evolution",
+          "youTubeId": "c7rHGsrqBU4",
+          "recordingStartUTC": "2015-03-09T15:06:00-07:00"
+        },
+        {
+          "lecture": "2015-03-11: Exploding Stars: Celestial Fireworks!",
+          "youTubeId": "EqBdNSI8YQ4",
+          "recordingStartUTC": "2015-03-11T15:07:00-07:00"
+        },
+        {
+          "lecture": "2015-03-13: The Corpses of Massive Stars",
+          "youTubeId": "NR2nUQ-OXq8",
+          "recordingStartUTC": "2015-03-13T15:06:00-07:00"
+        },
+        {
+          "lecture": "2015-03-18: The Milky Way and Other Galaxies",
+          "youTubeId": "vXr-DTe5D2E",
+          "recordingStartUTC": "2015-03-18T15:06:00-07:00"
+        },
+        {
+          "lecture": "2015-03-20: The Dark Side of Matter",
+          "youTubeId": "yg2EPjsAJGs",
+          "recordingStartUTC": "2015-03-20T15:06:00-07:00"
+        },
+        {
+          "lecture": "2015-03-30: The Expansion of the Universe",
+          "youTubeId": "DWbYMmXgx8k",
+          "recordingStartUTC": "2015-03-30T15:06:00-07:00"
+        },
+        {
+          "lecture": "2015-04-01: Black Holes: Hearts of Darkness",
+          "youTubeId": "Ax670ei7h2Q",
+          "recordingStartUTC": "2015-04-01T15:06:00-07:00"
+        }
+      ],
+      "audioOnly": false
+    },
+    {
+      "year": 2015,
+      "semester": "Spring",
+      "ccn": 5915,
+      "deptName": "ASTRON",
+      "catalogId": "C10",
+      "public": false,
+      "youTubePlaylist": "PL-XXv-cvA_iAn6Qt6B7D-phRT0Ld1GOUV",
+      "audioRSS": "http://wbe-itunes.berkeley.edu/media/common/courses/2015B/rss/5915_audio.rss",
+      "screenRSS": "http://wbe-itunes.berkeley.edu/media/common/courses/2015B/rss/5915_screen.rss",
+      "recordings": [
+        {
+          "lecture": "2015-01-21: A Grand Tour of the Cosmos",
+          "youTubeId": "E8WBr8u7YoI",
+          "recordingStartUTC": "2015-01-21T15:07:00-08:00"
+        },
+        {
+          "lecture": "2015-01-23: Journey Through Space and Time",
+          "youTubeId": "hoLFZNm3lsk",
+          "recordingStartUTC": "2015-01-23T15:07:00-08:00"
+        },
+        {
+          "lecture": "2015-01-26: Light â€“ The Supreme Informant",
+          "youTubeId": "a5arg3cSFeg",
+          "recordingStartUTC": "2015-01-26T15:07:00-08:00"
+        },
+        {
+          "lecture": "2015-01-28: The Fingerprints of Atoms",
+          "youTubeId": "ibG9xrcKs2g",
+          "recordingStartUTC": "2015-01-28T15:07:00-08:00"
+        },
+        {
+          "lecture": "2015-01-30: Thermal Radiation; Doppler Effect",
+          "youTubeId": "MGUFdWgjEyU",
+          "recordingStartUTC": "2015-01-30T15:07:00-08:00"
+        },
+        {
+          "lecture": "2015-01-30: Telescopes: Tools of the Trade",
+          "youTubeId": "OX2fKZNIXLA",
+          "recordingStartUTC": "2015-01-30T16:07:00-08:00"
+        },
+        {
+          "lecture": "2015-02-02: Telescopes; Twinkling; Lunar Phases",
+          "youTubeId": "5LF4QaTTR80",
+          "recordingStartUTC": "2015-02-02T15:07:00-08:00"
+        },
+        {
+          "lecture": "2015-02-04: Glorious Total Solar Eclipses",
+          "youTubeId": "IEK2sThtnB8",
+          "recordingStartUTC": "2015-02-04T15:07:00-08:00"
+        },
+        {
+          "lecture": "2015-02-06: Eclipses; Celestial Phenomena",
+          "youTubeId": "cISHdRPoml8",
+          "recordingStartUTC": "2015-02-06T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-02-09: Seasons; The Copernican Revolution",
+          "youTubeId": "CB-FypT3TwY",
+          "recordingStartUTC": "2015-02-09T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-02-11: On the Shoulders of Giants",
+          "youTubeId": "zE6PuqmEgIo",
+          "recordingStartUTC": "2015-02-11T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-02-18: Newton; Origin of Solar System; Earth",
+          "youTubeId": "aPs816-AzLg",
+          "recordingStartUTC": "2015-02-18T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-02-20: (Part 1) The Moon, Mercury, Venus, Mars",
+          "youTubeId": "Sb7_aZlZXjk",
+          "recordingStartUTC": "2015-02-20T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-02-20: (Part 2) Mars, Jupiter, Saturn",
+          "youTubeId": "LYUuTlcAgUk",
+          "recordingStartUTC": "2015-02-20T16:06:00-08:00"
+        },
+        {
+          "lecture": "2015-02-23: Uranus, Neptune, Pluto",
+          "youTubeId": "piwH4DTIx2Q",
+          "recordingStartUTC": "2015-02-23T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-02-25: Comets, Space Debris, Collisions",
+          "youTubeId": "1r3d3uq1gKQ",
+          "recordingStartUTC": "2015-02-25T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-02-27: Collisions; Exoplanets",
+          "youTubeId": "ZaRnqiMPzuE",
+          "recordingStartUTC": "2015-02-27T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-03-02: Other Worlds",
+          "youTubeId": "Dr3y8TNoWvs",
+          "recordingStartUTC": "2015-03-02T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-03-04: Our Sun and other Stars",
+          "youTubeId": "jq-1XmLFkMI",
+          "recordingStartUTC": "2015-03-04T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-03-06: (Part 1) Social Stars: Binaries and Clusters",
+          "youTubeId": "XEJvZ1H0BcU",
+          "recordingStartUTC": "2015-03-06T15:06:00-08:00"
+        },
+        {
+          "lecture": "2015-03-06: (Part 2) How Stars Shine: Cosmic Furnaces",
+          "youTubeId": "oPIOnqW1b1k",
+          "recordingStartUTC": "2015-03-06T16:06:00-08:00"
+        },
+        {
+          "lecture": "2015-03-09: The Fate of Our Sun: Stellar Evolution",
+          "youTubeId": "c7rHGsrqBU4",
+          "recordingStartUTC": "2015-03-09T15:06:00-07:00"
+        },
+        {
+          "lecture": "2015-03-11: Exploding Stars: Celestial Fireworks!",
+          "youTubeId": "EqBdNSI8YQ4",
+          "recordingStartUTC": "2015-03-11T15:07:00-07:00"
+        },
+        {
+          "lecture": "2015-03-13: The Corpses of Massive Stars",
+          "youTubeId": "NR2nUQ-OXq8",
+          "recordingStartUTC": "2015-03-13T15:06:00-07:00"
+        },
+        {
+          "lecture": "2015-03-18: The Milky Way and Other Galaxies",
+          "youTubeId": "vXr-DTe5D2E",
+          "recordingStartUTC": "2015-03-18T15:06:00-07:00"
+        },
+        {
+          "lecture": "2015-03-20: The Dark Side of Matter",
+          "youTubeId": "yg2EPjsAJGs",
+          "recordingStartUTC": "2015-03-20T15:06:00-07:00"
+        },
+        {
+          "lecture": "2015-03-30: The Expansion of the Universe",
+          "youTubeId": "DWbYMmXgx8k",
+          "recordingStartUTC": "2015-03-30T15:06:00-07:00"
+        },
+        {
+          "lecture": "2015-04-01: Black Holes: Hearts of Darkness",
+          "youTubeId": "Ax670ei7h2Q",
+          "recordingStartUTC": "2015-04-01T15:06:00-07:00"
+        }
+      ],
+      "audioOnly": false
     }
   ]
 }

--- a/spec/models/webcast/merged_spec.rb
+++ b/spec/models/webcast/merged_spec.rb
@@ -59,5 +59,22 @@ describe Webcast::Merged do
       end
     end
 
+    context 'cross-listed CCNs in merged feed' do
+      let(:feed) do
+        Webcast::Merged.new(2015, 'B', [51990, 5915], options).get_feed
+      end
+      it 'returns course media' do
+        expect(feed[:video_error_message]).to be_nil
+        ls_C70U = feed[:media]['2015-B-51990']
+        astro_C10 = feed[:media]['2015-B-5915']
+        expect(ls_C70U[:videos]).to have(28).items
+        expect(astro_C10[:videos]).to have(28).items
+        # These are cross-listed CCNs so we only include unique recordings
+        expect(feed[:videos]).to have(28).items
+        expect(feed[:videos]).to match_array astro_C10[:videos]
+        expect(feed[:audio]).to match_array astro_C10[:audio]
+      end
+    end
+
   end
 end

--- a/spec/models/webcast/recordings_spec.rb
+++ b/spec/models/webcast/recordings_spec.rb
@@ -6,7 +6,7 @@ describe Webcast::Recordings do
     context 'data organized by ccn' do
       let(:recordings) { Webcast::Recordings.new({:fake => true}).get }
       it 'should return a lot of playlists' do
-        expect(recordings[:courses].keys.length).to eq 19
+        expect(recordings[:courses].keys.length).to eq 21
         law_2723 = recordings[:courses]['2008-D-49688']
         expect(law_2723).to_not be_nil
         expect(law_2723[:recordings]).to have(12).items
@@ -20,7 +20,9 @@ describe Webcast::Recordings do
     context 'normal return of real data', :testext => true do
       it 'should return a bunch of playlists' do
         result = subject.get
-        expect(result[:courses].keys.length).to be >= 0
+        courses = result[:courses]
+        expect(courses).to_not be_nil
+        expect(courses.keys.length).to be >= 0
       end
     end
 

--- a/spec/models/webcast/sign_up_eligible_spec.rb
+++ b/spec/models/webcast/sign_up_eligible_spec.rb
@@ -1,0 +1,38 @@
+describe Webcast::SignUpEligible do
+
+  let (:eligible_for_webcast_json_uri) { URI.parse "#{Settings.webcast_proxy.base_url}/eligible-for-webcast.json" }
+
+  context 'a fake proxy' do
+    subject { Webcast::SignUpEligible.new({:fake => true}) }
+
+    context 'fake data' do
+      it 'should return all test data' do
+        terms = subject.get
+        expect(terms).to have(3).items
+        expect(terms['2015-spring']).to contain_exactly(5916, 51991)
+        expect(terms['2015-fall']).to contain_exactly(5917, 51992)
+        expect(terms['2016-spring']).to be_empty
+      end
+
+    end
+  end
+
+  context 'a real, non-fake proxy' do
+    subject { Webcast::SignUpEligible.new }
+
+    context 'real data', :testext => true do
+      it 'should return at least one term' do
+        expect(subject.get.keys).to have_at_least(1).items
+      end
+    end
+
+    context 'when webcast feature is disabled' do
+      before { Settings.features.videos = false }
+      after { Settings.features.videos = true }
+      it 'should return an empty hash' do
+        expect(subject.get).to be_empty
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5299

This bug has to do with the deprecated :video and :audio elements of Webcast merged feed. In the case of cross-listings we were merging all recordings into an array and thus the duplicates. My fix is to use a Set object instead. I added a test to verify.