### PR TITLE
CLC-5501 - Extend scrolling support in canvas-customization.js

### DIFF
--- a/src/assets/javascripts/angular/services/utilService.js
+++ b/src/assets/javascripts/angular/services/utilService.js
@@ -127,7 +127,7 @@
             heightElement = alternativeElement[0];
           }
           var frameHeight = heightElement.scrollHeight;
-          var messageSubject = frameHeight > 5000 ? 'resizeLargeFrame' : 'lti.frameResize';
+          var messageSubject = frameHeight > 5000 ? 'changeParent' : 'lti.frameResize';
           var message = {subject: messageSubject, height: frameHeight};
           iframePostMessage(JSON.stringify(message));
         }, 250);


### PR DESCRIPTION
In order to provide better scrolling support between an LTI iFrame and the parent container, I've added a `getScrollInformation` event that will respond with the scroll information such as:

- LTI iFrame height
- Parent container height
- Current scroll position
- Current distance to bottom of screen

All other scrolling support events will now also respond with the same scroll information.

This will make it possible to add infinite scrolling capabilities to tools such as Collabosphere.