### PR TITLE
CLC-5209, merged webcast feed includes section and instructor metadata

### DIFF
--- a/app/controllers/mediacasts_controller.rb
+++ b/app/controllers/mediacasts_controller.rb
@@ -8,13 +8,14 @@ class MediacastsController < ApplicationController
 
   # GET /api/media/:year/:term_code/:dept/:catalog_id
   def get_media
+    uid = session['user_id']
     term_yr = params['year']
     term_cd = params['term_code']
     dept_name = params['dept']
     catalog_id = params['catalog_id']
     sections = CampusOracle::Queries.get_all_course_sections(term_yr, term_cd, dept_name, catalog_id)
     ccn_list = sections.map { |section| section['course_cntl_num'].to_i }
-    render :json => Webcast::Merged.new(term_yr, term_cd, ccn_list, @options).get_feed
+    render :json => Webcast::Merged.new(uid, term_yr, term_cd, ccn_list, @options).get_feed
   end
 
 end

--- a/app/models/canvas/webcast_eligible_courses.rb
+++ b/app/models/canvas/webcast_eligible_courses.rb
@@ -55,9 +55,8 @@ module Canvas
           sections.each do |section|
             ccn = section[:ccn].to_s.to_i
             if ccn > 0
-              section_key = "#{term_yr}-#{term_cd}-#{ccn}"
-              has_recordings = recordings_per_ccn.has_key?(section_key) && recordings_per_ccn[section_key][:videos].present?
-              logger.warn "#{section_key} has Webcast recordings (canvas_course_id = #{canvas_course_id})" if has_recordings
+              has_recordings = recordings_per_ccn.has_key?(ccn) && recordings_per_ccn[ccn][:videos].present?
+              logger.warn "#{term_yr}-#{term_cd}-#{ccn} has Webcast recordings (canvas_course_id = #{canvas_course_id})" if has_recordings
               is_webcast_eligible = !has_recordings && !sign_up_eligible_ccn_set.nil? && sign_up_eligible_ccn_set.include?(ccn)
               if has_recordings || is_webcast_eligible
                 section[:has_webcast_recordings] = has_recordings

--- a/app/models/canvas/webcast_recordings.rb
+++ b/app/models/canvas/webcast_recordings.rb
@@ -32,7 +32,7 @@ module Canvas
           end
         end
       end
-      Webcast::Merged.new(@term_yr, @term_cd, ccn_list, @options).get_feed
+      Webcast::Merged.new(@uid, @term_yr, @term_cd, ccn_list, @options).get_feed
     end
 
     def empty_feed

--- a/app/models/webcast/course_media.rb
+++ b/app/models/webcast/course_media.rb
@@ -30,20 +30,17 @@ module Webcast
           :proxyErrorMessage => error_message || media_hash[:body]
         }
       end
-      feed = {}
+      media_per_ccn = {}
       @ccn_list.each do |ccn|
-        key = Webcast::CourseMedia.id_per_ccn(@year, @term, ccn)
         data = media_hash[ccn]
         if data
           videos = get_videos_as_json data
           audio = get_audio_as_json data
           itunes = get_itunes_as_json data
-          feed[key] = videos.merge(audio).merge(itunes)
-        else
-          feed[key] = Webcast::Recordings::ERRORS
+          media_per_ccn[ccn] = videos.merge(audio).merge(itunes)
         end
       end
-      feed
+      media_per_ccn
     end
 
     def get_media_hash

--- a/spec/controllers/mediacasts_controller_spec.rb
+++ b/spec/controllers/mediacasts_controller_spec.rb
@@ -55,7 +55,7 @@ describe MediacastsController do
               ]
             }
           ]
-          MyAcademics::Teaching.any_instance.should_receive(:courses_list_from_ccns).once.and_return courses_list
+          expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).once.and_return courses_list
         end
         it 'should escape special characters in dept name' do
           json = post_course malay_100A

