### PR TITLE
CLC-5476: fix two WebDriver tests

### DIFF
--- a/spec/ui_selenium/my_dashboard_google_up_next_spec.rb
+++ b/spec/ui_selenium/my_dashboard_google_up_next_spec.rb
@@ -75,7 +75,7 @@ describe 'My Dashboard Up Next card', :testui => true do
 
       # On the Dashboard, wait a moment for the new event.  If not there, wait for a live update to occur.
       @up_next_card.load_page(@driver)
-      @up_next_card.events_list_element.when_visible(timeout=WebDriverUtils.google_task_timeout)
+      @up_next_card.events_list_element.when_present(timeout=WebDriverUtils.google_task_timeout)
       sleep(WebDriverUtils.page_event_timeout)
       unless @up_next_card.all_event_summaries.include?(@event_title)
         @up_next_card.click_live_update_button(WebDriverUtils.mail_live_update_timeout)

--- a/spec/ui_selenium/my_finances_ui_details_page_spec.rb
+++ b/spec/ui_selenium/my_finances_ui_details_page_spec.rb
@@ -67,11 +67,10 @@ describe 'My Finances details page', :testui => true do
           wait.until { @my_finances_details_page.visible_transaction_count == @fin_api_page.all_transactions.length }
         end
         it 'allow a user to filter all transactions by a specified string' do
-          transaction = @fin_api_page.all_transactions.last
-          search_string = @fin_api_page.trans_id(transaction)
           @my_finances_details_page.select_transactions_filter('All Transactions')
-          @my_finances_details_page.enter_search_string(search_string)
+          @my_finances_details_page.enter_search_string('DM0000589619')
           wait.until { @my_finances_details_page.visible_transaction_count == 1 }
+          expect(@my_finances_details_page.visible_transaction_descrip).to include('CLASS PASS FEE - TRANSIT')
           expect(@my_finances_details_page.show_more_button?).to be false
         end
         it 'allow a user to filter all transactions by a specific term' do
@@ -83,13 +82,11 @@ describe 'My Finances details page', :testui => true do
           wait.until { @my_finances_details_page.visible_transaction_count == @fin_api_page.term_transactions(term).length }
         end
         it 'allow a user to filter all transactions by a specific term and a specified string' do
-          transaction = @fin_api_page.all_transactions.last
-          search_string = @fin_api_page.trans_id(transaction)
-          search_term = @fin_api_page.trans_term(transaction)
           @my_finances_details_page.select_transactions_filter('Term')
-          @my_finances_details_page.select_term_filter(search_term)
-          @my_finances_details_page.enter_search_string(search_string)
+          @my_finances_details_page.select_term_filter('Fall 2013')
+          @my_finances_details_page.enter_search_string('DM0000589619')
           wait.until { @my_finances_details_page.visible_transaction_count == 1 }
+          expect(@my_finances_details_page.visible_transaction_descrip).to include('CLASS PASS FEE - TRANSIT')
           expect(@my_finances_details_page.show_more_button?).to be false
         end
         it 'allow a user to filter all transactions by a date range' do
@@ -125,14 +122,12 @@ describe 'My Finances details page', :testui => true do
           wait.until { @my_finances_details_page.visible_transaction_count == @fin_api_page.date_range_transactions(beginning_of_time, end_date).length }
         end
         it 'allow a user to filter all transactions by a date range and a specified string' do
-          transaction = @fin_api_page.all_transactions.last
-          date = Time.parse(@fin_api_page.trans_date(transaction)).strftime('%m/%d/%Y')
-          search_string = @fin_api_page.trans_id(transaction)
           @my_finances_details_page.select_transactions_filter('Date Range')
-          @my_finances_details_page.enter_search_start_date(date)
-          @my_finances_details_page.enter_search_end_date(date)
-          @my_finances_details_page.enter_search_string(search_string)
+          @my_finances_details_page.enter_search_start_date('10/01/2013')
+          @my_finances_details_page.enter_search_end_date('10/31/2013')
+          @my_finances_details_page.enter_search_string('DM0000589619')
           wait.until { @my_finances_details_page.visible_transaction_count == 1 }
+          expect(@my_finances_details_page.visible_transaction_descrip).to include('CLASS PASS FEE - TRANSIT')
           expect(@my_finances_details_page.show_more_button?).to be false
         end
         it 'filter transactions by balance due by default' do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5476

Fixes two tests: one that sorts and filters Oski's financial transactions and another that tests Up Next.