### PR TITLE
CLC-5209, we return nil instead of 'No Webcast data found'

### DIFF
--- a/app/models/webcast/proxy.rb
+++ b/app/models/webcast/proxy.rb
@@ -7,10 +7,6 @@ module Webcast
       :proxy_error_message => 'There was a problem fetching the Webcast-related data'
     }
 
-    ERRORS = {
-      :video_error_message => 'No Webcast data found.'
-    }
-
     def initialize(options = {})
       super(Settings.webcast_proxy, options)
     end

--- a/spec/models/webcast/merged_spec.rb
+++ b/spec/models/webcast/merged_spec.rb
@@ -176,7 +176,8 @@ describe Webcast::Merged do
         non_existent = spring_2015[1]
         recordings_planned = spring_2015[58301]
         recordings_exist = spring_2015[56745]
-        expect(non_existent).to eq Webcast::Recordings::ERRORS
+        expect(non_existent).to be_nil
+        expect(recordings_planned).not_to be_nil
         expect(recordings_planned[:videos]).to be_empty
         expect(recordings_planned[:body]).to be_nil
         expect(recordings_exist[:videos]).to have_at_least(10).items


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5209

DO NOT MERGE until https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CJT55-1 passes

* Fix to Bamboo failure: https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CLCMVPMASTER-3049/
* Remove the now obsolete :video_error_message => 'No Webcast data found'