### PR TITLE
NOJIRA, relevant describe for subset of webcast related expectations

### DIFF
--- a/spec/models/berkeley/course_policy_spec.rb
+++ b/spec/models/berkeley/course_policy_spec.rb
@@ -138,7 +138,9 @@ describe Berkeley::CoursePolicy do
         expect(subject.can_view_roster_photos?).to be false
       end
     end
+  end
 
+  describe '#can_view_webcast_sign_up?' do
     context 'when webcast content is served to a non-superuser' do
       before do
         allow_any_instance_of(User::Auth).to receive(:active?).and_return true


### PR DESCRIPTION
Bamboo failure https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CLCMVPMASTER-3159  gives confusing summary, "...#can_view_roster_photos? when webcast content...". I'm fixing the 'describe' and hoping Bamboo behaves on second try.