### PR TITLE
CLC-2890 Improve garbage collection logging in Torquebox

### DIFF
--- a/script/start-torquebox.sh
+++ b/script/start-torquebox.sh
@@ -25,7 +25,7 @@ echo "------------------------------------------" | $LOGIT
 echo "`date`: Starting CalCentral..." | $LOGIT
 OPTS=${CALCENTRAL_JRUBY_OPTS:="-Xcext.enabled=true -J-Djruby.thread.pool.enabled=true -J-Djava.io.tmpdir=$PWD/tmp"}
 export JRUBY_OPTS=$OPTS
-JVM_OPTS=${CALCENTRAL_JVM_OPTS:="\-server \-verbose:gc \-XX:+PrintGCTimeStamps \-XX:+PrintGCDetails \-XX:+UseConcMarkSweepGC \-Xms3000m \-Xmx3000m \-Xmn500m \-XX:PermSize=400m \-XX:MaxPermSize=400m \-XX:ReservedCodeCacheSize=128m \-XX:+UseCodeCacheFlushing"}
+JVM_OPTS=${CALCENTRAL_JVM_OPTS:="\-server \-verbose:gc \-XX:+PrintGCDateStamps \-XX:+PrintGCCause \-XX:+PrintGCDetails \-XX:+UseConcMarkSweepGC \-Xms3000m \-Xmx3000m \-Xmn500m \-XX:PermSize=400m \-XX:MaxPermSize=400m \-XX:ReservedCodeCacheSize=128m \-XX:+UseCodeCacheFlushing"}
 LOG_DIR=${CALCENTRAL_LOG_DIR:=`pwd`"/log"}
 MAX_THREADS=${CALCENTRAL_MAX_THREADS:="90"}
 export CALCENTRAL_LOG_DIR=$LOG_DIR


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-2890

Changes log file lines like:

``3069.896: [GC3069.896: [ParNew: 439129K->21021K(460800K), 0.0239510 secs] 1099234K->684402K(3020800K), 0.0242140 secs] [Times: user=0.09 sys=0.00, real=0.03 secs] ``

to log file lines like:

``2015-06-01T14:58:40.732+0800: [GC (Allocation Failure)2015-06-01T14:58:40.732+0800: [ParNew: 409600K->22682K(460800K), 0.0224090 secs] 409600K->22682K(1996800K), 0.0224830 secs] [Times: user=0.08 sys=0.01, real=0.02 secs] ``