### PR TITLE
CLC-5650 Give the new Service Alerts feed a short cache life

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -176,7 +176,7 @@ app_alerts_proxy:
 
 service_alerts_proxy:
   fake: false
-  base_url: 'https://www.ets.berkeley.edu/news-archive/calcentral-service-alert/feed'
+  base_url: 'http://www.ets.berkeley.edu/news-archive/calcentral-service-alert/feed'
 
 cal1card_proxy:
   fake: false
@@ -257,6 +257,7 @@ cache:
 
     Textbooks::Proxy: <%= 24.hours %>
     EtsBlog::Alerts: <%= 2.minutes %>
+    EtsBlog::ServiceAlerts: <%= 2.minutes %>
 
 # Cache warmer settings
 cache_warmer:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5650

This may not be the whole problem, but it certainly plays a key part.