### PR TITLE
CLC-5639, DriveManager class can create dir and upload file; plus YAML scheme

### DIFF
--- a/app/models/google_apps/client.rb
+++ b/app/models/google_apps/client.rb
@@ -19,10 +19,9 @@ module GoogleApps
         end
       end
 
-      def new_auth(credential_store, access_token_override = nil, options = {})
+      def new_auth(credential_store, options = {})
         storage = Google::APIClient::Storage.new credential_store
         auth = storage.authorize
-        auth.access_token = access_token_override unless access_token_override.nil?
         if options && options['refresh_token'] && options['expiration_time']
           auth.refresh_token = options['refresh_token']
           auth.expires_in = 3600

--- a/app/models/google_apps/credential_store.rb
+++ b/app/models/google_apps/credential_store.rb
@@ -17,9 +17,10 @@ module GoogleApps
         key = @app_name.to_sym
         credentials = google_configs[key].marshal_dump if google_configs.has_key? key
       end
-      # Per Google API spec
-      credentials[:access_token] = @access_token unless @access_token.nil?
-      credentials[:token_credential_uri] = 'https://accounts.google.com/o/oauth2/token' unless credentials.nil?
+      unless credentials.nil?
+        credentials[:access_token] = @access_token unless @access_token.nil?
+        credentials[:token_credential_uri] = 'https://accounts.google.com/o/oauth2/token'
+      end
       credentials
     end
 

--- a/app/models/google_apps/credential_store.rb
+++ b/app/models/google_apps/credential_store.rb
@@ -1,9 +1,10 @@
 module GoogleApps
-  class CredentialStore < Google::APIClient::FileStore
+  class CredentialStore
 
-    def initialize(app_name = nil)
-      super File.join(Rails.root, 'tmp/google', "#{app_name || 'default'}-credentials.json")
-      @app_name = app_name
+    def initialize(options = {})
+      @app_name = options[:app_name]
+      # Access token override
+      @access_token = options[:access_token]
     end
 
     def load_credentials
@@ -17,8 +18,15 @@ module GoogleApps
         credentials = google_configs[key].marshal_dump if google_configs.has_key? key
       end
       # Per Google API spec
+      credentials[:access_token] = @access_token unless @access_token.nil?
       credentials[:token_credential_uri] = 'https://accounts.google.com/o/oauth2/token' unless credentials.nil?
       credentials
+    end
+
+    def write_credentials(credentials_hash = {})
+      # Per http://google-api-python-client.googlecode.com/hg/docs/epy/oauth2client.file.Storage-class.html
+      # Our implementation does not cache (i.e., serialize) OAuth 2 tokens on disk.
+      # See Google::APIClient::FileStore for an alternate strategy.
     end
 
   end

--- a/app/models/google_apps/credential_store.rb
+++ b/app/models/google_apps/credential_store.rb
@@ -1,0 +1,25 @@
+module GoogleApps
+  class CredentialStore < Google::APIClient::FileStore
+
+    def initialize(app_name = nil)
+      super File.join(Rails.root, 'tmp/google', "#{app_name || 'default'}-credentials.json")
+      @app_name = app_name
+    end
+
+    def load_credentials
+      google_configs = Settings.google_proxy.marshal_dump
+      if @app_name.nil?
+        # Use default client credentials
+        credentials = google_configs
+      else
+        # Custom clients can be configured via YAML convention: google_proxy.my_app.client_id, etc.
+        key = @app_name.to_sym
+        credentials = google_configs[key].marshal_dump if google_configs.has_key? key
+      end
+      # Per Google API spec
+      credentials[:token_credential_uri] = 'https://accounts.google.com/o/oauth2/token' unless credentials.nil?
+      credentials
+    end
+
+  end
+end

--- a/app/models/google_apps/drive_manager.rb
+++ b/app/models/google_apps/drive_manager.rb
@@ -1,6 +1,8 @@
 module GoogleApps
   class DriveManager
 
+    include ClassLogger
+
     def initialize(credential_store)
       @credential_store = credential_store
     end
@@ -13,7 +15,7 @@ module GoogleApps
       dir.parents = [{ :id => parent_id }] if parent_id
       result = client.execute(:api_method => drive_api.files.insert, :body_object => dir)
       success = result.status == 200
