### PR TITLE
CLC-5427 Add new feed source for Alerts / Release Notes

### DIFF
--- a/app/controllers/blog_feed_controller.rb
+++ b/app/controllers/blog_feed_controller.rb
@@ -2,10 +2,8 @@ class BlogFeedController < ApplicationController
 
   def get_blog_info
     result = {}
-    if Settings.features.app_alerts
-      alert_data = EtsBlog::Alerts.new.get_latest
-      result.merge!(:alert => alert_data) unless alert_data.blank?
-    end
+    alert_data = EtsBlog::Alerts.new.get_latest
+    result.merge!(:alert => alert_data) unless alert_data.blank?
     result.merge!( EtsBlog::ReleaseNotes.new.get_latest_release_notes )
     render :json => result
   end

--- a/app/controllers/blog_feed_controller.rb
+++ b/app/controllers/blog_feed_controller.rb
@@ -2,9 +2,13 @@ class BlogFeedController < ApplicationController
 
   def get_blog_info
     result = {}
-    alert_data = EtsBlog::Alerts.new.get_latest
+    if Settings.features.service_alerts_rss
+      alert_data = EtsBlog::ServiceAlerts.new.get_latest
+    else
+      alert_data = EtsBlog::Alerts.new.get_latest
+    end
     result.merge!(:alert => alert_data) unless alert_data.blank?
-    result.merge!(:release_note => EtsBlog::ReleaseNotes.new.get_latest )
+    result.merge!(:releaseNote => EtsBlog::ReleaseNotes.new.get_latest )
     render :json => result
   end
 end

--- a/app/controllers/blog_feed_controller.rb
+++ b/app/controllers/blog_feed_controller.rb
@@ -4,7 +4,7 @@ class BlogFeedController < ApplicationController
     result = {}
     alert_data = EtsBlog::Alerts.new.get_latest
     result.merge!(:alert => alert_data) unless alert_data.blank?
-    result.merge!( EtsBlog::ReleaseNotes.new.get_latest_release_notes )
+    result.merge!(:release_note => EtsBlog::ReleaseNotes.new.get_latest )
     render :json => result
   end
 end

--- a/app/models/ets_blog/release_notes.rb
+++ b/app/models/ets_blog/release_notes.rb
@@ -1,10 +1,7 @@
 module EtsBlog
-  class ReleaseNotes < BaseProxy
-
+  class ReleaseNotes < RssProxy
     include ClassLogger
     include HtmlSanitizer
-    include Proxies::HttpClient
-    include Proxies::MockableXml
 
     def initialize(options = {})
       super(Settings.blog_latest_release_notes_feed_proxy, options)
@@ -13,36 +10,6 @@ module EtsBlog
 
     def default_message_on_exception
       'An error occurred retrieving release notes. Please try again later.'
-    end
-
-    def get_latest_release_notes
-      self.class.fetch_from_cache do
-        begin
-          logger.info "Fetching release notes from blog, cache expiration #{self.class.expires_in}"
-          #HTTParty won't parse automatically because the application/xml header is missing
-          response = MultiXml.parse(get_response(@settings.base_url).body)
-          entry = response['rss']['channel']['item'].first
-
-          d = Date.parse entry['pubDate']
-          # Clean up description and trim off text appended by Drupal
-          snippet = sanitize_html(entry['description']).squish.gsub(/read more$/, '')
-
-          {
-            entries: [
-              {
-                title: entry['title'],
-                link: entry['link'],
-                date: d.strftime('%b %d'),
-                snippet: snippet
-              }]
-          }
-        rescue StandardError => e
-          logger.error "Got an error fetching release notes: #{e.inspect}"
-          {
-            entries: []
-          }
-        end
-      end
     end
 
     def mock_xml

--- a/app/models/ets_blog/rss_proxy.rb
+++ b/app/models/ets_blog/rss_proxy.rb
@@ -1,0 +1,51 @@
+module EtsBlog
+  class RssProxy < BaseProxy
+    include DatedFeed
+    include Proxies::HttpClient
+    include Proxies::MockableXml
+
+    # Tell HTTParty that the 'application/rss+xml' content type used by Drupal should be parsed as XML.
+    class RssParser < HTTParty::Parser
+      SupportedFormats.merge!('application/rss+xml' => :xml)
+    end
+
+    def get_latest
+      self.class.fetch_from_cache do
+        begin
+          get_feed_internal(@settings.base_url)
+        end
+      end
+    end
+
+    def get_feed_internal(path)
+      begin
+        latest_entry = nil
+        logger.info "Fetching #{path}; fake=#{@fake}; cache expiration #{self.class.expires_in}"
+        response = get_response(path, {parser: RssParser})
+        entries = response['rss']['channel']['item']
+        if entries.present?
+          entry = entries.first
+          snippet = sanitize_html(entry['description']).squish.gsub(/read more$/, '')
+          {
+            title: entry['title'],
+            link: entry['link'],
+            timestamp: format_date(entry['pubDate'].to_datetime, '%b %d'),
+            snippet: snippet
+          }
+        else
+          nil
+        end
+      rescue StandardError => e
+        logger.error "Got an error fetching release notes: #{e.inspect}"
+        nil
+      end
+    end
+
+    def mock_response
+      response = super
+      response[:headers].merge!({'Content-Type' => 'application/rss+xml'})
+      response
+    end
+
+  end
+end

