### PR TITLE
Revert SIS fix to CLC-5104 

### DIFF
--- a/app/controllers/config_controller.rb
+++ b/app/controllers/config_controller.rb
@@ -1,6 +1,5 @@
 class ConfigController < ApplicationController
   before_filter :get_settings, :initialize_calcentral_config
-  skip_before_filter :check_reauthentication
 
   def get
     render json: @calcentral_config.merge({


### PR DESCRIPTION
The real fix happened in a different commit, https://github.com/ets-berkeley-edu/calcentral/pull/3629

Revert "CLC-5104 Skipping reauth should help ConfigController not return 302s"

This reverts commit 7365dbf305df631b0111b2206e4a5edb78019d86.