### PR TITLE
CLC-5507, Webcast::SignUpEligible error (backend) when eligible-for-webcast.json feed is empty

### DIFF
--- a/app/models/webcast/sign_up_eligible.rb
+++ b/app/models/webcast/sign_up_eligible.rb
@@ -12,12 +12,10 @@ module Webcast
 
     def request_internal
       return {} unless Settings.features.videos
-      ccn_set_by_term = {}
       data = get_json_data
-      data['semesters'].each do |term|
-        slug = "#{term['semester'].downcase}-#{term['year']}"
-        ccn_set_by_term[slug] = term['ccnSet'].to_a
-      end
+      ccn_set_by_term = {}
+      semesters = data['semesters']
+      semesters.each { |s| ccn_set_by_term["#{s['semester'].downcase}-#{s['year']}"] = s['ccnSet'].to_a } if semesters
       ccn_set_by_term
     end
 

--- a/spec/models/webcast/recordings_spec.rb
+++ b/spec/models/webcast/recordings_spec.rb
@@ -14,10 +14,10 @@ describe Webcast::Recordings do
     end
   end
 
-  context 'a real, non-fake proxy' do
+  context 'a real, non-fake proxy', :testext => true do
     subject { Webcast::Recordings.new }
 
-    context 'normal return of real data', :testext => true do
+    context 'normal return of real data' do
       it 'should return a bunch of playlists' do
         result = subject.get
         courses = result[:courses]
@@ -61,7 +61,7 @@ describe Webcast::Recordings do
       end
     end
 
-    context 'course with zero recordings is different than course not scheduled for recordings', :testext => true do
+    context 'course with zero recordings is different than course not scheduled for recordings' do
       it 'returns nil recordings attribute when course is scheduled for recordings' do
         result = subject.get
         non_existent = result[:courses]['2015-B-1']

--- a/spec/models/webcast/sign_up_eligible_spec.rb
+++ b/spec/models/webcast/sign_up_eligible_spec.rb
@@ -14,6 +14,16 @@ describe Webcast::SignUpEligible do
       end
     end
 
+    context 'no eligible CCNs' do
+      subject { Webcast::SignUpEligible.new }
+      before do
+        expect(subject).to receive(:get_json_data).exactly(1).times.and_return({})
+      end
+      it 'should handle empty feed with grace' do
+        expect(subject.get).to be_empty
+      end
+    end
+
     context 'sign-up phase is closed' do
       before {
         allow_any_instance_of(Webcast::SystemStatus).to receive(:get).and_return({ :isSignUpActive => false })


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5507

And a touch of cleanup on recordings_spec