### PR TITLE
CLC-5322, new Webcast domain name: webcast-cc

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -156,7 +156,7 @@ textbooks_proxy:
 
 webcast_proxy:
   fake: false
-  base_url: 'https://video-dev.ets.berkeley.edu/warehouse'
+  base_url: 'https://webcast-cc-dev.ets.berkeley.edu/warehouse'
   username: 'secret'
   password: 'secret'
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5322

DO NOT MERGE until Bamboo passes: 
https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CJT54-1

With the v57 release we will cut over to new Webcast sub-domain: webcast-cc. The Webcast dev and qa environments have already been moved to new sub-domain.

Why? Because ETS' Events and Production team would like to claim _video.berkeley.edu_.