### PR TITLE
CLC-5564 Have paged Canvas proxies return empty array on failure

### DIFF
--- a/app/models/canvas/course_assignments.rb
+++ b/app/models/canvas/course_assignments.rb
@@ -9,8 +9,7 @@ module Canvas
     # Interface to request all assignments in a course
     # See https://canvas.instructure.com/doc/api/assignments.html#method.assignments_api.index
     def course_assignments
-      response = paged_get request_path
-      response[:body] || []
+      assignments_response[:body]
     end
 
     def muted_assignments
@@ -25,6 +24,10 @@ module Canvas
           'muted' => false
         }
       }
+    end
+
+    def assignments_response
+      paged_get request_path
     end
 
     private

--- a/app/models/canvas/course_user.rb
+++ b/app/models/canvas/course_user.rb
@@ -14,7 +14,7 @@ module Canvas
     end
 
     def course_user(options = {})
-      response = optional_cache(options, key: "#{@course_id}/#{@user_id}", default: true) { wrapped_get request_path }
+      response = optional_cache(options, key: "#{@course_id}/#{@user_id}", default: true) { user_response }
       response[:body] if response[:statusCode] < 400
     end
 
@@ -63,6 +63,10 @@ module Canvas
       profile = course_user
       return [] if profile.nil? || profile['enrollments'].nil? || profile['enrollments'].empty?
       profile['enrollments'].collect {|enrollment| enrollment['type'] }
+    end
+
+    def user_response
+      wrapped_get request_path
     end
 
     # Do not need to log a stack trace when the user is not a course site member.

--- a/app/models/canvas/external_tools.rb
+++ b/app/models/canvas/external_tools.rb
@@ -42,8 +42,7 @@ module Canvas
 
     # Do not cache, since this is used to change external tools configurations on multiple Canvas servers.
     def external_tools_list
-      response = paged_get "#{@api_root}/external_tools"
-      response[:body]
+      external_tools_response[:body]
     end
 
     def reset_external_tool_config_by_url(tool_id, config_url)
@@ -86,6 +85,10 @@ module Canvas
     # LTI app configurations.
     def modify_external_tool(tool_id, parameters)
       wrapped_put "#{@api_root}/external_tools/#{tool_id}", parameters
+    end
+
+    def external_tools_response
+      paged_get "#{@api_root}/external_tools"
     end
 
     private

--- a/app/models/canvas/proxy.rb
+++ b/app/models/canvas/proxy.rb
@@ -55,10 +55,10 @@ module Canvas
     end
 
     def paged_get(api_path, opts={})
-      safe_request do
-        results = []
-        map_pages = opts.delete :map_pages
-        params = opts.reverse_merge(per_page: 100).to_query
+      map_pages = opts.delete :map_pages
+      params = opts.reverse_merge(per_page: 100).to_query
+      results = []
+      response = safe_request do
         while params do
           response = request_internal "#{api_path}?#{params}"
           initial_status_code ||= response.status
@@ -71,11 +71,9 @@ module Canvas
           yield response if block_given?
           params = next_page_params(response)
         end
-        {
-          statusCode: initial_status_code,
-          body: results
-        }
+        {statusCode: initial_status_code}
       end
+      response.merge(body: results)
     end
 
     def wrapped_request(api_path, opts)

--- a/app/models/canvas/section_enrollments.rb
+++ b/app/models/canvas/section_enrollments.rb
@@ -11,7 +11,7 @@ module Canvas
     end
 
     def list_enrollments(options = {})
-      response = optional_cache(options, key: @section_id, default: false) { paged_get request_path }
+      response = optional_cache(options, key: @section_id, default: false) { enrollments_response }
       response[:body]
     end
 
@@ -34,6 +34,10 @@ module Canvas
           'notify' => notify,
         }
       }
+    end
+
+    def enrollments_response
+      paged_get request_path
     end
 
     private

--- a/app/models/canvas/user_courses.rb
+++ b/app/models/canvas/user_courses.rb
@@ -4,10 +4,10 @@ module Canvas
     include Cache::UserCacheExpiry
 
     def courses
