### PR TITLE
CLC-5251 Ignore testext specs for CalGroups proxies

### DIFF
--- a/spec/models/cal_groups/find_groups_spec.rb
+++ b/spec/models/cal_groups/find_groups_spec.rb
@@ -61,7 +61,8 @@ describe CalGroups::FindGroups do
     end
   end
 
-  context 'using real data feed', testext: true do
+  # This testext group is disabled until CLC-5251 is resolved.
+  context 'using real data feed', testext: true, ignore: true do
     let(:fake) { false }
 
     context 'a known test group' do

--- a/spec/models/cal_groups/member_check_spec.rb
+++ b/spec/models/cal_groups/member_check_spec.rb
@@ -77,7 +77,8 @@ describe CalGroups::MemberCheck do
     end
   end
 
-  context 'using real data feed', testext: true do
+  # This testext group is disabled until CLC-5251 is resolved.
+  context 'using real data feed', testext: true, ignore: true do
     let(:fake) { false }
     let(:group_name) { 'testgroup' }
 

--- a/spec/models/cal_groups/members_check_spec.rb
+++ b/spec/models/cal_groups/members_check_spec.rb
@@ -68,7 +68,8 @@ describe CalGroups::MembersCheck do
     end
   end
 
-  context 'using real data feed', testext: true do
+  # This testext group is disabled until CLC-5251 is resolved.
+  context 'using real data feed', testext: true, ignore: true do
     let(:fake) { false }
 
     include_examples 'membership expectations'

--- a/spec/models/cal_groups/members_get_spec.rb
+++ b/spec/models/cal_groups/members_get_spec.rb
@@ -70,7 +70,8 @@ describe CalGroups::MembersGet do
     end
   end
 
-  context 'using real data feed', testext: true do
+  # This testext group is disabled until CLC-5251 is resolved.
+  context 'using real data feed', testext: true, ignore: true do
     let(:fake) { false }
 
     context 'a known test group' do


### PR DESCRIPTION
This should temporarily clear up Bamboo failures while waiting on a fix for https://jira.ets.berkeley.edu/jira/browse/CLC-5251 .