--- a/app/models/ets_blog/rss_proxy.rb
+++ b/app/models/ets_blog/rss_proxy.rb
@@ -10,33 +10,26 @@ module EtsBlog
     end
 
     def get_latest
-      self.class.fetch_from_cache do
-        begin
-          get_feed_internal(@settings.base_url)
-        end
+      self.class.smart_fetch_from_cache(return_nil_on_generic_error: true) do
+        get_feed_internal(@settings.base_url)
       end
     end
 
     def get_feed_internal(path)
-      begin
-        latest_entry = nil
-        logger.info "Fetching #{path}; fake=#{@fake}; cache expiration #{self.class.expires_in}"
-        response = get_response(path, {parser: RssParser})
-        entries = response['rss']['channel']['item']
-        if entries.present?
-          entry = entries.first
-          snippet = sanitize_html(entry['description']).squish.gsub(/read more$/, '')
-          {
-            title: entry['title'],
-            link: entry['link'],
-            timestamp: format_date(entry['pubDate'].to_datetime, '%b %d'),
-            snippet: snippet
-          }
-        else
-          nil
-        end
-      rescue StandardError => e
-        logger.error "Got an error fetching release notes: #{e.inspect}"
+      logger.info "Fetching #{path}; fake=#{@fake}; cache expiration #{self.class.expires_in}"
+      response = get_response(path, {parser: RssParser})
+      entries = response['rss']['channel']['item']
+      if entries.present?
+        entry = entries.first
+        snippet = sanitize_html(entry['description'])
+        snippet.squish!.gsub(/read more$/, '') if snippet.present?
+        {
+          title: entry['title'],
+          link: entry['link'],
+          timestamp: format_date(entry['pubDate'].to_datetime, '%b %d'),
+          snippet: snippet
+        }
+      else
         nil
       end
     end

--- a/app/models/ets_blog/service_alerts.rb
+++ b/app/models/ets_blog/service_alerts.rb
@@ -1,0 +1,20 @@
+module EtsBlog
+  class ServiceAlerts < RssProxy
+    include ClassLogger
+    include HtmlSanitizer
+
+    def initialize(options = {})
+      super(Settings.service_alerts_proxy, options)
+      initialize_mocks if @fake
+    end
+
+    def default_message_on_exception
+      'Alert server unreachable.'
+    end
+
+    def mock_xml
+      read_file('fixtures', 'xml', 'service_alerts_feed.xml')
+    end
+
+  end
+end

--- a/app/models/my_badges/merged.rb
+++ b/app/models/my_badges/merged.rb
@@ -21,7 +21,7 @@ module MyBadges
         badges: get_google_badges,
         studentInfo: StudentInfo.new(@uid).get
       }
-      feed[:alert] = EtsBlog::Alerts.new.get_latest if Settings.features.app_alerts
+      feed[:alert] = EtsBlog::Alerts.new.get_latest
       logger.debug "#{self.class.name} get_feed is #{feed.inspect}"
       feed
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -172,6 +172,10 @@ app_alerts_proxy:
   fake: false
   base_url: "http://ets.berkeley.edu/calcentral-alerts/feed"
 
+service_alerts_proxy:
+  fake: false
+  base_url: 'https://test-ets.pantheon.berkeley.edu/news-archive/calcentral-service-alert/feed'
+
 cal1card_proxy:
   fake: false
   base_url: 'https://webstage.housing.berkeley.edu/c1c/dyn/csc.asp'
@@ -293,6 +297,7 @@ features:
   course_manage_official_sections: false
   manage_site_mailing_lists: false
   webcast_sign_up_on_calcentral: false
+  service_alerts_rss: false
 
 youtube_splash_id: 'EQ-a7xrfVag'
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -282,7 +282,6 @@ background_jobs_check:
 # feature toggles. If a feature's key is false OR nil, it's disabled.
 features:
   my_fin_aid: false
-  research: false
   textbooks: false
   videos: false
   cal1card: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -285,7 +285,6 @@ features:
   research: false
   textbooks: false
   videos: false
-  app_alerts: false
   cal1card: false
   reauthentication: true
   audio: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -79,7 +79,6 @@ features:
   my_fin_aid: true
   textbooks: true
   videos: true
-  app_alerts: true
   cal1card: true
   reauthentication: false
   audio: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -48,7 +48,6 @@ features:
   telebears: true
   textbooks: true
   videos: true
-  research: true
   cal1card: true
   audio: true
   advising: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -49,7 +49,6 @@ features:
   textbooks: true
   videos: true
   research: true
