### PR TITLE
CLC-5469, 'Horn says 'recordings scheduled' but CalCentral says 'no recordings scheduled'

### DIFF
--- a/src/assets/templates/widgets/webcast.html
+++ b/src/assets/templates/widgets/webcast.html
@@ -47,7 +47,7 @@
     </div>
     <div data-ng-if="currentTabSelection === 'Webcasts'">
       <div data-ng-if="(!eligibleForSignUp || eligibleForSignUp.length === 0) && !videos && !audio">
-        There are no webcasts scheduled.
+        There are no course captures available.
       </div>
       <div data-ng-if="media">
         <span data-ng-repeat="section in media">


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5469
https://jira.ets.berkeley.edu/jira/browse/CLC-5381

Vague phrases are never incorrect. Maybe "course captures" are coming and maybe they're not... The LTI app does not know the answer.