### PR TITLE
CLC-5558 Change default mailing list settings: moderated, less verbose

### DIFF
--- a/app/models/calmail/add_list_member.rb
+++ b/app/models/calmail/add_list_member.rb
@@ -11,8 +11,6 @@ module Calmail
           body: {
             localpart: list_name,
             sub_address: email_address,
-            notify_owner: false,
-            send_welcome: false,
             fullname: full_name
           },
           on_error: {rescue_status: 500}

--- a/app/models/calmail/remove_list_member.rb
+++ b/app/models/calmail/remove_list_member.rb
@@ -10,9 +10,7 @@ module Calmail
         response = request('removeMember', {
           body: {
             localpart: list_name,
-            unsub_address: email_address,
-            notify_owner: false,
-            send_ack: false,
+            unsub_address: email_address
           },
           on_error: {rescue_status: 500}
         })

--- a/app/models/mailing_lists/site_mailing_list.rb
+++ b/app/models/mailing_lists/site_mailing_list.rb
@@ -104,7 +104,7 @@ module MailingLists
         owner_address: Settings.calmail_proxy.owner_address,
         advertised: 0,
         subscribe_policy: 3,
-        moderate: 0,
+        moderate: 1,
         generic_nonmember_action: 1
       }
       Settings.calmail_proxy.base_url.sub(/api1\Z/, "list/domain_create_list2?#{params.to_query}")


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5558

@raydavis should sign off before merge.

- New members default to moderated.
- Production Calmail seems to evaluate Boolean query parameters as true, no matter what the value. Only if they are omitted entirely from the query will they default to false.