### PR TITLE
CLC-5292 Allow saved users to appear under Recent Users without save link

### DIFF
--- a/app/controllers/stored_users_controller.rb
+++ b/app/controllers/stored_users_controller.rb
@@ -11,9 +11,6 @@ class StoredUsersController < ApplicationController
 
   def store_saved_uid
     response = User::StoredUsers.store_saved_uid(current_user.real_user_id, params['uid'])
-    if response[:success]
-      User::StoredUsers.delete_recent_uid(session['original_user_id'], params['uid'])
-    end
     render json: response.to_json
   end
 

--- a/app/models/user/stored_users.rb
+++ b/app/models/user/stored_users.rb
@@ -29,9 +29,12 @@ module User
         uid_hash[user['ldap_uid']] = user
       end
 
+      saved_uid_set = Set.new
+
       uid_entries[:saved].each do |entry|
         user = uid_hash[entry[:stored_uid]]
         if user.present?
+          saved_uid_set.add entry[:stored_uid]
           users[:saved] << user
         end
       end
@@ -39,7 +42,7 @@ module User
       uid_entries[:recent].each do |entry|
         user = uid_hash[entry[:stored_uid]]
         if user.present?
-          users[:recent] << user
+          users[:recent] << user.merge('saved' => saved_uid_set.include?(entry[:stored_uid]))
         end
       end
 

--- a/src/assets/templates/settings.html
+++ b/src/assets/templates/settings.html
@@ -71,7 +71,7 @@
                 UID: <button type="submit" class="cc-button-link" data-ng-click="admin.updateIDField(user.ldap_uid)" data-ng-bind="user.ldap_uid"></button>
                 (SID: <span data-ng-bind="user.student_id || 'none'"></span>)
               </span>
-              <span data-ng-if="block.storeUser">(<button type="button" class="cc-button-link" data-ng-click="block.storeUser(user)">save</button>)</span>
+              <span data-ng-if="block.storeUser && !user.saved">(<button type="button" class="cc-button-link" data-ng-click="block.storeUser(user)">save</button>)</span>
               <span data-ng-if="block.clearUser">(<button type="button" class="cc-button-link" data-ng-click="block.clearUser(user)">delete</button>)</span>
             </li>
           </ul>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5292

Note that this reverts the change in #3725 to StoredUsersController#store_saved_uid, which removed a user from the Recent Users list after saving.