### PR TITLE
CLC-5376, camelCase and flattened structure in feed to Webcast front-end

### DIFF
--- a/app/models/webcast/course_media.rb
+++ b/app/models/webcast/course_media.rb
@@ -24,7 +24,7 @@ module Webcast
     def get_feed
       return {} unless Settings.features.videos
       media_hash = get_media_hash
-      error_message = media_hash[:proxy_error_message]
+      error_message = media_hash[:proxyErrorMessage]
       unless error_message.blank? && media_hash[:body].blank?
         return {
           :proxyErrorMessage => error_message || media_hash[:body]

--- a/app/models/webcast/merged.rb
+++ b/app/models/webcast/merged.rb
@@ -3,7 +3,7 @@ module Webcast
     include Cache::CachedFeed
 
     def initialize(uid, term_yr, term_cd, ccn_list, options = {})
-      super(uid, options)
+      super(uid.nil? ? nil : uid.to_i, options)
       @term_yr = term_yr.to_i unless term_yr.nil?
       @term_cd = term_cd
       @ccn_list = ccn_list
@@ -11,6 +11,7 @@ module Webcast
     end
 
     def get_feed_internal
+      @academics = MyAcademics::Teaching.new(@uid)
       feed = { :system_status => Webcast::SystemStatus.new(@options).get }
       feed.merge get_media_feed
     end
@@ -19,53 +20,88 @@ module Webcast
 
     def get_media_feed
       feed = {}
-      media_per_ccn = get_media_per_confirmed_ccn
-      if media_per_ccn.any?
-        # Put CCNs eligible for Webcast sign-up
-        slug = Berkeley::TermCodes.to_slug(@term_yr, @term_cd)
-        all_eligible = Webcast::SignUpEligible.new(@options).get[slug]
-        unless all_eligible.nil?
-          eligible_ccn_set = []
-          all_eligible.each do |eligible_ccn|
-            ccn_padded = sprintf('%05d', eligible_ccn)
-            eligible_ccn_set << ccn_padded unless media_per_ccn.has_key? ccn_padded
-          end
-          feed.merge!({ :eligible_for_sign_up => eligible_ccn_set }) if eligible_ccn_set.any?
-        end
+      media = get_media
+      eligible_for_sign_up = get_sections_not_yet_signed_up media
+      feed.merge!({ :eligibleForSignUp => eligible_for_sign_up }) if eligible_for_sign_up.any?
+      if media.any?
         # Put video and audio
-        media_per_term = { @term_yr => { @term_cd => media_per_ccn } }
+        # media_per_term = { @term_yr => { @term_cd => media } }
         media_hash = {
-          :media => media_per_term,
-          :videos => merge(media_per_term, :videos),
-          :audio => merge(media_per_term, :audio),
-          :itunes => merge_itunes(media_per_term)
+          :media => media,
+          :videos => merge(media, :videos),
+          :audio => merge(media, :audio),
+          :iTunes => merge_itunes(media)
         }
         feed.merge! media_hash
       end
       feed
     end
 
-    def get_media_per_confirmed_ccn
-      feed = {}
+    def get_sections_not_yet_signed_up(media)
+      not_yet_signed_up = []
+      if @term_yr && @term_cd
+        slug = Berkeley::TermCodes.to_slug(@term_yr, @term_cd)
+        all_eligible = Webcast::SignUpEligible.new(@options).get[slug]
+        unless all_eligible.nil?
+          all_eligible = @ccn_list & all_eligible
+          eligible_sections = []
+          ccn_with_media = media.map { |entry| entry[:ccn] }
+          all_eligible.each do |eligible_ccn|
+            ccn_padded = sprintf('%05d', eligible_ccn)
+            unless ccn_with_media.include? ccn_padded
+              eligible_sections << ccn_padded
+            end
+          end
+          if eligible_sections.any?
+            courses = @academics.courses_list_from_ccns(@term_yr, @term_cd, eligible_sections.map { |ccn| ccn.to_i })
+            courses.each do |course|
+              if course[:classes].present?
+                course[:classes].each do |next_class|
+                  next_class[:sections].each do |section|
+                    instructors = HashConverter.camelize extract_authorized(section[:instructors])
+                    this_user_can_sign_up = instructors.map { |instructor| instructor[:uid].to_i }.include? @uid
+                    not_yet_signed_up << {
+                      :termYr => @term_yr,
+                      :termCd => @term_cd,
+                      :ccn => section[:ccn],
+                      :webcastAuthorizedInstructors => instructors,
+                      :thisUserCanSignUp => this_user_can_sign_up,
+                      :deptName => next_class[:dept],
+                      :catalogId => next_class[:courseCatalog],
+                      :instructionFormat => section[:instruction_format],
+                      :sectionNumber => section[:section_number]
+                    }
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+      not_yet_signed_up
+    end
+
+    def get_media
+      feed = []
       if @term_yr && @term_cd
         media_per_ccn = Webcast::CourseMedia.new(@term_yr, @term_cd, @ccn_list, @options).get_feed
         if media_per_ccn.any?
-          sections = MyAcademics::Teaching.new(@uid).courses_list_from_ccns(@term_yr, @term_cd, media_per_ccn.keys)
-          if sections.any? && sections[0][:classes].present?
-            sections[0][:classes].each do |next_class|
-              if next_class[:sections].any?
-                next_class[:sections].each do |section|
-                  section_metadata = {
-                    :webcast_authorized_instructors => extract_authorized(section[:instructors]),
-                    :dept_name => next_class[:dept],
-                    :catalog_id => next_class[:courseCatalog],
-                    :instruction_format => section[:instruction_format],
-                    :section_number => section[:section_number]
-                  }
-                  ccn = section[:ccn]
-                  media = media_per_ccn[ccn.to_i]
-                  feed[ccn] = media.merge section_metadata if media
-                end
+          courses = @academics.courses_list_from_ccns(@term_yr, @term_cd, media_per_ccn.keys)
+          courses.each do |course|
+            course[:classes].each do |next_class|
+              next_class[:sections].each do |section|
+                ccn = section[:ccn]
+                section_metadata = {
+                  :termYr => @term_yr,
+                  :termCd => @term_cd,
+                  :ccn => ccn,
+                  :deptName => next_class[:dept],
+                  :catalogId => next_class[:courseCatalog],
+                  :instructionFormat => section[:instruction_format],
+                  :sectionNumber => section[:section_number]
+                }
+                media = media_per_ccn[ccn.to_i]
+                feed << media.merge(section_metadata) if media
               end
             end
           end
@@ -82,10 +118,9 @@ module Webcast
       @term_yr && @term_cd ? Webcast::CourseMedia.id_per_ccn(@term_yr, @term_cd, @ccn_list.to_s) : @options[:user_id]
     end
 
-    def merge(media_by_term, media_type)
-      return [] if media_by_term.empty? || media_by_term[@term_yr][@term_cd].empty?
+    def merge(media_per_ccn, media_type)
       all_recordings = Set.new
-      media_by_term[@term_yr][@term_cd].values.each do |section|
+      media_per_ccn.each do |section|
         recordings = section[media_type]
         recordings.each { |r| all_recordings << r } if recordings
       end
@@ -93,8 +128,8 @@ module Webcast
     end
 
     def merge_itunes(course)
-      course.values.each { |s| return s[:itunes] if s[:itunes] } if course
-      { 'audio' => nil, 'video' => nil }
+      course.each { |s| return s[:itunes] if s[:itunes] } if course
+      { :audio => nil, :video => nil }
     end
 
   end

--- a/app/models/webcast/proxy.rb
+++ b/app/models/webcast/proxy.rb
@@ -4,7 +4,7 @@ module Webcast
     include ClassLogger, SafeJsonParser
 
     PROXY_ERROR = {
-      :proxy_error_message => 'There was a problem fetching the Webcast-related data'
+      :proxyErrorMessage => 'There was a problem fetching the Webcast-related data'
     }
 
     def initialize(options = {})
@@ -13,7 +13,7 @@ module Webcast
 
     def get
       self.class.smart_fetch_from_cache(
-        {user_message_on_exception: PROXY_ERROR[:proxy_error_message]}) do
+        {user_message_on_exception: PROXY_ERROR[:proxyErrorMessage]}) do
         request_internal
       end
     end