-  app_alerts: true
   cal1card: true
   audio: true
   advising: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -42,6 +42,10 @@ app_alerts_proxy:
   fake: true
   base_url: "http://ets-dev.berkeley.edu/calcentral-alerts/feed"
 
+service_alerts_proxy:
+  fake: true
+  base_url: 'https://test-ets.pantheon.berkeley.edu/news-archive/calcentral-service-alert/feed'
+
 features:
   bearfacts: true
   financials: true
@@ -52,6 +56,7 @@ features:
   audio: true
   advising: true
   webcast_sign_up_on_calcentral: true
+  service_alerts_rss: true
 
 cache:
   store: "memory"

--- a/config/settings/testext.yml
+++ b/config/settings/testext.yml
@@ -28,8 +28,7 @@ features:
   telebears: true
   textbooks: true
   videos: true
-  research: true
-  app_alerts: true
+  research: true TODO
   cal1card: true
   audio: true
   advising: true

--- a/config/settings/testext.yml
+++ b/config/settings/testext.yml
@@ -28,7 +28,6 @@ features:
   telebears: true
   textbooks: true
   videos: true
-  research: true TODO
   cal1card: true
   audio: true
   advising: true

--- a/fixtures/xml/service_alerts_feed.xml
+++ b/fixtures/xml/service_alerts_feed.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?><rss version="2.0" xml:base="https://test-ets.pantheon.berkeley.edu/news-archive/calcentral-service-alert/feed" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>News</title>
+    <link>https://test-ets.pantheon.berkeley.edu/news-archive/calcentral-service-alert/feed</link>
+    <description></description>
+    <language>en</language>
+    <item>
+      <title>Second CalCentral test alert</title>
+      <link>https://test-ets.pantheon.berkeley.edu/news/second-calcentral-test-alert</link>
+      <description>This is a short summary.</description>
+      <pubDate>Wed, 08 Jul 2015 00:00:00 -0700</pubDate>
+      <dc:creator />
+      <guid isPermaLink="false">7b7ae7f5-d9f4-42e9-ba90-e9295e8206e4</guid>
+    </item>
+    <item>
+      <title>Service Alert test</title>
+      <link>https://test-ets.pantheon.berkeley.edu/news/service-alert-test</link>
+      <description>CalCentral test alert. Reviewing layout and apperance. Does this work?</description>
+      <pubDate>Mon, 15 Jun 2015 00:00:00 -0700</pubDate>
+      <dc:creator />
+      <guid isPermaLink="false">0c79d3a2-1559-41a1-91db-975d795d4325</guid>
+    </item>
+  </channel>
+</rss>

--- a/fixtures/xml/service_alerts_feed_diacriticals.xml
+++ b/fixtures/xml/service_alerts_feed_diacriticals.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?><rss version="2.0" xml:base="https://test-ets.pantheon.berkeley.edu/news-archive/calcentral-service-alert/feed" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>News</title>
+    <link>https://test-ets.pantheon.berkeley.edu/news-archive/calcentral-service-alert/feed</link>
+    <description></description>
+    <language>en</language>
+    <item>
+      <title>¡El Señor González se zampó un extraño sándwich de vodka y ajo! (¢, ®, ™, ©, •, ÷, –, ¿)</title>
+      <link>hדג סקרן שט בים מאוכזב ולפתע מצא לו חברה</link>
+      <description>جامع الحروف عند البلغاء يطلق على الكلام المركب من جميع حروف التهجي بدون تكرار أحدها في لفظ واحد، أما في لفظين فهو جائز</description>
+      <pubDate>Thu, 09 Jul 2015 00:00:00 -0700</pubDate>
+      <dc:creator />
+      <guid isPermaLink="false">d766469f-945f-4369-956e-ab8afa690361</guid>
+    </item>
+    <item>
+      <title>Test alert for CalCentral with title only</title>
+      <link>https://test-ets.pantheon.berkeley.edu/news/test-alert-calcentral-title-only</link>
+      <description></description>
+      <pubDate>Wed, 08 Jul 2015 00:00:00 -0700</pubDate>
+      <dc:creator />
+      <guid isPermaLink="false">e97462e1-b33d-465b-8cea-ccc98efa7b54</guid>
+    </item>
+    <item>
+      <title>Second CalCentral test alert</title>
+      <link>https://test-ets.pantheon.berkeley.edu/news/second-calcentral-test-alert</link>
+      <description>This is a short summary.</description>
+      <pubDate>Wed, 08 Jul 2015 00:00:00 -0700</pubDate>
+      <dc:creator />
+      <guid isPermaLink="false">7b7ae7f5-d9f4-42e9-ba90-e9295e8206e4</guid>
+    </item>
+    <item>
+      <title>Service Alert test</title>
+      <link>https://test-ets.pantheon.berkeley.edu/news/service-alert-test</link>
+      <description>CalCentral test alert. Reviewing layout and apperance. Does this work?</description>
+      <pubDate>Mon, 15 Jun 2015 00:00:00 -0700</pubDate>
+      <dc:creator />
+      <guid isPermaLink="false">0c79d3a2-1559-41a1-91db-975d795d4325</guid>
+    </item>
+  </channel>
+</rss>

