### PR TITLE
CLC-5635, 'scope' value used by google_auth_controller is now set in yml 

### DIFF
--- a/app/controllers/google_auth_controller.rb
+++ b/app/controllers/google_auth_controller.rb
@@ -91,11 +91,7 @@ class GoogleAuthController < ApplicationController
       :controller => 'google_auth',
       :action => 'handle_callback')
     client.state = Base64.encode64 final_redirect
-    client.scope = ['profile', 'email',
-                    'https://www.googleapis.com/auth/calendar',
-                    'https://www.googleapis.com/auth/tasks',
-                    'https://www.googleapis.com/auth/drive.readonly.metadata',
-                    'https://mail.google.com/mail/feed/atom/']
+    client.scope = Settings.google_proxy.scope
     client
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -97,6 +97,7 @@ ldap:
 google_proxy:
   client_id: 1
   client_secret: 'someMumboJumbo'
+  scope: 'profile email https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/tasks https://www.googleapis.com/auth/drive.readonly.metadata https://mail.google.com/mail/feed/atom/'
   fake: false
   #Maps to tammi.chang.clc@gmail.com. Used for testing + recording responses
   test_user_access_token: "someMumboJumbo"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5635

In google_auth_controller, scope was set as an array. Now we're passing in a set of space-separated values. The underlying OAuth2::Client code is flexible and can handle both:

    case new_scope
    when Array
      ...
    when String
      @scope = new_scope.split(' ')