### PR TITLE
CLC-5211 CLC-5212 Backend and rake task for site mailing lists

### DIFF
--- a/app/controllers/canvas_mailing_lists_controller.rb
+++ b/app/controllers/canvas_mailing_lists_controller.rb
@@ -1,0 +1,42 @@
+class CanvasMailingListsController < ApplicationController
+  include ClassLogger
+  include SpecificToCourseSite
+
+  before_action :api_authenticate
+  before_action :authorize_mailing_list_administration
+
+  rescue_from StandardError, with: :handle_api_exception
+  rescue_from Errors::ClientError, with: :handle_client_error
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  def authorize_mailing_list_administration
+    raise ArgumentError, 'No Canvas Course ID in request' if canvas_course_id.blank?
+    authorize current_user, :can_administrate_canvas?
+  end
+
+  # GET /api/academics/canvas/mailing_lists/:canvas_course_id
+
+  def show
+    list = MailingLists::SiteMailingList.find_or_initialize_by canvas_site_id: canvas_course_id.to_s
+    render json: list.to_json
+  end
+
+  # POST /api/academics/canvas/mailing_lists/:canvas_course_id/create
+
+  def create
+    list = MailingLists::SiteMailingList.create canvas_site_id: canvas_course_id.to_s, list_name: params['list_name']
+    render json: list.to_json
+  end
+
+  # POST /api/academics/canvas/mailing_lists/:canvas_course_id/populate
+
+  def populate
+    if (list = MailingLists::SiteMailingList.find_by canvas_site_id: canvas_course_id.to_s)
+      list.populate
+      render json: list.to_json
+    else
+      raise Errors::BadRequestError, "Bad course site ID #{canvas_course_id}"
+    end
+  end
+
+end

--- a/app/models/mailing_lists/site_mailing_list.rb
+++ b/app/models/mailing_lists/site_mailing_list.rb
@@ -1,10 +1,205 @@
 module MailingLists
   class SiteMailingList < ActiveRecord::Base
     include ActiveRecordHelper
+    include ClassLogger
+    include DatedFeed
 
     self.table_name = 'canvas_site_mailing_lists'
 
     attr_accessible :canvas_site_id, :list_name, :state, :populated_at
