### PR TITLE
CLC-5363, Zero-padding needed on certain CCNs in Junction's Webcast feed

### DIFF
--- a/app/models/webcast/merged.rb
+++ b/app/models/webcast/merged.rb
@@ -37,13 +37,14 @@ module Webcast
           sections[0][:classes].each do |next_class|
             if next_class[:sections].any?
               next_class[:sections].each do |section|
-                ccn = section[:ccn].to_i
                 section_metadata = {
                   :webcast_authorized_instructors => extract_authorized(section[:instructors]),
                   :instruction_format => section[:instruction_format],
                   :section_number => section[:section_number],
                 }
-                media_per_confirmed_ccn[ccn] = media_per_ccn[ccn].merge section_metadata if media_per_ccn[ccn]
+                ccn = section[:ccn]
+                media = media_per_ccn[ccn.to_i]
+                media_per_confirmed_ccn[ccn] = media.merge section_metadata if media
               end
             end
           end

--- a/spec/models/canvas/webcast_recordings_spec.rb
+++ b/spec/models/canvas/webcast_recordings_spec.rb
@@ -40,13 +40,13 @@ describe Canvas::WebcastRecordings do
         media_by_ccn = feed[:media][2009]['B']
         expect(media_by_ccn).to have(2).items
 
-        law_27171 = media_by_ccn[49982]
+        law_27171 = media_by_ccn['49982']
         expect(law_27171[:audio]).to have(13).items
         expect(law_27171[:audio][12][:title]).to match('Lecture 1')
         expect(law_27171[:itunes][:audio]).to end_with('354822513')
         expect(law_27171[:itunes][:video]).to end_with('354822509')
 
-        sociol_150A = media_by_ccn[81853]
+        sociol_150A = media_by_ccn['81853']
         expect(sociol_150A[:audio]).to have_at_least(10).items
         expect(sociol_150A[:audio][12][:title]).to_not be_nil
         expect(sociol_150A[:itunes][:audio]).to_not be_nil

--- a/spec/models/webcast/merged_spec.rb
+++ b/spec/models/webcast/merged_spec.rb
@@ -52,7 +52,7 @@ describe Webcast::Merged do
       it 'returns one match media' do
         spring_2014 = feed[:media][2014]['B']
         expect(spring_2014[1]).to be_nil
-        videos = spring_2014[87432][:videos]
+        videos = spring_2014['87432'][:videos]
         expect(videos).to have(31).items
         # Verify backwards compatibility
         expect(feed[:videos]).to eq videos
@@ -109,13 +109,13 @@ describe Webcast::Merged do
         expect(spring_2014[1]).to be_nil
         expect(spring_2014[2]).to be_nil
 
-        stat_131A = spring_2014[87432]
+        stat_131A = spring_2014['87432']
         expect(stat_131A[:videos]).to have(31).items
         expect(stat_131A[:instruction_format]).to eq 'LEC'
         expect(stat_131A[:section_number]).to eq '101'
         expect(stat_131A[:webcast_authorized_instructors]).to be_empty
 
-        pb_hlth_241 = spring_2014[76207]
+        pb_hlth_241 = spring_2014['76207']
         expect(pb_hlth_241[:videos]).to have(35).items
         # Feed excludes instructors per instructor_func
         authorized_instructors = pb_hlth_241[:webcast_authorized_instructors]
@@ -142,7 +142,7 @@ describe Webcast::Merged do
             :classes=>[
               {
                 :sections=>[
-                  { :ccn=>'5915', :section_number=>'101', :instruction_format=>'LEC' },
+                  { :ccn=>'05915', :section_number=>'101', :instruction_format=>'LEC' },
                   { :ccn=>'51990', :section_number=>'201', :instruction_format=>'LEC' }
                 ]
               }
@@ -155,13 +155,13 @@ describe Webcast::Merged do
         expect(feed[:video_error_message]).to be_nil
         spring_2015 = feed[:media][2015]['B']
         # These are cross-listed CCNs so we only include unique recordings
-        ccn_5915_videos = spring_2015[5915][:videos]
+        ccn_5915_videos = spring_2015['05915'][:videos]
         expect(ccn_5915_videos).to have(28).items
-        expect(ccn_5915_videos).to match_array spring_2015[51990][:videos]
+        expect(ccn_5915_videos).to match_array spring_2015['51990'][:videos]
         # TODO: remove these deprecated properties from the Webcast feed
         expect(feed[:videos]).to have(28).items
         expect(feed[:videos]).to match_array ccn_5915_videos
-        expect(feed[:audio]).to match_array spring_2015[5915][:audio]
+        expect(feed[:audio]).to match_array spring_2015['05915'][:audio]
       end
     end
   end
@@ -174,8 +174,8 @@ describe Webcast::Merged do
       it 'identifies course that is scheduled for recordings' do
         spring_2015 = feed[:media][2015]['B']
         non_existent = spring_2015[1]
-        recordings_planned = spring_2015[58301]
-        recordings_exist = spring_2015[56745]
+        recordings_planned = spring_2015['58301']
+        recordings_exist = spring_2015['56745']
         expect(non_existent).to be_nil
         expect(recordings_planned).not_to be_nil
         expect(recordings_planned[:videos]).to be_empty


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5363

