### PR TITLE
CLC-5106 Show webcast recordings in Recent Activity

### DIFF
--- a/app/models/my_academics/academics_module.rb
+++ b/app/models/my_academics/academics_module.rb
@@ -1,5 +1,6 @@
 module MyAcademics
   module AcademicsModule
+    extend self
 
     def initialize(uid)
       @uid = uid

--- a/app/models/my_activities/merged.rb
+++ b/app/models/my_activities/merged.rb
@@ -17,11 +17,12 @@ module MyActivities
       @proxies = [
         MyActivities::NotificationActivities,
         MyActivities::RegBlocks,
+        MyActivities::Webcasts
       ]
     end
 
     def self.cutoff_date
-      @cutoff_date ||= Time.zone.today.in_time_zone.to_datetime.advance(:days => -10).to_time.to_i
+      @cutoff_date ||= (Settings.terms.fake_now || Time.zone.today.in_time_zone).to_datetime.advance(days: -10).to_time.to_i
     end
 
     # Note that MyActivities feed processing has a direct dependency on MyClasses and MyGroups.

--- a/app/models/my_activities/webcasts.rb
+++ b/app/models/my_activities/webcasts.rb
@@ -1,0 +1,75 @@
+module MyActivities
+  class Webcasts
+    include DatedFeed
+
+    def self.append!(uid, activities)
+      term_code = get_current_term_code
+      courses_by_ccn = get_courses_by_ccn(uid, term_code)
+      webcast_feed = Webcast::Recordings.new.get
+      return unless webcast_feed[:courses]
+
+      webcast_feed[:courses].each do |course_code, webcast_course|
+        next unless course_code.start_with?(term_code) && webcast_course[:recordings]
+        # Zero-pad CCNs from the Webcasts feed to match campus data.
+        ccn = course_code.sub("#{term_code}-", '').rjust(5, '0')
+        if (campus_course = courses_by_ccn[ccn])
+          activity = course_attributes(campus_course, uid)
+          course_url = MyAcademics::AcademicsModule.class_to_url campus_course
+          each_recent_recording(webcast_course) do |recording|
+            activities << activity.merge(recording_attributes(recording, course_url))
+          end
+        end
+      end
+    end
+
+    def self.course_attributes(campus_course, uid)
+      english_term = Berkeley::TermCodes.to_english(campus_course[:term_yr], campus_course[:term_cd])
+      {
+        emitter: 'Webcasts',
+        id: '',
+        linkText: 'View webcast',
+        source: campus_course[:course_code],
+        summary: "A new webcast recording for your #{english_term} course, #{campus_course[:name]}, is now available.",
+        type: 'webcast',
+        title: 'Webcast Available',
+        user_id: uid
+      }
+    end
+
+    def self.each_recent_recording(webcast_course)
+      webcast_course[:recordings].each do |recording|
+        next unless recording['recordingStartUTC'].present? && (start_time = DateTime.parse recording['recordingStartUTC'])
+        if start_time.to_i >= MyActivities::Merged.cutoff_date
+          yield recording.merge('startTime' => start_time)
+        end
+      end
+    end
+
+    def self.get_courses_by_ccn(uid, term_code)
+      courses = {}
+      all_courses = CampusOracle::UserCourses::All.new(user_id: uid).get_all_campus_courses
+      if (current_term_courses = all_courses[term_code])
+        current_term_courses.each do |course|
+          course[:sections].each { |section| courses[section[:ccn]] = course }
+        end
+      end
+      courses
+    end
+
+    def self.get_current_term_code
+      current_term = Berkeley::Terms.fetch.current
+      "#{current_term.year}-#{current_term.code}"
+    end
+
+    def self.recording_attributes(recording, course_url)
+      url = course_url.dup
+      url << '?' << {video: recording['youTubeId']}.to_param if recording['youTubeId']
+      {
+        date: format_date(recording['startTime']),
+        sourceUrl: url,
+        url: url
+      }
+    end
+
+  end
+end