+    attr_accessor :bad_request_error
+    attr_accessor :population_results
+
+    validates :bad_request_error, absence: true
+    validates :canvas_site_id, uniqueness: true
+    validates :list_name, uniqueness: true
+    validates :list_name, format: {with: /\A[\w-]+\Z/, message: 'Only lowercase, numeric, underscore and hyphen characters are permitted.'}
+
+    after_initialize :get_canvas_site
+    after_initialize :init_unregistered, if: :new_record?
+
+    before_create { self.state = 'pending' }
+
+    after_find { check_for_creation if self.state == 'pending' }
+
+    def populate
+      if self.state != 'created'
+        self.bad_request_error = "Mailing list \"#{self.list_name}\" must be created before being populated."
+        return {error: bad_request_error}
+      end
+
+      course_users = Canvas::CourseUsers.new(course_id: self.canvas_site_id).course_users
+      list_members = Calmail::ListMembers.new.list_members self.list_name
+
+      if !course_users
+        self.bad_request_error = "Could not retrieve current site roster for \"#{self.list_name}\"."
+        {error: bad_request_error}
+      elsif !list_members[:response] || !list_members[:response][:addresses]
+        self.bad_request_error = "Could not retrieve existing list roster for \"#{self.list_name}\"."
+        {error: bad_request_error}
+      else
+        update_memberships(course_users, list_members[:response][:addresses])
+        self.population_results
+      end
+    end
+
+    def to_json
+      feed = {
+        canvasSite: {
+          canvasCourseId: self.canvas_site_id
+        }
+      }
+      if @canvas_site
+        feed[:canvasSite].merge!({
+          sisCourseId: @canvas_site['sis_course_id'],
+          name: @canvas_site['name'],
+          courseCode: @canvas_site['course_code'],
+          url: "#{Settings.canvas_proxy.url_root}/courses/#{@canvas_site['id']}",
+          term: parse_term(@canvas_site['term'])
+        })
+        feed[:mailingList] = {
+          name: self.list_name,
+          domain: Settings.calmail_proxy.domain,
+          state: self.state
+        }
+        feed[:mailingList][:creationUrl] = build_creation_url if self.state == 'pending'
+        feed[:mailingList][:timeLastPopulated] = format_date(self.populated_at) if self.populated_at
+        feed[:populationResults] = population_results if population_results.present?
+      end
+      if bad_request_error
+        feed[:displayError] = 'badRequest'
+        feed[:badRequestError] = bad_request_error
+      elsif errors.any?
+        feed[:displayError] = 'badRequest'
+        feed[:validationErrors] = errors
+      end
+      feed.to_json
+    end
+
+    private
+
+    def build_creation_url
+      Settings.calmail_proxy.base_url.sub(
+        /api1\Z/,
+        [
+          "list/domain_create_list2?domain_name=#{Settings.calmail_proxy.domain}",
+          "listname=#{self.list_name}",
+          "owner_address=#{Settings.calmail_proxy.owner_address}",
+          "advertised=0",
+          "subscribe_policy=3",
+          "moderate=0",
+          "generic_nonmember_action=1"
+        ].join('&')
+      )
+    end
+
+    def check_for_creation
+      self.state = 'created' if !name_available?
+    end
+
+    def generate_list_name
+      # 'CHEM 1A LEC 003' => 'chem_1a_lec_003-sp15'
+      # {{design}} => 'design-sp15'
+      # 'The "Wild"-"Wild" West?' => 'the_wild_wild_west-sp15'
+      # 'Conversation intermédiaire' => 'conversation_intermediaire-sp15'
+      if @canvas_site
+        normalized_name = I18n.transliterate(@canvas_site['name']).downcase.split(/[^a-z0-9]+/).reject(&:blank?).join('_')
+        term = Canvas::Proxy.sis_term_id_to_term(@canvas_site['term']['sis_term_id'])
+        short_term_name = Berkeley::TermCodes.codes[term[:term_cd].to_sym].downcase[0,2]
+        short_term_year = term[:term_yr][-2,2]
+        "#{normalized_name}-#{short_term_name}#{short_term_year}"
+      end
+    end
+
+    def get_canvas_site
+      return if self.canvas_site_id.blank?
+      unless (@canvas_site = Canvas::Course.new(canvas_course_id: self.canvas_site_id).course)
+        self.bad_request_error = "No bCourses site found with ID \"#{self.canvas_site_id}\"."
+      end
+    end
+
+    def init_unregistered
+      self.state = 'unregistered'
+      self.list_name ||= generate_list_name
+      if !name_available?
+        self.bad_request_error = "Mailing list name \"#{self.list_name}\" is already taken."
+      end
+    end
+
+    def name_available?
+      if (check_namespace = Calmail::CheckNamespace.new.name_available? self.list_name)
+        check_namespace[:response]
+      end
+    end
+
+    def parse_term(term)
+      if (parsed_term = Canvas::Proxy.sis_term_id_to_term(term['sis_term_id']))
+        parsed_term.merge(name: Berkeley::TermCodes.to_english(parsed_term[:term_yr], parsed_term[:term_cd]))
+      end
+    end
+
+    def update_memberships(course_users, list_addresses)
+      self.population_results = {
+        add: {
+          total: 0,
+          success: 0,
+          failure: []
+        },
+        remove: {
+          total: 0,
+          success: 0,
+          failure: []
+        }
+      }
+      list_address_set = list_addresses.to_set
+      addresses_to_remove = list_address_set.clone
+
+      logger.info "Starting population of mailing list #{self.list_name} for course site #{self.canvas_site_id}."
+
+      add_member_proxy = Calmail::AddListMember.new
+
+      course_users.map{ |user| user['login_id'] }.each_slice(1000) do |uid_slice|
+        user_slice = CampusOracle::Queries.get_basic_people_attributes uid_slice
+        user_slice.each do |user|
+          addresses_to_remove.delete user['email_address']
+          unless list_address_set.include? user['email_address']
+            population_results[:add][:total] += 1
+            proxy_response = add_member_proxy.add_member(self.list_name, user['email_address'], "#{user['first_name']} #{user['last_name']}")
+            if proxy_response[:response] && proxy_response[:response][:added]
+              population_results[:add][:success] += 1
+            else
+              population_results[:add][:failure] << user['email_address']
+            end
+          end
+        end
+      end
+
+      logger.info "Added #{population_results[:add][:success]} of #{population_results[:add][:total]} new site members."
+      if population_results[:add][:failure].any?
+        logger.error "Failed to add #{population_results[:add][:failure]} addresses to #{self.list_name}: #{population_results[:add][:failure].join(' , ')}"
+      end
+
+      remove_member_proxy = Calmail::RemoveListMember.new
+      population_results[:remove][:total] = addresses_to_remove.count
+
+      addresses_to_remove.each do |address|
+        proxy_response = remove_member_proxy.remove_member(self.list_name, address)
+        if proxy_response[:response] && proxy_response[:response][:removed]
+          population_results[:remove][:success] += 1
+        else
+          population_results[:remove][:failure] << address
+        end
+      end
+
+      logger.info "Removed #{population_results[:remove][:success]} of #{population_results[:remove][:total]} former site members."
+      if population_results[:remove][:failure].any?
+        logger.error "Failed to remove #{population_results[:remove][:failure]} addresses from #{self.list_name}: #{population_results[:remove][:failure].join(' , ')}"
+      end
+
+      logger.info "Finished population of mailing list #{self.list_name}."
+      self.populated_at = DateTime.now
+      save
+    end
 
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,9 @@ Calcentral::Application.routes.draw do
   get '/api/academics/canvas/course_add_user/:canvas_course_id/course_sections' => 'canvas_course_add_user#course_sections', :via => :get, :as => :canvas_course_add_user_course_sections, :defaults => { :format => 'json' }
   post '/api/academics/canvas/course_add_user/:canvas_course_id/add_user' => 'canvas_course_add_user#add_user', :via => :post, :as => :canvas_course_add_user_add_user, :defaults => { :format => 'json' }
   get '/api/canvas/media/:canvas_course_id' => 'canvas_webcast_recordings#get_media', :defaults => { :format => 'json' }
