### PR TITLE
CLC-5591: Fix Selenium UpNext test to expect organizer email

### DIFF
--- a/spec/ui_selenium/my_dashboard_google_up_next_spec.rb
+++ b/spec/ui_selenium/my_dashboard_google_up_next_spec.rb
@@ -120,7 +120,7 @@ describe 'My Dashboard Up Next card', :testui => true do
 
       it 'shows event organizers' do
         logger.info("#{@up_next_card.all_event_organizers}")
-        expect(@up_next_card.all_event_organizers).to eql(@initial_event_organizers.push('ETS Quality').sort)
+        expect(@up_next_card.all_event_organizers).to eql(@initial_event_organizers.push(UserUtils.qa_gmail_username).sort)
       end
 
     end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5591

The existing Selenium test for Google events verifies the organizer in the Up Next card.  For now, the test will expect the organizer's email address rather than display name.