### PR TITLE
CLC-5211 CLC-5212 Site mailing lists: back-end followup

### DIFF
--- a/app/models/berkeley/term_codes.rb
+++ b/app/models/berkeley/term_codes.rb
@@ -25,6 +25,15 @@ module Berkeley
       "#{term} #{term_yr}"
     end
 
+    def to_abbreviation(term_yr, term_cd)
+      # 'fa14', 'sp15'
+      term = codes[term_cd.to_sym]
+      unless term
+        raise ArgumentError, "No such term code: #{term_cd}"
+      end
+      "#{term.downcase[0,2]}#{term_yr[-2,2]}"
+    end
+
     def to_slug(term_yr, term_cd)
       term = codes[term_cd.to_sym]
       unless term

--- a/app/models/calmail/proxy.rb
+++ b/app/models/calmail/proxy.rb
@@ -14,6 +14,8 @@ module Calmail
 
     def request(path, options = {})
       url = "#{@settings.base_url}/#{path}"
+      logger.info "Fake = #{@fake}; Making request to #{url}"
+
       body_options = options.delete(:body) || {}
       body_options.reverse_merge!(
         apikey: @settings.api_key,
@@ -24,7 +26,10 @@ module Calmail
         body: body_options,
         parser: LegacyJsonParser
       }.merge(options)
-      get_response(url, request_options)
+
+      response = get_response(url, request_options)
+      logger.debug "Remote server status #{response.code}, Body = #{response.body}"
+      response
     end
 
     def mock_request


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5211
https://jira.ets.berkeley.edu/jira/browse/CLC-5212

Follow-up to #3765 based on code review and testing.
- Force-downcase email addresses from campus data to match Mailman's internal storage;
- Fix logging in the SiteMailingList class and add logging to the Calmail proxies;
- Use `Hash#to_param` to build the list creation URL;
- Move term code abbreviation to Berkeley::TermCodes.