+  get '/api/academics/canvas/mailing_lists/:canvas_course_id' => 'canvas_mailing_lists#show', :defaults => { :format => 'json' }
+  post '/api/academics/canvas/mailing_lists/:canvas_course_id/create' => 'canvas_mailing_lists#create', :defaults => { :format => 'json' }
+  post '/api/academics/canvas/mailing_lists/:canvas_course_id/populate' => 'canvas_mailing_lists#populate', :defaults => { :format => 'json' }
 
   # System utility endpoints
   get '/api/cache/clear' => 'cache#clear', :defaults => { :format => 'json' }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -128,6 +128,7 @@ calmail_proxy:
   api_key: '99999'
   base_url: 'https://example.com/manage/api1'
   domain: 'bcourses-lists.berkeley.edu'
+  owner_address: 'owner@example.com'
   owner_uid: '211159'
 
 regstatus_proxy:

--- a/lib/tasks/mailing_lists.rake
+++ b/lib/tasks/mailing_lists.rake
@@ -1,0 +1,22 @@
+namespace :mailing_lists do
+
+  desc 'Update all mailing list populations'
+  task :populate => :environment do
+    Rails.logger.warn "Starting update task for #{MailingLists::SiteMailingList.count} mailing lists."
+    add = {total: 0, success: 0}
+    remove = {total: 0, success: 0}
+    MailingLists::SiteMailingList.find_each do |list|
+      results = list.populate
+      if results[:add] && results[:remove]
+        add[:total] += results[:add][:total]
+        add[:success] += results[:add][:success]
+        remove[:total] += results[:remove][:total]
+        remove[:success] += results[:remove][:success]
+      elsif results[:error]
+        Rails.logger.warn "Update task failed for #{list.list_name}: #{results[:error]}."
+      end
+    end
+    Rails.logger.warn "All mailing lists updated; #{add[:success]} of #{add[:total]} new members added, #{remove[:success]} of #{remove[:total]} former members removed."
+  end
+
+end