-      request_courses[:body] || []
+      courses_response[:body]
     end
 
-    def request_courses
+    def courses_response
       self.class.fetch_from_cache(@uid) do
         paged_get request_path, as_user_id: "sis_login_id:#{@uid}", include: ['term']
       end

--- a/spec/models/canvas/authorization_configs_spec.rb
+++ b/spec/models/canvas/authorization_configs_spec.rb
@@ -14,7 +14,7 @@ describe Canvas::AuthorizationConfigs do
     context 'on request failure' do
       let(:failing_request) { {method: :get} }
       let(:response) { subject.authorization_configs }
-      it_should_behave_like 'a Canvas proxy handling request failure'
+      it_should_behave_like 'a paged Canvas proxy handling request failure'
     end
   end
 
@@ -45,7 +45,7 @@ describe Canvas::AuthorizationConfigs do
     context 'on request failure' do
       let(:failing_request) { {method: :put} }
       let(:response) { subject.reset_authorization_config(authorization_config_hash['id'], authorization_config_hash) }
-      it_should_behave_like 'a Canvas proxy handling request failure'
+      it_should_behave_like 'an unpaged Canvas proxy handling request failure'
     end
   end
 

--- a/spec/models/canvas/course_assignments_spec.rb
+++ b/spec/models/canvas/course_assignments_spec.rb
@@ -22,6 +22,12 @@ describe Canvas::CourseAssignments do
     expect(assignments[1]['points_possible']).to eq 50
   end
 