--- a/spec/controllers/mediacasts_controller_spec.rb
+++ b/spec/controllers/mediacasts_controller_spec.rb
@@ -1,12 +1,12 @@
 describe MediacastsController do
 
-  before { session['user_id'] = rand(99999).to_s }
-
   # Test data has no entry with a single digit CCN. Using the ccn_sets below, we expect 'No Webcast data found' for
   # each single digit ccn.
   let(:law_2723) { {:dept_name => 'LAW', :catalog_id => '2723', :term_yr => '2008', :term_cd => 'D', :ccn_set => [1, 49688, 2]} }
   let(:chem_101) { {:dept_name => 'CHEM', :catalog_id => '101', :term_yr => '2014', :term_cd => 'B', :ccn_set => [1, 2, 3]} }
   let(:malay_100A) { {:dept_name => 'MALAY/I', :catalog_id => '100A', :term_yr => '2014', :term_cd => 'D', :ccn_set => [85006]} }
+
+  before { session['user_id'] = rand(99999).to_s }
 
   describe 'when serving webcast recordings' do
     context 'when Webcast feature flag is false' do
@@ -25,31 +25,45 @@ describe MediacastsController do
 
       context 'when no Webcast recordings found' do
         it 'should campus_db query results are empty' do
-          term_yr = '2014', term_cd = 'D', dept_name = 'ECON', catalog_id = '101'
+          term_yr = '2014'
+          term_cd = 'D'
+          dept_name = 'ECON'
+          catalog_id = '101'
           CampusOracle::Queries.should_receive(:get_all_course_sections).with(term_yr, term_cd, dept_name, catalog_id).and_return []
           post :get_media, year: term_yr, term_code: term_cd, dept: dept_name, catalog_id: catalog_id
           expect(response.status).to eq 200
           json = JSON.parse response.body
-          expect(json['media']).to eq({})
+          expect(json['media']['2014']['D']).to be_empty
         end
 
         it 'should pay attention to term code' do
           json = post_course chem_101
-          expect(json['media']).to have(3).items
-          %w(1 2 3).each do |ccn|
-            expect(json['media']["2014-B-#{ccn}"]['video_error_message']).to eq 'No Webcast data found.'
-          end
+          expect(json['media']['2014']['B']).to be_empty
         end
       end
 
       context 'when Webcast recordings found' do
+        before(:each) do
+          courses_list = [
+            {
+              :classes=>[
+                {
+                  :sections=>[
+                    { :ccn=>'85006', :section_number=>'201', :instruction_format=>'LEC' }
+                  ]
+                }
+              ]
+            }
+          ]
+          MyAcademics::Teaching.any_instance.should_receive(:courses_list_from_ccns).once.and_return courses_list
+        end
         it 'should escape special characters in dept name' do
           json = post_course malay_100A
           # This course happens to have zero YouTube videos
-          course = json['media']['2014-D-85006']
+          course = json['media']['2014']['D']['85006']
           expect(course['videos']).to be_empty
           expect(course['itunes']['audio']).to be_nil
-          expect(course['itunes']['video']).to include('819827828')
+          expect(course['itunes']['video']).to include '819827828'
         end
       end
     end

--- a/spec/models/canvas/webcast_recordings_spec.rb
+++ b/spec/models/canvas/webcast_recordings_spec.rb
@@ -8,7 +8,7 @@ describe Canvas::WebcastRecordings do
       )
     end
 
-    subject { Canvas::WebcastRecordings.new({course_id: canvas_course_id, fake: true}) }
+    subject { Canvas::WebcastRecordings.new({user_id: rand(99999).to_s, course_id: canvas_course_id, fake: true}) }
 
     context 'when the Canvas course site maps to campus class sections' do
       let(:canvas_course_sections_list) do
@@ -18,20 +18,35 @@ describe Canvas::WebcastRecordings do
           {'id' => rand(99999).to_s, 'name' => 'c', 'course_id' => canvas_course_id, 'sis_section_id' => 'SEC:2009-B-81853'}
         ]
       end
