### PR TITLE
CLC-5374 Make model callbacks play more nicely with RailsAdmin

### DIFF
--- a/app/models/mailing_lists/site_mailing_list.rb
+++ b/app/models/mailing_lists/site_mailing_list.rb
@@ -115,7 +115,10 @@ module MailingLists
     end
 
     def check_for_creation
-      self.state = 'created' if name_available? == false
+      if name_available? == false
+        self.state = 'created'
+        save
+      end
     end
 
     def generate_list_name
@@ -156,6 +159,7 @@ module MailingLists
     end
 
     def name_available?
+      return if list_name.blank?
       if (check_namespace = Calmail::CheckNamespace.new.name_available? self.list_name) &&
           (check_namespace[:response] == true || check_namespace[:response] == false)
         check_namespace[:response]


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5374

1. Once Calmail confirms list creation, save state right away to avoid redundant queries;
2. Don't bother asking Calmail about the blank list names that RailsAdmin initializes as part of its business.
