### PR TITLE
SISRP-5147 and SISRP-5148 - T&C and Title4 POST endpoints

### DIFF
--- a/app/controllers/campus_solutions_controller.rb
+++ b/app/controllers/campus_solutions_controller.rb
@@ -33,4 +33,9 @@ class CampusSolutionsController < ApplicationController
     render json: model.update(params)
   end
 
+  def title4
+    model = CampusSolutions::MyTitle4.from_session(session)
+    render json: model.update(params)
+  end
+
 end

--- a/app/controllers/campus_solutions_controller.rb
+++ b/app/controllers/campus_solutions_controller.rb
@@ -28,4 +28,9 @@ class CampusSolutionsController < ApplicationController
     render json: model.get_feed_as_json
   end
 
+  def terms_and_conditions
+    model = CampusSolutions::MyTermsAndConditions.from_session(session)
+    render json: model.update(params)
+  end
+
 end

--- a/app/controllers/campus_solutions_controller.rb
+++ b/app/controllers/campus_solutions_controller.rb
@@ -30,12 +30,12 @@ class CampusSolutionsController < ApplicationController
 
   def terms_and_conditions
     model = CampusSolutions::MyTermsAndConditions.from_session(session)
-    render json: model.update(params)
+    render json: model.update(request.request_parameters)
   end
 
   def title4
     model = CampusSolutions::MyTitle4.from_session(session)
-    render json: model.update(params)
+    render json: model.update(request.request_parameters)
   end
 
 end

--- a/app/models/campus_solutions/direct_proxy.rb
+++ b/app/models/campus_solutions/direct_proxy.rb
@@ -16,18 +16,5 @@ module CampusSolutions
       }
     end
 
-    # lets us restrict updated params to what's on the whitelist of field mappings.
-    def filter_updateable_params(params)
-      return {} unless params
-      updateable = {}
-      known_fields = self.class.field_mappings
-      params.each do |calcentral_param_name, value|
-        if known_fields[calcentral_param_name.to_sym].present?
-          updateable[calcentral_param_name.to_sym] = value
-        end
-      end
-      updateable
-    end
-
   end
 end

--- a/app/models/campus_solutions/direct_proxy.rb
+++ b/app/models/campus_solutions/direct_proxy.rb
@@ -29,16 +29,5 @@ module CampusSolutions
       updateable
     end
 
-    def construct_cs_post(filtered_params)
-      cs_post = {}
-      filtered_params.each do |calcentral_param_name, value|
-        mapping = self.class.field_mappings[calcentral_param_name]
-        next if mapping.blank?
-        cs_param_name = mapping[:campus_solutions_name]
-        cs_post[cs_param_name] = value
-      end
-      cs_post
-    end
-
   end
 end

--- a/app/models/campus_solutions/integration_hub_proxy.rb
+++ b/app/models/campus_solutions/integration_hub_proxy.rb
@@ -16,10 +16,5 @@ module CampusSolutions
       "#{@settings.base_url}/00000137"
     end
 
-    def build_feed(response)
-      #HTTParty won't parse automatically because the application/xml header is missing
-      MultiXml.parse response.body
-    end
-
   end
 end

--- a/app/models/campus_solutions/my_terms_and_conditions.rb
+++ b/app/models/campus_solutions/my_terms_and_conditions.rb
@@ -1,0 +1,10 @@
+module CampusSolutions
+  class MyTermsAndConditions < UserSpecificModel
+
+    def update(params = {})
+      proxy = CampusSolutions::TermsAndConditions.new({user_id: @uid, params: params})
+      proxy.get
+    end
+
+  end
+end

--- a/app/models/campus_solutions/my_title4.rb
+++ b/app/models/campus_solutions/my_title4.rb
@@ -1,0 +1,10 @@
+module CampusSolutions
+  class MyTitle4 < UserSpecificModel
+
+    def update(params = {})
+      proxy = CampusSolutions::Title4.new({user_id: @uid, params: params})
+      proxy.get
+    end
+
+  end
+end

--- a/app/models/campus_solutions/posting_proxy.rb
+++ b/app/models/campus_solutions/posting_proxy.rb
@@ -1,10 +1,10 @@
 module CampusSolutions