+      before do
+        courses_list = [
+          {
+            :classes=>[
+              {
+                :sections=>[
+                  { :ccn=>'49982', :section_number=>'101', :instruction_format=>'LEC' },
+                  { :ccn=>'81853', :section_number=>'201', :instruction_format=>'LEC' }
+                ]
+              }
+            ]
+          }
+        ]
+        MyAcademics::Teaching.any_instance.should_receive(:courses_list_from_ccns).once.and_return courses_list
+      end
 
       it 'contains two sets of recordings' do
         feed = subject.get_feed
         expect(feed[:system_status]['is_sign_up_active']).to be true
-        expect(feed[:rooms]).to have(26).items
-        expect(feed[:media]).to have(2).items
+        media_by_ccn = feed[:media][2009]['B']
+        expect(media_by_ccn).to have(2).items
 
-        law_27171 = feed[:media]['2009-B-49982']
+        law_27171 = media_by_ccn[49982]
         expect(law_27171[:audio]).to have(13).items
         expect(law_27171[:audio][12][:title]).to match('Lecture 1')
         expect(law_27171[:itunes][:audio]).to end_with('354822513')
         expect(law_27171[:itunes][:video]).to end_with('354822509')
 
-        sociol_150A = feed[:media]['2009-B-81853']
+        sociol_150A = media_by_ccn[81853]
         expect(sociol_150A[:audio]).to have_at_least(10).items
         expect(sociol_150A[:audio][12][:title]).to_not be_nil
         expect(sociol_150A[:itunes][:audio]).to_not be_nil
@@ -49,7 +64,6 @@ describe Canvas::WebcastRecordings do
       it 'is empty' do
         feed = subject.get_feed
         expect(feed[:system_status]['is_sign_up_active']).to be true
-        expect(feed[:rooms]).to have(26).items
         expect(feed[:media]).to be_empty
       end
     end

--- a/spec/models/canvas/webcast_recordings_spec.rb
+++ b/spec/models/canvas/webcast_recordings_spec.rb
@@ -31,7 +31,7 @@ describe Canvas::WebcastRecordings do
             ]
           }
         ]
-        MyAcademics::Teaching.any_instance.should_receive(:courses_list_from_ccns).once.and_return courses_list
+        expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).once.and_return courses_list
       end
 
       it 'contains two sets of recordings' do

--- a/spec/models/webcast/course_media_spec.rb
+++ b/spec/models/webcast/course_media_spec.rb
@@ -28,7 +28,7 @@ describe Webcast::CourseMedia do
     context 'when proxy error message is not blank' do
       before do
         proxy_error_hash = {:proxy_error_message => 'Proxy Error'}
-        subject.should_receive(:get_media_hash).and_return proxy_error_hash
+        expect(subject).to receive(:get_media_hash).and_return proxy_error_hash
       end
       it 'should return the proxy error message' do
         response = subject.get_feed
@@ -49,7 +49,7 @@ describe Webcast::CourseMedia do
     subject { Webcast::CourseMedia.new(2008, 'D', [49688], {:fake => true}) }
 
     context 'when proxy error message is blank' do
-      before { subject.should_receive(:get_audio_as_json).with(anything).and_return audio_as_json }
+      before { expect(subject).to receive(:get_audio_as_json).with(anything).and_return audio_as_json }
       it 'should parse Webcast JSON per normal procedure' do
         response = subject.get_feed[49688]
         expect(response).not_to be_nil
@@ -66,7 +66,7 @@ describe Webcast::CourseMedia do
   context 'when serving multiple sets of Webcast recordings' do
     context 'when ccn matches a set of Webcast recordings' do
       subject { Webcast::CourseMedia.new(2014, 'B', [1, 87432, 2, 76207], {:fake => true}) }
-      before { subject.should_receive(:get_audio_as_json).with(anything).twice.and_return audio_as_json }
+      before { expect(subject).to receive(:get_audio_as_json).with(anything).twice.and_return audio_as_json }
       it 'should return youtube videos' do
         response = subject.get_feed
         expect(response[1]).to be_nil
