### PR TITLE
CLC-5520 Fix course associations for Canvas group sites

### DIFF
--- a/app/models/canvas/merged_user_sites.rb
+++ b/app/models/canvas/merged_user_sites.rb
@@ -78,7 +78,7 @@ module Canvas
         site_url: "#{@url_root}/groups/#{group['id']}"
       }
       if group['context_type'] == 'Course'
-        group_data[:course_id] = group['course_id']
+        group_data[:course_id] = group['course_id'].to_s
       end
       group_data
     end

--- a/app/models/my_activities/canvas_activities.rb
+++ b/app/models/my_activities/canvas_activities.rb
@@ -132,8 +132,7 @@ module MyActivities
 
     def self.process_source(entry, classes)
       if (site = get_site_for_entry(entry, classes))
-        source = (site[:siteType] == 'course') ? course_codes_for_site(site, classes) : site[:source]
-        source ||= site[:name]
+        source = course_codes_for_site(site, classes) || site[:source] || site[:name]
       end
       source || Canvas::Proxy::APP_NAME
     end

--- a/spec/models/canvas/merged_user_sites_spec.rb
+++ b/spec/models/canvas/merged_user_sites_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe Canvas::MergedUserSites do
   let(:uid) { rand(999999).to_s }
   let(:canvas_course_id) { rand(999999) }
@@ -81,7 +79,9 @@ describe Canvas::MergedUserSites do
     context 'when a Canvas group site is associated with a course site' do
       let(:canvas_group) {canvas_group_base.merge({ 'context_type' => 'Course', 'course_id' => canvas_course_id })}
       it_behaves_like 'a group site item'
-      its([:course_id]) { should eq(canvas_course_id) }
+      it 'reports association by course id' do
+        expect(subject[:course_id]).to eq canvas_course_id.to_s
+      end
     end
     context 'when a Canvas group site is associated with an account' do
       let(:canvas_group) {canvas_group_base.merge({ 'context_type' => 'Account', 'account_id' => rand(999999) })}


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5520

Fixes an association that was broken by integer/string mismatch, and extends the course-site improvement in #3968 to cover group sites as well.