### PR TITLE
CLC-5217, instructor_func added to instructors_feed; update course_sections_spec

### DIFF
--- a/app/models/campus_oracle/course_sections.rb
+++ b/app/models/campus_oracle/course_sections.rb
@@ -88,7 +88,8 @@ module CampusOracle
         found_instructors.each do |instructor|
           instructors << {
             :name => instructor['person_name'],
-            :uid => instructor['ldap_uid']
+            :uid => instructor['ldap_uid'],
+            :instructor_func => instructor['instructor_func']
           }
         end
       end

--- a/spec/models/campus_oracle/course_sections_spec.rb
+++ b/spec/models/campus_oracle/course_sections_spec.rb
@@ -1,49 +1,40 @@
-require "spec_helper"
+describe 'CampusOracle::CourseSections' do
 
-describe "CampusOracle::CourseSections" do
-
-  it "should correctly translate schedule codes" do
+  it 'should correctly translate schedule codes' do
     client = CampusOracle::CourseSections.new({user_id: '300939'})
-    client.translate_meeting(
+    expect(client.translate_meeting({ 'meeting_days' => 'S' })).to eq 'Su'
+    expect(client.translate_meeting(
       {
-        "meeting_days" => "S"
-      }).should == "Su"
-    client.translate_meeting(
-      {
-        "meeting_days" => "SMTWTFS",
-        "meeting_start_time" => "0900",
-        "meeting_start_time_ampm_flag" => "A",
-        "meeting_end_time" => "1100",
-        "meeting_end_time_ampm_flag" => "P"
-      }).should == "SuMTuWThFSa 9:00A-11:00P"
-    client.translate_meeting(
-      {
-        "meeting_days" => "  T T  "
-      }).should == "TuTh"
-    client.translate_meeting(nil).should == ""
+        'meeting_days' => 'SMTWTFS',
+        'meeting_start_time' => '0900',
+        'meeting_start_time_ampm_flag' => 'A',
+        'meeting_end_time' => '1100',
+        'meeting_end_time_ampm_flag' => 'P'
+      })).to eq 'SuMTuWThFSa 9:00A-11:00P'
+    expect(client.translate_meeting({ 'meeting_days' => '  T T  ' })).to eq 'TuTh'
+    expect(client.translate_meeting(nil)).to be_empty
   end
 
-  describe "get_section_data" do
-
-    it "should return pre-populated test sections", :if => Sakai::SakaiData.test_data? do
+  describe 'get_section_data' do
+    it 'should return pre-populated test sections', :if => Sakai::SakaiData.test_data? do
       client = CampusOracle::CourseSections.new({term_yr: '2013', term_cd: 'D', ccn: '16171'})
       data = client.get_section_data
-      data.empty?.should be_falsey
-
-      data[:instructors].length.should == 1
-      data[:instructors][0][:name].present?.should be_truthy
-      data[:instructors][0][:uid].should == "238382"
-      data[:schedules].length.should == 2
-      data[:schedules][0][:schedule].should == "TuTh 2:00P-3:30P"
-      data[:schedules][0][:buildingName].should == "WHEELER"
-      data[:schedules][1][:schedule].should == "W 4:00P-5:30P"
-      data[:schedules][1][:buildingName].should == "DWINELLE"
+      expect(data).to_not be_empty
+      expect(data[:instructors]).to have(1).items
+      expect(data[:instructors][0][:name]).to be_present
+      expect(data[:instructors][0][:uid]).to eq '238382'
+      expect(data[:instructors][0][:instructor_func]).to eq '1'
+      expect(data[:schedules]).to have(2).items
+      expect(data[:schedules][0][:schedule]).to eq 'TuTh 2:00P-3:30P'
+      expect(data[:schedules][0][:buildingName]).to eq 'WHEELER'
+      expect(data[:schedules][1][:schedule]).to eq 'W 4:00P-5:30P'
+      expect(data[:schedules][1][:buildingName]).to eq 'DWINELLE'
     end
 
