### PR TITLE
CLC-5394, spec to verify iTunes audio when iTunes video is nil

### DIFF
--- a/fixtures/webcast/warehouse/webcast.json
+++ b/fixtures/webcast/warehouse/webcast.json
@@ -1430,7 +1430,7 @@
       "audioOnly": false,
       "public": true,
       "youTubePlaylist": "-XXv-cvA_iBacs-uhTVhDhip4sGWoq2C",
-      "iTunesVideo": 805328862,
+      "iTunesAudio": 805328862,
       "screenRSS": "http://wbe-itunes.berkeley.edu/media/common/courses/spring_2014/rss/public_health_241_001_screen.rss",
       "recordings": [
         {

--- a/spec/models/webcast/merged_spec.rb
+++ b/spec/models/webcast/merged_spec.rb
@@ -161,11 +161,12 @@ describe Webcast::Merged do
         expect(stat_131A[:eligibleForSignUp]).to be_nil
         expect(pb_hlth_241[:ccn]).to eq '76207'
         expect(pb_hlth_241[:videos]).to have(35).items
-        expect(pb_hlth_241[:iTunes][:video]).to include('805328862')
+        expect(pb_hlth_241[:iTunes][:audio]).to include('805328862')
+        expect(pb_hlth_241[:iTunes][:video]).to be_nil
         expect(feed[:videos]).to match_array(pb_hlth_241[:videos] + stat_131A[:videos])
         expect(feed[:audio]).to be_empty
-        expect(feed[:iTunes][:audio]).to be_nil
-        expect(feed[:iTunes][:video]).to include('805328862')
+        expect(feed[:iTunes][:audio]).to include('805328862')
+        expect(feed[:iTunes][:video]).to be_nil
 
         # Instructors that can sign up for Webcast
         eligible_for_sign_up = feed[:eligibleForSignUp]


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5394

Bug is already fixed on master. This spec hopes to prevent future breakage. 