### PR TITLE
CLC-5408 Quell registration alerts during term transitions

### DIFF
--- a/app/models/campus_oracle/user_attributes.rb
+++ b/app/models/campus_oracle/user_attributes.rb
@@ -19,16 +19,13 @@ module CampusOracle
     def get_feed_internal
       result = CampusOracle::Queries.get_person_attributes(@uid)
       if result
-        result[:reg_status] = {
-          :code => result["reg_status_cd"],
-          :summary => reg_status_translator.status(result["reg_status_cd"]),
-          :explanation => reg_status_translator.status_explanation(result["reg_status_cd"]),
-          :needsAction => !reg_status_translator.is_registered(result["reg_status_cd"])
-        }
-        result[:education_level] = educ_level_translator.translate(result["educ_level"])
-        result[:california_residency] = cal_residency_translator.translate(result["cal_residency_flag"])
-        result[:roles] = roles_from_campus_row(result)
-        result.merge!(Berkeley::SpecialRegistrationProgram.attributes_from_code(result['reg_special_pgm_cd']))
+        regstatus_code = (Berkeley::Terms.fetch.current.sis_term_status == 'CT') ? result['reg_status_cd'] : nil
+        result[:reg_status] = reg_status_translator.translate_for_feed regstatus_code
+
+        result[:education_level] = educ_level_translator.translate result['educ_level']
+        result[:california_residency] = cal_residency_translator.translate result['cal_residency_flag']
+        result[:roles] = roles_from_campus_row result
+        result.merge! Berkeley::SpecialRegistrationProgram.attributes_from_code(result['reg_special_pgm_cd'])
         result
       else
         {}

--- a/app/models/my_badges/student_info.rb
+++ b/app/models/my_badges/student_info.rb
@@ -12,12 +12,20 @@ module MyBadges
       campus_attributes = CampusOracle::UserAttributes.new(user_id: @uid).get_feed
 
       result = {
-        :californiaResidency => campus_attributes[:california_residency],
-        :isLawStudent => law_student,
-        :regStatus => campus_attributes[:reg_status],
-        :regBlock => get_reg_blocks
+        californiaResidency: campus_attributes[:california_residency],
+        isLawStudent: law_student,
+        regBlock: get_reg_blocks,
+        regStatus: campus_attributes[:reg_status]
       }
-      return result
+      
+      if result[:regStatus] && result[:regStatus][:code].nil?
+        transition_status = MyAcademics::TransitionRegStatus.new(@uid).reg_status_from_feed
+        if (transition_status && transition_status[:registered])
+          result[:regStatus] = Notifications::RegStatusTranslator.new.translate_for_feed 'R'
+        end
+      end
+
+      result
     end
 
 

--- a/app/models/notifications/reg_status_translator.rb
+++ b/app/models/notifications/reg_status_translator.rb
@@ -9,16 +9,16 @@ module Notifications
     def translate(notification)
       data = notification.data
       uid = notification.uid
-      event = data["event"]
+      event = data['event']
       timestamp = notification.occurred_at.to_datetime
-      reg_status = data["reg_status"]
+      reg_status = data['reg_status']
 
       Rails.logger.info "#{self.class.name} translating: #{notification}; accept? #{accept?(event)}; timestamp = #{timestamp}; uid = #{uid}; reg_status = #{reg_status}"
 
       return false unless accept?(event) && timestamp && uid && reg_status
 
-      explanation = status_explanation reg_status["reg_status_cd"]
-      status = status reg_status["reg_status_cd"]
+      explanation = status_explanation reg_status['reg_status_cd']
+      status = status reg_status['reg_status_cd']
 
       title = "Registration status updated to: #{status}"
       summary = "#{explanation} If you have a question about your registration status change, please contact the Office of the Registrar. orweb@berkeley.edu"
@@ -28,107 +28,66 @@ module Notifications
         :title => title,
         :summary => summary,
         :source => 'Bear Facts',
-        :type => "alert",
+        :type => 'alert',
         :date => format_date(timestamp),
-        :url => "https://bearfacts.berkeley.edu/bearfacts/",
-        :sourceUrl => "https://bearfacts.berkeley.edu/bearfacts/",
-        :emitter => "Bear Facts",
+        :url => 'https://bearfacts.berkeley.edu/bearfacts/',
+        :sourceUrl => 'https://bearfacts.berkeley.edu/bearfacts/',
+        :emitter => 'Bear Facts',
         :isRegstatusActivity => true
       }
     end
 
+    def translate_for_feed(reg_status)
+      {
+        code: reg_status,
+        summary: status(reg_status),
+        explanation: status_explanation(reg_status),
+        needsAction: !(reg_status.nil? || is_registered(reg_status))
+      }
+    end
+
     def status(reg_status)
-      admincancelled = "Administratively Cancelled"
-      cancelled = "Cancelled"
-      dismissed = "Dismissed"
-      registered = "Registered"
-      unregistered = "Not Registered"
-      withdrawn = "Withdrawn"
-
-      if reg_status == nil
-        return nil
-      end
-
+      return nil if reg_status.nil?
       case reg_status.upcase
-        when " "
-          unregistered
-        when "A"
-          unregistered
-        when "C"
-          registered
-        when "L"
-          registered
-        when "N"
-          registered
-        when "R"
-          registered
-        when "V"
-          registered
-        when "D"
-          dismissed
-        when "U"
-          admincancelled
-        when "X"
-          cancelled
-        when "Z"
-          unregistered
-        when "W"
-          withdrawn
-        when "S"
-          registered
+        when 'C', 'L', 'N', 'R', 'S', 'V'
+          'Registered'
+        when 'D'
+          'Dismissed'
+        when 'U', 'X'
+          'Administratively Cancelled'
+        when 'W'
+          'Withdrawn'
         else