-      Rails.logger.error "An error occurred: #{result.data['error']['message']}" unless success
+      logger.error "An error occurred: #{result.data['error']['message']}" unless success
       success ? result.data : nil
     end
 
@@ -31,7 +33,7 @@ module GoogleApps
         :media => media,
         :parameters => { :uploadType => 'multipart', :alt => 'json'})
       success = result.status == 200
-      Rails.logger.error "An error occurred: #{result.data['error']['message']}" unless success
+      logger.error "An error occurred: #{result.data['error']['message']}" unless success
       success ? result.data : nil
     end
 

--- a/app/models/google_apps/drive_manager.rb
+++ b/app/models/google_apps/drive_manager.rb
@@ -1,0 +1,47 @@
+module GoogleApps
+  class DriveManager
+
+    def initialize(credential_store)
+      @credential_store = credential_store
+    end
+
+    def create_folder(title, parent_id)
+      client = get_google_api
+      drive_api = client.discovered_api('drive', 'v2')
+      metadata = { :title => title, :mimeType => 'application/vnd.google-apps.folder' }
+      dir = drive_api.files.insert.request_schema.new metadata
+      dir.parents = [{ :id => parent_id }] if parent_id
+      result = client.execute(:api_method => drive_api.files.insert, :body_object => dir)
+      success = result.status == 200
+      Rails.logger.error "An error occurred: #{result.data['error']['message']}" unless success
+      success ? result.data : nil
+    end
+
+    def upload_file(title, description, parent_id, mime_type, file_absolute_path)
+      client = get_google_api
+      drive_api = client.discovered_api('drive', 'v2')
+      metadata = { :title => title, :description => description, :mimeType => mime_type }
+      file = drive_api.files.insert.request_schema.new metadata
+      # Target directory is optional
+      file.parents = [{ :id => parent_id }] if parent_id
+      media = Google::APIClient::UploadIO.new(file_absolute_path, mime_type)
+      result = client.execute(
+        :api_method => drive_api.files.insert,
+        :body_object => file,
+        :media => media,
+        :parameters => { :uploadType => 'multipart', :alt => 'json'})
+      success = result.status == 200
+      Rails.logger.error "An error occurred: #{result.data['error']['message']}" unless success
+      success ? result.data : nil
+    end
+
+    private
+
+    def get_google_api
+      client = GoogleApps::Client.client
+      client.authorization = GoogleApps::Client.new_auth @credential_store
+      client
+    end
+
+  end
+end

--- a/app/models/google_apps/proxy.rb
+++ b/app/models/google_apps/proxy.rb
@@ -8,22 +8,24 @@ module GoogleApps
 
     attr_accessor :authorization, :json_filename
 
-    APP_ID = "Google"
+    APP_ID = 'Google'
 
     def initialize(options = {})
       super(Settings.google_proxy, options)
 
-      credentials = GoogleApps::CredentialStore.new
       if @fake
-        @authorization = GoogleApps::Client.new_auth(credentials, 'fake_access_token')
+        credentials = GoogleApps::CredentialStore.new(access_token: 'fake_access_token')
+        @authorization = GoogleApps::Client.new_auth credentials
       elsif options[:user_id]
         token_settings = User::Oauth2Data.get(@uid, APP_ID)
         options = token_settings || { 'access_token' => '' }
-        @authorization = GoogleApps::Client.new_auth(credentials, options['access_token'], options)
+        credentials = GoogleApps::CredentialStore.new(access_token: options['access_token'])
+        @authorization = GoogleApps::Client.new_auth(credentials, options)
       else
         auth_related_entries = [:access_token, :refresh_token, :expiration_time]
         token_settings = options.select { |k, v| auth_related_entries.include? k }.stringify_keys!
-        @authorization = GoogleApps::Client.new_auth(credentials, token_settings['access_token'], token_settings)
+        credentials = GoogleApps::CredentialStore.new(access_token: token_settings['access_token'])
+        @authorization = GoogleApps::Client.new_auth(credentials, token_settings)
       end
 
       @fake_options = options[:fake_options] || {}

--- a/app/models/google_apps/proxy.rb
+++ b/app/models/google_apps/proxy.rb
@@ -13,15 +13,17 @@ module GoogleApps
     def initialize(options = {})
       super(Settings.google_proxy, options)
 
