### PR TITLE
CLC-5403, show sign-up text in CalCentral if user.viewing_as?

### DIFF
--- a/app/policies/authentication_state.rb
+++ b/app/policies/authentication_state.rb
@@ -58,7 +58,7 @@ class AuthenticationState
   end
 
   def viewing_as?
-    original_user_id && user_id && (original_user_id != user_id)
+    original_user_id.present? && user_id.present? && (original_user_id != user_id)
   end
 
 end

--- a/app/policies/authentication_state_policy.rb
+++ b/app/policies/authentication_state_policy.rb
@@ -62,6 +62,6 @@ class AuthenticationStatePolicy
 
   def can_view_webcast_sign_up?
     # By default, only superusers can debug in non-prod. Sub-classes can override with, for example, Canvas-specific rules.
-    !Rails.env.production? && can_administrate?
+    !Rails.env.production? && (can_administrate? || @user.viewing_as?)
   end
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5403  (Closed #3876 in favor of this PR)

The method changed in authentication_state.rb was returning nil instead of false. My spec didn't like that. I think a non-nil return value is more intuitive.    
