### PR TITLE
CLC-5403, CoursePolicy paradigm to manage auth in webcast merged feed

### DIFF
--- a/app/controllers/canvas_webcast_recordings_controller.rb
+++ b/app/controllers/canvas_webcast_recordings_controller.rb
@@ -10,8 +10,9 @@ class CanvasWebcastRecordingsController < ApplicationController
   # A Canvas course ID of "embedded" means to retrieve from session properties.
   def get_media
     raise Errors::BadRequestError, "Bad course site ID #{canvas_course_id}" if canvas_course_id.blank?
-    authorize Canvas::Course.new(canvas_course_id: canvas_course_id), :can_view_course?
-    render :json => Canvas::WebcastRecordings.new(user_id: session['user_id'], course_id: canvas_course_id).get_feed
+    course = Canvas::Course.new(canvas_course_id: canvas_course_id)
+    authorize course, :can_view_course?
+    render :json => Canvas::WebcastRecordings.new(policy(course), canvas_course_id).get_feed
   end
 
 end

--- a/app/controllers/mediacasts_controller.rb
+++ b/app/controllers/mediacasts_controller.rb
@@ -8,14 +8,14 @@ class MediacastsController < ApplicationController
 
   # GET /api/media/:year/:term_code/:dept/:catalog_id
   def get_media
-    uid = session['user_id']
     term_yr = params['year']
     term_cd = params['term_code']
     dept_name = params['dept']
     catalog_id = params['catalog_id']
     sections = CampusOracle::Queries.get_all_course_sections(term_yr, term_cd, dept_name, catalog_id)
     ccn_list = sections.map { |section| section['course_cntl_num'].to_i }
-    render :json => Webcast::Merged.new(uid, term_yr, term_cd, ccn_list, @options).get_feed
+    policy = policy(Berkeley::Course.new @options)
+    render :json => Webcast::Merged.new(policy, term_yr, term_cd, ccn_list, @options).get_feed
   end
 
 end

--- a/app/models/canvas/webcast_recordings.rb
+++ b/app/models/canvas/webcast_recordings.rb
@@ -3,9 +3,9 @@ module Canvas
     extend Cache::Cacheable
     include ClassLogger
 
-    def initialize(options = {})
-      @uid = options[:user_id]
-      @canvas_course_id = options[:course_id]
+    def initialize(course_policy, canvas_course_id, options = {})
+      @course_policy = course_policy
+      @canvas_course_id = canvas_course_id
       @options = options
     end
 
@@ -32,7 +32,7 @@ module Canvas
           end
         end
       end
-      Webcast::Merged.new(@uid, @term_yr, @term_cd, ccn_list, @options).get_feed
+      Webcast::Merged.new(@course_policy, @term_yr, @term_cd, ccn_list, @options).get_feed
     end
 
   end

--- a/app/models/webcast/merged.rb
+++ b/app/models/webcast/merged.rb
@@ -2,12 +2,13 @@ module Webcast
   class Merged < UserSpecificModel
     include Cache::CachedFeed
 
-    def initialize(uid, term_yr, term_cd, ccn_list, options = {})
-      super(uid.nil? ? nil : uid.to_i, options)
+    def initialize(course_policy, term_yr, term_cd, ccn_list, options = {})
+      super(course_policy.user.user_id.to_i, options)
       @term_yr = term_yr.to_i unless term_yr.nil?
       @term_cd = term_cd
       @ccn_list = ccn_list
       @options = options
+      @course_policy = course_policy
     end
 
     def get_feed_internal
@@ -19,10 +20,8 @@ module Webcast
     private
 
     def get_media_feed
-      feed = {}
       media = get_media
