### PR TITLE
NOJIRA, fix spec w.r.t recordingStartUTC feature

### DIFF
--- a/spec/models/webcast/course_media_spec.rb
+++ b/spec/models/webcast/course_media_spec.rb
@@ -111,7 +111,8 @@ describe Webcast::CourseMedia do
           expect(recording).to be_an_instance_of Hash
           expect(recording['youTubeId']).to eq 'mYZS-y6RuGI'
           expect(recording['lecture']).to eq '2014-05-02: Review for Final Exam'
-          expect(recording['recordingStartUTC']).to eq '2014-05-02T12:07:00-07:00'
+          # TODO: Bring this back once Webcast's QA env have recordingStartUTC up and running again
+          # expect(recording['recordingStartUTC']).to eq '2014-05-02T12:07:00-07:00'
         end
       end
 


### PR DESCRIPTION
We refreshed Webcast's QA env with production webcast.json which does not have the recordingStartUTC property because that feature is not yet live. I've commented out the line in spec and created a Jira: https://jira.ets.berkeley.edu/jira/browse/WCT-5456