+      credentials = GoogleApps::CredentialStore.new
       if @fake
-        @authorization = GoogleApps::Client.new_fake_auth
+        @authorization = GoogleApps::Client.new_auth(credentials, 'fake_access_token')
       elsif options[:user_id]
         token_settings = User::Oauth2Data.get(@uid, APP_ID)
-        @authorization = GoogleApps::Client.new_client_auth token_settings || {"access_token" => ''}
+        options = token_settings || { 'access_token' => '' }
+        @authorization = GoogleApps::Client.new_auth(credentials, options['access_token'], options)
       else
         auth_related_entries = [:access_token, :refresh_token, :expiration_time]
         token_settings = options.select { |k, v| auth_related_entries.include? k }.stringify_keys!
-        @authorization = GoogleApps::Client.new_client_auth token_settings
+        @authorization = GoogleApps::Client.new_auth(credentials, token_settings['access_token'], token_settings)
       end
 
       @fake_options = options[:fake_options] || {}

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -102,6 +102,13 @@ google_proxy:
   test_user_access_token: "someMumboJumbo"
   test_user_refresh_token: "someMumboJumbo"
   atom_mail_feed_url: "https://mail.google.com/mail/feed/atom/"
+  oec:
+    client_id: 'moreMumboJumbo'
+    client_secret: 'moreMumboJumbo'
+    access_token: 'tokenThis'
+    refresh_token: 'tokenThat'
+    scope: 'https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.apps.readonly'
+
 sakai_proxy:
   host: "https://sakai-dev.berkeley.edu"
   fake: false

--- a/spec/models/google_apps/credential_store_spec.rb
+++ b/spec/models/google_apps/credential_store_spec.rb
@@ -1,21 +1,24 @@
 describe GoogleApps::CredentialStore do
 
   it 'should load default calcentral credentials' do
-    store = GoogleApps::CredentialStore.new
+    custom_token = 'custom_access_token'
+    store = GoogleApps::CredentialStore.new(access_token: custom_token)
     credentials = store.load_credentials
     expect(credentials[:client_id]).to_not be_nil
     expect(credentials[:token_credential_uri]).to_not be_nil
+    expect(credentials[:access_token]).to eq custom_token
   end
 
   it 'should load custom credentials' do
-    store = GoogleApps::CredentialStore.new 'oec'
+    store = GoogleApps::CredentialStore.new(app_name: 'oec')
     credentials = store.load_credentials
     expect(credentials[:client_id]).to_not be_nil
     expect(credentials[:token_credential_uri]).to_not be_nil
+    expect(credentials[:access_token]).to_not be_nil
   end
 
   it 'should return nil when no such key mapping exists' do
-    store = GoogleApps::CredentialStore.new 'no_such_key'
+    store = GoogleApps::CredentialStore.new(app_name: 'no_such_key')
     expect(store.load_credentials).to be_nil
   end
 

--- a/spec/models/google_apps/credential_store_spec.rb
+++ b/spec/models/google_apps/credential_store_spec.rb
@@ -1,0 +1,22 @@
+describe GoogleApps::CredentialStore do
+
+  it 'should load default calcentral credentials' do
+    store = GoogleApps::CredentialStore.new
+    credentials = store.load_credentials
+    expect(credentials[:client_id]).to_not be_nil
+    expect(credentials[:token_credential_uri]).to_not be_nil
+  end
+
+  it 'should load custom credentials' do
+    store = GoogleApps::CredentialStore.new 'oec'
+    credentials = store.load_credentials
+    expect(credentials[:client_id]).to_not be_nil
+    expect(credentials[:token_credential_uri]).to_not be_nil
+  end
+
+  it 'should return nil when no such key mapping exists' do
+    store = GoogleApps::CredentialStore.new 'no_such_key'
+    expect(store.load_credentials).to be_nil
+  end
+
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5646
https://jira.ets.berkeley.edu/jira/browse/CLC-5639

Changes include:
* YAML scheme to support custom google api credentials
* CredentialStore class which aligns with Google API convention and follows our convention
* DriveManager provides CRUD operations. I don't see a need for a class per CRUD type.
