### PR TITLE
CLC-5553, rename Webcast service to 'Course Capture'

### DIFF
--- a/app/models/canvas_lti/external_app_configurations.rb
+++ b/app/models/canvas_lti/external_app_configurations.rb
@@ -32,7 +32,7 @@ module CanvasLti
         },
         'course_mediacasts' => {
           xml_name: 'lti_course_mediacasts',
-          app_name: 'Webcasts',
+          app_name: 'Course Captures',
           account: main_account_id
         },
         'course_manage_official_sections' => {

--- a/app/models/canvas_lti/webcast_eligible_courses.rb
+++ b/app/models/canvas_lti/webcast_eligible_courses.rb
@@ -56,7 +56,7 @@ module CanvasLti
             ccn = section[:ccn].to_s.to_i
             if ccn > 0
               has_recordings = recordings_per_ccn.has_key?(ccn) && recordings_per_ccn[ccn][:videos].present?
-              logger.warn "#{term_yr}-#{term_cd}-#{ccn} has Webcast recordings (canvas_course_id = #{canvas_course_id})" if has_recordings
+              logger.warn "#{term_yr}-#{term_cd}-#{ccn} has recordings (canvas_course_id = #{canvas_course_id})" if has_recordings
               is_webcast_eligible = !has_recordings && !sign_up_eligible_ccn_set.nil? && sign_up_eligible_ccn_set.include?(ccn)
               if has_recordings || is_webcast_eligible
                 section[:has_webcast_recordings] = has_recordings

--- a/app/models/canvas_lti/webcast_lti_refresh.rb
+++ b/app/models/canvas_lti/webcast_lti_refresh.rb
@@ -26,7 +26,7 @@ module Canvas
       external_tools = Canvas::ExternalTools.new @options.merge(canvas_course_id: canvas_course_id)
       tab = external_tools.find_canvas_course_tab @canvas_webcast_tool_id
       if tab.nil?
-        logger.warn "No Webcast tab, hidden or otherwise, found on course site #{canvas_course_id}"
+        logger.warn "No Course Captures tab, hidden or otherwise, found on course site #{canvas_course_id}"
       else
         has_recordings = false
         is_webcast_eligible = false
@@ -53,10 +53,10 @@ module Canvas
       record = Webcast::CourseSiteLog.find_by canvas_course_site_id: canvas_course_id
       if record
         unhidden_date = record.webcast_tool_unhidden_at.strftime('%m/%d/%Y')
-        logger.warn "Do nothing to course site #{canvas_course_id} because Webcast tool was un-hidden on #{unhidden_date}."
+        logger.warn "Do nothing to course site #{canvas_course_id} because Course Captures tool was un-hidden on #{unhidden_date}."
       else
         modified_tab = external_tools.show_course_site_tab tab
-        logger.warn "The Webcast tool #{modified_tab ? 'has been' : 'FAILED to be' } un-hidden on course site #{canvas_course_id}"
+        logger.warn "The Course Captures tool #{modified_tab ? 'has been' : 'FAILED to be' } un-hidden on course site #{canvas_course_id}"
         if modified_tab
           record = Webcast::CourseSiteLog.find_or_initialize_by(canvas_course_site_id: canvas_course_id)
           record.webcast_tool_unhidden_at = Time.zone.now
@@ -68,7 +68,7 @@ module Canvas
 
     def hide_course_site_tab(canvas_course_id, tab, external_tools)
       modified_tab = external_tools.hide_course_site_tab tab
-      logger.warn "The Webcast tool #{modified_tab ? 'has been' : 'FAILED to be' } hidden on course site #{canvas_course_id}"
+      logger.warn "The Course Captures tool #{modified_tab ? 'has been' : 'FAILED to be' } hidden on course site #{canvas_course_id}"
       modified_tab
     end
 

--- a/app/models/my_activities/webcasts.rb
+++ b/app/models/my_activities/webcasts.rb
@@ -29,7 +29,7 @@ module MyActivities
         id: '',
         linkText: 'View recording',
         source: campus_course[:course_code],
-        summary: "A new recording of your #{english_term} course, #{campus_course[:name]}, is now available.",
+        summary: "A new recording for your #{english_term} course, #{campus_course[:name]}, is now available.",
         type: 'webcast',
         title: 'Recording Available',
         user_id: uid

--- a/app/models/my_activities/webcasts.rb
+++ b/app/models/my_activities/webcasts.rb
@@ -25,13 +25,13 @@ module MyActivities
     def self.course_attributes(campus_course, uid)
       english_term = Berkeley::TermCodes.to_english(campus_course[:term_yr], campus_course[:term_cd])
       {
-        emitter: 'Webcasts',
+        emitter: 'Course Captures',
         id: '',
-        linkText: 'View webcast',
+        linkText: 'View recording',
         source: campus_course[:course_code],
-        summary: "A new webcast recording for your #{english_term} course, #{campus_course[:name]}, is now available.",
+        summary: "A new recording of your #{english_term} course, #{campus_course[:name]}, is now available.",
         type: 'webcast',
-        title: 'Webcast Available',
+        title: 'Recording Available',
         user_id: uid
       }
     end

--- a/app/views/canvas_lti/lti_course_mediacasts.xml.erb
+++ b/app/views/canvas_lti/lti_course_mediacasts.xml.erb
@@ -8,8 +8,8 @@
     http://www.imsglobal.org/xsd/imsbasiclti_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imsbasiclti_v1p0.xsd
     http://www.imsglobal.org/xsd/imslticm_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticm_v1p0.xsd
     http://www.imsglobal.org/xsd/imslticp_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticp_v1p0.xsd">
-    <blti:title>Webcast Recordings</blti:title>
-    <blti:description>Webcast recordings for this course</blti:description>
+    <blti:title>Course Captures</blti:title>
+    <blti:description>Recordings of this course</blti:description>
     <blti:icon></blti:icon>
     <blti:launch_url><%= @launch_url_for_app  %></blti:launch_url>
     <blti:extensions platform="canvas.instructure.com">
@@ -17,7 +17,7 @@
       <lticm:property name="privacy_level">public</lticm:property>
       <lticm:options name="course_navigation">
         <lticm:property name="url"><%= @launch_url_for_app %></lticm:property>
-        <lticm:property name="text">Webcasts</lticm:property>
+        <lticm:property name="text">Course Captures</lticm:property>
         <lticm:property name="visibility">public</lticm:property>
         <lticm:property name="default">disabled</lticm:property>
         <lticm:property name="enabled">true</lticm:property>

--- a/spec/models/my_activities/webcasts_spec.rb
+++ b/spec/models/my_activities/webcasts_spec.rb
@@ -21,13 +21,13 @@ describe MyActivities::Webcasts do
 
     it 'should include course and uid data' do
       expect(activities).to all include({
-        emitter: 'Webcasts',
+        emitter: 'Course Captures',
         id: '',
-        linkText: 'View webcast',
+        linkText: 'View recording',
         source: 'BIOLOGY 1A',
-        summary: 'A new webcast recording for your Fall 2013 course, General Biology Lecture, is now available.',
+        summary: 'A new recording for your Fall 2013 course, General Biology Lecture, is now available.',
         type: 'webcast',
-        title: 'Webcast Available',
+        title: 'Recording Available',
         user_id: uid
       })
     end

--- a/src/assets/javascripts/angular/controllers/widgets/webcastController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/webcastController.js
@@ -8,7 +8,7 @@ var angular = require('angular');
 angular.module('calcentral.controllers').controller('WebcastController', function(apiService, webcastFactory, $route, $routeParams, $scope) {
   // Is this for an official campus class or for a Canvas course site?
   var courseMode = 'campus';
-  var outerTabs = ['Webcast Sign-up', 'Webcasts'];
+  var outerTabs = ['Course Capture Sign-up', 'Course Captures'];
   $scope.accessibilityAnnounce = apiService.util.accessibilityAnnounce;
 
   /**
@@ -78,7 +78,7 @@ angular.module('calcentral.controllers').controller('WebcastController', functio
   };
 
   $scope.switchSelectedOption = function(selectedOption) {
-    $scope.accessibilityAnnounce('Loaded ' + selectedOption + ' Webcasts');
+    $scope.accessibilityAnnounce('Loaded ' + selectedOption + ' recordings');
     $scope.currentSelection = selectedOption;
   };
 
@@ -105,7 +105,7 @@ angular.module('calcentral.controllers').controller('WebcastController', functio
     } else {
       canvasCourseId = $routeParams.canvasCourseId;
     }
-    apiService.util.setTitle('Course Webcasts');
+    apiService.util.setTitle('Course Captures');
     getWebcasts(canvasCourseId);
     setSelectOptions();
   } else {

--- a/src/assets/javascripts/angular/factories/activityFactory.js
+++ b/src/assets/javascripts/angular/factories/activityFactory.js
@@ -26,7 +26,7 @@ angular.module('calcentral.factories').factory('activityFactory', function(apiSe
       discussion: ' Discussions',
       gradePosting: ' Grades Posted',
       message: ' Status Changes',
-      webcast: ' Webcasts',
+      webcast: ' Course Captures',
       webconference: ' Webconferences'
     };
 

--- a/src/assets/templates/academics_classinfo.html
+++ b/src/assets/templates/academics_classinfo.html
@@ -130,7 +130,7 @@
 
       <div class="cc-widget cc-widget-webcast" data-ng-if="api.user.profile.features.videos">
         <div class="cc-widget-title">
-          <h2>Webcasts</h2>
+          <h2>Course Captures</h2>
         </div>
         <div data-ng-include src="'widgets/webcast.html'"></div>
       </div>

--- a/src/assets/templates/academics_student_profile.html
+++ b/src/assets/templates/academics_student_profile.html
@@ -59,7 +59,7 @@
             <li>Class enrollments, including waitlist information.</li>
             <li>Your academic status, including standing, GPA, units, major, college, and more.</li>
             <li>Your registration status, including any blocks limiting your access to campus services.</li>
-            <li>Course information, including class and exam schedules, class locations, textbooks, and webcasts.</li>
+            <li>Course information, including class and exam schedules, class locations, textbooks, and recordings.</li>
           </ul>
         </div>
       </div>

--- a/src/assets/templates/widgets/webcast.html
+++ b/src/assets/templates/widgets/webcast.html
@@ -48,7 +48,7 @@
     </div>
     <div data-ng-if="currentTabSelection === 'Course Captures'">
       <div data-ng-if="(!eligibleForSignUp || eligibleForSignUp.length === 0) && !videos && !audio">
-        There are no course captures available.
+        There are no recordings available.
       </div>
       <div data-ng-if="media">
         <span data-ng-repeat="section in media">

--- a/src/assets/templates/widgets/webcast.html
+++ b/src/assets/templates/widgets/webcast.html
@@ -2,7 +2,7 @@
   <div data-cc-spinner-directive></div>
   <div data-ng-bind="proxyErrorMessage"></div>
   <div data-ng-if="!proxyErrorMessage">
-    <h1 class="cc-visuallyhidden" data-ng-if="isEmbedded">Webcasts</h1>
+    <h1 class="cc-visuallyhidden" data-ng-if="isEmbedded">Course Captures</h1>
     <div data-ng-if="eligibleForSignUp && eligibleForSignUp.length > 0" class="bc-tab-navigation">
       <ul data-ng-if="videos || audio" class="bc-tab-group cc-clearfix-container" role="tablist">
         <li class="bc-tab"
@@ -15,24 +15,25 @@
           </a>
         </li>
       </ul>
-      <div data-ng-if="currentTabSelection === 'Webcast Sign-up'">
-        <h1 class="cc-visuallyhidden" data-ng-if="isEmbedded">Webcast Sign-up</h1>
+      <div data-ng-if="currentTabSelection === 'Course Capture Sign-up'">
+        <h1 class="cc-visuallyhidden" data-ng-if="isEmbedded">Course Capture Sign-up</h1>
         <div data-ng-if="userCanSignUpOneOrMore">
           <p>
-            The following classes are eligible for Webcast.
-            <a href="http://ets.berkeley.edu/help/webcast-classroom-capture-services-explained">Find out more about Webcast</a>.
+            The following classes are eligible for Course Capture.
+            <a href="http://ets.berkeley.edu/help/webcast-classroom-capture-services-explained">Find out more about Course Capture</a>.
           </p>
           <p>
-            If you wish to webcast any class below, please use the adjacent link(s) to schedule recordings. Please sign
+            If you wish to record any class below, please use the adjacent link(s) to schedule recordings. Please sign
             up before the semester starts to avoid missing recordings. Deadline for sign-ups is 4th week of classes. If
-            you do not intend to webcast, you can hide this tool by going to <i>Settings &gt; Navigation</i> and
-            dragging the webcast tool out of the list.
+            you do not intend to record, you can hide this tool by going to <i>Settings &gt; Navigation</i> and
+            dragging the Course Captures tool out of the list.
           </p>
         </div>
         <div data-ng-if="!userCanSignUpOneOrMore">
-          Classes in this course site that you teach are eligible for Webcast but have not been signed up yet.
-          Find out more about Webcast. Only instructors of record can sign up. If you wish to webcast any
-          class below, please talk to the instructor of record for the classes you wish to webcast.
+          Classes in this course site that you teach are eligible for Course Capture but have not been signed up yet.
+          <a href="http://ets.berkeley.edu/help/webcast-classroom-capture-services-explained">Find out more about Course Capture</a>.
+          Only instructors of record can sign up. If you wish to record any class below, please talk to the instructor
+          of record for the classes you wish to record.
         </div>
         <div data-ng-repeat="eligible in eligibleForSignUp">
           <span data-ng-bind-template="{{eligible.deptName}} {{eligible.catalogId}} {{eligible.instructionFormat}} {{eligible.sectionNumber}}"></span>
@@ -40,19 +41,19 @@
               | <a data-ng-href="{{eligible.signUpURL}}">Sign up</a>
           </span><br/>
           <span data-ng-if="eligible.webcastAuthorizedInstructors && eligible.webcastAuthorizedInstructors.length > 1">
-            This class has co-instructors. All instructors of record must sign up before classes are webcast.
+            This class has co-instructors. All qualified instructors must sign up before classes are recorded.
           </span>
         </div>
       </div>
     </div>
-    <div data-ng-if="currentTabSelection === 'Webcasts'">
+    <div data-ng-if="currentTabSelection === 'Course Captures'">
       <div data-ng-if="(!eligibleForSignUp || eligibleForSignUp.length === 0) && !videos && !audio">
         There are no course captures available.
       </div>
       <div data-ng-if="media">
         <span data-ng-repeat="section in media">
           <span data-ng-if="!section.videos.length && !section.audio.length">
-            <span ng-if="$first">Webcasts for </span>
+            <span ng-if="$first">Recordings of </span>
             <span ng-if="$last && (media.length > 1)"> and </span>
             <strong data-ng-bind-template="{{section.deptName}} {{section.catalogId}} {{media.length > 1 ? section.instructionFormat : ''}} {{media.length > 1 ? section.sectionNumber : ' lecture'}}"></strong><span ng-if="!$last && ($index < media.length - 2)">, </span>
             <span ng-if="$last">will appear here after classes start.</span>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5553
https://jira.ets.berkeley.edu/jira/browse/WCT-5478

Includes name change in:
* LTI app
* My Activities
* Widget

The term "webcast" is still pervasive in the code (e.g., 'type' attribute in my_activities feed). My changes only apply to user-facing text. 