### PR TITLE
CLC-5371 Add grading-in-progress term information to My Classes feed

### DIFF
--- a/app/models/my_activities/dashboard_sites.rb
+++ b/app/models/my_activities/dashboard_sites.rb
@@ -1,9 +1,9 @@
 module MyActivities
   class DashboardSites
     def self.fetch(uid, options={})
-      dashboard_sites = MyClasses::Merged.new(uid, options).get_feed[:classes]
-      dashboard_sites.concat(MyGroups::Merged.new(uid, options).get_feed[:groups])
-      dashboard_sites
+      classes_feed = MyClasses::Merged.new(uid, options).get_feed
+      groups_feed = MyGroups::Merged.new(uid, options).get_feed
+      classes_feed[:classes] + classes_feed[:gradingInProgressClasses].to_a + groups_feed[:groups]
     end
   end
 end

--- a/app/models/my_classes/campus.rb
+++ b/app/models/my_classes/campus.rb
@@ -3,10 +3,15 @@ module MyClasses
     include ClassesModule
 
     def fetch
-      # Only include classes for current terms.
+      terms = {current: classes_for_term(current_term)}
+      terms.merge!({gradingInProgress: classes_for_term(grading_in_progress_term)}) if grading_in_progress_term
+      terms
+    end
+
+    def classes_for_term(term)
       classes = []
       all_courses = CampusOracle::UserCourses::All.new(user_id: @uid).get_all_campus_courses
-      semester_key = "#{current_term.year}-#{current_term.code}"
+      semester_key = "#{term.year}-#{term.code}"
       if all_courses[semester_key]
         # Ask My Academics for the URL to this class info page in My Academics, and to merge
         # any crosslisted courses for non-students.

--- a/app/models/my_classes/canvas.rb
+++ b/app/models/my_classes/canvas.rb
@@ -2,12 +2,12 @@ module MyClasses
   class Canvas
     include ClassesModule
 
-    def merge_sites(campus_courses, sites)
+    def merge_sites(campus_courses, term, sites)
       return unless ::Canvas::Proxy.access_granted?(@uid)
       if (canvas_sites = ::Canvas::MergedUserSites.new(@uid).get_feed)
         included_course_sites = {}
         canvas_sites[:courses].each do |course_site|