--- a/fixtures/webcast/warehouse/webcast.json
+++ b/fixtures/webcast/warehouse/webcast.json
@@ -534,9 +534,9 @@
     {
       "year": 2013,
       "semester": "Fall",
-      "ccn": 1203,
-      "catalogId": "C1",
-      "deptName": "ENVECON",
+      "ccn": 7309,
+      "catalogId": "1A",
+      "deptName": "BIOLOGY",
       "audioOnly": false,
       "public": true,
       "youTubePlaylist": "-XXv-cvA_iDoDi4YEjSRuViC1hIjenaF",
@@ -545,115 +545,143 @@
       "recordings": [
         {
           "lecture": "Lecture 1",
-          "youTubeId": "hA4h5uUcFYI"
+          "youTubeId": "hA4h5uUcFYI",
+          "recordingStartUTC": "2013-08-25T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 2",
-          "youTubeId": "mpRyi0O0Ji4"
+          "youTubeId": "mpRyi0O0Ji4",
+          "recordingStartUTC": "2013-08-27T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 3",
-          "youTubeId": "UZprWZYadQY"
+          "youTubeId": "UZprWZYadQY",
+          "recordingStartUTC": "2013-08-29T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 4",
-          "youTubeId": "Pl33Ko_9P7A"
+          "youTubeId": "Pl33Ko_9P7A",
+          "recordingStartUTC": "2013-09-01T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 5",
-          "youTubeId": "0yrS_TwBKt8"
+          "youTubeId": "0yrS_TwBKt8",
+          "recordingStartUTC": "2013-09-03T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 6",
-          "youTubeId": "iLTisnUHdII"
+          "youTubeId": "iLTisnUHdII",
+          "recordingStartUTC": "2013-09-05T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 7",
-          "youTubeId": "AfrBBBOEcbE"
+          "youTubeId": "AfrBBBOEcbE",
+          "recordingStartUTC": "2013-09-08T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 8",
-          "youTubeId": "xQGDR1rnXb8"
+          "youTubeId": "xQGDR1rnXb8",
+          "recordingStartUTC": "2013-09-10T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 9",
-          "youTubeId": "kBFzUVI8V6E"
+          "youTubeId": "kBFzUVI8V6E",
+          "recordingStartUTC": "2013-09-12T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 10",
-          "youTubeId": "hTav_QtrvUM"
+          "youTubeId": "hTav_QtrvUM",
+          "recordingStartUTC": "2013-09-15T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 11",
-          "youTubeId": "FP1kgjuJcCc"
+          "youTubeId": "FP1kgjuJcCc",
+          "recordingStartUTC": "2013-09-17T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 12",
-          "youTubeId": "wF6DtdfnzRI"
+          "youTubeId": "wF6DtdfnzRI",
+          "recordingStartUTC": "2013-09-19T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 13",
-          "youTubeId": "a74--WOf2xk"
+          "youTubeId": "a74--WOf2xk",
+          "recordingStartUTC": "2013-09-22T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 15",
-          "youTubeId": "mdNiLbDdjw4"
+          "youTubeId": "mdNiLbDdjw4",
+          "recordingStartUTC": "2013-09-24T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 16:No aud last mins of lec",
-          "youTubeId": "CItwUXHrjAg"
+          "youTubeId": "CItwUXHrjAg",
+          "recordingStartUTC": "2013-09-26T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 17",
-          "youTubeId": "MTEpbIBhEVQ"
+          "youTubeId": "MTEpbIBhEVQ",
+          "recordingStartUTC": "2013-09-29T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 18",
-          "youTubeId": "na3dSFKGW2U"
+          "youTubeId": "na3dSFKGW2U",
+          "recordingStartUTC": "2013-10-01T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 19",
-          "youTubeId": "HYOcgTI9CiM"
+          "youTubeId": "HYOcgTI9CiM",
+          "recordingStartUTC": "2013-10-03T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 20",
-          "youTubeId": "jDZVcCRrv9g"
+          "youTubeId": "jDZVcCRrv9g",
+          "recordingStartUTC": "2013-10-06T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 21",
-          "youTubeId": "HK3XLGGWXYg"
+          "youTubeId": "HK3XLGGWXYg",
+          "recordingStartUTC": "2013-10-08T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 22",
-          "youTubeId": "Rj3yLrTxe4o"
+          "youTubeId": "Rj3yLrTxe4o",
+          "recordingStartUTC": "2013-10-10T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 23",
-          "youTubeId": "-F0sUIIpPAY"
+          "youTubeId": "-F0sUIIpPAY",
+          "recordingStartUTC": "2013-10-13T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 24",
-          "youTubeId": "EQHM0ZGXtPM"
+          "youTubeId": "EQHM0ZGXtPM",
+          "recordingStartUTC": "2013-10-15T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 25",
-          "youTubeId": "mEKFW4FI31s"
+          "youTubeId": "mEKFW4FI31s",
+          "recordingStartUTC": "2013-10-17T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 26",
-          "youTubeId": "OHBOtDLnFCI"
+          "youTubeId": "OHBOtDLnFCI",
+          "recordingStartUTC": "2013-10-20T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 27",
-          "youTubeId": "VHCRgCHKNps"
+          "youTubeId": "VHCRgCHKNps",
+          "recordingStartUTC": "2013-10-22T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 28:No audio after min 18",
-          "youTubeId": "YXl9PFH0m24"
+          "youTubeId": "YXl9PFH0m24",
+          "recordingStartUTC": "2013-10-24T16:06:00-08:00"
         },
         {
           "lecture": "Lecture 29: Last mins not avail",
-          "youTubeId": "u2PGzidDgdY"
+          "youTubeId": "u2PGzidDgdY",
+          "recordingStartUTC": "2013-10-27T16:06:00-08:00"
         }
       ]
     },

