### PR TITLE
CLC-2107 CLC-5482 Set source of course-site activities to campus course code

### DIFF
--- a/app/models/my_activities/canvas_activities.rb
+++ b/app/models/my_activities/canvas_activities.rb
@@ -2,16 +2,16 @@ module MyActivities
   class CanvasActivities
     include ClassLogger, DatedFeed, HtmlSanitizer, SafeJsonParser
 
-    def self.append!(uid, sites, activities)
+    def self.append!(uid, classes, activities)
       return unless Canvas::Proxy.access_granted?(uid)
-      canvas_results = get_feed(uid, sites)
+      canvas_results = get_feed(uid, index_classes_by_emitter(classes))
       activities.concat canvas_results
     end
 
-    def self.get_feed(uid, canvas_sites)
+    def self.get_feed(uid, classes)
       response = Canvas::UserActivityStream.new(user_id: uid).user_activity
       if (response && response.status == 200 && raw_feed = safe_json(response.body))
-        raw_feed.map { |entry| format_entry(uid, entry, canvas_sites) }.compact
+        raw_feed.map { |entry| format_entry(uid, entry, classes) }.compact
       else
         []
       end
@@ -19,13 +19,29 @@ module MyActivities
 
     private
 
-    def self.format_entry(uid, entry, canvas_sites)
+    def self.index_classes_by_emitter(classes)
+      indexed = {
+        campus: {},
+        canvas: {}
+      }
+      classes.each do |course|
+        case course[:emitter]
+        when 'Campus'
+          course[:listings].each { |listing| indexed[:campus][listing[:id]] = listing }
+        when Canvas::Proxy::APP_NAME
+          indexed[:canvas][course[:id]] = course
+        end
+      end
+      indexed
+    end
+
+    def self.format_entry(uid, entry, classes)
       if (date = process_date entry) && (title = process_title entry)
         {
           date: format_date(date),
           emitter: Canvas::Proxy::APP_NAME,
           id: "canvas_#{entry['id']}",
-          source: process_source(entry, canvas_sites),
+          source: process_source(entry, classes),
           sourceUrl: entry['html_url'],
           summary: process_message(entry) + process_score(entry),
           title: title,
@@ -100,11 +116,6 @@ module MyActivities
       score_message || ''
     end
 
-    def self.filter_classes(classes = [])
-      classes.select! { |entry| entry[:emitter] == 'bCourses'}
-      Hash[*classes.map { |entry| [Integer(entry[:id], 10), entry]}.flatten]
-    end
-
     def self.split_summary(text)
       (split = split_title_and_summary text) && split[1]
     end
@@ -119,20 +130,30 @@ module MyActivities
       end
     end
 
-    def self.process_source(entry, canvas_sites)
-      if %w(Course Group).include? entry['context_type']
-        type = entry['context_type'].downcase
-        entry_site = canvas_sites.find do |site|
-          site[:siteType] == type &&
-            site[:id] == entry["#{type}_id"].to_s &&
-            site[:emitter] == Canvas::Proxy::APP_NAME
-        end
-        if entry_site
-          source = entry_site[:source] if type == 'group'
-          source ||= entry_site[:name]
-        end
+    def self.process_source(entry, classes)
+      if (site = get_site_for_entry(entry, classes))
+        source = (site[:siteType] == 'course') ? course_codes_for_site(site, classes) : site[:source]
+        source ||= site[:name]
       end
       source || Canvas::Proxy::APP_NAME
     end
+
+    def self.course_codes_for_site(site, classes)
+      return unless site[:courses]
+      course_listings = site[:courses].map { |course| classes[:campus][course[:id]] }.compact
+      if course_listings.any?
+        course_codes = course_listings.map { |listing| listing[:course_code] }
+        course_codes.length == 1 ? course_codes.first : course_codes
+      end
+    end
+
+    def self.get_site_for_entry(entry, classes)
+      site_type = entry['context_type'].downcase if entry['context_type']
+      site = classes[:canvas][entry["#{site_type}_id"].to_s]
+      if site && site[:siteType] == site_type
+        site
+      end
+    end
+
   end
 end

--- a/spec/models/my_activities/canvas_spec.rb
+++ b/spec/models/my_activities/canvas_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 describe MyActivities::CanvasActivities do
   let!(:documented_types) { %w(alert announcement assignment discussion gradePosting message webconference) }
 
+  let(:activities) { MyActivities::CanvasActivities.get_feed(@user_id, indexed_classes) }
+  let(:indexed_classes) { MyActivities::CanvasActivities.index_classes_by_emitter(classes) }
+
   before do
     @user_id = Settings.canvas_proxy.test_user_id
     @fake_activity_stream_proxy = Canvas::UserActivityStream.new({fake: true})
@@ -10,127 +13,203 @@ describe MyActivities::CanvasActivities do
     @fake_time = Time.zone.today.in_time_zone.to_datetime
   end
 
-  it "should be able to process a normal canvas feed" do
-    activities = MyActivities::CanvasActivities.get_feed(@user_id, [])
-    activities.instance_of?(Array).should == true
-    activities.each do | activity |
-      activity[:id].blank?.should_not == true
-      activity[:user_id].should == @user_id
-      activity[:date][:epoch].is_a?(Integer).should == true
-      activity[:source].blank?.should_not be_truthy
-      activity[:emitter].should == Canvas::Proxy::APP_NAME
-      activity[:type].blank?.should_not == true
-      documented_types.include?(activity[:type]).should be_truthy
+  context 'when classes feed is empty' do
+    let(:classes) { [] }
+
+    it 'should be able to process a normal canvas feed' do
+      activities.each do |activity|
+        expect(activity[:id]).to be_present
+        expect(activity[:date][:epoch]).to be_a Integer
+        expect(activity[:source]).to be_present
+        expect(activity).to include({
+          user_id: @user_id,
+          emitter: Canvas::Proxy::APP_NAME
+        })
+        expect(documented_types).to include(activity[:type])
+      end
+    end
+
+    it 'should be able to ignore malformed entries from the canvas feed' do
+      bad_date_entry = { 'id' => @user_id, 'user_id' => @user_id, 'created_at' => 'stone-age'}
+      flawed_activity_stream = @fake_activity_stream + [bad_date_entry]
+      Canvas::UserActivityStream.stub(:new).and_return(stub_proxy(:user_activity, flawed_activity_stream))
+      expect(activities.size).to eq @fake_activity_stream.size
+    end
+
+    context 'fake activity stream' do
+      before { allow(Canvas::UserActivityStream).to receive(:new).and_return @fake_activity_stream_proxy }
+
+      it 'should sometimes have score and instructor message appended to the summary field' do
+        # Search for a particular entry in the cassette and make sure it's appended to properly
+        activity = activities.select {|entry| entry[:id] == 'canvas_40544495'}.first
+        expect(activity[:summary]).to eq 'Please write more neatly next time. 87 out of 100 - Good work!'
+      end
+
+      it 'should strip system generated "click here" URLs from the summary field' do
+        activity = activities.select {|entry| entry[:id] == 'canvas_43225861'}.first
+        expect(activity[:summary]).to eq 'First, some instructor-written text. Click here to view the assignment: https://ucberkeley.instructure.com/courses/832071/assignments/3043635 A new assignment has been created for your course, Biology for Poets Report to STC due: Apr 1 at 11:59pm'
+      end
+
+      it 'should not over-strip by removing instructor-added "click here" URLs' do
+        activity = activities.select {|entry| entry[:id] == 'canvas_43395837'}.first
+        expect(activity[:summary]).to eq 'First, some instructor-added text. You can view the submission here: http://example.com?p=123 Oski Bear has just turned in a late submission for Tibullus paper in the course Biology for Poets'
+      end
     end
   end
 
-  it "should merge raw Canvas feed with transformed site feeds" do
-    active_stream_feed = [
-      {
-        id: 1999,
-        context_type: 'Course',
-        type: 'Message',
-        course_id: 1,
-        title: 'Assignment created',
-        updated_at: @fake_time,
-        created_at: @fake_time
-      },
-      {
-        id: 2999,
-        context_type: 'Group',
-        type: 'Message',
-        group_id: 2,
-        title: 'Assignment deleted',
-        updated_at: @fake_time,
-        created_at: @fake_time
-      },
-      {
-        id: 3999,
-        context_type: 'Group',
-        type: 'Message',
-        group_id: 3,
-        title: 'Party date',
-        updated_at: @fake_time,
-        created_at: @fake_time
-      },
-      {
-        id: 4999,
-        type: 'Conversation',
-        conversation_id: 4,
-        title: nil,
-        updated_at: @fake_time,
-        created_at: @fake_time
-      }
-    ]
-    Canvas::UserActivityStream.stub(:new).and_return(stub_proxy(:user_activity, active_stream_feed))
-    canvas_sites = [
-      {
-        id: '1',
-        name: 'Course Code 1',
-        shortDescription: 'Course site name 1',
-        siteType: 'course',
-        emitter: Canvas::Proxy::APP_NAME
-      },
-      {
-        id: '3',
-        name: 'Group title 3',
-        siteType: 'group',
-        emitter: Canvas::Proxy::APP_NAME
-      },
-      {
-        id: '2',
-        source: 'Course Code 2',
-        name: 'Course-linked group title',
-        siteType: 'group',
-        emitter: Canvas::Proxy::APP_NAME
-      }
-    ]
-    activities = MyActivities::CanvasActivities.get_feed(@user_id, canvas_sites)
-    activities.length.should == 4
-    activities.each do | activity |
-      activity[:user_id].should == @user_id
-      activity[:emitter].should == "bCourses"
-      activity[:type].blank?.should_not == true
+  context 'when classes feed contains sites' do
+    let(:classes) do
+      [
+        {
+          id: '1',
+          name: 'Site 1 name',
+          shortDescription: 'Site 1 description',
+          siteType: 'course',
+          emitter: Canvas::Proxy::APP_NAME,
+          courses: course_ids
+        },
+        {
+          id: '2',
+          source: 'Site 2 source',
+          name: 'Site 2 name',
+          siteType: 'group',
+          emitter: Canvas::Proxy::APP_NAME
+        },
+        {
+          id: '3',
+          name: 'Group name 3',
+          siteType: 'group',
+          emitter: Canvas::Proxy::APP_NAME
+        }
+      ].concat(campus_classes)
     end
-    enrolled_activity = activities.select{|item| item[:id] == 'canvas_1999'}[0]
-    enrolled_activity[:source].should == 'Course Code 1'
-    unofficial_activity = activities.select{|item| item[:id] == 'canvas_2999'}[0]
-    unofficial_activity[:source].should == 'Course Code 2'
-    group_activity = activities.select{|item| item[:id] == 'canvas_3999'}[0]
-    group_activity[:source].should == 'Group title 3'
-    siteless_activity = activities.select{|item| item[:id] == 'canvas_4999'}[0]
-    siteless_activity[:source].should == 'bCourses'
-    siteless_activity[:title].should == 'New/Updated Conversation'
-    siteless_activity[:type].should == 'discussion'
+    let(:canvas_feed) do
+      [
+        {
+          id: 1999,
+          context_type: 'Course',
+          type: 'Message',
+          course_id: 1,
+          title: 'Assignment created',
+          updated_at: @fake_time,
+          created_at: @fake_time
+        },
+        {
+          id: 2999,
+          context_type: 'Group',
+          type: 'Message',
+          group_id: 2,
+          title: 'Assignment deleted',
+          updated_at: @fake_time,
+          created_at: @fake_time
+        },
+        {
+          id: 3999,
+          context_type: 'Group',
+          type: 'Message',
+          group_id: 3,
+          title: 'Party date',
+          updated_at: @fake_time,
+          created_at: @fake_time
+        },
+        {
+          id: 4999,
+          type: 'Conversation',
+          conversation_id: 4,
+          title: nil,
+          updated_at: @fake_time,
+          created_at: @fake_time
+        }
+      ]
+    end
+
+    let(:course_ids) { nil }
+    let(:campus_classes) { [] }
+
+    before { allow(Canvas::UserActivityStream).to receive(:new).and_return stub_proxy(:user_activity, canvas_feed) }
+
+    it 'should transform raw Canvas feed entries to activities' do
+      activities.length.should == 4
+      activities.each do |activity|
+        expect(activity).to include({
+          user_id: @user_id,
+          emitter: 'bCourses'
+        })
+        expect(activity[:type]).to be_present
+      end
+    end
+
+    describe 'source property' do
+      context 'an activity from a course site' do
+        let(:activity) { activities.select{|item| item[:id] == 'canvas_1999'}[0] }
+
+        context 'with no associated campus course' do
+          it 'should fall back on Canvas site name' do
+            expect(activity[:source]).to eq 'Site 1 name'
+          end
+        end
+
+        context 'with an associated campus course' do
+          let(:course_ids) { [{id: 'anthro-3ac-2013-D'}] }
+          let(:campus_classes) do
+            [{
+              emitter: 'Campus',
+              listings: [{course_code: 'ANTHRO 3AC', id: 'anthro-3ac-2013-D'}]
+            }]
+          end
+          it 'should select the campus course code' do
+            expect(activity[:source]).to eq 'ANTHRO 3AC'
+          end
+        end
+
+        context 'with multiple associated campus courses' do
+          let(:course_ids) do
+            [
+              {id: 'anthro-3ac-2013-D'},
+              {id: 'anthro-99-2013-D'},
+            ]
+          end
+          let(:campus_classes) do
+            [{
+              emitter: 'Campus',
+              listings: [{course_code: 'ANTHRO 3AC', id: 'anthro-3ac-2013-D'}]
+            },
+            {
+              emitter: 'Campus',
+              listings: [{course_code: 'ANTHRO 99', id: 'anthro-99-2013-D'}]
+            }]
+          end
+          it 'should map to an array of campus course codes' do
+            expect(activity[:source]).to contain_exactly('ANTHRO 3AC', 'ANTHRO 99')
+          end
+        end
+      end
+
+      context 'a group site with a source property' do
+        let(:activity) { activities.select{|item| item[:id] == 'canvas_2999'}[0] }
+        it 'should preferentially select the source property' do
+          expect(activity[:source]).to eq 'Site 2 source'
+        end
+      end
+
+      context 'a group site without a source property' do
+        let(:activity) { activities.select{|item| item[:id] == 'canvas_3999'}[0] }
+        it 'should fall back on the name property' do
+          expect(activity[:source]).to eq 'Group name 3'
+        end
+      end
+
+      context 'an activity with no site' do
+        let(:activity) { activities.select{|item| item[:id] == 'canvas_4999'}[0] }
+        it 'should fall back on emitter name' do
+          expect(activity).to include({
+            source: 'bCourses',
+            title: 'New/Updated Conversation',
+            type: 'discussion'
+          })
+        end
+      end
+
+    end
   end
-
-  it "should be able to ignore malformed entries from the canvas feed" do
-    bad_date_entry = { "id" => @user_id, "user_id" => @user_id, "created_at" => "stone-age"}
-    flawed_activity_stream = @fake_activity_stream + [bad_date_entry]
-    Canvas::UserActivityStream.stub(:new).and_return(stub_proxy(:user_activity, flawed_activity_stream))
-    activities = MyActivities::CanvasActivities.get_feed(@user_id, [])
-    activities.instance_of?(Array).should == true
-    activities.size.should == @fake_activity_stream.size
-  end
-
-  it "should sometimes have score and instructor message appended to the summary field" do
-    # Search for a particular entry in the cassette and make sure it's appended to properly
-    Canvas::UserActivityStream.stub(:new).and_return(@fake_activity_stream_proxy)
-    activities = MyActivities::CanvasActivities.get_feed(@user_id, [])
-    activity = activities.select {|entry| entry[:id] == "canvas_40544495"}.first
-    activity[:summary].should eq("Please write more neatly next time. 87 out of 100 - Good work!")
-  end
-
-  it "should strip system generated 'click here' URLs from the summary field" do
-    # But should not over-strip by removing instructor-added 'click here' URLs
-    Canvas::UserActivityStream.stub(:new).and_return(@fake_activity_stream_proxy)
-    activities = MyActivities::CanvasActivities.get_feed(@user_id, [])
-
-    activity = activities.select {|entry| entry[:id] == "canvas_43225861"}.first
-    activity[:summary].should eq("First, some instructor-written text. Click here to view the assignment: https://ucberkeley.instructure.com/courses/832071/assignments/3043635 A new assignment has been created for your course, Biology for Poets Report to STC due: Apr 1 at 11:59pm")
-
-    activity = activities.select {|entry| entry[:id] == "canvas_43395837"}.first
-    activity[:summary].should eq("First, some instructor-added text. You can view the submission here: http://example.com?p=123 Oski Bear has just turned in a late submission for Tibullus paper in the course Biology for Poets")
-  end
-
 end

--- a/src/assets/javascripts/angular/factories/activityFactory.js
+++ b/src/assets/javascripts/angular/factories/activityFactory.js
@@ -66,6 +66,12 @@
         }
       };
 