--- a/fixtures/xml/service_alerts_feed_empty.xml
+++ b/fixtures/xml/service_alerts_feed_empty.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?><rss version="2.0" xml:base="https://test-ets.pantheon.berkeley.edu/news-archive/calcentral-service-alert/feed" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>News</title>
+    <link>https://test-ets.pantheon.berkeley.edu/news-archive/calcentral-service-alert/feed</link>
+    <description></description>
+    <language>en</language>
+  </channel>
+</rss>

--- a/fixtures/xml/service_alerts_feed_title_only.xml
+++ b/fixtures/xml/service_alerts_feed_title_only.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?><rss version="2.0" xml:base="https://test-ets.pantheon.berkeley.edu/news-archive/calcentral-service-alert/feed" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>News</title>
+    <link>https://test-ets.pantheon.berkeley.edu/news-archive/calcentral-service-alert/feed</link>
+    <description></description>
+    <language>en</language>
+    <item>
+      <title>Test alert for CalCentral with title only</title>
+      <link>https://test-ets.pantheon.berkeley.edu/news/test-alert-calcentral-title-only</link>
+      <description></description>
+      <pubDate>Wed, 08 Jul 2015 00:00:00 -0700</pubDate>
+      <dc:creator />
+      <guid isPermaLink="false">e97462e1-b33d-465b-8cea-ccc98efa7b54</guid>
+    </item>
+    <item>
+      <title>Second CalCentral test alert</title>
+      <link>https://test-ets.pantheon.berkeley.edu/news/second-calcentral-test-alert</link>
+      <description>This is a short summary.</description>
+      <pubDate>Wed, 08 Jul 2015 00:00:00 -0700</pubDate>
+      <dc:creator />
+      <guid isPermaLink="false">7b7ae7f5-d9f4-42e9-ba90-e9295e8206e4</guid>
+    </item>
+    <item>
+      <title>Service Alert test</title>
+      <link>https://test-ets.pantheon.berkeley.edu/news/service-alert-test</link>
+      <description>CalCentral test alert. Reviewing layout and apperance. Does this work?</description>
+      <pubDate>Mon, 15 Jun 2015 00:00:00 -0700</pubDate>
+      <dc:creator />
+      <guid isPermaLink="false">0c79d3a2-1559-41a1-91db-975d795d4325</guid>
+    </item>
+  </channel>
+</rss>

