### PR TITLE
CLC-5419: fix Selenium residency test

### DIFF
--- a/spec/ui_selenium/my_academics_data_status_blocks_spec.rb
+++ b/spec/ui_selenium/my_academics_data_status_blocks_spec.rb
@@ -168,23 +168,33 @@ describe 'My Academics Status and Blocks', :testui => true do
 
               # CALIFORNIA RESIDENCY
 
-              api_res_status = badges_api_page.residency_summary
-              api_res_needs_action = badges_api_page.residency_needs_action
-              my_acad_res_status = my_academics_page.res_status_summary
+              if academics_api_page.transition_term?
 
-              it "shows residency status of '#{my_acad_res_status}' for UID #{uid}" do
-                expect(my_acad_res_status).to eql(api_res_status)
-              end
+                has_residency_status = my_academics_page.res_status_summary?
 
-              if api_res_needs_action == true
-                has_red_res_status_icon = my_academics_page.res_status_icon_red?
-                it "shows a red residency status icon for UID #{uid}" do
-                  expect(has_red_res_status_icon).to be true
+                it "shows no residency status for UID #{uid} during the transition term" do
+                  expect(has_residency_status).to be false
                 end
               else
-                has_green_res_status_icon = my_academics_page.res_status_icon_green?
-                it "shows a green residency status icon for UID #{uid}" do
-                  expect(has_green_res_status_icon).to be true
+
+                api_res_status = badges_api_page.residency_summary
+                api_res_needs_action = badges_api_page.residency_needs_action
+                my_acad_res_status = my_academics_page.res_status_summary
+
+                it "shows residency status of '#{my_acad_res_status}' for UID #{uid}" do
+                  expect(my_acad_res_status).to eql(api_res_status)
+                end
+
+                if api_res_needs_action == true
+                  has_red_res_status_icon = my_academics_page.res_status_icon_red?
+                  it "shows a red residency status icon for UID #{uid}" do
+                    expect(has_red_res_status_icon).to be true
+                  end
+                else
+                  has_green_res_status_icon = my_academics_page.res_status_icon_green?
+                  it "shows a green residency status icon for UID #{uid}" do
+                    expect(has_green_res_status_icon).to be true
+                  end
                 end
               end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5419

Suppressing residency breaks QA's test, which expects it to be visible regardless of term.  The test now checks for a transition term before assuming residency is present.