### PR TITLE
CLC-5453, extra args for tab api; cleanup in find_canvas_course_tab()

### DIFF
--- a/app/models/canvas/external_tools.rb
+++ b/app/models/canvas/external_tools.rb
@@ -68,16 +68,19 @@ module Canvas
     def find_canvas_course_tab(tool_id)
       response = request_uncached("#{@api_root}/tabs", '_find_canvas_course_tab', { method: :get })
       all_tabs = response && safe_json(response.body)
-      matching_tab = all_tabs && all_tabs.select { |tab| tab['id'].ends_with? "_#{tool_id}" }
-      matching_tab ? matching_tab.first : nil
+      if all_tabs
+        all_tabs.find { |tab| tab['id'].end_with? "_#{tool_id}" }
+      else
+        nil
+      end
     end
 
-    def hide_course_site_tab(tab_id)
-      update_course_site_tab_hidden(tab_id, true)
+    def hide_course_site_tab(tab)
+      update_course_site_tab_hidden(tab, true)
     end
 
-    def show_course_site_tab(tab_id)
-      update_course_site_tab_hidden(tab_id, false)
+    def show_course_site_tab(tab)
+      update_course_site_tab_hidden(tab, false)
     end
 
     def create_external_tool_by_xml(tool_name, xml_string)
@@ -124,11 +127,18 @@ module Canvas
 
     private
 
-    def update_course_site_tab_hidden(tab_id, set_to_hidden)
+    def update_course_site_tab_hidden(tab, set_to_hidden)
       begin
+        tab_id = tab['id']
+        tab_position = tab['position']
         options = {
           :method => :put,
-          :body => { 'hidden' => set_to_hidden },
+          :body => {
+            'id' => tab_id,
+            'hidden' => set_to_hidden,
+            'position' => tab_position,
+            'visibility' => 'public'
+          }
         }
         url = "#{@api_root}/tabs/#{tab_id}"
         logger.warn "Update course site_tab with url=#{url} and options: #{options}"

--- a/app/models/canvas/webcast_lti_refresh.rb
+++ b/app/models/canvas/webcast_lti_refresh.rb
@@ -55,7 +55,7 @@ module Canvas
         unhidden_date = record.webcast_tool_unhidden_at.strftime('%m/%d/%Y')
         logger.warn "Do nothing to course site #{canvas_course_id} because Webcast tool was un-hidden on #{unhidden_date}."
       else
-        modified_tab = external_tools.show_course_site_tab tab['id']
+        modified_tab = external_tools.show_course_site_tab tab
         logger.warn "The Webcast tool #{modified_tab ? 'has been' : 'FAILED to be' } un-hidden on course site #{canvas_course_id}"
         if modified_tab
           record = Webcast::CourseSiteLog.find_or_initialize_by(canvas_course_site_id: canvas_course_id)
@@ -67,7 +67,7 @@ module Canvas
     end
 
     def hide_course_site_tab(canvas_course_id, tab, external_tools)
-      modified_tab = external_tools.hide_course_site_tab tab['id']
+      modified_tab = external_tools.hide_course_site_tab tab
       logger.warn "The Webcast tool #{modified_tab ? 'has been' : 'FAILED to be' } hidden on course site #{canvas_course_id}"
       modified_tab
     end

--- a/spec/models/canvas/external_tools_spec.rb
+++ b/spec/models/canvas/external_tools_spec.rb
@@ -57,6 +57,7 @@ describe Canvas::ExternalTools do
 
     context 'when modifying tab settings per canvas_course_id' do
       let(:tab_id) { 'my_tab_external_tool_4' }
+      let(:tab) { { 'id' => tab_id, 'position' => 16 } }
       let(:canvas_course_id) { 98765 }
       let(:options) { {canvas_course_id: "#{canvas_course_id}"} }
       let(:api_path) { "courses/#{canvas_course_id}/tabs/#{tab_id}" }
@@ -68,7 +69,7 @@ describe Canvas::ExternalTools do
           'label' => 'My Tab',
           'type' => 'external',
           'visibility' => 'public',