--- a/public/dummy/json/badges.json
+++ b/public/dummy/json/badges.json
@@ -1,12 +1,12 @@
 {
   "alert": {
     "title": "CalCentral Scheduled Maintenance 3/17",
-    "teaser": "CalCentral v32 release at 6 - 7am",
-    "url": "http://ets-dev.berkeley.edu/calcentral-scheduled-maintenance-317",
+    "snippet": "CalCentral v32 release at 6 - 7am",
+    "link": "http://ets-dev.berkeley.edu/calcentral-scheduled-maintenance-317",
     "timestamp": {
       "epoch": 1393495946,
       "dateTime": "2014-02-27T02:12:26-08:00",
-      "dateString": "2/27"
+      "dateString": "Feb 27"
     }
   },
   "badges": {

--- a/public/dummy/json/badges_registration_alert.json
+++ b/public/dummy/json/badges_registration_alert.json
@@ -1,12 +1,12 @@
 {
   "alert": {
     "title": "CalCentral Scheduled Maintenance 3/17",
-    "teaser": "CalCentral v32 release at 6 - 7am",
-    "url": "http://ets-dev.berkeley.edu/calcentral-scheduled-maintenance-317",
+    "snippet": "CalCentral v32 release at 6 - 7am",
+    "link": "http://ets-dev.berkeley.edu/calcentral-scheduled-maintenance-317",
     "timestamp": {
       "epoch": 1393495946,
       "dateTime": "2014-02-27T02:12:26-08:00",
-      "dateString": "2/27"
+      "dateString": "Feb 27"
     }
   },
   "badges": {

--- a/public/dummy/json/badges_transition.json
+++ b/public/dummy/json/badges_transition.json
@@ -1,12 +1,12 @@
 {
   "alert": {
     "title": "CalCentral Scheduled Maintenance 3/17",
-    "teaser": "CalCentral v32 release at 6 - 7am",
-    "url": "http://ets-dev.berkeley.edu/calcentral-scheduled-maintenance-317",
+    "snippet": "CalCentral v32 release at 6 - 7am",
+    "link": "http://ets-dev.berkeley.edu/calcentral-scheduled-maintenance-317",
     "timestamp": {
       "epoch": 1393495946,
       "dateTime": "2014-02-27T02:12:26-08:00",
-      "dateString": "2/27"
+      "dateString": "Feb 27"
     }
   },
   "badges": {

--- a/public/dummy/json/blog.json
+++ b/public/dummy/json/blog.json
@@ -1,19 +1,22 @@
 {
   "alert": {
     "title": "CalCentral Emergency Outage",
-    "teaser": "CalCentral will be undergoing an unscheduled outage on Tuesday, March 4, 2014. &nbsp;We apologize for any inconvenience this may cause.",
-    "url": "http://ets-dev.berkeley.edu/calcentral-emergency-outage",
+    "snippet": "CalCentral will be undergoing an unscheduled outage on Tuesday, March 4, 2014. &nbsp;We apologize for any inconvenience this may cause.",
+    "link": "http://ets-dev.berkeley.edu/calcentral-emergency-outage",
     "timestamp": {
       "epoch": 1393620301,
       "dateTime": "2014-02-28T12:45:01-08:00",
-      "dateString": "2/28"
+      "dateString": "Feb 28"
     }
   },
-  "entries":[
-    {
-      "title":"CalCentral v.31 Release Notes: 3/3/14",
-      "link":"https://ets.berkeley.edu/article/calcentral-v31-release-notes-3314",
-      "date":"Mar 03",
-      "snippet":"Version 31 of CalCentral includes a Print button and more advanced searching and filtering in My Finances as well as other enhancements and bug fixes.\u00a0"}
-  ]
+  "release_note": {
+    "title":" CalCentral v.31 Release Notes: 3/3/14",
+    "link": "https://ets.berkeley.edu/article/calcentral-v31-release-notes-3314",
+    "timestamp": {
+      "epoch": 1393871738,
+      "dateTime": "2014-03-03T10:35:38-08:00",
+      "dateString": "Mar 03"
+    },
+    "snippet": "Version 31 of CalCentral includes a Print button and more advanced searching and filtering in My Finances as well as other enhancements and bug fixes.\u00a0"
+  }
 }

--- a/public/dummy/json/blog.json
+++ b/public/dummy/json/blog.json
@@ -9,7 +9,7 @@
       "dateString": "Feb 28"
     }
   },
-  "release_note": {
+  "releaseNote": {
     "title":" CalCentral v.31 Release Notes: 3/3/14",
     "link": "https://ets.berkeley.edu/article/calcentral-v31-release-notes-3314",
     "timestamp": {

--- a/public/dummy/json/status.json
+++ b/public/dummy/json/status.json
@@ -6,8 +6,7 @@
     "my_fin_aid": true,
     "research": false,
     "textbooks": true,
-    "videos": true,
-    "app_alerts": true
+    "videos": true
   },
   "actingAsUid": "1051203",
   "isSuperuser": false,

--- a/public/dummy/json/status.json
+++ b/public/dummy/json/status.json
@@ -4,7 +4,6 @@
   "isLoggedIn": true,
   "features": {
     "my_fin_aid": true,
-    "research": false,
     "textbooks": true,
     "videos": true
   },

--- a/public/dummy/json/status_loggedout.json
+++ b/public/dummy/json/status_loggedout.json
@@ -5,7 +5,6 @@
     "my_fin_aid": true,
     "research": false,
     "textbooks": true,
-    "videos": true,
-    "app_alerts": true
+    "videos": true
   }
 }

--- a/public/dummy/json/status_loggedout.json
+++ b/public/dummy/json/status_loggedout.json
@@ -3,7 +3,6 @@
   "isLoggedIn": false,
   "features": {
     "my_fin_aid": true,
-    "research": false,
     "textbooks": true,
     "videos": true
   }

--- a/spec/controllers/blog_feed_controller_spec.rb
+++ b/spec/controllers/blog_feed_controller_spec.rb
@@ -2,22 +2,36 @@ require "spec_helper"
 
 describe BlogFeedController do
 
-  before do
-    @alert_ok = EtsBlog::Alerts.new({fake:true}).get_latest;
-    @alert_ko = EtsBlog::Alerts.new({fake:true}).stub(:get_latest).and_return('');
+  let!(:nonempty_alert_feed) do
+    EtsBlog::Alerts.new({fake:true}).get_latest
   end
 
-  it "should return an alert and entries for non-authenticated users" do
-    get :get_blog_info
-    assert_response :success
-    response.status.should == 200
-    json_response = JSON.parse(response.body)
-    json_response.is_a?(Hash).should be_truthy
-    json_response["alert"].is_a?(Hash).should be_truthy if @alert_ok
-    json_response["alert"].should be_nil if @alert_ko
-    json_response["entries"].present?.should be_truthy
-    json_response["entries"].is_a?(Array).should be_truthy
-    json_response["entries"].count.should > 0
+  before do
+    allow_any_instance_of(EtsBlog::Alerts).to receive(:get_latest).and_return(fake_alerts)
+  end
+
+  context 'when there are alerts' do
+    let(:fake_alerts) { nonempty_alert_feed }
+    it 'should return both an alert and a release note for non-authenicated users' do
+      get :get_blog_info
+      assert_response :success
+      response.status.should == 200
+      json_response = JSON.parse(response.body)
+      json_response["alert"].should be_present
+      json_response["release_note"].should be_present
+    end
+  end
+
+  context 'when there are alerts' do
+    let(:fake_alerts) { nil }
+    it 'should return only a release note for non-authenicated users' do
+      get :get_blog_info
+      assert_response :success
+      response.status.should == 200
+      json_response = JSON.parse(response.body)
+      json_response["alert"].should be_blank
+      json_response["release_note"].should be_present
+    end
   end
 
 end

--- a/spec/controllers/blog_feed_controller_spec.rb
+++ b/spec/controllers/blog_feed_controller_spec.rb
@@ -2,36 +2,77 @@ require "spec_helper"
 
 describe BlogFeedController do
 
-  let!(:nonempty_alert_feed) do
-    EtsBlog::Alerts.new({fake:true}).get_latest
-  end
+  describe 'with legacy alerts feed' do
+    before do
+      allow(Settings.features).to receive('service_alerts_rss').and_return(false)
+      allow_any_instance_of(EtsBlog::Alerts).to receive(:get_latest).and_return(fake_alerts)
+      allow(EtsBlog::ServiceAlerts).to receive(:new).exactly(0).times
+    end
 
-  before do
-    allow_any_instance_of(EtsBlog::Alerts).to receive(:get_latest).and_return(fake_alerts)
-  end
+    let!(:nonempty_alert_feed) do
+      EtsBlog::Alerts.new({fake:true}).get_latest
+    end
 
-  context 'when there are alerts' do
-    let(:fake_alerts) { nonempty_alert_feed }
-    it 'should return both an alert and a release note for non-authenicated users' do
-      get :get_blog_info
-      assert_response :success
-      response.status.should == 200
-      json_response = JSON.parse(response.body)
-      json_response["alert"].should be_present
-      json_response["release_note"].should be_present
+    context 'when there are alerts' do
+      let(:fake_alerts) { nonempty_alert_feed }
+      it 'should return both an alert and a release note for non-authenticated users' do
+        get :get_blog_info
+        assert_response :success
+        response.status.should == 200
+        json_response = JSON.parse(response.body)
+        json_response["alert"].should be_present
+        json_response["releaseNote"].should be_present
+      end
+    end
+
+    context 'when there are alerts' do
+      let(:fake_alerts) { nil }
+      it 'should return only a release note for non-authenticated users' do
+        get :get_blog_info
+        assert_response :success
+        response.status.should == 200
+        json_response = JSON.parse(response.body)
+        json_response["alert"].should be_blank
+        json_response["releaseNote"].should be_present
+      end
     end
   end
 
-  context 'when there are alerts' do
-    let(:fake_alerts) { nil }
-    it 'should return only a release note for non-authenicated users' do
-      get :get_blog_info
-      assert_response :success
-      response.status.should == 200
-      json_response = JSON.parse(response.body)
-      json_response["alert"].should be_blank
-      json_response["release_note"].should be_present
+  describe 'with hosted alerts RSS feed' do
+    before do
+      allow(Settings.features).to receive('service_alerts_rss').and_return(true)
+      allow_any_instance_of(EtsBlog::ServiceAlerts).to receive(:get_latest).and_return(fake_alerts)
+      allow(EtsBlog::Alerts).to receive(:new).exactly(0).times
+    end
+
+    let!(:nonempty_alert_feed) do
+      EtsBlog::ServiceAlerts.new({fake:true}).get_latest
+    end
+
+    context 'when there are alerts' do
+      let(:fake_alerts) { nonempty_alert_feed }
+      it 'should return both an alert and a release note for non-authenticated users' do
+        get :get_blog_info
+        assert_response :success
+        response.status.should == 200
+        json_response = JSON.parse(response.body)
+        json_response["alert"].should be_present
+        json_response["releaseNote"].should be_present
+      end
+    end
+
+    context 'when there are alerts' do
+      let(:fake_alerts) { nil }
+      it 'should return only a release note for non-authenticated users' do
+        get :get_blog_info
+        assert_response :success
+        response.status.should == 200
+        json_response = JSON.parse(response.body)
+        json_response["alert"].should be_blank
+        json_response["releaseNote"].should be_present
+      end
     end
   end
+
 
 end

--- a/spec/models/ets_blog/alerts_spec.rb
+++ b/spec/models/ets_blog/alerts_spec.rb
@@ -18,8 +18,8 @@ describe EtsBlog::Alerts do
   it 'should format and return the latest well-formed feed message' do
     alert = fake_proxy.get_latest
     alert[:title].should == 'CalCentral Scheduled Upgrade (Test Announce Only)'
-    alert[:teaser].should == 'CalCentral Scheduled Upgrade (Test Announce Only)'
-    alert[:url].should == 'http://ets-dev.berkeley.edu/news/calcentral-scheduled-upgrade-test-announce-only'
+    alert[:snippet].should == 'CalCentral Scheduled Upgrade (Test Announce Only)'
+    alert[:link].should == 'http://ets-dev.berkeley.edu/news/calcentral-scheduled-upgrade-test-announce-only'
     alert[:timestamp][:epoch].should == 1393257625
   end
 
@@ -29,8 +29,8 @@ describe EtsBlog::Alerts do
       fake_proxy.stub(:get_feed).and_return(MultiXml.parse File.read(xml_multibyte_characters))
       alert = fake_proxy.get_latest
       alert[:title].should == '¡El Señor González se zampó un extraño sándwich de vodka y ajo! (¢, ®, ™, ©, •, ÷, –, ¿)'
-      alert[:url].should == 'hדג סקרן שט בים מאוכזב ולפתע מצא לו חברה'
-      alert[:teaser].should == 'جامع الحروف عند البلغاء يطلق على الكلام المركب من جميع حروف التهجي بدون تكرار أحدها في لفظ واحد، أما في لفظين فهو جائز'
+      alert[:link].should == 'hדג סקרן שט בים מאוכזב ולפתע מצא לו חברה'
+      alert[:snippet].should == 'جامع الحروف عند البلغاء يطلق على الكلام المركب من جميع حروف التهجي بدون تكرار أحدها في لفظ واحد، أما في لفظين فهو جائز'
     end
   end
 
@@ -39,7 +39,7 @@ describe EtsBlog::Alerts do
     it 'should return non-teaser attributes' do
       alert = fake_proxy.get_latest
       expect(alert[:title]).to be_present
-      expect(alert[:url]).to be_present
+      expect(alert[:link]).to be_present
       expect(alert[:timestamp][:epoch]).to be_present
     end
   end

--- a/spec/models/ets_blog/release_notes_spec.rb
+++ b/spec/models/ets_blog/release_notes_spec.rb
@@ -8,55 +8,55 @@ describe EtsBlog::ReleaseNotes do
 
   context 'fetching fake data feed' do
     include_context 'it writes to the cache'
-    subject { fake_proxy.get_latest_release_notes }
-    
+    subject { fake_proxy.get_latest }
+
     it_behaves_like 'a polite HTTP client'
 
     it 'should have the expected fake data' do
-      expect(subject[:entries][0][:title]).to eq 'CalCentral v.42 (Sprint 44) Release Notes, 8/27/14'
-      expect(subject[:entries][0][:link]).to eq 'https://ets.berkeley.edu/article/calcentral-v42-sprint-44-release-notes-82714'
-      expect(subject[:entries][0][:date]).to eq 'Aug 27'
-      expect(subject[:entries][0][:snippet]).to be
+      expect(subject[:title]).to eq 'CalCentral v.42 (Sprint 44) Release Notes, 8/27/14'
+      expect(subject[:link]).to eq 'https://ets.berkeley.edu/article/calcentral-v42-sprint-44-release-notes-82714'
+      expect(subject[:timestamp][:dateString]).to eq 'Aug 27'
+      expect(subject[:snippet]).to be
     end
   end
 
   context 'getting real data feed', testext: true do
     include_context 'it writes to the cache'
-    subject { real_proxy.get_latest_release_notes }
-    it { should_not be_empty }
-    its([:entries]) { should be }
+    subject { real_proxy.get_latest }
+    it { should_not be_blank }
+    its([:link]) { should be }
   end
 
   context 'server 404s' do
     include_context 'it writes to the cache'
     after(:each) { WebMock.reset! }
-    subject { real_proxy.get_latest_release_notes }
+    subject { real_proxy.get_latest }
 
     context '404 error on remote server' do
       before do
         stub_request(:any, /.*#{feed_uri.hostname}.*/).to_return(status: 404)
       end
-      its([:entries]) { should be_empty }
+      it { should be_blank }
     end
   end
 
   context 'server errors' do
     include_context 'it writes to the cache'
     after(:each) { WebMock.reset! }
-    subject { real_proxy.get_latest_release_notes }
+    subject { real_proxy.get_latest }
 
     context 'unreachable remote server (connection errors)' do
       before do
         stub_request(:any, /.*#{feed_uri.hostname}.*/).to_raise(Errno::ECONNREFUSED)
       end
-      its([:entries]) { should be_empty }
+      it { should be_blank }
     end
 
     context 'error on remote server (5xx errors)' do
       before do
         stub_request(:any, /.*#{feed_uri.hostname}.*/).to_return(status: 506)
       end
-      its([:entries]) { should be_empty }
+      it { should be_blank }
     end
   end
 

--- a/spec/models/ets_blog/service_alerts_spec.rb
+++ b/spec/models/ets_blog/service_alerts_spec.rb
@@ -1,0 +1,67 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe EtsBlog::ServiceAlerts do
+
+  let(:fake_proxy) { EtsBlog::ServiceAlerts.new({fake: true}) }
+
+  describe 'shared examples' do
+    subject { EtsBlog::ServiceAlerts.new(fake: false).get_latest }
+    it_behaves_like 'a polite HTTP client'
+  end
+
+  it 'should format and return the latest well-formed feed message' do
+    alert = fake_proxy.get_latest
+    alert[:title].should == 'Second CalCentral test alert'
+    alert[:snippet].should == 'This is a short summary.'
+    alert[:link].should == 'https://test-ets.pantheon.berkeley.edu/news/second-calcentral-test-alert'
+    alert[:timestamp][:dateString].should == 'Jul 08'
+    alert[:timestamp][:epoch].should == 1436338800
+  end
+
+  describe 'with other mock data' do
+    before { allow_any_instance_of(EtsBlog::ServiceAlerts).to receive(:mock_xml).and_return(fake_proxy.read_file('fixtures', 'xml', mock_xml_file)) }
+    subject { EtsBlog::ServiceAlerts.new({fake: true}) }
+
+    context 'when the xml contains multibyte characters' do
+      let(:mock_xml_file) { 'service_alerts_feed_diacriticals.xml' }
+      it 'should parse' do
+        alert = subject.get_latest
+        alert[:title].should == '¡El Señor González se zampó un extraño sándwich de vodka y ajo! (¢, ®, ™, ©, •, ÷, –, ¿)'
+        alert[:link].should == 'hדג סקרן שט בים מאוכזב ולפתע מצא לו חברה'
+        alert[:snippet].should == 'جامع الحروف عند البلغاء يطلق على الكلام المركب من جميع حروف التهجي بدون تكرار أحدها في لفظ واحد، أما في لفظين فهو جائز'
+      end
+    end
+
+    context 'when the alert only has a title' do
+      let(:mock_xml_file) { 'service_alerts_feed_title_only.xml' }
+      it 'should return basic attributes' do
+        alert = subject.get_latest
+        expect(alert[:title]).to be_present
+        expect(alert[:link]).to be_present
+        expect(alert[:timestamp][:epoch]).to be_present
+        expect(alert[:snippet]).to be_blank
+      end
+    end
+
+    context 'when there are no alerts in the feed' do
+      let(:mock_xml_file) { 'service_alerts_feed_empty.xml' }
+      it 'should return nil' do
+        alert = subject.get_latest
+        expect(alert).to be_blank
+      end
+    end
+  end
+
+  context 'when exceptions are raised' do
+    before { allow(fake_proxy).to receive(:get_feed_internal).and_raise(SocketError) }
+    context 'caching failures' do
+      include_context 'short-lived cache write of NilClass on failures'
+      it 'should write to cache when handling exceptions' do
+        expect(fake_proxy.get_latest).to be_nil
+      end
+    end
+  end
+
+end

--- a/src/assets/javascripts/angular/controllers/pages/splashController.js
+++ b/src/assets/javascripts/angular/controllers/pages/splashController.js
@@ -11,7 +11,7 @@
       if (data.alert && data.alert.title) {
         $scope.splashNote = data.alert;
       } else {
-        $scope.splashNote = data.release_note;
+        $scope.splashNote = data.releaseNote;
       }
     });
   });

--- a/src/assets/javascripts/angular/controllers/pages/splashController.js
+++ b/src/assets/javascripts/angular/controllers/pages/splashController.js
@@ -9,14 +9,9 @@
 
     blogFactory.getBlog().success(function(data) {
       if (data.alert && data.alert.title) {
-        $scope.splashNote = {
-          date: $filter('date')(data.alert.timestamp.epoch * 1000, 'MMM dd'),
-          link: data.alert.url,
-          snippet: data.alert.teaser,
-          title: data.alert.title
-        };
+        $scope.splashNote = data.alert;
       } else {
-        $scope.splashNote = data.entries[0];
+        $scope.splashNote = data.release_note;
       }
     });
   });

--- a/src/assets/templates/alerts.html
+++ b/src/assets/templates/alerts.html
@@ -8,6 +8,6 @@
     </span>
   </p>
   <p class="cc-right cc-alerts-bar-more-container">
-    <a class="cc-alerts-bar-more" data-ng-href="{{alert.url}}"><strong>Learn More</strong></a>
+    <a class="cc-alerts-bar-more" data-ng-href="{{alert.link}}"><strong>Learn More</strong></a>
   </p>
 </div>

--- a/src/assets/templates/splash.html
+++ b/src/assets/templates/splash.html
@@ -13,7 +13,7 @@
 
     <div class="row collapse cc-page-splash-blog-panel" data-ng-if="splashNote.title">
       <div class="medium-2 columns hide-for-small cc-page-splash-blog-date">
-        <p>{{splashNote.date}}</p>
+        <p>{{splashNote.timestamp.dateString}}</p>
       </div>
       <div class="medium-10 columns small-12">
         <p class="cc-page-splash-blog-title">


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5427

I got rid of two obsolete feature flags before adding the new one.

After the transition to the new feed sources, we'll want to delete the old "Alerts" class.