+  context 'on request failure' do
+    let(:failing_request) { {method: :get} }
+    let(:response) { subject.assignments_response }
+    it_should_behave_like 'a paged Canvas proxy handling request failure'
+  end
+
   context 'when providing muted assignments' do
     let(:fake_assignments) do
       [
@@ -45,9 +51,17 @@ describe Canvas::CourseAssignments do
     end
   end
 
-  it 'unmutes assignments' do
-    result = subject.unmute_assignment(11)
-    expect(result[:body]['id']).to eq 11
-    expect(result[:body]['muted']).to eq false
+  context 'unmuting assignments' do
+    it 'unmutes assignments' do
+      result = subject.unmute_assignment(11)
+      expect(result[:body]['id']).to eq 11
+      expect(result[:body]['muted']).to eq false
+    end
+
+    context 'on request failure' do
+      let(:failing_request) { {method: :put} }
+      let(:response) { subject.unmute_assignment(11) }
+      it_should_behave_like 'an unpaged Canvas proxy handling request failure'
+    end
   end
 end

--- a/spec/models/canvas/course_enrollments_spec.rb
+++ b/spec/models/canvas/course_enrollments_spec.rb
@@ -1,6 +1,6 @@
 describe Canvas::CourseEnrollments do
 
-  let(:uid)               { rand(99999).to_s }
+  let(:uid)               { Settings.canvas_proxy.test_user_id }
   let(:canvas_user_id)    { rand(99999) }
   let(:canvas_course_id)  { rand(99999) }
   let(:add_enrollment_response_body)  { '{
@@ -83,6 +83,12 @@ describe Canvas::CourseEnrollments do
       expect(response['enrollment_state']).to eq 'active'
       expect(response['role']).to eq 'Owner'
       expect(response['role_id']).to eq 12
+    end
+
+    context 'on request failure' do
+      let(:failing_request) { {method: :post} }
+      let(:response) { subject.enroll_user(canvas_user_id, 'TaEnrollment', 'active', false, :role_id => 12) }
+      it_should_behave_like 'an unpaged Canvas proxy handling request failure'
     end
   end
 end

--- a/spec/models/canvas/course_sections_spec.rb
+++ b/spec/models/canvas/course_sections_spec.rb
@@ -41,7 +41,7 @@ describe Canvas::CourseSections do
     context 'on request failure' do
       let(:failing_request) { {method: :get} }
       let(:response) { subject.sections_list }
-      it_should_behave_like 'a Canvas proxy handling request failure'
+      it_should_behave_like 'an unpaged Canvas proxy handling request failure'
     end
   end
 
@@ -101,6 +101,12 @@ describe Canvas::CourseSections do
       expect(result['integration_id']).to eq nil
       expect(result['sis_import_id']).to eq nil
       expect(result['nonxlist_course_id']).to eq nil
+    end
+
+    context 'on request failure' do
+      let(:failing_request) { {method: :post} }
+      let(:response) { subject.create('Data Structures', '') }
+      it_should_behave_like 'an unpaged Canvas proxy handling request failure'
     end
   end
 

--- a/spec/models/canvas/course_settings_spec.rb
+++ b/spec/models/canvas/course_settings_spec.rb
@@ -56,6 +56,12 @@ describe Canvas::CourseSettings do
         course = subject.set_grading_scheme(123456)[:body]
         expect(course['name']).to eq 'Just another course site'
       end
+
+      context 'on request failure' do
+        let(:failing_request) { {method: :put} }
+        let(:response) { subject.set_grading_scheme(123456) }
+        it_should_behave_like 'an unpaged Canvas proxy handling request failure'
+      end
     end
 
     context 'if course does not exist in canvas' do
@@ -71,7 +77,7 @@ describe Canvas::CourseSettings do
     context 'on request failure' do
       let(:failing_request) { {method: :get} }
       let(:response) { subject.settings }
-      it_should_behave_like 'a Canvas proxy handling request failure'
+      it_should_behave_like 'an unpaged Canvas proxy handling request failure'
     end
   end
 

--- a/spec/models/canvas/course_spec.rb
+++ b/spec/models/canvas/course_spec.rb
@@ -49,7 +49,7 @@ describe Canvas::Course do
     context 'on request failure' do
       let(:failing_request) { {method: :get} }
       let(:response) { subject.course }
-      it_should_behave_like 'a Canvas proxy handling request failure'
+      it_should_behave_like 'an unpaged Canvas proxy handling request failure'
     end
   end
 
@@ -107,7 +107,7 @@ describe Canvas::Course do
     context 'on request failure' do
       let(:failing_request) { {uri_matching: api_path, method: :post} }
       let(:response) { subject.create(canvas_account_id, 'Project X', 'Project X', term_id, sis_course_id) }
-      it_should_behave_like 'a Canvas proxy handling request failure'
+      it_should_behave_like 'an unpaged Canvas proxy handling request failure'
     end
   end
 

--- a/spec/models/canvas/course_user_spec.rb
+++ b/spec/models/canvas/course_user_spec.rb
@@ -64,6 +64,12 @@ describe Canvas::CourseUser do
         user = subject.course_user(:cache => false)
         expect(user['id']).to eq 4321321
       end
+
+      context 'on request failure' do
+        let(:failing_request) { {method: :get} }
+        let(:response) { subject.user_response }
+        it_should_behave_like 'an unpaged Canvas proxy handling request failure'
+      end
     end
 
     context 'if course user does not exist in canvas' do

--- a/spec/models/canvas/course_users_spec.rb
+++ b/spec/models/canvas/course_users_spec.rb
@@ -45,4 +45,10 @@ describe Canvas::CourseUsers do
     worker = Canvas::CourseUsers.new(:user_id => user_id, :course_id => canvas_course_id, :paging_callback => paging_callback)
     worker.course_users(cache: false)
   end
+
+  context 'on request failure' do
+    let(:failing_request) { {method: :get} }
+    let(:response) { subject.course_users }
+    it_should_behave_like 'a paged Canvas proxy handling request failure'
+  end
 end

--- a/spec/models/canvas/external_tools_spec.rb
+++ b/spec/models/canvas/external_tools_spec.rb
@@ -157,6 +157,12 @@ describe Canvas::ExternalTools do
       json_feed = Canvas::ExternalTools.public_list_as_json
       expect(json_feed).to eq raw_feed.to_json
     end
+
+    context 'on request failure' do
+      let(:failing_request) { {method: :get} }
+      let(:response) { subject.external_tools_response }
+      it_should_behave_like 'a paged Canvas proxy handling request failure'
+    end
   end
 
 end

--- a/spec/models/canvas/groups_spec.rb
+++ b/spec/models/canvas/groups_spec.rb
@@ -1,9 +1,16 @@
 describe Canvas::Groups do
 
+  subject { Canvas::Groups.new(user_id: @user_id) }
+  let(:response) { subject.groups }
+
   it 'should get groups as known member' do
-    groups = Canvas::Groups.new(user_id: @user_id).groups
-    expect(groups[:body]).to_not be_empty
-    expect(groups[:body][0]['name']).to be_present
+    expect(response[:body]).to_not be_empty
+    expect(response[:body][0]['name']).to be_present
+  end
+
+  context 'on request failure' do
+    let(:failing_request) { {method: :get} }
+    it_should_behave_like 'a paged Canvas proxy handling request failure'
   end
 
 end

--- a/spec/models/canvas/section_enrollments_spec.rb
+++ b/spec/models/canvas/section_enrollments_spec.rb
@@ -70,6 +70,12 @@ describe Canvas::SectionEnrollments do
         'role' => 'TaEnrollment'
       })
     end
