### PR TITLE
CLC-5526, Canvas Tab API bug + Webcast cron = workaround B

### DIFF
--- a/spec/models/canvas/external_tools_spec.rb
+++ b/spec/models/canvas/external_tools_spec.rb
@@ -56,35 +56,72 @@ describe Canvas::ExternalTools do
     subject { Canvas::ExternalTools.new options }
 
     context 'when modifying tab settings per canvas_course_id' do
-      let(:tab_id) { 'my_tab_external_tool_4' }
-      let(:tab) { { 'id' => tab_id, 'position' => 16 } }
       let(:canvas_course_id) { 98765 }
       let(:options) { {canvas_course_id: "#{canvas_course_id}"} }
-      let(:api_path) { "courses/#{canvas_course_id}/tabs/#{tab_id}" }
-      let(:vcr_id) { '_update_course_site_tab_hidden' }
-      let(:tab_showing) {
-        {
-          'html_url' => '/courses/1/external_tools/4',
-          'id' => "#{tab_id}",
-          'label' => 'My Tab',
-          'type' => 'external',
-          'visibility' => 'public',
-          'position' => tab['position']
+      let(:tab_showing) { create_tab(canvas_course_id, 'tab_showing_1') }
+      let(:tab_hidden) { create_tab(canvas_course_id, 'tab_hidden_2', {'hidden' => 'true'}) }
+      let(:untargeted_tab) { create_tab(canvas_course_id, 'untargeted_tab_3', {'hidden' => 'true'}) }
+      let(:all_tabs) { [tab_showing, tab_hidden, untargeted_tab] }
+      let(:all_tabs_url) { "courses/#{canvas_course_id}/tabs" }
+
+      it 'should return tab with hidden equals true' do
+        all_tabs_response = double(status: 200, body: all_tabs.to_json)
+        expect(subject).to receive(:request_uncached).with(all_tabs_url, '_course_site_tab_list', anything).twice.and_return all_tabs_response
+        tab_id = tab_showing['id']
+        url = "courses/#{canvas_course_id}/tabs/#{tab_id}"
+        hidden_after_update = create_tab(canvas_course_id, tab_id, {'hidden' => 'true'})
+        update_response = double(status: 200, body: hidden_after_update.to_json)
+        expect(subject).to receive(:request_uncached).with(url, '_update_course_site_tab', expected_options(tab_id, true)).and_return update_response
+        result = subject.hide_course_site_tab tab_showing
+        expect(result.to_json).to eq update_response.body
+      end
+
+      it 'should fix collateral damage when untargeted tabs are updated' do
+        all_tabs_response = double(status: 200, body: all_tabs.to_json)
+        # Expect snapshot of tabs before update
+        expect(subject).to receive(:request_uncached).with(all_tabs_url, '_course_site_tab_list', anything).once.and_return all_tabs_response
+        # Expect standard update
+        target_tab_id = tab_hidden['id']
+        update_tab_response = double(status: 200, body: create_tab(canvas_course_id, target_tab_id).to_json)
+        update_tab_url = "courses/#{canvas_course_id}/tabs/#{target_tab_id}"
+        expect(subject).to receive(:request_uncached).with(update_tab_url, '_update_course_site_tab', expected_options(target_tab_id, false)).once.and_return update_tab_response
+        # Expect update to untargeted tab
+        untargeted_id = untargeted_tab['id']
+        collateral_damage =  create_tab(canvas_course_id, untargeted_id)
+        all_tabs_after_update = double(status: 200, body: [tab_showing, tab_hidden, collateral_damage].to_json)
+        expect(subject).to receive(:request_uncached).with(all_tabs_url, '_course_site_tab_list', anything).once.and_return all_tabs_after_update
+        # Expect restoration of untargeted tab
+        fixed_tab = untargeted_tab.merge({'hidden' => true})
+        untargeted_tab_updated = double(status: 200, body: fixed_tab.to_json)
+        url = "courses/#{canvas_course_id}/tabs/#{untargeted_id}"
+        expect(subject).to receive(:request_uncached).with(url, '_update_course_site_tab', expected_options(untargeted_id, true)).once.and_return untargeted_tab_updated
+        # Now test
+        result = subject.show_course_site_tab tab_hidden
+        tab_now_showing = create_tab(canvas_course_id, target_tab_id)
+        expect(result).to eq tab_now_showing
+      end
+    end
+
+    def create_tab(canvas_course_id, tab_id, options = {})
+      {
+        'html_url' => "/courses/#{canvas_course_id}/external_tools/#{tab_id}",
+        'id' => "#{tab_id}",
+        'label' => "Tab #{tab_id}",
+        'position' => tab_id,
+        'visibility' => 'public'
+      }.merge options
+    end
+
+    def expected_options(tab_id, expect_set_to_hidden)
+      {
+        :method => :put,
+        :body => {
+          'id' => tab_id,
+          'hidden' => expect_set_to_hidden,
+          'position' => tab_id,
+          'visibility' => 'public'
         }
       }
-      let(:tab_hidden) { tab_showing.merge({ 'hidden' => true }) }
-      let(:tab_hidden_response) { double(status: 200, body: tab_hidden.to_json) }
-      let(:tab_showing_response) { double(status: 200, body: tab_showing.to_json) }
-
-      it 'should return tab with hidden=true' do
-        expect(subject).to receive(:request_uncached).with(api_path, vcr_id, anything).and_return tab_hidden_response
-        expect(subject.hide_course_site_tab tab).to eq tab_hidden
-      end
-
-      it 'should return tab with no hidden attribute' do
-        expect(subject).to receive(:request_uncached).with(api_path, vcr_id, anything).and_return tab_showing_response
-        expect(subject.show_course_site_tab tab).to eq tab_showing
-      end
     end
   end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5526

When we use the Canvas Tab API we must avoid collateral damage. I.e., changes to 'hidden' property on non-targeted tabs. Therefore, the extraneous tabs are self-healing. 