+      var pushUnique = function(array, element) {
+        if (array.indexOf(element) === -1) {
+          array.push(element);
+        }
+      };
+
       /**
        * Create the list of sources
        * @param {Array} original The original array
@@ -77,8 +83,12 @@
           if (!apiService.user.profile.features.regstatus && item.isRegstatusActivity) {
             return false;
           }
-          if (sources.indexOf(item.source) === -1) {
-            sources.push(item.source);
+          if (item.source && typeof(item.source) !== 'string') {
+            item.source.map(function(source) {
+              pushUnique(sources, source);
+            });
+          } else {
+            pushUnique(sources, item.source);
           }
         });
         return sources.sort();
@@ -90,7 +100,14 @@
        * @return {Array} activities array, with similar items collapsed under pseduo-activity postings.
        */
       var threadOnSource = function(original) {
-        var source = angular.copy(original);
+        var source = original.map(function(item) {
+          var sourceItem = angular.copy(item);
+          if (sourceItem.source && typeof(sourceItem.source) !== 'string') {
+            sourceItem.source = sourceItem.source.join(', ');
+          }
+          return sourceItem;
+        });
+
         var multiElementArray = [];
 
         /**


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5482 has incorporated much of https://jira.ets.berkeley.edu/jira/browse/CLC-2107.

See CLC-5482 on the motivation for the `activityFactory.js` changes, which cover the rare case of a course site associated with multiple campus courses.