+
+    context 'on request failure' do
+      let(:failing_request) { {method: :post} }
+      let(:response) { subject.enroll_user(user_id, 'TaEnrollment', 'active', false) }
+      it_should_behave_like 'an unpaged Canvas proxy handling request failure'
+    end
   end
 
   context 'when obtaining list of enrollments in canvas course section' do
@@ -105,6 +111,12 @@ describe Canvas::SectionEnrollments do
       Canvas::SectionEnrollments.should_receive(:fetch_from_cache).and_return(statusCode: 200, body: {cached: 'hash'})
       enrollments = subject.list_enrollments(:cache => true)
       expect(enrollments).to eq(cached: 'hash')
+    end
+
+    context 'on request failure' do
+      let(:failing_request) { {method: :get} }
+      let(:response) { subject.enrollments_response }
+      it_should_behave_like 'a paged Canvas proxy handling request failure'
     end
   end
 

--- a/spec/models/canvas/sis_course_spec.rb
+++ b/spec/models/canvas/sis_course_spec.rb
@@ -50,7 +50,7 @@ describe Canvas::SisCourse do
     context 'on request failure' do
       let(:failing_request) { {method: :get} }
       let(:response) { subject.course }
-      it_should_behave_like 'a Canvas proxy handling request failure'
+      it_should_behave_like 'an unpaged Canvas proxy handling request failure'
     end
   end
 

--- a/spec/models/canvas/sis_user_profile_spec.rb
+++ b/spec/models/canvas/sis_user_profile_spec.rb
@@ -5,7 +5,7 @@ describe Canvas::SisUserProfile do
   context 'on request failure' do
     let(:failing_request) { {method: :get} }
     let(:response) { subject.sis_user_profile }
-    it_should_behave_like 'a Canvas proxy handling request failure'
+    it_should_behave_like 'an unpaged Canvas proxy handling request failure'
   end
 
   context 'when canvas user profile api request succeeds' do

--- a/spec/models/canvas/terms_spec.rb
+++ b/spec/models/canvas/terms_spec.rb
@@ -30,6 +30,13 @@ describe Canvas::Terms do
     end
   end
 
+  context 'on request failure' do
+    subject { Canvas::Terms.new }
+    let(:failing_request) { {method: :get} }
+    let(:response) { subject.terms }
+    it_should_behave_like 'a paged Canvas proxy handling request failure'
+  end
+
   describe '#current_terms' do
     before { allow(Settings.terms).to receive(:fake_now).and_return(fake_now) }
     subject {Canvas::Terms.current_terms}

--- a/spec/models/canvas/user_activity_stream_spec.rb
+++ b/spec/models/canvas/user_activity_stream_spec.rb
@@ -1,17 +1,24 @@
 describe Canvas::UserActivityStream do
 
+  let(:uid) { Settings.canvas_proxy.test_user_id }
+  subject { Canvas::UserActivityStream.new(user_id: uid) }
+  let(:response) { subject.user_activity }
+
   before do
