### PR TITLE
CLC-5431 CLC-5433 Allow regstatus feed to override nil registration status during term transitions

### DIFF
--- a/app/models/campus_oracle/user_attributes.rb
+++ b/app/models/campus_oracle/user_attributes.rb
@@ -20,15 +20,15 @@ module CampusOracle
       result = CampusOracle::Queries.get_person_attributes(@uid)
       if result
         result[:education_level] = educ_level_translator.translate result['educ_level']
+        result[:reg_status] = reg_status_translator.translate_for_feed result['reg_status_cd']
         result[:roles] = roles_from_campus_row result
         result.merge! Berkeley::SpecialRegistrationProgram.attributes_from_code(result['reg_special_pgm_cd'])
 
         if term_transition?
           result[:california_residency] = nil
-          result[:reg_status] = result['reg_status_cd'] ? {transitionTerm: true} : reg_status_translator.translate_for_feed(nil)
+          result[:reg_status][:transitionTerm] = true
         else
           result[:california_residency] = cal_residency_translator.translate result['cal_residency_flag']
-          result[:reg_status] = reg_status_translator.translate_for_feed result['reg_status_cd']
         end
 
         result

--- a/app/models/my_badges/student_info.rb
+++ b/app/models/my_badges/student_info.rb
@@ -15,21 +15,24 @@ module MyBadges
         regBlock: get_reg_blocks
       }
       if campus_attributes[:reg_status] && campus_attributes[:reg_status][:transitionTerm]
-        result[:regStatus] = get_transition_reg_status
+        result[:regStatus] = get_transition_reg_status(campus_attributes[:reg_status][:code])
       else
         result[:regStatus] = campus_attributes[:reg_status]
       end
       result
     end
 
-    def get_transition_reg_status
+    def get_transition_reg_status(code)
       regstatus_feed = MyAcademics::TransitionTerm.new(@uid).regstatus_feed
       return {errored: true} unless regstatus_feed
 
       if regstatus_feed[:registered]
         Notifications::RegStatusTranslator.new.translate_for_feed 'R'
+      elsif code.nil?
+        # If not registered during a term transition, let nil status remain nil.
+        Notifications::RegStatusTranslator.new.translate_for_feed nil
       else
-        # If not registered during a term transition, communicate this without alarm.
+        # If status is not nil, communicate 'not registered' without alarm.
         {
           code: ' ',
           summary: "Not registered for #{regstatus_feed[:termName]}",

--- a/spec/models/campus_oracle/user_attributes_spec.rb
+++ b/spec/models/campus_oracle/user_attributes_spec.rb
@@ -22,16 +22,16 @@ describe CampusOracle::UserAttributes do
         shared_examples 'expected feed values' do
           it 'includes expected feed values' do
             expect(subject[:education_level]).to eq 'Masters'
+            expect(subject[:reg_status][:code]).to eq ' '
+            expect(subject[:reg_status][:summary]).to eq 'Not Registered'
+            expect(subject[:reg_status][:explanation]).to eq 'In order to be officially registered, you must pay at least 20% of your registration fees, have no outstanding blocks, and be enrolled in at least one class.'
+            expect(subject[:reg_status][:needsAction]).to eq true
           end
         end
         context 'normal term' do
           let(:current_sis_term_status) { 'CT' }
           include_examples 'expected feed values'
-          it 'reports not registered' do
-            expect(subject[:reg_status][:code]).to eq ' '
-            expect(subject[:reg_status][:summary]).to eq 'Not Registered'
-            expect(subject[:reg_status][:explanation]).to eq 'In order to be officially registered, you must pay at least 20% of your registration fees, have no outstanding blocks, and be enrolled in at least one class.'
-            expect(subject[:reg_status][:needsAction]).to eq true
+          it 'does not report term transition' do
             expect(subject[:reg_status]).not_to include(:transitionTerm)
           end
           it 'includes residency status' do
@@ -42,7 +42,7 @@ describe CampusOracle::UserAttributes do
           let(:current_sis_term_status) { 'CS' }
           include_examples 'expected feed values'
           it 'reports term transition' do
-            expect(subject[:reg_status]).to eq({transitionTerm: true})
+            expect(subject[:reg_status][:transitionTerm]).to eq true
           end
           it 'omits residency status' do
             expect(subject[:california_residency]).to eq nil

--- a/spec/models/my_badges/student_info_spec.rb
+++ b/spec/models/my_badges/student_info_spec.rb
@@ -40,11 +40,12 @@ describe 'MyBadges::StudentInfo' do
   context 'term transitions' do
     let(:term_name) { 'Summer 2015' }
     before do
-      allow(CampusOracle::UserAttributes).to receive(:new).and_return(double(get_feed: {reg_status: {transitionTerm: true}}))
+      allow(CampusOracle::UserAttributes).to receive(:new).and_return(double(get_feed: {reg_status: {code: code, transitionTerm: true}}))
       allow_any_instance_of(MyAcademics::TransitionTerm).to receive(:regstatus_feed).and_return({registered: is_registered, termName: term_name})
     end
     let(:result) { MyBadges::StudentInfo.new(random_uid).get }
     context 'registered during transition' do
+      let(:code) { ' ' }
       let(:is_registered) { true }
       it 'reports registration' do
         expect(result[:regStatus][:code]).to eq 'R'
@@ -54,10 +55,21 @@ describe 'MyBadges::StudentInfo' do
       end
     end
     context 'not registered during transition' do
+      let(:code) { ' ' }
       let(:is_registered) { false }
       it 'reports not registered with no action required' do
         expect(result[:regStatus][:code]).to eq ' '
         expect(result[:regStatus][:summary]).to eq "Not registered for #{term_name}"
+        expect(result[:regStatus][:explanation]).to be_nil
+        expect(result[:regStatus][:needsAction]).to eq false
+      end
+    end
+    context 'nil registration status during transition' do
+      let(:code) { nil }
+      let(:is_registered) { false }
+      it 'reports nil registration status' do
+        expect(result[:regStatus][:code]).to be_nil
+        expect(result[:regStatus][:summary]).to be_nil
         expect(result[:regStatus][:explanation]).to be_nil
         expect(result[:regStatus][:needsAction]).to eq false
       end


### PR DESCRIPTION
One more rejiggering of the summer registration logic. 

In the case of nil registration status during a term transition, check MyAcademics::TermTransition and,
- If registered, override;
- If not registered, let the nil status pass through.

See https://jira.ets.berkeley.edu/jira/browse/CLC-5431 for motivation and https://jira.ets.berkeley.edu/jira/browse/CLC-5433 for a corollary.