-          'position' => 2
+          'position' => tab['position']
         }
       }
       let(:tab_hidden) { tab_showing.merge({ 'hidden' => true }) }
@@ -77,12 +78,12 @@ describe Canvas::ExternalTools do
 
       it 'should return tab with hidden=true' do
         expect(subject).to receive(:request_uncached).with(api_path, vcr_id, anything).and_return tab_hidden_response
-        expect(subject.hide_course_site_tab tab_id).to eq tab_hidden
+        expect(subject.hide_course_site_tab tab).to eq tab_hidden
       end
 
       it 'should return tab with no hidden attribute' do
         expect(subject).to receive(:request_uncached).with(api_path, vcr_id, anything).and_return tab_showing_response
-        expect(subject.show_course_site_tab tab_id).to eq tab_showing
+        expect(subject.show_course_site_tab tab).to eq tab_showing
       end
     end
   end

--- a/spec/models/canvas/webcast_lti_refresh_spec.rb
+++ b/spec/models/canvas/webcast_lti_refresh_spec.rb
@@ -29,7 +29,7 @@ describe Canvas::WebcastLtiRefresh do
         end
 
         it 'should show the Webcast tool because it has videos' do
-          allow_any_instance_of(Canvas::ExternalTools).to receive(:find_canvas_course_tab).and_return({ 'id' => 1, 'hidden' => true })
+          allow_any_instance_of(Canvas::ExternalTools).to receive(:find_canvas_course_tab).and_return({ 'id' => 1, 'position' => 16, 'hidden' => true })
           expect(Webcast::CourseSiteLog).to receive(:find_by).exactly(2).times.with(anything).and_return nil
           allow_any_instance_of(Canvas::ExternalTools).to receive(:show_course_site_tab).and_return :return
           modified_tab_hash = subject.refresh_canvas
@@ -41,7 +41,7 @@ describe Canvas::WebcastLtiRefresh do
             expect(Webcast::CourseSiteLog).to receive(:find_by).once.with({ :canvas_course_site_id => id }).and_return log_entry
           end
           # Canvas docs say 'hidden' property not present when value is false
-          allow_any_instance_of(Canvas::ExternalTools).to receive(:find_canvas_course_tab).and_return({ 'id' => 1, 'hidden' => true })
+          allow_any_instance_of(Canvas::ExternalTools).to receive(:find_canvas_course_tab).and_return({ 'id' => 1, 'position' => 16, 'hidden' => true })
           expect(subject.refresh_canvas).to be_empty
         end
       end
@@ -85,15 +85,15 @@ describe Canvas::WebcastLtiRefresh do
         end
 
         it 'should hide webcast tab' do
-          tab = { 'id' => tab_id }
+          tab = { 'id' => tab_id, 'position' => 16 }
           allow_any_instance_of(Canvas::ExternalTools).to receive(:find_canvas_course_tab).with(webcast_tool_id).and_return tab
-          hidden_tab = { 'id' => tab_id, 'hidden' => true }
-          allow_any_instance_of(Canvas::ExternalTools).to receive(:hide_course_site_tab).with(tab_id).and_return hidden_tab
+          hidden_tab = { 'id' => tab_id, 'position' => 16, 'hidden' => true }
+          allow_any_instance_of(Canvas::ExternalTools).to receive(:hide_course_site_tab).with(tab).and_return hidden_tab
           allow_any_instance_of(Webcast::CourseSiteLog).to receive(:create).with anything
           expect(subject.refresh_canvas).to have(2).items
         end
         it 'should not hide the already hidden tab' do
-          tab = { 'id' => tab_id, 'hidden' => true }
+          tab = { 'id' => tab_id, 'position' => 16, 'hidden' => true }
           allow_any_instance_of(Canvas::ExternalTools).to receive(:find_canvas_course_tab).with(webcast_tool_id).and_return tab
           allow_any_instance_of(Canvas::ExternalTools).to receive(:show_course_site_tab).and_raise StandardError
           expect(subject.refresh_canvas).to be_empty


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5453

This does not resolve the Jira but I would like to run webcast-cron with 'id' passed in body of the HTTP PUT. I'm also passing 'position' and 'visibility' to rule out their necessity.