### PR TITLE
CLC-5639, find_folders_by_title and find_items_by_title (more generic)

### DIFF
--- a/app/models/google_apps/drive_manager.rb
+++ b/app/models/google_apps/drive_manager.rb
@@ -7,6 +7,35 @@ module GoogleApps
       @credential_store = credential_store
     end
 
+    def find_folders_by_title(title, parent_id = nil)
+      find_items_by_title(title, mime_type: 'application/vnd.google-apps.folder', parent_id: parent_id)
+    end
+
+    def find_items_by_title(title, options = {})
+      client = get_google_api
+      drive_api = client.discovered_api('drive', 'v2')
+      items = []
+      # mime_type, parent_id = nil
+      parent_id = options[:parent_id] || 'root'
+      query = "'#{parent_id}' in parents and title='#{title}' and trashed=false"
+      query.concat " and mimeType='#{options[:mime_type]}'" if options.has_key? :mime_type
+      page_token = nil
+      begin
+        parameters = { :q => query }
+        parameters[:pageToken] = page_token unless page_token.nil?
+        api_response = client.execute(:api_method => drive_api.files.list, :parameters => parameters)
+        if api_response.status == 200
+          files = api_response.data
+          items.concat files.items
+          page_token = files.next_page_token
+        else
+          puts "An error occurred: #{api_response.data['error']['message']}"
+          page_token = nil
+        end
+      end while page_token.to_s != ''
+      items
+    end
+
     def create_folder(title, parent_id)
       client = get_google_api
       drive_api = client.discovered_api('drive', 'v2')

--- a/app/models/google_apps/drive_manager.rb
+++ b/app/models/google_apps/drive_manager.rb
@@ -15,7 +15,6 @@ module GoogleApps
       client = get_google_api
       drive_api = client.discovered_api('drive', 'v2')
       items = []
-      # mime_type, parent_id = nil
       parent_id = options[:parent_id] || 'root'
       query = "'#{parent_id}' in parents and title='#{title}' and trashed=false"
       query.concat " and mimeType='#{options[:mime_type]}'" if options.has_key? :mime_type


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5639

Google Drive is strange. A folder can have multiple items with the same name. Furthermore, an item can belong to multiple folders (i.e., parents).  The new methods in this PR try to account for such rules. 