-  class PostingProxy < DirectProxy
+  class PostingProxy < IntegrationHubProxy
 
     attr_reader :params
 
-    def initialize(options = {})
-      super options
+    def initialize(settings, options = {})
+      super(settings, options)
       @params = options[:params]
       initialize_mocks if @fake
     end
@@ -22,6 +22,19 @@ module CampusSolutions
 
     def default_post_params
       {}
+    end
+
+    # lets us restrict updated params to what's on the whitelist of field mappings.
+    def filter_updateable_params(params)
+      return {} unless params
+      updateable = {}
+      known_fields = self.class.field_mappings
+      params.each do |calcentral_param_name, value|
+        if known_fields[calcentral_param_name.to_sym].present?
+          updateable[calcentral_param_name.to_sym] = value
+        end
+      end
+      updateable
     end
 
     def construct_cs_post(filtered_params)

--- a/app/models/campus_solutions/posting_proxy.rb
+++ b/app/models/campus_solutions/posting_proxy.rb
@@ -1,18 +1,39 @@
 module CampusSolutions
   class PostingProxy < DirectProxy
 
-    attr_accessor :params
+    attr_reader :params
+
+    def initialize(options = {})
+      super options
+      @params = options[:params]
+      initialize_mocks if @fake
+    end
+
+    def mock_request
+      super.merge(method: :post)
+    end
 
     def request_options
       updateable_params = filter_updateable_params params
       cs_post = construct_cs_post updateable_params
-      options = super.merge(method: :post, query: cs_post)
-      logger.debug "All POST Options: #{options.inspect}"
-      options
+      logger.debug "POST Body: #{cs_post}"
+      super.merge(method: :post, body: cs_post)
     end
 
-    def post
-      get
+    def default_post_params
+      {}
+    end
+
+    def construct_cs_post(filtered_params)
+      cs_post = default_post_params
+      filtered_params.each do |calcentral_param_name, value|
+        mapping = self.class.field_mappings[calcentral_param_name]
+        next if mapping.blank?
+        cs_param_name = mapping[:campus_solutions_name]
+        cs_post[cs_param_name] = value
+      end
+      # CampusSolutions will barf if it encounters whitespace or newlines
+      cs_post.to_xml(root: root_xml_node, dasherize: false, indent: 0)
     end
 
   end

--- a/app/models/campus_solutions/proxy.rb
+++ b/app/models/campus_solutions/proxy.rb
@@ -20,6 +20,10 @@ module CampusSolutions
       read_file('fixtures', 'xml', 'campus_solutions', xml_filename)
     end
 
+    def mock_request
+      super.merge(uri_matching: url)
+    end
+
     def get
       internal_response = self.class.smart_fetch_from_cache(id: instance_key) do
         get_internal

--- a/app/models/campus_solutions/terms_and_conditions.rb
+++ b/app/models/campus_solutions/terms_and_conditions.rb
@@ -1,6 +1,11 @@
 module CampusSolutions
   class TermsAndConditions < PostingProxy
 