--- a/app/models/webcast/sign_up_eligible.rb
+++ b/app/models/webcast/sign_up_eligible.rb
@@ -11,7 +11,7 @@ module Webcast
     end
 
     def request_internal
-      is_webcast_sign_up_active = Webcast::SystemStatus.new(@options).get['is_sign_up_active']
+      is_webcast_sign_up_active = Webcast::SystemStatus.new(@options).get[:isSignUpActive]
       logger.info "Webcast sign-up period #{is_webcast_sign_up_active ? 'is' : 'is not'} active."
       return {} unless Settings.features.videos && is_webcast_sign_up_active
       ccn_set_by_term = {}

--- a/app/models/webcast/system_status.rb
+++ b/app/models/webcast/system_status.rb
@@ -7,7 +7,7 @@ module Webcast
 
     def request_internal
       {
-        'is_sign_up_active' => Settings.features.videos ? get_json_data['isSignUpActive'] : false
+        :isSignUpActive => Settings.features.videos ? get_json_data['isSignUpActive'] : false
       }
     end
 

--- a/fixtures/webcast/eligible-for-webcast.json
+++ b/fixtures/webcast/eligible-for-webcast.json
@@ -12,6 +12,13 @@
       "year": 2015,
       "semester": "Fall",
       "ccnSet": []
