### PR TITLE
View As: limit number of Recent Users to 30

### DIFF
--- a/app/models/user/recent_uid.rb
+++ b/app/models/user/recent_uid.rb
@@ -2,11 +2,22 @@ module User
   class RecentUid < ActiveRecord::Base
     include ActiveRecordHelper
 
+    MAX_PER_OWNER_ID = 30
+
     self.table_name = 'recent_uids'
 
     belongs_to :data, :class_name => 'User::Data', :foreign_key => 'owner_id'
 
     attr_accessible :stored_uid
+
+    before_create :limit_by_owner_id
+
+    def limit_by_owner_id
+      record_ids = self.class.where(owner_id: self.owner_id.to_s).order(:created_at).pluck(:id)
+      if record_ids.count >= MAX_PER_OWNER_ID
+        self.class.delete record_ids.slice(0..-MAX_PER_OWNER_ID)
+      end
+    end
 
   end
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5157

The number 30 is a wild guess at what looks reasonable in the new/old UI. This can be changed.