### PR TITLE
CLC-5452, Webcast: instructor of record does not have sign-up UI

### DIFF
--- a/app/controllers/canvas_webcast_recordings_controller.rb
+++ b/app/controllers/canvas_webcast_recordings_controller.rb
@@ -12,7 +12,7 @@ class CanvasWebcastRecordingsController < ApplicationController
     raise Errors::BadRequestError, "Bad course site ID #{canvas_course_id}" if canvas_course_id.blank?
     course = Canvas::Course.new(canvas_course_id: canvas_course_id)
     authorize course, :can_view_course?
-    render :json => Canvas::WebcastRecordings.new(policy(course), canvas_course_id).get_feed
+    render :json => Canvas::WebcastRecordings.new(session['user_id'], policy(course), canvas_course_id).get_feed
   end
 
 end

--- a/app/controllers/mediacasts_controller.rb
+++ b/app/controllers/mediacasts_controller.rb
@@ -15,7 +15,8 @@ class MediacastsController < ApplicationController
     sections = CampusOracle::Queries.get_all_course_sections(term_yr, term_cd, dept_name, catalog_id)
     ccn_list = sections.map { |section| section['course_cntl_num'].to_i }
     policy = policy(Berkeley::Course.new @options)
-    render :json => Webcast::Merged.new(policy, term_yr, term_cd, ccn_list, @options).get_feed
+    uid = session['user_id']
+    render :json => Webcast::Merged.new(uid, policy, term_yr, term_cd, ccn_list, @options).get_feed
   end
 
 end

--- a/app/models/canvas/webcast_recordings.rb
+++ b/app/models/canvas/webcast_recordings.rb
@@ -3,7 +3,8 @@ module Canvas
     extend Cache::Cacheable
     include ClassLogger
 
-    def initialize(course_policy, canvas_course_id, options = {})
+    def initialize(uid, course_policy, canvas_course_id, options = {})
+      @uid = uid.to_i unless uid.nil?
       @course_policy = course_policy
       @canvas_course_id = canvas_course_id
       @options = options
@@ -11,7 +12,7 @@ module Canvas
 
     # Authorization checks are performed by the controller.
     def get_feed
-      self.class.fetch_from_cache @canvas_course_id do
+      self.class.fetch_from_cache "#{@canvas_course_id}/#{@uid}" do
         get_feed_internal
       end
     end
@@ -32,7 +33,7 @@ module Canvas
           end
         end
       end
-      Webcast::Merged.new(@course_policy, @term_yr, @term_cd, ccn_list, @options).get_feed
+      Webcast::Merged.new(@uid, @course_policy, @term_yr, @term_cd, ccn_list, @options).get_feed
     end
 
   end

--- a/app/models/webcast/merged.rb
+++ b/app/models/webcast/merged.rb
@@ -2,8 +2,8 @@ module Webcast
   class Merged < UserSpecificModel
     include Cache::CachedFeed
 
-    def initialize(course_policy, term_yr, term_cd, ccn_list, options = {})
-      super(course_policy.user.user_id.to_i, options)
+    def initialize(uid, course_policy, term_yr, term_cd, ccn_list, options = {})
+      super(uid.nil? ? nil : uid.to_i, options)
       @term_yr = term_yr.to_i unless term_yr.nil?
       @term_cd = term_cd
       @ccn_list = ccn_list

--- a/spec/controllers/canvas_webcast_recordings_controller_spec.rb
+++ b/spec/controllers/canvas_webcast_recordings_controller_spec.rb
@@ -12,7 +12,7 @@ shared_examples 'a protected controller' do
       expect(Canvas::CourseUser).to receive(:new).with(user_id: user_id, course_id: canvas_course_id).and_return(
         double(course_user: {enrollments: [role: 'StudentEnrollment']})
       )
-      expect(Canvas::WebcastRecordings).to receive(:new).with(anything, canvas_course_id).and_return(
+      expect(Canvas::WebcastRecordings).to receive(:new).with(user_id, anything, canvas_course_id).and_return(
         double(get_feed: {videos: []})
       )
     end
@@ -42,7 +42,7 @@ shared_examples 'a protected controller' do
       allow(Canvas::CourseUser).to receive(:new).with(user_id: user_id, course_id: canvas_course_id).and_return(
         double(course_user: nil)
       )
-      expect(Canvas::WebcastRecordings).to receive(:new).with(anything, canvas_course_id).and_return(
+      expect(Canvas::WebcastRecordings).to receive(:new).with(user_id, anything, canvas_course_id).and_return(
         double(get_feed: {videos: []})
       )
     end

--- a/spec/models/canvas/webcast_recordings_spec.rb
+++ b/spec/models/canvas/webcast_recordings_spec.rb
@@ -9,8 +9,9 @@ describe Canvas::WebcastRecordings do
     end
 
     subject {
-      policy = AuthenticationStatePolicy.new(AuthenticationState.new('user_id' => rand(99999).to_s), nil)
-      Canvas::WebcastRecordings.new(policy, canvas_course_id, {fake: true})
+      uid = rand(99999).to_s
+      policy = AuthenticationStatePolicy.new(AuthenticationState.new('user_id' => uid), nil)
+      Canvas::WebcastRecordings.new(uid, policy, canvas_course_id, {fake: true})
     }
 
     context 'when the Canvas course site maps to campus class sections' do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5452

This problem was caused by wrong id passed to fetch_from_cache in Canvas::WebcastRecordings class.   The id was @canvas_course_id and it's now "#{@canvas_course_id}/#{@uid}"