+    },
+    {
+      "year": 2014,
+      "semester": "Spring",
+      "ccnSet": [
+        7620
+      ]
     }
   ]
 }

--- a/spec/controllers/mediacasts_controller_spec.rb
+++ b/spec/controllers/mediacasts_controller_spec.rb
@@ -60,7 +60,8 @@ describe MediacastsController do
         it 'should escape special characters in dept name' do
           json = post_course malay_100A
           # This course happens to have zero YouTube videos
-          course = json['media']['2014']['D']['85006']
+          course = json['media'][0]
+          expect(course['ccn']).to eq '85006'
           expect(course['videos']).to be_empty
           expect(course['itunes']['audio']).to be_nil
           expect(course['itunes']['video']).to include '819827828'

--- a/spec/models/canvas/webcast_recordings_spec.rb
+++ b/spec/models/canvas/webcast_recordings_spec.rb
@@ -36,17 +36,19 @@ describe Canvas::WebcastRecordings do
 
       it 'contains two sets of recordings' do
         feed = subject.get_feed
-        expect(feed[:system_status]['is_sign_up_active']).to be true
-        media_by_ccn = feed[:media][2009]['B']
+        expect(feed[:system_status][:isSignUpActive]).to be true
+        media_by_ccn = feed[:media]
         expect(media_by_ccn).to have(2).items
 
-        law_27171 = media_by_ccn['49982']
+        law_27171 = media_by_ccn[0]
+        expect(law_27171[:ccn]).to eq '49982'
         expect(law_27171[:audio]).to have(13).items
         expect(law_27171[:audio][12][:title]).to match('Lecture 1')
         expect(law_27171[:itunes][:audio]).to end_with('354822513')
         expect(law_27171[:itunes][:video]).to end_with('354822509')
 
-        sociol_150A = media_by_ccn['81853']
+        sociol_150A = media_by_ccn[1]
+        expect(sociol_150A[:ccn]).to eq '81853'
         expect(sociol_150A[:audio]).to have_at_least(10).items
         expect(sociol_150A[:audio][12][:title]).to_not be_nil
         expect(sociol_150A[:itunes][:audio]).to_not be_nil