@@ -78,7 +78,7 @@ describe Webcast::CourseMedia do
 
     context 'when videos are not present' do
       subject { Webcast::CourseMedia.new(2014, 'D', [123], {:fake => true}) }
-      before { subject.should_receive(:get_audio_as_json).with(anything).and_return audio_as_json }
+      before { expect(subject).to receive(:get_audio_as_json).with(anything).and_return audio_as_json }
       it 'should return an empty array' do
         response = subject.get_feed[123]
         expect(response[:videos]).to be_empty
@@ -90,7 +90,7 @@ describe Webcast::CourseMedia do
 
     context 'when course title has a _slash_' do
       subject { Webcast::CourseMedia.new(2014, 'D', [85006], {:fake => true}) }
-      before { subject.should_receive(:get_audio_as_json).with(anything).and_return audio_as_json }
+      before { expect(subject).to receive(:get_audio_as_json).with(anything).and_return audio_as_json }
       it 'should decode _slash_ to /' do
         expect(subject.get_feed[85006]).to be_an_instance_of Hash
       end

--- a/spec/models/webcast/course_media_spec.rb
+++ b/spec/models/webcast/course_media_spec.rb
@@ -51,7 +51,7 @@ describe Webcast::CourseMedia do
     context 'when proxy error message is blank' do
       before { subject.should_receive(:get_audio_as_json).with(anything).and_return audio_as_json }
       it 'should parse Webcast JSON per normal procedure' do
-        response = subject.get_feed['2008-D-49688']
+        response = subject.get_feed[49688]
         expect(response).not_to be_nil
         expect(response[:videos]).to have(12).items
         expect(response[:videos][0]['youTubeId']).to eq 'bBithUtaaas'
@@ -69,10 +69,10 @@ describe Webcast::CourseMedia do
       before { subject.should_receive(:get_audio_as_json).with(anything).twice.and_return audio_as_json }
       it 'should return youtube videos' do
         response = subject.get_feed
-        expect(response['2014-B-1']).to eq Webcast::Recordings::ERRORS
-        expect(response['2014-B-87432'][:videos]).to have(31).items
-        expect(response['2014-B-2']).to eq Webcast::Recordings::ERRORS
-        expect(response['2014-B-76207'][:videos]).to have(35).items
+        expect(response[1]).to be_nil
+        expect(response[87432][:videos]).to have(31).items
+        expect(response[2]).to be_nil
+        expect(response[76207][:videos]).to have(35).items
       end
     end
 
@@ -80,7 +80,7 @@ describe Webcast::CourseMedia do
       subject { Webcast::CourseMedia.new(2014, 'D', [123], {:fake => true}) }
       before { subject.should_receive(:get_audio_as_json).with(anything).and_return audio_as_json }
       it 'should return an empty array' do
-        response = subject.get_feed['2014-D-123']
+        response = subject.get_feed[123]
         expect(response[:videos]).to be_empty
         itunes = response[:itunes]
         expect(itunes[:audio]).to be_nil
@@ -92,7 +92,7 @@ describe Webcast::CourseMedia do
       subject { Webcast::CourseMedia.new(2014, 'D', [85006], {:fake => true}) }
       before { subject.should_receive(:get_audio_as_json).with(anything).and_return audio_as_json }
       it 'should decode _slash_ to /' do
-        expect(subject.get_feed['2014-D-85006']).to be_an_instance_of Hash
+        expect(subject.get_feed[85006]).to be_an_instance_of Hash
       end
     end
   end
@@ -104,7 +104,7 @@ describe Webcast::CourseMedia do
 
       context 'normal return of real data' do
         it 'should return correct recordings' do
-          result = subject.get_feed['2014-B-11147']
+          result = subject.get_feed[11147]
           expect(result[:videos]).to be_an_instance_of Array
           expect(result[:videos].size).to eq 14
           recording = result[:videos][0]
