### PR TITLE
CLC-5329, tolerate Webcast audio RSS 404; don't bother front-end with such problems

### DIFF
--- a/app/models/webcast/audio.rb
+++ b/app/models/webcast/audio.rb
@@ -20,10 +20,12 @@ module Webcast
     def request_internal
       audio_items = []
       if Settings.features.audio && @audio_rss.present?
-        response = get_response @audio_rss
-        if response
-          audio_items = filter_audio response unless response.code == 404
+        begin
+          response = get_response @audio_rss
           logger.debug "Remote server status #{response.code}, Body = #{response.body}"
+          audio_items = filter_audio response if response && response.code < 400
+        rescue => e
+          logger.error "HTTP GET of Webcast audio RSS (#{@audio_rss}) failed: #{e.to_s}"
         end
       end
       {

--- a/app/models/webcast/course_media.rb
+++ b/app/models/webcast/course_media.rb
@@ -23,17 +23,17 @@ module Webcast
 
     def get_feed
       return {} unless Settings.features.videos
-      playlist_data_hash = get_playlist_hash
-      error_message = playlist_data_hash[:proxy_error_message]
-      unless error_message.blank? && playlist_data_hash[:body].blank?
+      media_hash = get_media_hash
+      error_message = media_hash[:proxy_error_message]
+      unless error_message.blank? && media_hash[:body].blank?
         return {
-          :proxyErrorMessage => error_message || playlist_data_hash[:body]
+          :proxyErrorMessage => error_message || media_hash[:body]
         }
       end
       feed = {}
       @ccn_list.each do |ccn|
         key = Webcast::CourseMedia.id_per_ccn(@year, @term, ccn)
-        data = playlist_data_hash[ccn]
+        data = media_hash[ccn]
         if data
           videos = get_videos_as_json data
           audio = get_audio_as_json data
@@ -46,17 +46,17 @@ module Webcast
       feed
     end
 
-    def get_playlist_hash
-      playlist_hash = {}
-      recordings = Webcast::Recordings.new(@options).get
-      if recordings && recordings[:courses]
+    def get_media_hash
+      media_hash = {}
+      all_media = Webcast::Recordings.new(@options).get
+      if all_media && all_media[:courses]
         @ccn_list.each do |ccn|
           key = Webcast::CourseMedia.id_per_ccn(@year, @term, ccn)
-          playlist = recordings[:courses][key]
-          playlist_hash[ccn] = playlist unless playlist.blank?
+          media = all_media[:courses][key]
+          media_hash[ccn] = media unless media.nil?
         end
       end
-      playlist_hash
+      media_hash
     end
 
     def get_itunes_url(id)

--- a/app/models/webcast/merged.rb
+++ b/app/models/webcast/merged.rb
@@ -21,9 +21,6 @@ module Webcast
         :audio => merge(course, :audio),
         :itunes => merge_itunes(course)
       }
-      if merged_feeds[:videos].empty? && merged_feeds[:audio].empty?
-        merged_feeds.merge! Webcast::Recordings::ERRORS
-      end
       merged_feeds
     end
 

--- a/spec/models/webcast/audio_spec.rb
+++ b/spec/models/webcast/audio_spec.rb
@@ -33,13 +33,12 @@ describe Webcast::Audio do
     context 'on remote server errors' do
       let! (:body) { 'An unknown error occurred.' }
       let! (:status) { 506 }
-      include_context 'expecting logs from server errors'
       before(:each) {
         stub_request(:any, rss_url).to_return(status: status, body: body)
       }
-      it 'should return a 503 status code' do
+      it 'should deliver empty ' do
         proxy_response = proxy.get
-        expect(proxy_response[:statusCode]).to eq 503
+        expect(proxy_response[:audio]).to be_empty
       end
     end
 
@@ -47,9 +46,9 @@ describe Webcast::Audio do
       before(:each) {
         stub_request(:any, rss_url).to_return(status: 200, body: 'bogus xml')
       }
-      it 'should return a 503 status code' do
+      it 'should return empty array when RSS parsing fails' do
         proxy_response = proxy.get
-        expect(proxy_response[:statusCode]).to eq 503
+        expect(proxy_response[:audio]).to be_empty
       end
     end
 
