### PR TITLE
CLC-5613 Ugly temporary fix for our double-alerts-feed marquee

### DIFF
--- a/app/models/my_badges/merged.rb
+++ b/app/models/my_badges/merged.rb
@@ -21,7 +21,7 @@ module MyBadges
         badges: get_google_badges,
         studentInfo: StudentInfo.new(@uid).get
       }
-      feed[:alert] = EtsBlog::Alerts.new.get_latest
+      feed[:alert] = get_latest_alert
       logger.debug "#{self.class.name} get_feed is #{feed.inspect}"
       feed
     end
@@ -46,6 +46,14 @@ module MyBadges
         end
       end
       badges
+    end
+
+    def get_latest_alert
+      if Settings.features.service_alerts_rss
+        EtsBlog::ServiceAlerts.new.get_latest
+      else
+        EtsBlog::Alerts.new.get_latest
+      end
     end
 
   end

--- a/spec/controllers/my_badges_controller_spec.rb
+++ b/spec/controllers/my_badges_controller_spec.rb
@@ -49,7 +49,8 @@ describe MyBadgesController do
     before do
       session['user_id'] = user_id
       expect(Settings.google_proxy).to receive(:fake).at_least(:once).and_return(true)
-      expect(Settings.app_alerts_proxy).to receive(:fake).at_least(:once).and_return(true)
+      expect(Settings.features).to receive('service_alerts_rss').and_return(true)
+      expect(Settings.service_alerts_proxy).to receive(:fake).at_least(:once).and_return(true)
       expect(Settings.bearfacts_proxy).to receive(:fake).at_least(:once).and_return(true)
     end
     it 'should not give a real user a cached censored feed' do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5613

If this tests out on calcentral-dev, it will have to go into the interim release as well.