### PR TITLE
CLC-5346 Set explicit user agent on Calmail proxy requests

### DIFF
--- a/app/models/calmail/proxy.rb
+++ b/app/models/calmail/proxy.rb
@@ -22,6 +22,8 @@ module Calmail
         domain: @settings.domain
       )
       request_options = {
+        # For the moment, these requests set an explicit user-agent as a workaround for CLC-5346.
+        headers: {'User-Agent' => 'Ruby'},
         method: :post,
         body: body_options,
         parser: LegacyJsonParser

--- a/spec/models/calmail/check_namespace_spec.rb
+++ b/spec/models/calmail/check_namespace_spec.rb
@@ -35,10 +35,7 @@ describe Calmail::CheckNamespace do
   end
 
   describe '#check_namespace' do
-    # These testext tests are disabled because they fail for unknown reasons when they're run as part
-    # of a full suite by our continuous integration server. Run by themselves, they're still useful.
-    # TODO Figure out the cause of the failure. See CLC-5170 for details.
-    context 'using real data feed', testext: true, ignore: true do
+    context 'using real data feed', testext: true do
       let(:response) { subject.check_namespace(list_name) }
       context 'known mailing list' do
         let(:list_name) {'raytest'}


### PR DESCRIPTION
A workaround for https://jira.ets.berkeley.edu/jira/browse/CLC-5346. 