### PR TITLE
CLC-5419 Do not surface residency status during term transitions

### DIFF
--- a/app/models/campus_oracle/user_attributes.rb
+++ b/app/models/campus_oracle/user_attributes.rb
@@ -20,13 +20,14 @@ module CampusOracle
       result = CampusOracle::Queries.get_person_attributes(@uid)
       if result
         result[:education_level] = educ_level_translator.translate result['educ_level']
-        result[:california_residency] = cal_residency_translator.translate result['cal_residency_flag']
         result[:roles] = roles_from_campus_row result
         result.merge! Berkeley::SpecialRegistrationProgram.attributes_from_code(result['reg_special_pgm_cd'])
 
-        if result['reg_status_cd'] && Berkeley::Terms.fetch.current.sis_term_status != 'CT'
-          result[:reg_status] = {transitionTerm: true}
+        if term_transition?
+          result[:california_residency] = nil
+          result[:reg_status] = result['reg_status_cd'] ? {transitionTerm: true} : reg_status_translator.translate_for_feed(nil)
         else
+          result[:california_residency] = cal_residency_translator.translate result['cal_residency_flag']
           result[:reg_status] = reg_status_translator.translate_for_feed result['reg_status_cd']
         end
 
@@ -52,6 +53,10 @@ module CampusOracle
         return true if get_feed[:roles] && (get_feed[:roles][:faculty] || get_feed[:roles][:staff])
       end
       false
+    end
+
+    def term_transition?
+      Berkeley::Terms.fetch.current.sis_term_status != 'CT'
     end
 
   end

--- a/spec/models/campus_oracle/user_attributes_spec.rb
+++ b/spec/models/campus_oracle/user_attributes_spec.rb
@@ -22,7 +22,6 @@ describe CampusOracle::UserAttributes do
         shared_examples 'expected feed values' do
           it 'includes expected feed values' do
             expect(subject[:education_level]).to eq 'Masters'
-            expect(subject[:california_residency][:summary]).to eq 'Non-Resident'
           end
         end
         context 'normal term' do
@@ -35,12 +34,18 @@ describe CampusOracle::UserAttributes do
             expect(subject[:reg_status][:needsAction]).to eq true
             expect(subject[:reg_status]).not_to include(:transitionTerm)
           end
+          it 'includes residency status' do
+            expect(subject[:california_residency][:summary]).to eq 'Non-Resident'
+          end
         end
         context 'term transition' do
           let(:current_sis_term_status) { 'CS' }
           include_examples 'expected feed values'
           it 'reports term transition' do
             expect(subject[:reg_status]).to eq({transitionTerm: true})
+          end
+          it 'omits residency status' do
+            expect(subject[:california_residency]).to eq nil
           end
         end
       end

--- a/src/assets/templates/academics_status_and_blocks.html
+++ b/src/assets/templates/academics_status_and_blocks.html
@@ -1,11 +1,11 @@
-<div class="cc-widget cc-academics-status-and-blocks" data-ng-if="!regblocks.noStudentId || studentInfo.regStatus.code !== null">
+<div class="cc-widget cc-academics-status-and-blocks" data-ng-if="!regblocks.noStudentId || studentInfo.regStatus.code !== null || studentInfo.californiaResidency">
 
   <div class="cc-widget-title">
-    <h2><span data-ng-if="studentInfo.regStatus.code !== null">Status and </span>Blocks</h2>
+    <h2><span data-ng-if="studentInfo.regStatus.code !== null || studentInfo.californiaResidency">Status and </span>Blocks</h2>
   </div>
 
   <div class="cc-widget-padding">
-    <div class="cc-table" data-ng-if="studentInfo.regStatus.code !== null">
+    <div class="cc-table" data-ng-if="studentInfo.regStatus.code !== null || studentInfo.californiaResidency">
       <h3>Status</h3>
       <table class="cc-academics-status-and-blocks-status-table">
         <thead>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5419

Back to the blunt hammer! No one, resident or not, sees any residency status during term transitions including summer.