-          if (entry = course_site_entry(campus_courses, course_site))
+          if (entry = course_site_entry(campus_courses, course_site, term))
             sites << entry
             included_course_sites[entry[:id]] = {
               source: entry[:name],

--- a/app/models/my_classes/classes_module.rb
+++ b/app/models/my_classes/classes_module.rb
@@ -9,35 +9,30 @@ module MyClasses::ClassesModule
     @current_term ||= Berkeley::Terms.fetch.current
   end
 
-  def current_term?(term_yr, term_cd)
-    current_term.year == term_yr.to_i && current_term.code == term_cd
+  def grading_in_progress_term
+    @grading_in_progress_term ||= Berkeley::Terms.fetch.grading_in_progress
   end
 
-  def course_site_entry(campus_courses, course_site)
-    # My Classes only includes course sites for current terms.
-    if (term_yr = course_site[:term_yr]) && (term_cd = course_site[:term_cd]) && current_term?(term_yr, term_cd)
-      linked_campus = []
-      if (sections = course_site[:sections])
-        candidate_ccns = sections.collect {|s| s[:ccn].to_i}
-        campus_courses.each do |campus|
-          if campus[:term_yr] == term_yr && campus[:term_cd]
-            if campus[:sections].index {|s| candidate_ccns.include?(s[:ccn].to_i)}.present?
-              linked_campus << {id: campus[:listings].first[:id]}
-            end
-          end
+  def course_site_entry(campus_courses, course_site, term)
+    return unless matches_term?(course_site, term)
+    linked_campus_courses = []
+    if (sections = course_site[:sections])
+      candidate_ccns = sections.collect {|s| s[:ccn].to_i}
+      campus_courses.each do |campus_course|
+        if matches_term?(campus_course, term) && campus_course[:sections].find {|s| candidate_ccns.include?(s[:ccn].to_i)}
+          linked_campus_courses << {id: campus_course[:listings].first[:id]}
         end
       end
-      course_site.slice(:emitter, :id, :name, :shortDescription, :site_url).merge(
-        {
-          siteType: 'course',
-          term_cd: term_cd,
-          term_yr: term_yr,
-          courses: linked_campus.uniq
-        }
-      )
-    else
-      nil
     end
+    course_site.slice(:emitter, :id, :name, :shortDescription, :site_url, :term_cd, :term_yr).merge({
+      siteType: 'course',
+      courses: linked_campus_courses.uniq
+    })
   end
 
+  private
+
+  def matches_term?(course, term)
+    term && term.year == course[:term_yr].to_i && term.code == course[:term_cd]
+  end
 end

--- a/app/models/my_classes/merged.rb
+++ b/app/models/my_classes/merged.rb
@@ -5,17 +5,26 @@ module MyClasses
     include Cache::JsonAddedCacher
 
     def get_feed_internal
-      sites = []
       campus = Campus.new(@uid)
       campus_courses = campus.fetch
-      sites.concat(campus_courses)
-      Canvas.new(@uid).merge_sites(campus_courses, sites)
-      SakaiClasses.new(@uid).merge_sites(campus_courses, sites)
-      {
-        classes: sites,
+      site_emitters = [
+        Canvas.new(@uid),
+        SakaiClasses.new(@uid)
+      ]
+      feed = {
+        classes: merge_sites(campus_courses[:current], campus.current_term, site_emitters),
         current_term: campus.current_term.to_english
       }
+      if campus_courses[:gradingInProgress]
+        feed[:gradingInProgressClasses] = merge_sites(campus_courses[:gradingInProgress], campus.grading_in_progress_term, site_emitters)
+      end
+      feed
     end
 
+    def merge_sites(courses, term, emitters)
+      sites = courses.dup
+      emitters.each { |emitter| emitter.merge_sites(courses, term, sites) }
+      sites
+    end
   end
 end

--- a/app/models/my_classes/sakai_classes.rb
+++ b/app/models/my_classes/sakai_classes.rb
@@ -2,11 +2,11 @@ module MyClasses
   class SakaiClasses
     include MyClasses::ClassesModule
 
-    def merge_sites(campus_courses, sites)
+    def merge_sites(campus_courses, term, sites)
       return unless Sakai::Proxy.access_granted?(@uid)
       sakai_sites = Sakai::SakaiMergedUserSites.new(user_id: @uid).get_feed
       sakai_sites[:courses].each do |course_site|
-        if (entry = course_site_entry(campus_courses, course_site))
+        if (entry = course_site_entry(campus_courses, course_site, term))
           sites << entry
         end
       end

--- a/spec/models/my_classes/merged_spec.rb
+++ b/spec/models/my_classes/merged_spec.rb
@@ -1,24 +1,44 @@
-require "spec_helper"
-
 describe MyClasses::Merged do
   let(:user_id) {rand(99999).to_s}
+  let(:feed) { MyClasses::Merged.new(user_id).get_feed }
 
   describe '#get_feed_internal' do
     context 'when no campus course associations or LMS access' do
-      subject { MyClasses::Merged.new(user_id).get_feed }
-      before {Canvas::Proxy.stub(:access_granted?).with(user_id).and_return(false)}
-      before {Sakai::Proxy.stub(:access_granted?).with(user_id).and_return(false)}
-      before {CampusOracle::UserCourses::All.stub(:new).and_return(double({get_all_campus_courses: {}}) )}
-      its([:classes]) {should eq []}
-      its([:current_term]) {should be_present}
+      before { allow(Canvas::Proxy).to receive(:access_granted?).with(user_id).and_return false }
+      before { allow(Sakai::Proxy).to receive(:access_granted?).with(user_id).and_return false }
+      before { allow(CampusOracle::UserCourses::All).to receive(:new).and_return double({get_all_campus_courses: {}}) }
+      it 'includes term with no classes' do
+        expect(feed[:current_term]).to be_present
+        expect(feed[:classes]).to eq []
+        expect(feed).not_to include :gradingInProgressClasses
+      end
     end
-    context 'when an instructor in the test data', :if => CampusOracle::Queries.test_data? do
+    context 'when an instructor in the test data', if: CampusOracle::Queries.test_data? do
       let(:user_id) {'238382'}
-      subject { MyClasses::Merged.new(user_id).get_feed[:classes] }
-      it 'contains at least one class for the instructor' do
-        instructing_classes = subject.select {|entry| entry[:role] == "Instructor" }
-        expect(instructing_classes.empty?).to be_falsey
-        instructing_classes.each {|c| expect(c[:site_url].blank?).to be_falsey}
+
+      shared_examples 'a feed with instructor classes' do
+        it 'contains at least one class for the instructor' do
+          instructing_classes = subject.select {|entry| entry[:role] == 'Instructor' }
+          expect(instructing_classes).not_to be_empty
+          instructing_classes.each {|c| expect(c[:site_url]).to be_present}
+        end
+      end
+
+      context 'term in progress' do
+        subject { feed[:classes] }
+        it_should_behave_like 'a feed with instructor classes'
+        it 'does not report grading in progress' do
+          expect(feed).not_to include :gradingInProgressClasses
+        end
+      end
+
+      context 'term just ended' do
+        before { allow(Settings.terms).to receive(:fake_now).and_return(DateTime.parse('2013-12-30')) }
+        subject { feed[:gradingInProgressClasses] }
+        it_should_behave_like 'a feed with instructor classes'
+        it 'includes empty class list for current term' do
+          expect(feed[:classes]).to be_empty
+        end
       end
     end
   end

--- a/spec/models/my_classes/sakai_classes_spec.rb
+++ b/spec/models/my_classes/sakai_classes_spec.rb
@@ -1,12 +1,10 @@
-require "spec_helper"
-
 describe MyClasses::SakaiClasses do
   let(:uid) {rand(99999).to_s}
   let(:sites) {[]}
   let(:ccn) {rand(9999)}
   let(:course_id) {"econ-#{rand(999)}B"}
   let(:campus_courses) do
-    [{
+    {current: [{
       listings: [{
         id: course_id
       }],
@@ -15,7 +13,7 @@ describe MyClasses::SakaiClasses do
       sections: [{
         ccn: ccn
       }]
-    }]
+    }]}
   end
   let(:sakai_site_id) {"#{rand(99999)}-#{rand(99999)}"}
   let(:sakai_site_base) do
@@ -31,7 +29,7 @@ describe MyClasses::SakaiClasses do
   end
   before {Sakai::SakaiMergedUserSites.stub(:new).with(user_id: uid).and_return(double(get_feed: sakai_sites))}
   subject do
-    MyClasses::SakaiClasses.new(uid).merge_sites(campus_courses, sites)
+    MyClasses::SakaiClasses.new(uid).merge_sites(campus_courses[:current], Berkeley::Terms.fetch.current, sites)
     sites
   end
   context 'when Sakai course is within a current term' do

--- a/spec/models/rosters/campus_spec.rb
+++ b/spec/models/rosters/campus_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Rosters::Campus' do
   let(:term_yr) {'2014'}
   let(:term_cd) {'B'}
@@ -128,7 +126,7 @@ describe 'Rosters::Campus' do
   context 'cross-listed courses', if: CampusOracle::Connection.test_data? do
     include_context 'instructor for crosslisted courses'
     let!(:crosslisted_course_id) do
-      classes_for_instructor = MyClasses::Campus.new(instructor_id).fetch
+      classes_for_instructor = MyClasses::Campus.new(instructor_id).fetch[:current]
       classes_for_instructor.first[:listings].first[:id]
     end
 


### PR DESCRIPTION
See https://jira.ets.berkeley.edu/jira/browse/CLC-5371 for motivation.

A `gradingInProgressClasses` key is added to My Classes for the four-week period after end of term, when grading information is likely to show up. This surfaces no new information in My Classes, but lets the Recent Activity widget associate announcements with recently completed courses.

It might have been more elegant to arrange the My Classes semesters in an array, as with My Academics, but it's clearly more pragmatic to leave existing feed elements alone.