@@ -121,10 +121,7 @@ describe Webcast::CourseMedia do
         }
         after(:each) { WebMock.reset! }
         it 'should return the fetch error message' do
-          response = subject.get_feed
-          response.each do |key, json|
-            expect(json).to eq(Webcast::Recordings::ERRORS), "Unexpected message with #{key}: #{json.inspect}"
-          end
+          expect(subject.get_feed).to be_empty
         end
       end
 
@@ -134,10 +131,7 @@ describe Webcast::CourseMedia do
         }
         after(:each) { WebMock.reset! }
         it 'should return the fetch error message' do
-          response = subject.get_feed
-          response.each do |key, json|
-            expect(json).to eq(Webcast::Recordings::ERRORS), "Unexpected message with #{key}: #{json.inspect}"
-          end
+          expect(subject.get_feed).to be_empty
         end
       end
 

--- a/spec/models/webcast/merged_spec.rb
+++ b/spec/models/webcast/merged_spec.rb
@@ -1,21 +1,23 @@
 describe Webcast::Merged do
 
+  let(:ldap_uid) { 904715 }
+
   context 'a fake proxy' do
     let(:options) { {:fake => true} }
 
     context 'no matching course' do
       let(:feed) do
-        Webcast::Merged.new(2014, 'B', [1], options).get_feed
+        Webcast::Merged.new(ldap_uid, 2014, 'B', [1], options).get_feed
       end
-
+      before do
+        MyAcademics::Teaching.should_not_receive :new
+      end
       it 'returns system status when authenticated' do
         expect(feed[:system_status]['is_sign_up_active']).to be true
-        expect(feed[:rooms]).to have(26).items
-        expect(feed[:rooms]['VALLEY LSB']).to contain_exactly('2040', '2050', '2060')
-        course = feed[:media]['2014-B-1']
-        expect(course).to eq Webcast::Recordings::ERRORS
-        expect(course[:videos]).to be_nil
-        expect(course[:audio]).to be_nil
+        # TODO: Bring 'rooms' back in the feed as needed by front-end
+        # expect(feed[:rooms]).to have(26).items
+        # expect(feed[:rooms]['VALLEY LSB']).to contain_exactly('2040', '2050', '2060')
+        expect(feed[:media][2014]['B']).to be_empty
         # Verify backwards compatibility
         expect(feed[:videos]).to be_empty
         expect(feed[:audio]).to be_empty
@@ -26,11 +28,31 @@ describe Webcast::Merged do
 
     context 'one matching course' do
       let(:feed) do
-        Webcast::Merged.new(2014, 'B', [1, 87432], options).get_feed
+        Webcast::Merged.new(ldap_uid, 2014, 'B', [1, 87432], options).get_feed
       end
-      it 'returns course media' do
-        expect(feed[:media]['2014-B-1']).to eq Webcast::Recordings::ERRORS
-        videos = feed[:media]['2014-B-87432'][:videos]
+      before do
+        courses_list = [
+          {
+            :classes=>[
+              {
+                :sections=>[
+                  { :ccn=>'87435', :section_number=>'101', :instruction_format=>'LAB' },
+                  { :ccn=>'87438', :section_number=>'102', :instruction_format=>'LAB' },
+                  { :ccn=>'87444', :section_number=>'201', :instruction_format=>'LAB' },
+                  { :ccn=>'87447', :section_number=>'202', :instruction_format=>'LAB' },
+                  { :ccn=>'87432', :section_number=>'001', :instruction_format=>'LEC' },
+                  { :ccn=>'87441', :section_number=>'002', :instruction_format=>'LEC' }
+                ]
+              }
+            ]
+          }
+        ]
+        MyAcademics::Teaching.any_instance.should_receive(:courses_list_from_ccns).once.and_return courses_list
+      end
+      it 'returns one match media' do
+        spring_2014 = feed[:media][2014]['B']
+        expect(spring_2014[1]).to be_nil
+        videos = spring_2014[87432][:videos]
         expect(videos).to have(31).items
         # Verify backwards compatibility
         expect(feed[:videos]).to eq videos