-      eligible_for_sign_up = get_sections_not_yet_signed_up media
-      feed.merge!({ :eligibleForSignUp => eligible_for_sign_up }) if eligible_for_sign_up.any?
+      feed = get_eligible_for_sign_up media
       if media.any?
         # Put video and audio
         media_hash = {
@@ -36,9 +35,10 @@ module Webcast
       feed
     end
 
-    def get_sections_not_yet_signed_up(media)
-      not_yet_signed_up = []
-      if @term_yr && @term_cd
+    def get_eligible_for_sign_up(media)
+      eligible_for_sign_up = []
+      can_sign_up_one_or_more = false
+      if @term_yr && @term_cd && @course_policy.can_view_webcast_sign_up?
         slug = Berkeley::TermCodes.to_slug(@term_yr, @term_cd)
         all_eligible = Webcast::SignUpEligible.new(@options).get[slug]
         unless all_eligible.nil?
@@ -59,20 +59,21 @@ module Webcast
                 course[:classes].each do |next_class|
                   next_class[:sections].each do |section|
                     instructors = HashConverter.camelize extract_authorized(section[:instructors])
-                    this_user_can_sign_up = instructors.map { |instructor| instructor[:uid].to_i }.include? @uid
+                    user_can_sign_up = instructors.map { |instructor| instructor[:uid].to_i }.include? @uid
                     ccn = section[:ccn]
-                    not_yet_signed_up << {
+                    eligible_for_sign_up << {
                       :termYr => @term_yr,
                       :termCd => @term_cd,
                       :ccn => ccn,
                       :signUpURL => "#{webcast_base_url}/signUp.html?id=#{@term_yr}#{@term_cd.upcase}#{ccn.to_i}",
                       :webcastAuthorizedInstructors => instructors,
-                      :thisUserCanSignUp => this_user_can_sign_up,
+                      :userCanSignUp => user_can_sign_up,
                       :deptName => next_class[:dept],
                       :catalogId => next_class[:courseCatalog],
                       :instructionFormat => section[:instruction_format],
                       :sectionNumber => section[:section_number]
                     }
+                    can_sign_up_one_or_more ||= user_can_sign_up
                   end
                 end
               end
@@ -80,7 +81,10 @@ module Webcast
           end
         end
       end
-      not_yet_signed_up
+      {
+        :userCanSignUpOneOrMore => can_sign_up_one_or_more,
+        :eligibleForSignUp => eligible_for_sign_up
+      }
     end
 
     def get_media

--- a/spec/controllers/canvas_webcast_recordings_controller_spec.rb
+++ b/spec/controllers/canvas_webcast_recordings_controller_spec.rb
@@ -12,7 +12,7 @@ shared_examples 'a protected controller' do
       expect(Canvas::CourseUser).to receive(:new).with(user_id: user_id, course_id: canvas_course_id).and_return(
         double(course_user: {enrollments: [role: 'StudentEnrollment']})
       )
-      expect(Canvas::WebcastRecordings).to receive(:new).with(user_id: user_id, course_id: canvas_course_id).and_return(
+      expect(Canvas::WebcastRecordings).to receive(:new).with(anything, canvas_course_id).and_return(
         double(get_feed: {videos: []})
       )
     end
@@ -42,7 +42,7 @@ shared_examples 'a protected controller' do
       allow(Canvas::CourseUser).to receive(:new).with(user_id: user_id, course_id: canvas_course_id).and_return(
         double(course_user: nil)
       )
-      expect(Canvas::WebcastRecordings).to receive(:new).with(user_id: user_id, course_id: canvas_course_id).and_return(
+      expect(Canvas::WebcastRecordings).to receive(:new).with(anything, canvas_course_id).and_return(
         double(get_feed: {videos: []})
       )
     end

--- a/spec/models/canvas/webcast_recordings_spec.rb
+++ b/spec/models/canvas/webcast_recordings_spec.rb
@@ -8,7 +8,10 @@ describe Canvas::WebcastRecordings do
       )
     end
 
-    subject { Canvas::WebcastRecordings.new({user_id: rand(99999).to_s, course_id: canvas_course_id, fake: true}) }
+    subject {
+      policy = AuthenticationStatePolicy.new(AuthenticationState.new('user_id' => rand(99999).to_s), nil)
+      Canvas::WebcastRecordings.new(policy, canvas_course_id, {fake: true})
+    }
 
     context 'when the Canvas course site maps to campus class sections' do
       let(:canvas_course_sections_list) do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5403
Follow up to #3877

What to notice:
* policy object passed to Merged class
* we use can_view_webcast_sign_up?  to determine who on the front-end gets webcast sign-up info
* one enhancement to the feed: 
** boolean userCanSignUpOneOrMore determines boilerplate in the widget 
** boolean userCanSignUp determines whether we show sign-up link per section