--- a/spec/models/my_activities/webcasts_spec.rb
+++ b/spec/models/my_activities/webcasts_spec.rb
@@ -1,0 +1,74 @@
+describe MyActivities::Webcasts do
+  let(:recordings_proxy) { Webcast::Recordings.new(fake: fake) }
+  before { allow(Webcast::Recordings).to receive(:new).and_return recordings_proxy }
+
+  let(:activities) do
+    activities = []
+    described_class.append!(uid, activities)
+    activities
+  end
+
+  shared_examples 'a feed with no webcast activities' do
+    it 'should append nothing' do
+      expect(activities).to be_empty
+    end
+  end
+
+  shared_examples 'a feed with webcast activities' do
+    it 'should include notifications' do
+      expect(activities).not_to be_empty
+    end
+
+    it 'should include course and uid data' do
+      expect(activities).to all include({
+        emitter: 'Webcasts',
+        id: '',
+        linkText: 'View webcast',
+        source: 'BIOLOGY 1A',
+        summary: 'A new webcast recording for your Fall 2013 course, General Biology Lecture, is now available.',
+        type: 'webcast',
+        title: 'Webcast Available',
+        user_id: uid
+      })
+    end
+
+    it 'should include recording-specific URLs' do
+      activities.each do |activity|
+        expect(activity[:sourceUrl]).to match /academics.*biology-1a\?video=.+/
+        expect(activity[:url]).to eq activity[:sourceUrl]
+      end
+    end
+
+    it 'should only include webcasts after cutoff date' do
+      expect(activities.collect{|activity| activity[:date][:epoch]}).to all be > MyActivities::Merged.cutoff_date
+    end
+  end
+
+  context 'fake webcast proxy', if: CampusOracle::Connection.test_data? do
+    let(:fake) { true }
+
+    context 'student enrolled in webcast course' do
+      let(:uid) { '300939' }
+      it_should_behave_like 'a feed with webcast activities'
+    end
+
+    context 'instructor of webcast course' do
+      let(:uid) { '238382' }
+      it_should_behave_like 'a feed with webcast activities'
+    end
+
+    context 'student not enrolled in webcast course' do
+      let(:uid) { '300940' }
+      it_should_behave_like 'a feed with no webcast activities'
+    end
+  end
+
+  context 'connection failure' do
+    let(:fake) { false }
+    let(:uid) { random_id }
+    before { stub_request(:any, /.*/).to_raise(Errno::EHOSTUNREACH) }
+    after { WebMock.reset! }
+
+    it_should_behave_like 'a feed with no webcast activities'
+  end
+end