@@ -63,7 +65,7 @@ describe Canvas::WebcastRecordings do
       end
       it 'is empty' do
         feed = subject.get_feed
-        expect(feed[:system_status]['is_sign_up_active']).to be true
+        expect(feed[:system_status][:isSignUpActive]).to be true
         expect(feed[:media]).to be_nil
       end
     end

--- a/spec/models/webcast/course_media_spec.rb
+++ b/spec/models/webcast/course_media_spec.rb
@@ -27,7 +27,7 @@ describe Webcast::CourseMedia do
 
     context 'when proxy error message is not blank' do
       before do
-        proxy_error_hash = {:proxy_error_message => 'Proxy Error'}
+        proxy_error_hash = {:proxyErrorMessage => 'Proxy Error'}
         expect(subject).to receive(:get_media_hash).and_return proxy_error_hash
       end
       it 'should return the proxy error message' do

--- a/spec/models/webcast/merged_spec.rb
+++ b/spec/models/webcast/merged_spec.rb
@@ -49,8 +49,6 @@ describe Webcast::Merged do
         expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).once.and_return courses_list
       end
       it 'returns one match media' do
-        # spring_2014 =
-        # expect(spring_2014[1]).to be_nil
         stat_131A = feed[:media][0]
         expect(stat_131A[:termYr]).to eq 2014
         expect(stat_131A[:termCd]).to eq 'B'
@@ -230,7 +228,7 @@ describe Webcast::Merged do
   context 'a real, non-fake proxy', :testext => true do
     context 'course with zero recordings is different than course not scheduled for recordings' do
       let(:feed) do
-        Webcast::Merged.new(ldap_uid, 2015, 'B', [1, 58301, 56745]).get_feed
+        Webcast::Merged.new(rand(99999).to_s, 2015, 'B', [1, 58301, 56745]).get_feed
       end
       it 'identifies course that is scheduled for recordings' do
         media = feed[:media]

--- a/spec/models/webcast/merged_spec.rb
+++ b/spec/models/webcast/merged_spec.rb
@@ -1,19 +1,17 @@
 describe Webcast::Merged do
 
-  let(:ldap_uid) { 904715 }
-
   context 'a fake proxy' do
     let(:options) { {:fake => true} }
 
     context 'no matching course' do
       let(:feed) do
-        Webcast::Merged.new(ldap_uid, 2014, 'B', [1], options).get_feed
+        Webcast::Merged.new(rand(99999).to_s, 2014, 'B', [1], options).get_feed
       end
       before do
         expect_any_instance_of(MyAcademics::Teaching).not_to receive :new
       end
       it 'returns system status when authenticated' do
-        expect(feed[:system_status]['is_sign_up_active']).to be true
+        expect(feed[:system_status][:isSignUpActive]).to be true
         # TODO: Bring 'rooms' back in the feed as needed by front-end
         # expect(feed[:rooms]).to have(26).items
         # expect(feed[:rooms]['VALLEY LSB']).to contain_exactly('2040', '2050', '2060')
@@ -21,13 +19,13 @@ describe Webcast::Merged do
         # Verify backwards compatibility
         expect(feed[:videos]).to be_nil
         expect(feed[:audio]).to be_nil
-        expect(feed[:itunes]).to be_nil
+        expect(feed[:iTunes]).to be_nil
       end
     end
 
     context 'one matching course' do
       let(:feed) do
-        Webcast::Merged.new(ldap_uid, 2014, 'B', [1, 87432], options).get_feed
+        Webcast::Merged.new(rand(99999).to_s, 2014, 'B', [1, 87432], options).get_feed
       end
       before do
         courses_list = [
@@ -51,22 +49,25 @@ describe Webcast::Merged do
         expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).once.and_return courses_list
       end
       it 'returns one match media' do