-          unregistered
+          'Not Registered'
       end
     end
 
     def is_registered(reg_status)
-      if reg_status == nil
-        return false
-      end
-
-      ["C", "L", "N", "R", "S", "V"].include?(reg_status.upcase)
+      return false if reg_status.nil?
+      %w(C L N R S V).include? reg_status.upcase
     end
 
     def status_explanation(reg_status)
-
-      if reg_status == nil
-        return nil
-      end
-
-      unregistered = "In order to be officially registered, you must pay at least 20% of your registration fees, have no outstanding blocks, and be enrolled in at least one class."
-      registered = "You are officially registered for this term and are entitled to access campus services."
+      return nil if reg_status.nil?
 
       case reg_status.upcase
-        when " "
-          unregistered
-        when "A"
-          unregistered
-        when "C"
-          registered
-        when "L"
-          registered
-        when "N"
-          registered
-        when "R"
-          registered
-        when "V"
-          registered
-        when "D"
+        when 'C', 'L', 'N', 'R', 'S', 'V'
+          'You are officially registered for this term and are entitled to access campus services.'
+        when ' ', 'A'
+          'In order to be officially registered, you must pay at least 20% of your registration fees, have no outstanding blocks, and be enrolled in at least one class.'
+        when 'D'
           'You have been academically dismissed for this term.'
-        when "U"
+        when 'U'
           'You have been administratively cancelled for this term.'
-        when "X"
+        when 'X'
           'Your registration has been canceled for this term.'
-        when "Z"
+        when 'Z'
           'The Office of the Registrar has been notified of the death of this student ID.'
-        when "W"
+        when 'W'
           'You are withdrawn for this term and may owe fees depending on your date of withdrawal.'
-        when "S"
-          registered
         else
           'Unknown Status.'
       end
-
     end
 
   end

--- a/spec/models/campus_oracle/user_attributes_spec.rb
+++ b/spec/models/campus_oracle/user_attributes_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe CampusOracle::UserAttributes do
 
   context 'obtaining user attributes feed' do
@@ -20,11 +18,32 @@ describe CampusOracle::UserAttributes do
     context 'working against test data', if: CampusOracle::Queries.test_data? do
       context 'student with blank REG_STATUS_CD' do
         let(:uid) {300847}
-        it 'includes expected feed values' do
-          expect(subject[:reg_status][:summary]).to eq 'Not Registered'
-          expect(subject[:reg_status][:needsAction]).to be_truthy
-          expect(subject[:education_level]).to eq 'Masters'
-          expect(subject[:california_residency][:summary]).to eq 'Non-Resident'
+        before { Berkeley::Terms.stub_chain(:fetch, :current).and_return(double(sis_term_status: current_sis_term_status)) }
+        context 'normal term' do
+          let(:current_sis_term_status) { 'CT' }
+          it 'reports not registered' do
+            expect(subject[:reg_status][:code]).to eq ' '
+            expect(subject[:reg_status][:summary]).to eq 'Not Registered'
+            expect(subject[:reg_status][:explanation]).to eq 'In order to be officially registered, you must pay at least 20% of your registration fees, have no outstanding blocks, and be enrolled in at least one class.'
+            expect(subject[:reg_status][:needsAction]).to eq true
+          end
+          it 'includes expected feed values' do
+            expect(subject[:education_level]).to eq 'Masters'
+            expect(subject[:california_residency][:summary]).to eq 'Non-Resident'
+          end
+        end
+        context 'term transition' do
+          let(:current_sis_term_status) { 'CS' }
+          it 'omits registration data' do
+            expect(subject[:reg_status][:code]).to eq nil
+            expect(subject[:reg_status][:summary]).to eq nil
+            expect(subject[:reg_status][:explanation]).to eq nil
+            expect(subject[:reg_status][:needsAction]).to eq false
+          end
+          it 'includes expected feed values' do
+            expect(subject[:education_level]).to eq 'Masters'
+            expect(subject[:california_residency][:summary]).to eq 'Non-Resident'
+          end
         end
       end
       context 'student with Education Abroad REG_SPECIAL_PGM_CD' do

--- a/spec/models/my_academics/exams_spec.rb
+++ b/spec/models/my_academics/exams_spec.rb
@@ -34,7 +34,7 @@ describe 'MyAcademics::Exams' do
   end
 
   it 'should not return any exam schedules for exam information not matching current_year and term' do
-    Berkeley::Terms.stub_chain(:fetch, :current).and_return(double(code: 'B', year: 1984))
+    Berkeley::Terms.stub_chain(:fetch, :current).and_return(double(code: 'B', year: 1984, sis_term_status: 'PT'))
     proxy = Bearfacts::Exams.new({:user_id => '865826', :fake => true})
     Bearfacts::Exams.stub(:new).and_return(proxy)
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5408

The most expedient approach to a quieter /my/badges feed:
1. Check if the CalCentral current term is not considered current in campus data;
2. If so, return nil registration data from CampusOracle::UserAttributes;
3. Have MyBadges::StudentInfo attempt to fill in that nil data by calling out to MyAcademics::TransitionRegStatus;
3a. If the student is registered for the CalCentral current term, say so;
3b. If the student is not registered for the CalCentral current term, pass along null, no-action-required data that won't trigger front-end alerts.