-    @user_id = Settings.canvas_proxy.test_user_id
-    User::Oauth2Data.new_or_update(@user_id, Canvas::Proxy::APP_ID,
-                             Settings.canvas_proxy.test_user_access_token)
-    @client = Canvas::Proxy.new(:user_id => @user_id)
+    User::Oauth2Data.new_or_update(uid, Canvas::Proxy::APP_ID, Settings.canvas_proxy.test_user_access_token)
   end
 
   after { WebMock.reset! }
 
+  subject { Canvas::UserActivityStream.new(user_id: uid) }
+
   it 'should get real user activity feed using the Tammi account', :testext => true do
-    response = Canvas::UserActivityStream.new(user_id: @user_id).user_activity
     user_activity = response[:body]
     expect(user_activity).to be_a Array
+  end
+
+  context 'on request failure' do
+    let(:failing_request) { {method: :get} }
+    it_should_behave_like 'an unpaged Canvas proxy handling request failure'
   end
 end

--- a/spec/models/canvas/user_courses_spec.rb
+++ b/spec/models/canvas/user_courses_spec.rb
@@ -12,28 +12,11 @@ describe Canvas::UserCourses do
     expect(courses[0]['term']['name']).to be_present
   end
 
-  it 'should return empty array if server is not available' do
-    client = Canvas::UserCourses.new(user_id: @user_id, fake: false)
-    stub_request(:any, /#{Regexp.quote(Settings.canvas_proxy.url_root)}.*/).to_raise(Faraday::Error::ConnectionFailed)
-    suppress_rails_logging {
-      response = client.courses
-      expect(response).to eq []
-    }
-    WebMock.reset!
+  context 'request failure' do
+    subject { Canvas::UserCourses.new }
+    let(:failing_request) { {method: :get} }
+    let(:response) { subject.courses_response }
+    it_should_behave_like 'a paged Canvas proxy handling request failure'
   end
-
-  it 'should return empty array if server returns error status' do
-    client = Canvas::UserCourses.new(user_id: @user_id, fake: false)
-    stub_request(:any, /#{Regexp.quote(Settings.canvas_proxy.url_root)}.*/).to_return(
-      status: 503,
-      body: "<?xml version='1.0' encoding='ISO-8859-1'?>"
-    )
-    suppress_rails_logging {
-      response = client.courses
-      expect(response).to eq []
-    }
-    WebMock.reset!
-  end
-
 
 end

--- a/spec/models/canvas/user_profile_spec.rb
+++ b/spec/models/canvas/user_profile_spec.rb
@@ -4,7 +4,7 @@ describe Canvas::UserProfile do
   context 'on request failure' do
     let(:failing_request) { {method: :get} }
     let(:response) { subject.user_profile }
-    it_should_behave_like 'a Canvas proxy handling request failure'
+    it_should_behave_like 'an unpaged Canvas proxy handling request failure'
   end
 
   context 'when canvas user profile api request is unsuccessful' do

--- a/spec/support/canvas_shared_examples.rb
+++ b/spec/support/canvas_shared_examples.rb
@@ -15,10 +15,22 @@ shared_examples 'a Canvas proxy handling request failure' do
   it 'returns errors as objects' do
     expect(response[:statusCode]).to eq 503
     expect(response[:error]).to be_present
+  end
+end
+
+shared_examples 'an unpaged Canvas proxy handling request failure' do
+  include_examples 'a Canvas proxy handling request failure'
+  it 'does not include a body' do
     expect(response).not_to include :body
   end
 end
 
+shared_examples 'a paged Canvas proxy handling request failure' do
+  include_examples 'a Canvas proxy handling request failure'
+  it 'returns an empty array as body' do
+    expect(response[:body]).to eq []
+  end
+end
 
 ########################################################
 # Canvas Controller Authorizations


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5564

`Canvas::Proxy#paged_get` is changed to patch leaky exception handling and guarantee the response body that other classes are expecting, by default an empty array.

Tests are tightened up, and the expectation is made clearer that on request failure, a paged proxy will return an empty array under `:body`, but an unpaged proxy will not return `:body`. 

For ease in testing, some short Canvas proxy methods are split into two even shorter methods: one returning a full response with headers, and another returning the body alone.