--- a/src/assets/javascripts/angular/controllers/widgets/webcastController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/webcastController.js
@@ -11,14 +11,22 @@
     $scope.accessibilityAnnounce = apiService.util.accessibilityAnnounce;
 
     /**
-     * Select the first options in the video / audio feed
+     * Select media items from video/audio dropdowns, defaulting to first
      */
-    var selectFirstOptions = function() {
-      if ($scope.videos) {
-        $scope.selectedVideo = $scope.videos[0];
-      }
+    var selectMediaOptions = function() {
       if ($scope.audio) {
         $scope.selectedAudio = $scope.audio[0];
+      }
+      if ($scope.videos) {
+        if ($routeParams.video) {
+          for (var i = 0; i < $scope.videos.length; i++) {
+            if ($scope.videos[i].youTubeId === $routeParams.video) {
+              $scope.selectedVideo = $scope.videos[i];
+              break;
+            }
+          }
+        }
+        $scope.selectedVideo = $scope.selectedVideo || $scope.videos[0];
       }
     };
 
@@ -47,7 +55,7 @@
         url: webcastUrl(title)
       }).success(function(data) {
         angular.extend($scope, data);
-        selectFirstOptions();
+        selectMediaOptions();
         setSelectedOption();
       });
     };

--- a/src/assets/javascripts/angular/factories/activityFactory.js
+++ b/src/assets/javascripts/angular/factories/activityFactory.js
@@ -25,6 +25,7 @@
         discussion: ' Discussions',
         gradePosting: ' Grades Posted',
         message: ' Status Changes',
+        webcast: ' Webcasts',
         webconference: ' Webconferences'
       };
 
@@ -37,6 +38,7 @@
         gradePosting: 'trophy',
         info: 'info-circle',
         message: 'check-circle',
+        webcast: 'video-camera',
         webconference: 'video-camera'
       };
 

--- a/src/assets/templates/widgets/activity_list.html
+++ b/src/assets/templates/widgets/activity_list.html
@@ -29,7 +29,7 @@
             <p data-ng-switch-default data-ng-bind-html="activity.summary | linky" class="cc-widget-activities-summary"></p>
           </div>
           <a class="cc-widget-activities-info-link" data-ng-click="api.util.preventBubble($event);api.analytics.trackExternalLink('Activities', activity.source, activity.sourceUrl)" data-ng-if="activity.sourceUrl" data-ng-href="{{activity.sourceUrl}}">
-            More info
+            <span data-ng-bind="activity.linkText || 'More info'"></span>
             <span class="cc-visuallyhidden">View more info about {{ activity.title }} in {{ activity.source }}</span>
           </a>
         </div>
@@ -49,7 +49,7 @@
                   <p class="cc-widget-activities-sub-activity-summary cc-break-word" data-ng-bind-html="subActivity.summary | linky">
                   </p>
                   <a class="cc-widget-activities-info-link" data-ng-click="api.util.preventBubble($event);api.analytics.trackExternalLink('Activities', subActivity.source, subActivity.sourceUrl)" data-ng-href="{{subActivity.sourceUrl}}">
-                    More info
+                    <span data-ng-bind="subActivity.linkText || 'More info'"></span>
                     <span class="cc-visuallyhidden">View more info about {{ subActivity.title }} in {{ subActivity.source }}</span>
                   </a>
                 </div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5106

- Webcast recordings from current-term courses dated within the last ten days will appear in Recent Activity.
- A new 'linkText' property overrides the 'More info' text with 'View webcast.'
- Clicking 'View webcast' passes the recording's YouTube ID to the Class Info page and pre-selects the proper recording in the Webcasts widget.