-    it "should filter out the empty schedules" do
+    it 'should filter out the empty schedules' do
       stubbed_schedules = [
-        {"building_name"=>"OFF CAMPUS", "room_number"=>nil, "meeting_days"=>"    T", "meeting_start_time"=>"0330", "meeting_start_time_ampm_flag"=>"P", "meeting_end_time"=>"0630", "meeting_end_time_ampm_flag"=>"P"},
-        {"building_name"=>nil, "room_number"=>nil, "meeting_days"=>nil, "meeting_start_time"=>nil, "meeting_start_time_ampm_flag"=>nil, "meeting_end_time"=>nil, "meeting_end_time_ampm_flag"=>nil},
+        {'building_name'=>'OFF CAMPUS', 'room_number'=>nil, 'meeting_days'=>'    T', 'meeting_start_time'=>'0330', 'meeting_start_time_ampm_flag'=>'P', 'meeting_end_time'=>'0630', 'meeting_end_time_ampm_flag'=>'P'},
+        {'building_name'=>nil, 'room_number'=>nil, 'meeting_days'=>nil, 'meeting_start_time'=>nil, 'meeting_start_time_ampm_flag'=>nil, 'meeting_end_time'=>nil, 'meeting_end_time_ampm_flag'=>nil},
       ]
       client = CampusOracle::CourseSections.new({term_yr: '2013', term_cd: 'D', ccn: '16171'})
       # CampusOracle::Queries.get_section_schedules(@term_yr, @term_cd, @ccn)
@@ -51,23 +42,23 @@ describe "CampusOracle::CourseSections" do
       #allow(CampusOracle::Queries).to receive(:get_section_schedules).and_return(stubbed_schedules)
       result = client.get_section_data
 
-      result.should be_an_instance_of Hash
-      result.should have_key(:schedules)
-      result[:schedules].length.should == 1
+      expect(result).to be_an_instance_of Hash
+      expect(result).to have_key :schedules
+      expect(result[:schedules]).to have(1).items
     end
 
-    it "should strip leading zeros from room_number" do
+    it 'should strip leading zeros from room_number' do
       stubbed_schedules = [
-        {"building_name"=>"OFF CAMPUS", "room_number"=>nil, "meeting_days"=>"    T", "meeting_start_time"=>"0330", "meeting_start_time_ampm_flag"=>"P", "meeting_end_time"=>"0630", "meeting_end_time_ampm_flag"=>"P"},
-        {"building_name"=>nil, "room_number"=> "0001", "meeting_days"=>nil, "meeting_start_time"=>nil, "meeting_start_time_ampm_flag"=>nil, "meeting_end_time"=>nil, "meeting_end_time_ampm_flag"=>nil},
+        {'building_name'=>'OFF CAMPUS', 'room_number'=>nil, 'meeting_days'=>'    T', 'meeting_start_time'=>'0330', 'meeting_start_time_ampm_flag'=>'P', 'meeting_end_time'=>'0630', 'meeting_end_time_ampm_flag'=>'P'},
+        {'building_name'=>nil, 'room_number'=> '0001', 'meeting_days'=>nil, 'meeting_start_time'=>nil, 'meeting_start_time_ampm_flag'=>nil, 'meeting_end_time'=>nil, 'meeting_end_time_ampm_flag'=>nil},
       ]
       client = CampusOracle::CourseSections.new({term_yr: '2013', term_cd: 'D', ccn: '16171'})
       # CampusOracle::Queries.get_section_schedules(@term_yr, @term_cd, @ccn)
       CampusOracle::Queries.should_receive(:get_section_schedules).and_return(stubbed_schedules)
       #allow(CampusOracle::Queries).to receive(:get_section_schedules).and_return(stubbed_schedules)
       result = client.get_section_data
-      result[:schedules][0][:roomNumber].should == nil
-      result[:schedules][1][:roomNumber].should == "1"
+      expect(result[:schedules][0][:roomNumber]).to be_nil
+      expect(result[:schedules][1][:roomNumber]).to eq '1'
     end
 
   end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5217
Webcast front-end needs to know about instructor_func. PR includes refactor of course_sections_spec.rb

Note: In an upcoming PR the Webcast merged feed will leverage this change in order to put "webcast authorized" instructors in its front-end api