+    def initialize(options = {})
+      super(Settings.cs_terms_and_conditions_proxy, options)
+      initialize_mocks if @fake
+    end
+
     def self.field_mappings
       @field_mappings ||= FieldMapping.to_hash(
         [

--- a/app/models/campus_solutions/terms_and_conditions.rb
+++ b/app/models/campus_solutions/terms_and_conditions.rb
@@ -9,8 +9,8 @@ module CampusSolutions
     def self.field_mappings
       @field_mappings ||= FieldMapping.to_hash(
         [
-          FieldMapping.required(:uc_response, :UC_RESPONSE),
-          FieldMapping.required(:aid_year, :AID_YEAR)
+          FieldMapping.required(:response, :UC_RESPONSE),
+          FieldMapping.required(:aidYear, :AID_YEAR)
         ]
       )
     end
@@ -33,7 +33,7 @@ module CampusSolutions
     end
 
     def instance_key
-      "#{@uid}-#{params[:aid_year]}"
+      "#{@uid}-#{params[:aidYear]}"
     end
 
     def url

--- a/app/models/campus_solutions/terms_and_conditions.rb
+++ b/app/models/campus_solutions/terms_and_conditions.rb
@@ -10,13 +10,33 @@ module CampusSolutions
       )
     end
 
+    def root_xml_node
+      'Terms_Conditions'
+    end
+
     def xml_filename
       'terms_and_conditions.xml'
     end
 
-    def url
+    def default_post_params
       # TODO ID is hardcoded until we can use ID crosswalk service to convert CalNet ID to CS Student ID
-      "#{@settings.base_url}/UC_FA_T_C.v1/post/EMPLID=00000165&INSTITUTION=UCB01"
+      {
+        EMPLID: '00000165',
+        INSTITUTION: 'UCB01',
+        LASTUPDOPRID: '1086132'
+      }
+    end
+
+    def instance_key
+      "#{@uid}-#{params[:aid_year]}"
+    end
+
+    def url
+      "#{@settings.base_url}/UC_FA_T_C.v1/post"
+    end
+
+    def build_feed(response)
+      response.parsed_response['UC_FA_T_C_RSP']
     end
 
   end

--- a/app/models/campus_solutions/title4.rb
+++ b/app/models/campus_solutions/title4.rb
@@ -9,7 +9,7 @@ module CampusSolutions
     def self.field_mappings
       @field_mappings ||= FieldMapping.to_hash(
         [
-          FieldMapping.required(:uc_response, :UC_RESPONSE)
+          FieldMapping.required(:response, :UC_RESPONSE)
         ]
       )
     end

--- a/app/models/campus_solutions/title4.rb
+++ b/app/models/campus_solutions/title4.rb
@@ -1,0 +1,43 @@
+module CampusSolutions
+  class Title4 < PostingProxy
+
+    def initialize(options = {})
+      super(Settings.cs_title4_proxy, options)
+      initialize_mocks if @fake
+    end
+
+    def self.field_mappings
+      @field_mappings ||= FieldMapping.to_hash(
+        [
+          FieldMapping.required(:uc_response, :UC_RESPONSE)
+        ]
+      )
+    end
+
+    def root_xml_node
+      'Title4'
+    end
+
+    def xml_filename
+      'title4.xml'
+    end
+
+    def default_post_params
+      # TODO ID is hardcoded until we can use ID crosswalk service to convert CalNet ID to CS Student ID
+      {
+        EMPLID: '00000165',
+        INSTITUTION: 'UCB01',
+        LASTUPDOPRID: '1086132'
+      }
+    end
+
+    def url
+      "#{@settings.base_url}/UC_FA_TITL4.v1/post"
+    end
+
+    def build_feed(response)
+      response.parsed_response['UC_FA_TITL4_RSP']
+    end
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,6 +139,7 @@ Calcentral::Application.routes.draw do
   get '/api/campus_solutions/aid_years' => 'campus_solutions#aid_years', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/financial_aid_data' => 'campus_solutions#financial_aid_data', :via => :get, :defaults => { :format => 'json' }
   post '/api/campus_solutions/terms_and_conditions' => 'campus_solutions#terms_and_conditions', :via => :post, :defaults => { :format => 'json' }
+  post '/api/campus_solutions/title4' => 'campus_solutions#title4', :via => :post, :defaults => { :format => 'json' }
 
   # All the other paths should use the bootstrap page
   # We need this because we use html5mode=true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,6 +138,7 @@ Calcentral::Application.routes.draw do
   post '/api/campus_solutions/address' => 'campus_solutions#update_address', :via => :post, :defaults => { :format => 'json' }
   get '/api/campus_solutions/aid_years' => 'campus_solutions#aid_years', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/financial_aid_data' => 'campus_solutions#financial_aid_data', :via => :get, :defaults => { :format => 'json' }
+  post '/api/campus_solutions/terms_and_conditions' => 'campus_solutions#terms_and_conditions', :via => :post, :defaults => { :format => 'json' }
 
   # All the other paths should use the bootstrap page
   # We need this because we use html5mode=true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -384,6 +384,12 @@ cs_financial_aid_data_proxy:
   app_id: 'secret'
   app_key: 'secret'
 
+cs_terms_and_conditions_proxy:
+  fake: true
+  base_url: 'https://apis.berkeley.edu/PSIGW/RESTListeningConnector/PSFT_CS'
+  app_id: 'secret'
+  app_key: 'secret'
+
 campus_solutions_proxy:
   fake: true
   base_url: 'http://sis-demo-02.is.berkeley.edu'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -258,6 +258,9 @@ cache:
     Textbooks::Proxy: <%= 24.hours %>
     EtsBlog::Alerts: <%= 2.minutes %>
 
+    CampusSolutions::TermsAndConditions: <%= 1.seconds %>
+    CampusSolutions::Title4: <%= 1.seconds %>
+
 # Cache warmer settings
 cache_warmer:
   # Number to decrement db pool to limit the number of warmer threads

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -390,6 +390,12 @@ cs_terms_and_conditions_proxy:
   app_id: 'secret'
   app_key: 'secret'
 
+cs_title4_proxy:
+  fake: true
+  base_url: 'https://apis.berkeley.edu/PSIGW/RESTListeningConnector/PSFT_CS'
+  app_id: 'secret'
+  app_key: 'secret'
+
 campus_solutions_proxy:
   fake: true
   base_url: 'http://sis-demo-02.is.berkeley.edu'

--- a/fixtures/xml/campus_solutions/terms_and_conditions.xml
+++ b/fixtures/xml/campus_solutions/terms_and_conditions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<UC_FA_T_C_RSP>
+  <INSTITUTION>UCB01</INSTITUTION>
+  <AID_YEAR>2016</AID_YEAR>
+  <UC_HEADER_ACCEPT>Accept Terms and Conditions</UC_HEADER_ACCEPT>
+  <UC_LONG_TEXT_ACCPT>You have accepted Terms and Conditions.</UC_LONG_TEXT_ACCPT>
+</UC_FA_T_C_RSP>

--- a/fixtures/xml/campus_solutions/title4.xml
+++ b/fixtures/xml/campus_solutions/title4.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<UC_FA_TITL4_RSP>
+  <INSTITUTION>UCB01</INSTITUTION>
+  <UC_HEADER_ACCEPT>Accepted Title IV Release</UC_HEADER_ACCEPT>
+  <UC_LONG_TEXT_ACCPT>You have agree to utilized your financial aid to pay non Title IV charges.</UC_LONG_TEXT_ACCPT>
+</UC_FA_TITL4_RSP>

--- a/spec/controllers/campus_solutions_controller_spec.rb
+++ b/spec/controllers/campus_solutions_controller_spec.rb
@@ -115,7 +115,7 @@ describe CampusSolutionsController do
     context 'authenticated user' do
       before do
         session['user_id'] = '1234'
-        User::Auth.stub(:where).and_return([User::Auth.new(uid: '1234', is_superuser: true, active: true)])
+        User::Auth.stub(:where).and_return([User::Auth.new(uid: '1234', is_superuser: false, active: true)])
       end
       it 'should let an authenticated user post' do
         post :update_address,
@@ -142,6 +142,32 @@ describe CampusSolutionsController do
         expect(json['updatedFields']['state']).to eq 'TN'
         expect(json['updatedFields']['postal']).to eq '12345'
         expect(json['updatedFields']['bogus_field']).to be_nil
+      end
+    end
+  end
+  context 'updating terms and conditions' do
+    it 'should not let an unauthenticated user post' do
+      post :terms_and_conditions, {format: 'json', uid: '100'}
+      expect(response.status).to eq 401
+    end
+
+    context 'authenticated user' do
+      before do
+        session['user_id'] = '1234'
+        User::Auth.stub(:where).and_return([User::Auth.new(uid: '1234', is_superuser: false, active: true)])
+      end
+      it 'should let an authenticated user post' do
+        post :terms_and_conditions,
+             {
+               bogus_field: 'abc',
+               uc_response: 'Y',
+               aid_year: '2016'
+             }
+        expect(response.status).to eq 200
+        json = JSON.parse(response.body)
+        expect(json['statusCode']).to eq 200
+        expect(json['feed']).to be
+        expect(json['feed']['institution']).to eq 'UCB01'
       end
     end
   end

--- a/spec/controllers/campus_solutions_controller_spec.rb
+++ b/spec/controllers/campus_solutions_controller_spec.rb
@@ -160,8 +160,8 @@ describe CampusSolutionsController do
         post :terms_and_conditions,
              {
                bogus_field: 'abc',
-               uc_response: 'Y',
-               aid_year: '2016'
+               response: 'Y',
+               aidYear: '2016'
              }
         expect(response.status).to eq 200
         json = JSON.parse(response.body)
@@ -186,7 +186,7 @@ describe CampusSolutionsController do
         post :title4,
              {
                bogus_field: 'abc',
-               uc_response: 'Y'
+               response: 'Y'
              }
         expect(response.status).to eq 200
         json = JSON.parse(response.body)

--- a/spec/controllers/campus_solutions_controller_spec.rb
+++ b/spec/controllers/campus_solutions_controller_spec.rb
@@ -171,4 +171,29 @@ describe CampusSolutionsController do
       end
     end
   end
+  context 'updating title 4' do
+    it 'should not let an unauthenticated user post' do
+      post :title4, {format: 'json', uid: '100'}
+      expect(response.status).to eq 401
+    end
+
+    context 'authenticated user' do
+      before do
+        session['user_id'] = '1234'
+        User::Auth.stub(:where).and_return([User::Auth.new(uid: '1234', is_superuser: false, active: true)])
+      end
+      it 'should let an authenticated user post' do
+        post :title4,
+             {
+               bogus_field: 'abc',
+               uc_response: 'Y'
+             }
+        expect(response.status).to eq 200
+        json = JSON.parse(response.body)
+        expect(json['statusCode']).to eq 200
+        expect(json['feed']).to be
+        expect(json['feed']['institution']).to eq 'UCB01'
+      end
+    end
+  end
 end

--- a/spec/models/campus_solutions/terms_and_conditions_spec.rb
+++ b/spec/models/campus_solutions/terms_and_conditions_spec.rb
@@ -10,20 +10,20 @@ describe CampusSolutions::TermsAndConditions do
       let(:params) { {
         bogus: 1,
         invalid: 2,
-        uc_response: 'N'
+        response: 'N'
       } }
       subject { fake_proxy.filter_updateable_params(params) }
       it 'should strip out invalid fields' do
         expect(subject.keys.length).to eq 1
         expect(subject[:bogus]).to be_nil
         expect(subject[:invalid]).to be_nil
-        expect(subject[:uc_response]).to be
+        expect(subject[:response]).to be
       end
     end
 
     context 'converting params to Campus Solutions field names' do
       let(:params) { {
-        uc_response: 'Y'
+        response: 'Y'
       } }
       subject {
         result = fake_proxy.construct_cs_post(params)
@@ -37,8 +37,8 @@ describe CampusSolutions::TermsAndConditions do
 
     context 'performing a post' do
       let(:params) { {
-        uc_response: 'Y',
-        aid_year: '2016'
+        response: 'Y',
+        aidYear: '2016'
       } }
       subject {
         fake_proxy.get
@@ -52,8 +52,8 @@ describe CampusSolutions::TermsAndConditions do
 
   context 'with a real external service', :testext => true do
     let(:params) { {
-      uc_response: 'Y',
-      aid_year: '2016'
+      response: 'Y',
+      aidYear: '2016'
     } }
     let(:real_proxy) { CampusSolutions::TermsAndConditions.new(fake: false, user_id: random_id, params: params) }
 

--- a/spec/models/campus_solutions/title4_spec.rb
+++ b/spec/models/campus_solutions/title4_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe CampusSolutions::Title4 do
+
+  context 'post' do
+    let(:params) { {} }
+    let(:fake_proxy) { CampusSolutions::Title4.new(fake: true, user_id: random_id, params: params) }
+
+    context 'filtering out fields not on the whitelist' do
+      let(:params) { {
+        bogus: 1,
+        invalid: 2,
+        uc_response: 'N'
+      } }
+      subject { fake_proxy.filter_updateable_params(params) }
+      it 'should strip out invalid fields' do
+        expect(subject.keys.length).to eq 1
+        expect(subject[:bogus]).to be_nil
+        expect(subject[:invalid]).to be_nil
+        expect(subject[:uc_response]).to be
+      end
+    end
+
+    context 'converting params to Campus Solutions field names' do
+      let(:params) { {
+        uc_response: 'Y'
+      } }
+      subject {
+        result = fake_proxy.construct_cs_post(params)
+        MultiXml.parse(result)['Title4']
+      }
+      it 'should convert the CalCentral params to Campus Solutions params without exploding on bogus fields' do
+        expect(subject['UC_RESPONSE']).to eq 'Y'
+        expect(subject['INSTITUTION']).to eq 'UCB01'
+      end
+    end
+
+    context 'performing a post' do
+      let(:params) { {
+        uc_response: 'Y'
+      } }
+      subject {
+        fake_proxy.get
+      }
+      it 'should make a successful post' do
+        puts "Subject = #{subject.inspect}"
+        expect(subject[:statusCode]).to eq 200
+      end
+    end
+  end
+
+  context 'with a real external service' do # , :testext => true do
+    let(:params) { {
+      uc_response: 'Y'
+    } }
+    let(:real_proxy) { CampusSolutions::Title4.new(fake: false, user_id: random_id, params: params) }
+
+    context 'performing a real post' do
+      subject {
+        real_proxy.get
+      }
+      it 'should make a successful REAL post' do
+        puts "Subject = #{subject.inspect}"
+        expect(subject[:statusCode]).to eq 200
+      end
+    end
+  end
+end

--- a/spec/models/campus_solutions/title4_spec.rb
+++ b/spec/models/campus_solutions/title4_spec.rb
@@ -49,7 +49,7 @@ describe CampusSolutions::Title4 do
     end
   end
 
-  context 'with a real external service' do # , :testext => true do
+  context 'with a real external service', :testext => true do
     let(:params) { {
       uc_response: 'Y'
     } }

--- a/spec/models/campus_solutions/title4_spec.rb
+++ b/spec/models/campus_solutions/title4_spec.rb
@@ -10,20 +10,20 @@ describe CampusSolutions::Title4 do
       let(:params) { {
         bogus: 1,
         invalid: 2,
-        uc_response: 'N'
+        response: 'N'
       } }
       subject { fake_proxy.filter_updateable_params(params) }
       it 'should strip out invalid fields' do
         expect(subject.keys.length).to eq 1
         expect(subject[:bogus]).to be_nil
         expect(subject[:invalid]).to be_nil
-        expect(subject[:uc_response]).to be
+        expect(subject[:response]).to be
       end
     end
 
     context 'converting params to Campus Solutions field names' do
       let(:params) { {
-        uc_response: 'Y'
+        response: 'Y'
       } }
       subject {
         result = fake_proxy.construct_cs_post(params)
@@ -37,7 +37,7 @@ describe CampusSolutions::Title4 do
 
     context 'performing a post' do
       let(:params) { {
-        uc_response: 'Y'
+        response: 'Y'
       } }
       subject {
         fake_proxy.get
@@ -51,7 +51,7 @@ describe CampusSolutions::Title4 do
 
   context 'with a real external service', :testext => true do
     let(:params) { {
-      uc_response: 'Y'
+      response: 'Y'
     } }
     let(:real_proxy) { CampusSolutions::Title4.new(fake: false, user_id: random_id, params: params) }
 


### PR DESCRIPTION
Addresses https://jira.berkeley.edu/browse/SISRP-5147 and https://jira.berkeley.edu/browse/SISRP-5148 .

The front end does not yet call these endpoints. Here's how to do that: 
POST /api/campus_solutions/terms_and_conditions?uc_response=Y&aid_year=2016
POST /api/campus_solutions/title4?uc_response=N

Or put params in the form body and Rails will figure it out. 

Both T&C and Title4 go thru the hub. Params are sent to CS via the hub as an XML document. We use Rails to_xml to convert. It needs a couple of specific options because CS will choke on whitespace/newline. 
