### PR TITLE
CLC-5635, clean up GoogleAuthController and spec

### DIFF
--- a/app/controllers/google_auth_controller.rb
+++ b/app/controllers/google_auth_controller.rb
@@ -11,16 +11,16 @@ class GoogleAuthController < ApplicationController
     expire
     final_redirect = params['final_redirect'] || '/'
     if params['force_domain'].present? && params['force_domain'] == 'false'
-      client = get_client(final_redirect, force_domain = false)
+      client = get_google_api_auth(final_redirect, force_domain = false)
     end
-    client ||= get_client final_redirect
+    client ||= get_google_api_auth final_redirect
     url = client.authorization_uri(approval_prompt: 'force').to_s
     logger.debug "Initiating Oauth2 authorization request for user #{session['user_id']} - redirecting to #{url}"
     redirect_to url
   end
 
   def handle_callback
-    client = get_client
+    client = get_google_api_auth
     logger.debug "Handling Oauth2 authorization callback for user #{session['user_id']}"
     if params['code'] && params['error'].blank?
       client.code = params['code']
@@ -78,21 +78,18 @@ class GoogleAuthController < ApplicationController
     GoogleApps::Proxy::APP_ID
   end
 
-  def get_client(final_redirect = '', force_domain = true)
-    google_client = Google::APIClient.new(options={:application_name => 'CalCentral', :application_version => 'v1', :retries => 3})
-    client = google_client.authorization
-    unless force_domain == false
-      client.authorization_uri= URI 'https://accounts.google.com/o/oauth2/auth?hd=berkeley.edu'
-    end
-    client.client_id = Settings.google_proxy.client_id
-    client.client_secret = Settings.google_proxy.client_secret
-    client.redirect_uri = url_for(
-      :only_path => false,
-      :controller => 'google_auth',
-      :action => 'handle_callback')
-    client.state = Base64.encode64 final_redirect
-    client.scope = Settings.google_proxy.scope
-    client
+  private
+
+  def get_google_api_auth(final_redirect = '', force_domain = true)
+    options = { :application_name => 'CalCentral', :application_version => 'v1', :retries => 3 }
+    auth = Google::APIClient.new(options).authorization
+    auth.client_id = Settings.google_proxy.client_id
+    auth.client_secret = Settings.google_proxy.client_secret
+    auth.authorization_uri = URI('https://accounts.google.com/o/oauth2/auth?hd=berkeley.edu') if force_domain
+    auth.redirect_uri = url_for(:only_path => false, :controller => 'google_auth', :action => 'handle_callback')
+    auth.state = Base64.encode64 final_redirect
+    auth.scope = Settings.google_proxy.scope
+    auth
   end
 
 end

--- a/spec/controllers/google_auth_controller_spec.rb
+++ b/spec/controllers/google_auth_controller_spec.rb
@@ -1,33 +1,33 @@
-require "spec_helper"
-
 describe GoogleAuthController do
+
   let(:user_id) { random_id }
+
   before do
     session['user_id'] = user_id
   end
 
   describe '#dismiss_reminder' do
-    it "should store a dismiss_reminder key-value when there's no token for a user" do
-      GoogleApps::Proxy.stub(:access_granted?).with(user_id).and_return(false)
+    it 'should store a dismiss_reminder key-value when there is no token for a user' do
+      allow(GoogleApps::Proxy).to receive(:access_granted?).with(user_id).and_return false
       post :dismiss_reminder, { :format => 'json' }
-      response.status.should eq(200)
-      json_response = JSON.parse(response.body)
-      json_response['result'].should be_truthy
+      expect(response).to have_http_status :success
+      response_body = JSON.parse response.body
+      expect(response_body['result']).to be true
     end
 
-    it "should not store a dismiss_reminder key-value when there's an existing token" do
-      GoogleApps::Proxy.stub(:access_granted?).with(user_id).and_return(true)
+    it 'should not store a dismiss_reminder key-value when there is an existing token' do
+      allow(GoogleApps::Proxy).to receive(:access_granted?).with(user_id).and_return true
       post :dismiss_reminder, { :format => 'json' }
-      response.status.should eq(200)
-      json_response = JSON.parse(response.body)
-      json_response['result'].should be_falsey
+      expect(response).to have_http_status :success
+      response_body = JSON.parse response.body
+      expect(response_body['result']).to be false
     end
   end
 
   context 'indirectly authenticated' do
     before do
-      allow(GoogleApps::Proxy).to receive(:access_granted?).with(user_id).and_return(true)
-      expect(Google::APIClient).to receive(:new).never
+      allow(GoogleApps::Proxy).to receive(:access_granted?).with(user_id).and_return true
+      allow(Google::APIClient).to receive(:new).never
     end
     subject do
       post :request_authorization, {}
@@ -36,13 +36,13 @@ describe GoogleAuthController do
       before do
         session['original_user_id'] = random_id
       end
-      it { should_not be_success }
+      it { is_expected.not_to have_http_status :success }
     end
     context 'LTI embedded' do
       before do
         session['lti_authenticated_only'] = true
       end
-      it { should_not be_success }
+      it { is_expected.not_to have_http_status :success }
     end
   end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5635

Includes:
* rspec 3 treatment
* rename *get_client* to more accurate *get_google_api_auth*
* readability in *get_google_api_auth* method