--- a/public/dummy/json/canvas_site_mailing_list_bad_site.json
+++ b/public/dummy/json/canvas_site_mailing_list_bad_site.json
@@ -1,0 +1,8 @@
+{
+  "canvasSite": {
+    "canvasCourseId": 9999999999999
+    }
+  },
+  "displayError": "badRequest",
+  "badRequestError": "No bCourses site found with ID \"9999999999999\"."
+}

--- a/public/dummy/json/canvas_site_mailing_list_created.json
+++ b/public/dummy/json/canvas_site_mailing_list_created.json
@@ -1,0 +1,36 @@
+{
+  "canvasSite": {
+    "canvasCourseId": 1302228,
+    "sisCourseId": "CRS:CHEM-3A-2015-B-7A31AEBF",
+    "name": "3A - Spring 15 - Chemical Structure and Reactivity",
+    "courseCode": "Chem 3A",
+    "url": "https://bcourses.example.com/courses/1302228",
+    "term": {
+      "term_yr": "2015",
+      "term_cd": "B",
+      "name": "Spring 2015"
+    }
+  },
+  "mailingList": {
+    "name": "chem_3a-spring-2015",
+    "domain": "bcourses-lists.berkeley.edu",
+    "state": "created",
+    "timeLastPopulated": {
+      "epoch":1430771400,
+      "dateTime":"2015-05-04T13:30:00-07:00",
+      "dateString":"5/04"
+    }
+  },
+  "populationResults": {
+    "add": {
+      "total": 17,
+      "success": 17,
+      "failure": []
+    },
+    "remove": {
+      "total": 1,
+      "success": 1,
+      "failure": []
+    }
+  }
+}

--- a/public/dummy/json/canvas_site_mailing_list_new.json
+++ b/public/dummy/json/canvas_site_mailing_list_new.json
@@ -1,0 +1,21 @@
+{
+  "canvasSite": {
+    "canvasCourseId": 1302228,
+    "sisCourseId": "CRS:CHEM-3A-2015-B-7A31AEBF",
+    "name": "3A - Spring 15 - Chemical Structure and Reactivity",
+    "courseCode": "Chem 3A",
+    "url": "https://bcourses.example.com/courses/1302228",
+    "term": {
+      "term_yr": "2015",
+      "term_cd": "B",
+      "name": "Spring 2015"
+    }
+  },
+  "mailingList": {
+    "name": "chem_3a-spring-2015",
+    "domain": "bcourses-lists.example.com",
+    "state": "unregistered"
+  },
+  "displayError": "badRequest",
+  "badRequestError": "Mailing list name \"lab_goes_boom\" is already taken."
+}

--- a/public/dummy/json/canvas_site_mailing_list_pending.json
+++ b/public/dummy/json/canvas_site_mailing_list_pending.json
@@ -1,0 +1,20 @@
+{
+  "canvasSite": {
+    "canvasCourseId": 1302228,
+    "sisCourseId": "CRS:CHEM-3A-2015-B-7A31AEBF",
+    "name": "3A - Spring 15 - Chemical Structure and Reactivity",
+    "courseCode": "Chem 3A",
+    "url": "https://bcourses.example.com/courses/1302228",
+    "term": {
+      "term_yr": "2015",
+      "term_cd": "B",
+      "name": "Spring 2015"
+    }
+  },
+  "mailingList": {
+    "name": "chem_3a-spring-2015",
+    "domain": "bcourses-lists.example.com",
+    "state": "pending",
+    "creationUrl": "https://mailman.example.com/manage/list/domain_create_list2?domain_name=bcourses-lists.example.com&listname=chem_3a-spring-2015&owner_address=joe%40example.com&advertised=0&subscribe_policy=3&moderate=0&generic_nonmember_action=1"
+  }
+}