@@ -58,9 +57,9 @@ describe Webcast::Audio do
         stub_request(:any, /.#{audio_base_url.hostname}./).to_raise(Errno::ECONNREFUSED)
       }
 
-      it 'should return a 503 status code' do
+      it 'should return empty content when HTTP GET fails' do
         proxy_response = proxy.get
-        expect(proxy_response[:statusCode]).to eq 503
+        expect(proxy_response[:audio]).to be_empty
       end
     end
   end
@@ -70,7 +69,7 @@ describe Webcast::Audio do
 
     it 'should return an empty audio array' do
       proxy_response = proxy.get
-      expect(proxy_response[:audio]).to have(0).items
+      expect(proxy_response[:audio]).to be_empty
     end
   end
 

--- a/spec/models/webcast/course_media_spec.rb
+++ b/spec/models/webcast/course_media_spec.rb
@@ -28,7 +28,7 @@ describe Webcast::CourseMedia do
     context 'when proxy error message is not blank' do
       before do
         proxy_error_hash = {:proxy_error_message => 'Proxy Error'}
-        subject.should_receive(:get_playlist_hash).and_return proxy_error_hash
+        subject.should_receive(:get_media_hash).and_return proxy_error_hash
       end
       it 'should return the proxy error message' do
         response = subject.get_feed
@@ -97,13 +97,12 @@ describe Webcast::CourseMedia do
     end
   end
 
-  context 'with non-fake proxy' do
-
+  context 'with non-fake proxy', :testext => true do
     context 'when serving multiple sets of Webcast recordings' do
       let (:playlist_uri) { URI.parse "#{Settings.webcast_proxy.base_url}/webcast.json" }
       subject { Webcast::CourseMedia.new(2014, 'B', [7502, 11147, 1]) }
 
-      context 'normal return of real data', :testext => true do
+      context 'normal return of real data' do
         it 'should return correct recordings' do
           result = subject.get_feed['2014-B-11147']
           expect(result[:videos]).to be_an_instance_of Array

--- a/spec/models/webcast/merged_spec.rb
+++ b/spec/models/webcast/merged_spec.rb
@@ -1,8 +1,7 @@
 describe Webcast::Merged do
 
-  let(:options) { {:fake => true} }
-
-  context '#authenticated' do
+  context 'a fake proxy' do
+    let(:options) { {:fake => true} }
 
     context 'no matching course' do
       let(:feed) do
@@ -77,4 +76,23 @@ describe Webcast::Merged do
     end
 
   end
+
+  context 'a real, non-fake proxy', :testext => true do
+    context 'course with zero recordings is different than course not scheduled for recordings' do
+      let(:feed) do
+        Webcast::Merged.new(2015, 'B', [1, 58301, 56745]).get_feed
+      end
+      it 'identifies course that is scheduled for recordings' do
+        non_existent = feed[:media]['2015-B-1']
+        recordings_planned = feed[:media]['2015-B-58301']
+        recordings_exist = feed[:media]['2015-B-56745']
+        expect(non_existent).to eq Webcast::Recordings::ERRORS
+        expect(recordings_planned[:videos]).to be_empty
+        expect(recordings_planned[:body]).to be_nil
+        expect(recordings_exist[:videos]).to have_at_least(10).items
+        expect(recordings_exist[:body]).to be_nil
+      end
+    end
+  end
+
 end

--- a/spec/models/webcast/recordings_spec.rb
+++ b/spec/models/webcast/recordings_spec.rb
@@ -60,5 +60,18 @@ describe Webcast::Recordings do
         expect(result).to be_empty
       end
     end
+
+    context 'course with zero recordings is different than course not scheduled for recordings', :testext => true do
+      it 'returns nil recordings attribute when course is scheduled for recordings' do
+        result = subject.get
+        non_existent = result[:courses]['2015-B-1']
+        recordings_planned = result[:courses]['2015-B-58301']
+        recordings_exist = result[:courses]['2015-B-56745']
+        expect(non_existent).to be_nil
+        expect(recordings_planned[:recordings]).to be_nil
+        expect(recordings_exist[:recordings]).to have_at_least(10).items
+      end
+    end
   end
+
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5329

Notes:
* We log errors related to HTTP GET of audio RSS but we no longer put error info in merged feed
* New specs to make sure code sees a difference between (1) courses with zero recordings and (2) courses not signed up for Webcast
* simple renaming in course_media.rb