### PR TITLE
SISRP-6245 Expire cache for finaid endpoints when doing a POST

### DIFF
--- a/app/models/campus_solutions/address.rb
+++ b/app/models/campus_solutions/address.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class Address < PostingProxy
 
+    include Cache::UserCacheExpiry
+
     def self.field_mappings
       @field_mappings ||= FieldMapping.to_hash(
         [

--- a/app/models/campus_solutions/aid_years.rb
+++ b/app/models/campus_solutions/aid_years.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class AidYears < IntegrationHubProxy
 
+    include Cache::UserCacheExpiry
+
     def initialize(options = {})
       super(Settings.cs_aid_years_proxy, options)
       initialize_mocks if @fake

--- a/app/models/campus_solutions/awards.rb
+++ b/app/models/campus_solutions/awards.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class Awards < IntegrationHubProxy
 
+    include Cache::UserCacheExpiry
+
     def initialize(options = {})
       super(Settings.cs_awards_proxy, options)
       initialize_mocks if @fake

--- a/app/models/campus_solutions/budget.rb
+++ b/app/models/campus_solutions/budget.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class Budget < IntegrationHubProxy
 
+    include Cache::UserCacheExpiry
+
     def initialize(options = {})
       super(Settings.cs_budget_proxy, options)
       initialize_mocks if @fake

--- a/app/models/campus_solutions/checklist.rb
+++ b/app/models/campus_solutions/checklist.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class Checklist < Proxy
 
+    include Cache::UserCacheExpiry
+
     def initialize(options = {})
       super(Settings.cs_checklist_proxy, options)
       initialize_mocks if @fake

--- a/app/models/campus_solutions/financial_aid_data.rb
+++ b/app/models/campus_solutions/financial_aid_data.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class FinancialAidData < IntegrationHubProxy
 
+    include Cache::RelatedCacheKeyTracker
+
     def initialize(options = {})
       super(Settings.cs_financial_aid_data_proxy, options)
       @aid_year = options[:aid_year] || '0'
@@ -9,6 +11,11 @@ module CampusSolutions
 
     def instance_key
       "#{@uid}-#{@aid_year}"
+    end
+
+    def get
+      self.class.save_related_cache_key(@uid, self.class.cache_key(instance_key))
+      super
     end
 
     def xml_filename

--- a/app/models/campus_solutions/financial_aid_expiry.rb
+++ b/app/models/campus_solutions/financial_aid_expiry.rb
@@ -1,0 +1,9 @@
+module CampusSolutions
+  module FinancialAidExpiry
+    def self.expire(uid=nil)
+      [AidYears, FinancialAidData, MyAidYears, MyFinancialAidData].each do |klass|
+        klass.expire uid
+      end
+    end
+  end
+end

--- a/app/models/campus_solutions/my_financial_aid_data.rb
+++ b/app/models/campus_solutions/my_financial_aid_data.rb
@@ -5,6 +5,7 @@ module CampusSolutions
     include Cache::LiveUpdatesEnabled
     include Cache::FreshenOnWarm
     include Cache::JsonAddedCacher
+    include Cache::RelatedCacheKeyTracker
 
     attr_accessor :aid_year
 
@@ -15,6 +16,11 @@ module CampusSolutions
 
     def instance_key
       "#{@uid}-#{aid_year}"
+    end
+
+    def get_feed(force_cache_write=false)
+      self.class.save_related_cache_key(@uid, self.class.cache_key(instance_key))
+      super force_cache_write
     end
 
   end

--- a/app/models/campus_solutions/my_terms_and_conditions.rb
+++ b/app/models/campus_solutions/my_terms_and_conditions.rb
@@ -3,6 +3,7 @@ module CampusSolutions
 
     def update(params = {})
       proxy = CampusSolutions::TermsAndConditions.new({user_id: @uid, params: params})
+      FinancialAidExpiry.expire @uid
       proxy.get
     end
 

--- a/app/models/campus_solutions/my_title4.rb
+++ b/app/models/campus_solutions/my_title4.rb
@@ -3,6 +3,7 @@ module CampusSolutions
 
     def update(params = {})
       proxy = CampusSolutions::Title4.new({user_id: @uid, params: params})
+      FinancialAidExpiry.expire @uid
       proxy.get
     end
 

--- a/lib/cache/related_cache_key_tracker.rb
+++ b/lib/cache/related_cache_key_tracker.rb
@@ -6,6 +6,10 @@ module Cache
     end
 
     module ClassMethods
+      def user_key(uid)
+        "related-cache-keys-#{uid}"
+      end
+
       def expire(uid=nil)
         super uid
         keys = related_cache_keys uid
@@ -13,11 +17,11 @@ module Cache
         keys.keys.each do |key|
           Rails.cache.delete key
         end
-        Rails.cache.delete "additional-keys-#{uid}"
+        Rails.cache.delete(user_key(uid))
       end
 
       def related_cache_keys(uid=nil)
-        Rails.cache.read("related-cache-keys-#{uid}") || {}
+        Rails.cache.read(user_key(uid)) || {}
       end
 
       def save_related_cache_key(uid=nil, related_key=nil)
@@ -25,7 +29,7 @@ module Cache
         return if keys[related_key].present?
         keys[related_key] = 1
         logger.debug "Writing related keys for uid #{uid}: #{keys}"
-        Rails.cache.write("related-cache-keys-#{uid}",
+        Rails.cache.write(user_key(uid),
                           keys,
                           :expires_in => Settings.maximum_expires_in,
                           :force => true)

--- a/lib/cache/related_cache_key_tracker.rb
+++ b/lib/cache/related_cache_key_tracker.rb
@@ -14,20 +14,20 @@ module Cache
         super uid
         related_keys = related_cache_keys uid
         logger.debug "Will now expire these associated keys for uid #{uid}: #{related_keys.inspect}"
-        related_keys.each do |related_key|
+        related_keys.keys.each do |related_key|
           Rails.cache.delete related_key
         end
         Rails.cache.delete(user_key(uid))
       end
 
       def related_cache_keys(uid=nil)
-        Rails.cache.read(user_key(uid)) || Set.new
+        Rails.cache.read(user_key(uid)) || {}
       end
 
       def save_related_cache_key(uid=nil, related_key=nil)
         related_keys = related_cache_keys uid
-        return if related_keys.include?(related_key)
-        related_keys.add related_key
+        return if related_keys[related_key].present?
+        related_keys[related_key] = 1
         logger.debug "Writing related keys for uid #{uid}: #{related_keys.inspect}"
         Rails.cache.write(user_key(uid),
                           related_keys,

--- a/lib/cache/related_cache_key_tracker.rb
+++ b/lib/cache/related_cache_key_tracker.rb
@@ -1,0 +1,35 @@
+module Cache
+  module RelatedCacheKeyTracker
+
+    def self.included base
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def expire(uid=nil)
+        super uid
+        keys = related_cache_keys uid
+        logger.debug "Will now expire these associated keys for uid #{uid}: #{keys}"
+        keys.keys.each do |key|
+          Rails.cache.delete key
+        end
+        Rails.cache.delete "additional-keys-#{uid}"
+      end
+
+      def related_cache_keys(uid=nil)
+        Rails.cache.read("related-cache-keys-#{uid}") || {}
+      end
+
+      def save_related_cache_key(uid=nil, related_key=nil)
+        keys = related_cache_keys uid
+        return if keys[related_key].present?
+        keys[related_key] = 1
+        logger.debug "Writing related keys for uid #{uid}: #{keys}"
+        Rails.cache.write("related-cache-keys-#{uid}",
+                          keys,
+                          :expires_in => Settings.maximum_expires_in,
+                          :force => true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-6245

Whenever a POST to CS happens for T&C or Title4, the AidYears and FinancialAidData feeds get cache cleared as well. Also, other FinAid classes now participate correctly in the UserCacheExpiry scheme. 

Motivation for the RelatedCacheKeyTracker module: FinancialAidData feed needs two keys to work: uid and aid_year. This is because it's one-year-at-a-time. Since the feed needs two keys, so does its associated cache. Unfortunately, the UserCacheExpiry system (upon which HotPlate and LiveUpdates rely) can only expire based on uid. The set of uid-year keys cached by FinancialAidData remain unknown to UserCacheExpiry. So, we use RelatedCacheKeyTracker to record linked keys by uid as they go into the cache. That way we can expire them when UserCacheExpiry calls `klass.expire uid`. 

This malarkey would not be necessary if memcached allowed expiration based on key hierarchy or wildcard or similar. But then, it wouldn't be a key-value store if it did. 

FinancialAidExpiry is intended to invalidate cache of several feeds, but not all the user's feeds (which is what UserCacheExpiry does). We will have use of this pattern again and again as CS self-service endpoints get created. 

@raydavis and @paulkerschen , I'm curious to hear your input on the RelatedCacheKeyTracker solution. 