--- a/spec/controllers/canvas_mailing_lists_controller_spec.rb
+++ b/spec/controllers/canvas_mailing_lists_controller_spec.rb
@@ -1,0 +1,76 @@
+describe CanvasMailingListsController do
+  let(:course_id) { rand(999999).to_s }
+  let(:uid) { rand(999999).to_s }
+
+  before do
+    session['user_id'] = uid
+    allow_any_instance_of(AuthenticationStatePolicy).to receive(:can_administrate_canvas?).and_return(true)
+  end
+
+  shared_examples 'authorization and error handling' do
+    it_should_behave_like 'an api endpoint' do
+      before do
+        allow(MailingLists::SiteMailingList).to receive(:find_by).and_raise(RuntimeError, 'Something went wrong')
+        allow_any_instance_of(MailingLists::SiteMailingList).to receive(:initialize).and_raise(RuntimeError, 'Something went wrong')
+      end
+    end
+
+    it_should_behave_like 'a user authenticated api endpoint'
+
+    context 'when user is not authorized' do
+      before { allow_any_instance_of(AuthenticationStatePolicy).to receive(:can_administrate_canvas?).and_return(false) }
+      it 'should respond with empty http 403' do
+        make_request
+        expect(response.status).to eq 403
+        expect(response.body).to eq ' '
+      end
+    end
+  end
+
+  def fake_mailing_list(filename)
+    JSON.parse(File.read Rails.root.join('public', 'dummy', 'json', filename))
+  end
+
+  describe '#show' do
+    let(:make_request) { get :show, canvas_course_id: course_id }
+    include_examples 'authorization and error handling'
+
+    it 'returns a fake unregistered mailing list' do
+      allow(MailingLists::SiteMailingList).to receive(:find_or_initialize_by).and_return fake_mailing_list('canvas_site_mailing_list_new.json')
+
+      make_request
+      expect(response.status).to eq 200
+      expect(response.body).to include '"state":"unregistered"'
+    end
+  end
+
+  describe '#create' do
+    let(:make_request) { post :create, canvas_course_id: course_id, list_name: 'digression_analysis-sp15' }
+    include_examples 'authorization and error handling'
+
+    it 'returns a fake pending mailing list' do
+      allow(MailingLists::SiteMailingList).to receive(:create).and_return fake_mailing_list('canvas_site_mailing_list_pending.json')
+
+      make_request
+      expect(response.status).to eq 200
+      expect(response.body).to include '"state":"pending"'
+    end
+  end
+
+  describe '#populate' do
+    let(:make_request) { post :populate, canvas_course_id: course_id  }
+    include_examples 'authorization and error handling'
+
+    it 'returns a fake mailing list with time last populated' do
+      fake_created_list = fake_mailing_list('canvas_site_mailing_list_created.json')
+      allow(MailingLists::SiteMailingList).to receive(:find_by).and_return fake_created_list
+      allow(fake_created_list).to receive(:populate)
+
+      make_request
+      expect(response.status).to eq 200
+      expect(response.body).to include '"state":"created"'
+      expect(response.body).to include '"timeLastPopulated"'
+    end
+  end
+
+end