@@ -40,17 +62,69 @@ describe Webcast::Merged do
 
     context 'two matching course' do
       let(:feed) do
-        Webcast::Merged.new(2014, 'B', [1, 87432, 2, 76207], options).get_feed
+        Webcast::Merged.new(ldap_uid, 2014, 'B', [1, 87432, 2, 76207], options).get_feed
+      end
+      before do
+        courses_list = [
+          {
+            :classes=>[
+              {
+                :sections=>[
+                  {
+                    :ccn=>'87432',
+                    :section_number=>'101',
+                    :instruction_format=>'LEC' },
+                  {
+                    :ccn=>'76207',
+                    :section_number=>'102',
+                    :instruction_format=>'LEC',
+                    :instructors=>[
+                      {
+                        :name=>'Paul Duguid',
+                        :uid=>'18938',
+                        :instructor_func=>'1'
+                      },
+                      {
+                        :name=>'Geoffrey D. Nunberg',
+                        :uid=>'248421',
+                        :instructor_func=>'1'
+                      },
+                      {
+                        :name=>'Nikolai Smith',
+                        :uid=>'1016717',
+                        :instructor_func=>'2'
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+        MyAcademics::Teaching.any_instance.should_receive(:courses_list_from_ccns).once.and_return courses_list
       end
       it 'returns course media' do
         expect(feed[:video_error_message]).to be_nil
-        expect(feed[:media]['2014-B-1']).to eq Webcast::Recordings::ERRORS
-        expect(feed[:media]['2014-B-2']).to eq Webcast::Recordings::ERRORS
+        spring_2014 = feed[:media][2014]['B']
+        expect(spring_2014[1]).to be_nil
+        expect(spring_2014[2]).to be_nil
 
-        stat_131A = feed[:media]['2014-B-87432']
-        pb_hlth_241 = feed[:media]['2014-B-76207']
+        stat_131A = spring_2014[87432]
         expect(stat_131A[:videos]).to have(31).items
+        expect(stat_131A[:instruction_format]).to eq 'LEC'
+        expect(stat_131A[:section_number]).to eq '101'
+        expect(stat_131A[:webcast_authorized_instructors]).to be_empty
+
+        pb_hlth_241 = spring_2014[76207]
         expect(pb_hlth_241[:videos]).to have(35).items
+        # Feed excludes instructors per instructor_func
+        authorized_instructors = pb_hlth_241[:webcast_authorized_instructors]
+        expect(authorized_instructors).to have(2).items
+        expect(authorized_instructors[0][:uid]).to eq '18938'
+        expect(authorized_instructors[0][:instructor_func]).to eq '1'
+        expect(authorized_instructors[1][:uid]).to eq '248421'
+        expect(authorized_instructors[1][:instructor_func]).to eq '1'
+
         # Verify backwards compatibility. The feed[:videos] property is a union of ALL videos in the feed.
         expect(feed[:videos]).to match_array(pb_hlth_241[:videos] + stat_131A[:videos])
         expect(feed[:audio]).to be_empty
@@ -60,32 +134,48 @@ describe Webcast::Merged do
 
     context 'cross-listed CCNs in merged feed' do
       let(:feed) do
-        Webcast::Merged.new(2015, 'B', [51990, 5915], options).get_feed
+        Webcast::Merged.new(ldap_uid, 2015, 'B', [51990, 5915], options).get_feed
+      end
+      before do
+        courses_list = [
+          {
+            :classes=>[
+              {
+                :sections=>[
+                  { :ccn=>'5915', :section_number=>'101', :instruction_format=>'LEC' },
+                  { :ccn=>'51990', :section_number=>'201', :instruction_format=>'LEC' }
+                ]
+              }
+            ]
+          }
+        ]
+        MyAcademics::Teaching.any_instance.should_receive(:courses_list_from_ccns).once.and_return courses_list
       end
       it 'returns course media' do
         expect(feed[:video_error_message]).to be_nil
-        ls_C70U = feed[:media]['2015-B-51990']
-        astro_C10 = feed[:media]['2015-B-5915']
-        expect(ls_C70U[:videos]).to have(28).items
-        expect(astro_C10[:videos]).to have(28).items
+        spring_2015 = feed[:media][2015]['B']
         # These are cross-listed CCNs so we only include unique recordings
+        ccn_5915_videos = spring_2015[5915][:videos]
+        expect(ccn_5915_videos).to have(28).items
+        expect(ccn_5915_videos).to match_array spring_2015[51990][:videos]
+        # TODO: remove these deprecated properties from the Webcast feed
         expect(feed[:videos]).to have(28).items
-        expect(feed[:videos]).to match_array astro_C10[:videos]
-        expect(feed[:audio]).to match_array astro_C10[:audio]
+        expect(feed[:videos]).to match_array ccn_5915_videos
+        expect(feed[:audio]).to match_array spring_2015[5915][:audio]
       end
     end
-
   end
 
   context 'a real, non-fake proxy', :testext => true do
     context 'course with zero recordings is different than course not scheduled for recordings' do
       let(:feed) do
-        Webcast::Merged.new(2015, 'B', [1, 58301, 56745]).get_feed
+        Webcast::Merged.new(ldap_uid, 2015, 'B', [1, 58301, 56745]).get_feed
       end
       it 'identifies course that is scheduled for recordings' do
-        non_existent = feed[:media]['2015-B-1']
-        recordings_planned = feed[:media]['2015-B-58301']
-        recordings_exist = feed[:media]['2015-B-56745']
+        spring_2015 = feed[:media][2015]['B']
+        non_existent = spring_2015[1]
+        recordings_planned = spring_2015[58301]
+        recordings_exist = spring_2015[56745]
         expect(non_existent).to eq Webcast::Recordings::ERRORS
         expect(recordings_planned[:videos]).to be_empty
         expect(recordings_planned[:body]).to be_nil

--- a/spec/models/webcast/merged_spec.rb
+++ b/spec/models/webcast/merged_spec.rb
@@ -10,7 +10,7 @@ describe Webcast::Merged do
         Webcast::Merged.new(ldap_uid, 2014, 'B', [1], options).get_feed
       end
       before do
-        MyAcademics::Teaching.should_not_receive :new
+        expect_any_instance_of(MyAcademics::Teaching).not_to receive :new
       end
       it 'returns system status when authenticated' do
         expect(feed[:system_status]['is_sign_up_active']).to be true
@@ -47,7 +47,7 @@ describe Webcast::Merged do
             ]
           }
         ]
-        MyAcademics::Teaching.any_instance.should_receive(:courses_list_from_ccns).once.and_return courses_list
+        expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).once.and_return courses_list
       end
       it 'returns one match media' do
         spring_2014 = feed[:media][2014]['B']
@@ -101,7 +101,7 @@ describe Webcast::Merged do
             ]
           }
         ]
-        MyAcademics::Teaching.any_instance.should_receive(:courses_list_from_ccns).once.and_return courses_list
+        expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).once.and_return courses_list
       end
       it 'returns course media' do
         expect(feed[:video_error_message]).to be_nil
@@ -149,7 +149,7 @@ describe Webcast::Merged do
             ]
           }
         ]
-        MyAcademics::Teaching.any_instance.should_receive(:courses_list_from_ccns).once.and_return courses_list
+        expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).once.and_return courses_list
       end
       it 'returns course media' do
         expect(feed[:video_error_message]).to be_nil


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5209

Work necessary to support Webcast widget work:
* Use MyAcademics::Teaching to fold in section metadata. E.g., instructors authorized to sign up.
* Webcast::Merged is now UserSpecificModel.
* We put nothing in feed when CCN has no webcast. Previously, there was an error message, of sorts. 
* remove list of webcast enabled rooms from front-end api until it's necessary
