### PR TITLE
CLC-5408 Restore student alert popover when registration data missing

### DIFF
--- a/src/assets/templates/widgets/academic_profile_popover.html
+++ b/src/assets/templates/widgets/academic_profile_popover.html
@@ -1,7 +1,7 @@
 <div
   data-ng-controller="StatusController"
   class="cc-popover-container cc-popover-status"
-  data-ng-show="studentInfo.regStatus.code != null && api.user.profile.roles.student">
+  data-ng-show="api.user.profile.roles.student">
   <button class="cc-header-icon cc-header-icon-font cc-icon-status-person"
     data-ng-class="{'cc-icon-status-person-haslayover':(hasAlerts),'cc-header-icon-selected':(api.popover.status('cc-popover-academic-status'))}"
     data-ng-click="api.util.preventBubble($event);api.popover.toggle('cc-popover-academic-status')" title="Show your status">


### PR DESCRIPTION
Fix for the missing badges reported in comments to https://jira.ets.berkeley.edu/jira/browse/CLC-5408.

Use of a null regstatus wiped out the entire popover. The toggle removed here has been in the code a long time and seems to have been supplanted by finer-grained toggles within the template. Browser testing on a small batch of UIDs didn't turn up any bad behavior.