--- a/spec/models/mailing_lists/site_mailing_list_spec.rb
+++ b/spec/models/mailing_lists/site_mailing_list_spec.rb
@@ -1,0 +1,283 @@
+# encoding: UTF-8
+
+describe MailingLists::SiteMailingList do
+  let(:canvas_site_id) { '1121' }
+  let(:fake_course_data) { Canvas::Course.new(canvas_course_id: canvas_site_id, fake: true).course }
+  before { allow_any_instance_of(Canvas::Course).to receive(:course).and_return fake_course_data }
+  before { allow_any_instance_of(Calmail::CheckNamespace).to receive(:name_available?).and_return(response: true) }
+
+  let(:response) { JSON.parse list.to_json}
+
+  context 'a newly initialized list' do
+    let(:list) { described_class.new(canvas_site_id: canvas_site_id) }
+
+    it 'is valid' do
+      expect(response).not_to include 'displayError'
+      expect(response).not_to include 'badRequestError'
+      expect(response).not_to include 'validationError'
+    end
+
+    it 'returns Canvas site data' do
+      expect(response['canvasSite']['canvasCourseId']).to eq fake_course_data['id'].to_s
+      expect(response['canvasSite']['url']).to include fake_course_data['id'].to_s
+      expect(response['canvasSite']['courseCode']).to eq fake_course_data['course_code']
+      expect(response['canvasSite']['sisCourseId']).to eq fake_course_data['sis_course_id']
+      expect(response['canvasSite']['name']).to eq fake_course_data['name']
+    end
+
+    it 'initializes as unregistered' do
+      expect(response['mailingList']['state']).to eq 'unregistered'
+      expect(response['mailingList']['domain']).to eq Settings.calmail_proxy.domain
+      expect(response['mailingList']).not_to include('creationUrl')
+      expect(response['mailingList']).not_to include('timeLastPopulated')
+    end
+
+    it 'returns error on attempt to populate before save' do
+      list.populate
+      expect(response['displayError']).to eq 'badRequest'
+      expect(response['badRequestError']).to eq "Mailing list \"#{list.list_name}\" must be created before being populated."
+      expect(response['mailingList']).not_to include('timeLastPopulated')
+    end
+
+    describe 'normalizing list names' do
+      it 'normalizes caps and spaces' do
+        fake_course_data['name'] = 'CHEM 1A LEC 003'
+        expect(response['mailingList']['name']).to eq 'chem_1a_lec_003-fa13'
+      end
+
+      it 'normalizes punctuation' do
+        fake_course_data['name'] = 'The "Wild"-"Wild" West?'
+        expect(response['mailingList']['name']).to eq 'the_wild_wild_west-fa13'
+      end
+
+      it 'removes invalid leading and trailing characters' do
+        fake_course_data['name'] = '{{design}}'
+        expect(response['mailingList']['name']).to eq 'design-fa13'
+      end
+
+      it 'normalizes diacritics' do
+        fake_course_data['name'] = 'Conversation intermédiaire'
+        expect(response['mailingList']['name']).to eq 'conversation_intermediaire-fa13'
+      end
+    end
+
+    context 'nonexistent Canvas site' do
+      before { allow_any_instance_of(Canvas::Course).to receive(:course).and_return nil }
+
+      it 'returns error data' do
+        expect(response).not_to include :mailingList
+        expect(response['displayError']).to eq 'badRequest'
+        expect(response['badRequestError']).to eq "No bCourses site found with ID \"#{canvas_site_id}\"."
+      end
+    end
+  end
+
+  context 'creating a list' do
+    let(:create_list) { described_class.create(canvas_site_id: canvas_site_id) }
+    let(:list) { create_list }
+
+    it 'creates pending list with a valid name' do
+      count = described_class.count
+      create_list
+      expect(described_class.count).to eq count+1
+      expect(response['mailingList']['state']).to eq 'pending'
+      expect(response['mailingList']['creationUrl']).to be_present
+    end
+
+    context 'invalid list name' do
+      let(:create_list) { described_class.create(canvas_site_id: canvas_site_id, list_name: '$crooge McDuck and the 1%') }
+
+      it 'does not create a list with an invalid name' do
+        count = described_class.count
+        create_list
+        expect(described_class.count).to eq count
+        expect(response['displayError']).to eq 'badRequest'
+        expect(response['validationErrors']['list_name']).to be_present
+      end
+    end
+
+    context 'list name already exists in Calmail' do
+      before { allow_any_instance_of(Calmail::CheckNamespace).to receive(:name_available?).and_return(response: false) }
+
+      it 'reports error and does not create new record' do
+        count = described_class.count
+        create_list
+        expect(described_class.count).to eq count
+        expect(response['displayError']).to eq 'badRequest'
+        expect(response['badRequestError']).to eq "Mailing list name \"#{list.list_name}\" is already taken."
+      end
+    end
+
+    context 'list name already exists in database' do
+      let(:list_name) { random_string(15) }
+      let(:create_list) { described_class.create(canvas_site_id: canvas_site_id, list_name: list_name) }
+      before { described_class.create(canvas_site_id: random_id, list_name: list_name)  }
+
+      it 'does not create list and returns error' do
+        count = described_class.count
+        create_list
+        expect(described_class.count).to eq count
+        expect(response['displayError']).to eq 'badRequest'
+        expect(response['validationErrors']['list_name']).to be_present
+      end
+    end
+
+    context 'course id already exists in database' do
+      before { described_class.create(canvas_site_id: canvas_site_id)  }
+
+      it 'does not create new record and returns error' do
+        count = described_class.count
+        create_list
+        expect(described_class.count).to eq count
+        expect(response['displayError']).to eq 'badRequest'
+        expect(response['validationErrors']['canvas_site_id']).to be_present
+      end
+    end
+  end
+
+  context 'an existing list record' do
+    before { described_class.create(canvas_site_id: canvas_site_id)  }
+    let(:list) { described_class.find_by(canvas_site_id: canvas_site_id) }
+
+    context 'name does not exist in Calmail' do
+      before { allow_any_instance_of(Calmail::CheckNamespace).to receive(:name_available?).and_return(response: true) }
+
+      it 'reports state as pending' do
+        expect(response['mailingList']['state']).to eq 'pending'
+        expect(response['mailingList']['creationUrl']).to be_present
+      end
+
+      it 'returns error on attempt to populate' do
+        list.populate
+        expect(response['displayError']).to eq 'badRequest'
+        expect(response['badRequestError']).to eq "Mailing list \"#{list.list_name}\" must be created before being populated."
+        expect(response['mailingList']).not_to include('timeLastPopulated')
+      end
+    end
+
+    context 'name exists in Calmail' do
+      before { allow_any_instance_of(Calmail::CheckNamespace).to receive(:name_available?).and_return(response: false) }
+
+      it 'reports state as created' do
+        expect(response['mailingList']['state']).to eq 'created'
+        expect(response['mailingList']['creationUrl']).not_to be_present
+        expect(response['mailingList']).not_to include('timeLastPopulated')
+      end
+
+      context 'populating list' do
+        let(:course_users) { Canvas::CourseUsers.new(canvas_course_id: canvas_site_id, fake: true) }
+        let(:list_members) { Calmail::ListMembers.new(fake: true) }
+
+        let(:fake_add_proxy) { Calmail::AddListMember.new(fake: true) }
+        let(:fake_remove_proxy) { Calmail::RemoveListMember.new(fake: true) }
+
+        let(:oliver) { {'login_id' => '12345', 'first_name' => 'Oliver', 'last_name' => 'Heyer', 'email_address' => 'oheyer@berkeley.edu'}  }
+        let(:ray) { {'login_id' => '67890', 'first_name' => 'Ray', 'last_name' => 'Davis', 'email_address' => 'raydavis@berkeley.edu'}  }
+        let(:paul) { {'login_id' => '65536', 'first_name' => 'Paul', 'last_name' => 'Kerschen', 'email_address' => 'kerschen@berkeley.edu'}  }
+
+        before do
+          allow(Canvas::CourseUsers).to receive(:new).and_return course_users
+          allow(Calmail::ListMembers).to receive(:new).and_return list_members
+
+          allow(Calmail::AddListMember).to receive(:new).and_return fake_add_proxy
+          allow(Calmail::RemoveListMember).to receive(:new).and_return fake_remove_proxy
+
+          expect(course_users).to receive(:course_users).exactly(1).times.and_return fake_site_users
+          expect(list_members).to receive(:list_members).exactly(1).times.and_return fake_list_members
+          expect(CampusOracle::Queries).to receive(:get_basic_people_attributes).exactly(1).times.and_return fake_site_users
+        end
+
+        def expect_empty_population_results(action)
+          expect(response['populationResults'][action]['total']).to eq 0
+          expect(response['populationResults'][action]['success']).to eq 0
+          expect(response['populationResults'][action]['failure']).to eq []
+        end
+
+        context 'no change in list membership' do
+          let(:fake_site_users) { [oliver, ray, paul] }
+          let(:fake_list_members) { {response: {addresses: ['kerschen@berkeley.edu', 'oheyer@berkeley.edu', 'raydavis@berkeley.edu']}} }
+
+          it 'makes no requests' do
+            expect(fake_add_proxy).not_to receive(:add_member)
+            expect(fake_remove_proxy).not_to receive(:remove_member)
+            list.populate
+          end
+
+          it 'returns time, no errors and empty results' do
+            list.populate
+            expect(response['mailingList']['timeLastPopulated']).to be_present
+            expect(response).not_to include 'displayError'
+            expect(response).not_to include 'badRequestError'
+            expect_empty_population_results 'add'
+            expect_empty_population_results 'remove'
+          end
+        end
+
+        context 'populating an empty list' do
+          let(:fake_site_users) { [oliver, ray, paul] }
+          let(:fake_list_members) { {response: {addresses: []}} }
+
+          it 'requests addition and reports success' do
+            expect(fake_add_proxy).to receive(:add_member).exactly(3).times.and_call_original
+            expect(fake_remove_proxy).not_to receive(:remove_member)
+            list.populate
+            expect(response['populationResults']['add']['total']).to eq 3
+            expect(response['populationResults']['add']['success']).to eq 3
+            expect(response['populationResults']['add']['failure']).to eq []
+            expect_empty_population_results 'remove'
+          end
+
+          context 'failures from proxy' do
+            before do
+              expect(fake_add_proxy).to receive(:add_member).exactly(3).times.
+               and_return({response: {added: false}}, {response: {added: true}}, {response: {added: true}})
+            end
+
+            it 'reports failure' do
+              list.populate
+              expect(response['populationResults']['add']['total']).to eq 3
+              expect(response['populationResults']['add']['success']).to eq 2
+              expect(response['populationResults']['add']['failure']).to eq ['oheyer@berkeley.edu']
+              expect_empty_population_results 'remove'
+            end
+          end
+        end
+
+        context 'new users in course site' do
+          let(:fake_site_users) { [oliver, ray, paul] }
+          let(:fake_list_members) { {response: {addresses: ['oheyer@berkeley.edu']}} }
+
+          it 'requests addition of new users only' do
+            expect(fake_add_proxy).to receive(:add_member).
+              exactly(1).times.with(list.list_name, 'raydavis@berkeley.edu', 'Ray Davis').and_call_original
+            expect(fake_add_proxy).to receive(:add_member).
+              exactly(1).times.with(list.list_name, 'kerschen@berkeley.edu', 'Paul Kerschen').and_call_original
+            expect(fake_remove_proxy).not_to receive(:remove_member)
+            list.populate
+            expect(response['populationResults']['add']['total']).to eq 2
+            expect(response['populationResults']['add']['success']).to eq 2
+            expect(response['populationResults']['add']['failure']).to eq []
+            expect_empty_population_results 'remove'
+          end
+        end
+
+        context 'users no longer in course site' do
+          let(:fake_site_users) { [oliver, ray] }
+          let(:fake_list_members) { {response: {addresses: ['kerschen@berkeley.edu', 'oheyer@berkeley.edu', 'raydavis@berkeley.edu']}} }
+
+          it 'requests removal of departed users only' do
+            expect(fake_add_proxy).not_to receive(:add_member)
+            expect(fake_remove_proxy).to receive(:remove_member).
+              exactly(1).times.with(list.list_name, 'kerschen@berkeley.edu').and_call_original
+            list.populate
+            expect_empty_population_results 'add'
+            expect(response['populationResults']['remove']['total']).to eq 1
+            expect(response['populationResults']['remove']['success']).to eq 1
+            expect(response['populationResults']['remove']['failure']).to eq []
+          end
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5211
https://jira.ets.berkeley.edu/jira/browse/CLC-5212

This PR includes:
- Dummy JSON based on @raydavis's front-end sketchwork;
- Back-end code required to generate that JSON;
- A simple rake task exercising portions of that back-end code to repopulate all mailing lists registered in the local database.