-        spring_2014 = feed[:media][2014]['B']
-        expect(spring_2014[1]).to be_nil
-        stat_131A = spring_2014['87432']
-        expect(stat_131A[:dept_name]).to eq 'PLANTBI'
-        expect(stat_131A[:catalog_id]).to eq '150'
+        # spring_2014 =
+        # expect(spring_2014[1]).to be_nil
+        stat_131A = feed[:media][0]
+        expect(stat_131A[:termYr]).to eq 2014
+        expect(stat_131A[:termCd]).to eq 'B'
+        expect(stat_131A[:ccn]).to eq '87432'
+        expect(stat_131A[:deptName]).to eq 'PLANTBI'
+        expect(stat_131A[:catalogId]).to eq '150'
         videos = stat_131A[:videos]
         expect(videos).to have(31).items
         # Verify backwards compatibility
         expect(feed[:videos]).to eq videos
-        expect(feed[:video_error_message]).to be_nil
+        expect(feed[:videoErrorMessage]).to be_nil
       end
     end
 
     context 'ccn formatting per convention' do
       let(:feed) do
-        Webcast::Merged.new(ldap_uid, 2008, 'D', [9688], options).get_feed
+        Webcast::Merged.new(rand(99999).to_s, 2008, 'D', [9688], options).get_feed
       end
       before do
         courses_list = [{
@@ -76,30 +77,50 @@ describe Webcast::Merged do
         expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).once.and_return courses_list
       end
       it 'pads ccn with zeroes' do
-        law_course = feed[:media][2008]['D']['09688']
+        law_course = feed[:media][0]
         expect(law_course).to_not be_nil
+        expect(law_course[:ccn]).to eq '09688'
         expect(law_course[:videos]).to be_empty
       end
     end
 
     context 'two matching course' do
+      let(:ldap_uid) { '248421' }
       let(:feed) do
-        Webcast::Merged.new(ldap_uid, 2014, 'B', [1, 87432, 2, 76207], options).get_feed
+        Webcast::Merged.new(ldap_uid, 2014, 'B', [87432, 76207, 7620], options).get_feed
       end
       before do
-        courses_list = [
+        sections_with_recordings = [
           {
             :classes=>[
               {
                 :sections=>[
                   {
+                    :ccn=>'76207',
+                    :instruction_format=>'LEC',
+                    :section_number=>'101'
+                  },
+                  {
                     :ccn=>'87432',
                     :instruction_format=>'LEC',
-                    :section_number=>'101' },
+                    :section_number=>'101'
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+        webcast_eligible = [
+          {
+            :classes=>[
+              {
+                :dept => 'BIO',
+                :courseCatalog => '1B',
+                :sections=>[
                   {
-                    :ccn=>'76207',
-                    :section_number=>'102',
-                    :instruction_format=>'LEC',
+                    :ccn=>'07620',
+                    :section_number=>'312',
+                    :instruction_format => 'LAB',
                     :instructors=>[
                       {
                         :name=>'Paul Duguid',
@@ -107,9 +128,9 @@ describe Webcast::Merged do
                         :instructor_func=>'1'
                       },
                       {
-                        :name=>'Geoffrey D. Nunberg',
-                        :uid=>'248421',
-                        :instructor_func=>'1'
+                        :name=>'Geoffrey Nunberg',
+                        :uid=>ldap_uid,
+                        :instructor_func=>'3'
                       },
                       {
                         :name=>'Nikolai Smith',
@@ -123,68 +144,85 @@ describe Webcast::Merged do
             ]
           }
         ]
-        expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).once.and_return courses_list
+        expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).with(2014, 'B', [87432, 76207]).and_return sections_with_recordings
+        expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).with(2014, 'B', [7620]).and_return webcast_eligible
       end
       it 'returns course media' do
-        expect(feed[:video_error_message]).to be_nil
-        spring_2014 = feed[:media][2014]['B']
-        expect(spring_2014[1]).to be_nil
-        expect(spring_2014[2]).to be_nil
-
-        stat_131A = spring_2014['87432']
+        expect(feed[:videoErrorMessage]).to be_nil
+        media = feed[:media]
+        expect(media).to have(2).items
+        pb_hlth_241 = media[0]
+        stat_131A = media[1]
+        expect(stat_131A[:ccn]).to eq '87432'
         expect(stat_131A[:videos]).to have(31).items
-        expect(stat_131A[:instruction_format]).to eq 'LEC'
-        expect(stat_131A[:section_number]).to eq '101'
-        expect(stat_131A[:webcast_authorized_instructors]).to be_empty
-
-        pb_hlth_241 = spring_2014['76207']
+        expect(stat_131A[:instructionFormat]).to eq 'LEC'
+        expect(stat_131A[:sectionNumber]).to eq '101'
+        expect(stat_131A[:eligibleForSignUp]).to be_nil
+        expect(pb_hlth_241[:ccn]).to eq '76207'
         expect(pb_hlth_241[:videos]).to have(35).items
-        # Feed excludes instructors per instructor_func
-        authorized_instructors = pb_hlth_241[:webcast_authorized_instructors]
-        expect(authorized_instructors).to have(2).items
-        expect(authorized_instructors[0][:uid]).to eq '18938'
-        expect(authorized_instructors[0][:instructor_func]).to eq '1'
-        expect(authorized_instructors[1][:uid]).to eq '248421'
-        expect(authorized_instructors[1][:instructor_func]).to eq '1'
-
-        # Verify backwards compatibility. The feed[:videos] property is a union of ALL videos in the feed.
         expect(feed[:videos]).to match_array(pb_hlth_241[:videos] + stat_131A[:videos])
         expect(feed[:audio]).to be_empty
-        expect(feed[:itunes]['audio']).to be_nil
+        expect(feed[:iTunes][:audio]).to be_nil
+
+        # Instructors that can sign up for Webcast
+        eligible_for_sign_up = feed[:eligibleForSignUp]
+        expect(eligible_for_sign_up).to have(1).items
+        bio_lab = eligible_for_sign_up[0]
+        expect(bio_lab[:ccn]).to eq '07620'
+        expect(bio_lab[:deptName]).to eq 'BIO'
+        expect(bio_lab[:catalogId]).to eq '1B'
+        expect(bio_lab[:sectionNumber]).to eq '312'
+        expect(bio_lab[:instructionFormat]).to eq 'LAB'
+        instructors = bio_lab[:webcastAuthorizedInstructors]
+        expect(instructors).to have(2).items
+        expect(instructors).to have(2).items
+        expect(instructors[0][:name]).to eq 'Paul Duguid'
+        expect(instructors[1][:name]).to eq 'Geoffrey Nunberg'
       end
     end
 
     context 'cross-listed CCNs in merged feed' do
       let(:feed) do
-        Webcast::Merged.new(ldap_uid, 2015, 'B', [51990, 5915, 51992], options).get_feed
+        Webcast::Merged.new(rand(99999).to_s, 2015, 'B', [51990, 5915, 51992], options).get_feed
       end
       before do
-        courses_list = [
+        sections_with_recordings = [
           {
             :classes=>[
               {
                 :sections=>[
                   { :ccn=>'05915', :section_number=>'101', :instruction_format=>'LEC' },
-                  { :ccn=>'51990', :section_number=>'201', :instruction_format=>'LEC' },
+                  { :ccn=>'51990', :section_number=>'201', :instruction_format=>'LEC' }
+                ]
+              }
+            ]
+          }
+        ]
+        webcast_eligible = [
+          {
+            :classes=>[
+              {
+                :sections=>[
                   { :ccn=>'51992', :section_number=>'401', :instruction_format=>'DIS' }
                 ]
               }
             ]
           }
         ]
-        expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).once.and_return courses_list
+        expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).with(2015, 'B', [51990, 5915]).and_return sections_with_recordings
+        expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).with(2015, 'B', [51992]).and_return webcast_eligible
       end
       it 'returns course media' do
-        expect(feed[:video_error_message]).to be_nil
-        spring_2015 = feed[:media][2015]['B']
+        expect(feed[:videoErrorMessage]).to be_nil
+        media = feed[:media]
         # These are cross-listed CCNs so we only include unique recordings
-        ccn_5915_videos = spring_2015['05915'][:videos]
-        expect(ccn_5915_videos).to have(28).items
-        expect(ccn_5915_videos).to match_array spring_2015['51990'][:videos]
+        section_101 = media[0][:videos]
+        expect(section_101).to have(28).items
+        expect(section_101).to match_array media[1][:videos]
         # Verify CCNs not yet signed up for Webcast
-        eligible = feed[:eligible_for_sign_up]
-        expect(eligible).to_not be_nil
-        expect(eligible).to contain_exactly '51992'
+        eligible = feed[:eligibleForSignUp]
+        expect(eligible).to have(1).items
+        expect(eligible[0][:ccn]).to eq '51992'
       end
     end
   end
@@ -195,14 +233,15 @@ describe Webcast::Merged do
         Webcast::Merged.new(ldap_uid, 2015, 'B', [1, 58301, 56745]).get_feed
       end
       it 'identifies course that is scheduled for recordings' do
-        spring_2015 = feed[:media][2015]['B']
-        non_existent = spring_2015[1]
-        recordings_planned = spring_2015['58301']
-        recordings_exist = spring_2015['56745']
-        expect(non_existent).to be_nil
+        media = feed[:media]
+        recordings_planned = media[0]
         expect(recordings_planned).not_to be_nil
+        expect(recordings_planned[:ccn]).to eq '58301'
         expect(recordings_planned[:videos]).to be_empty
         expect(recordings_planned[:body]).to be_nil
+
+        recordings_exist = media[1]
+        expect(recordings_exist[:ccn]).to eq '56745'
         expect(recordings_exist[:videos]).to have_at_least(10).items
         expect(recordings_exist[:body]).to be_nil
       end

--- a/spec/models/webcast/recordings_spec.rb
+++ b/spec/models/webcast/recordings_spec.rb
@@ -36,7 +36,7 @@ describe Webcast::Recordings do
       after(:each) { WebMock.reset! }
       it 'should return the fetch error message' do
         response = subject.get
-        expect(response[:proxy_error_message]).to include('There was a problem')
+        expect(response[:proxyErrorMessage]).to include('There was a problem')
       end
     end
 
@@ -47,7 +47,7 @@ describe Webcast::Recordings do
       after(:each) { WebMock.reset! }
       it 'should return the fetch error message' do
         response = subject.get
-        expect(response[:proxy_error_message]).to include('There was a problem')
+        expect(response[:proxyErrorMessage]).to include('There was a problem')
       end
     end
 

--- a/spec/models/webcast/rooms_spec.rb
+++ b/spec/models/webcast/rooms_spec.rb
@@ -66,7 +66,7 @@ describe Webcast::Rooms do
       after(:each) { WebMock.reset! }
       it 'should return the fetch error message' do
         buildings = subject.get
-        expect(buildings[:proxy_error_message]).to include 'There was a problem'
+        expect(buildings[:proxyErrorMessage]).to include 'There was a problem'
       end
     end
 
@@ -77,7 +77,7 @@ describe Webcast::Rooms do
       after(:each) { WebMock.reset! }
       it 'should return the fetch error message' do
         buildings = subject.get
-        expect(buildings[:proxy_error_message]).to include 'There was a problem'
+        expect(buildings[:proxyErrorMessage]).to include 'There was a problem'
       end
     end
 

--- a/spec/models/webcast/sign_up_eligible_spec.rb
+++ b/spec/models/webcast/sign_up_eligible_spec.rb
@@ -3,21 +3,35 @@ describe Webcast::SignUpEligible do
   let (:eligible_for_webcast_json_uri) { URI.parse "#{Settings.webcast_proxy.base_url}/eligible-for-webcast.json" }
 
   context 'a fake proxy' do
-    subject { Webcast::SignUpEligible.new({:fake => true}) }
 
-    context 'fake data' do
+    context 'sign-up program is active' do
+      subject { Webcast::SignUpEligible.new({:fake => true}) }
+
       it 'should return all test data' do
         terms = subject.get
-        expect(terms).to have(2).items
+        expect(terms).to have(3).items
         expect(terms['fall-2015']).to be_empty
         expect(terms['spring-2015']).to contain_exactly(5915, 51992)
       end
     end
+
+    context 'sign-up program is not active' do
+      before {
+        allow_any_instance_of(Webcast::SystemStatus).to receive(:get).and_return({ :isSignUpActive => false })
+      }
+      subject { Webcast::SignUpEligible.new({:fake => true}) }
+
+      it 'should return all test data' do
+        terms = subject.get
+        expect(terms).to be_empty
+      end
+    end
+
   end
 
   context 'a real, non-fake proxy' do
     before {
-      allow_any_instance_of(Webcast::SystemStatus).to receive(:get).and_return({ 'is_sign_up_active' => true })
+      allow_any_instance_of(Webcast::SystemStatus).to receive(:get).and_return({ :isSignUpActive => true })
     }
     subject { Webcast::SignUpEligible.new }
 

--- a/spec/models/webcast/system_status_spec.rb
+++ b/spec/models/webcast/system_status_spec.rb
@@ -7,7 +7,7 @@ describe Webcast::SystemStatus do
 
     context 'fake data' do
       it 'should return webcast-enabled rooms' do
-        expect(subject.get['is_sign_up_active']).to be true
+        expect(subject.get[:isSignUpActive]).to be true
       end
     end
 
@@ -15,7 +15,7 @@ describe Webcast::SystemStatus do
       before { Settings.features.videos = false }
       after { Settings.features.videos = true }
       it 'should be false regardless of value in the feed' do
-        expect(subject.get['is_sign_up_active']).to be false
+        expect(subject.get[:isSignUpActive]).to be false
       end
     end
   end
@@ -25,7 +25,7 @@ describe Webcast::SystemStatus do
 
     context 'real data', :testext => true do
       it 'should return true or false' do
-        flag = subject.get['is_sign_up_active']
+        flag = subject.get[:isSignUpActive]
         expect([true, false]).to include flag
       end
     end

--- a/src/assets/templates/widgets/webcast.html
+++ b/src/assets/templates/widgets/webcast.html
@@ -9,14 +9,10 @@
         There are no Webcasts scheduled.
       </div>
       <div data-ng-if="media">
-        <div data-ng-repeat="(year, termHash) in media">
-          <div data-ng-repeat="(term, ccnHash) in termHash">
-            <div data-ng-repeat="(ccn, course) in ccnHash">
-              <div data-ng-if="!course.videos.length && !course.audio.length">
-                Webcasts for {{course.dept_name}} {{course.catalog_id}} {{course.instruction_format}} {{course.section_number}} will appear here after classes start.
-              </div>
+        <div data-ng-repeat="section in media">
+            <div data-ng-if="!section.videos.length && !section.audio.length">
+              Webcasts for {{section.deptName}} {{section.catalogId}} {{course.instructionFormat}} {{section.sectionNumber}} will appear here after classes start.
             </div>
-          </div>
         </div>
       </div>
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5376
https://jira.ets.berkeley.edu/jira/browse/CLC-5377

DO NOT https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CJT55-JOB1-19 passes

FYI
* structure changed from  *[media][year][term] = hash-per-ccn*   to   *[media] = array-of-sections*
* all keys in merged feed (consumed by front-end) are camelCase
* feed now includes *:thisUserCanSignUp* which is based on user's ldap_uid 
