### PR TITLE
CLC-5654 Add Google Drive methods to move files between folders

### DIFF
--- a/spec/models/google_apps/drive_manager_spec.rb
+++ b/spec/models/google_apps/drive_manager_spec.rb
@@ -39,6 +39,21 @@ describe 'GoogleDriveInsert' do
       expect(items[0].title).to eq @csv_filename
     end
 
+    it 'should copy CSV file to a new folder without modifying original' do
+      copy = @drive.copy_item_to_folder(@csv_file, 'root')
+
+      copied_items = @drive.find_items_by_title(@csv_filename, parent_id: 'root')
+      expect(copied_items).to have(1).item
+      expect(copied_items[0].id).to eq copy.id
+      expect(copied_items[0].title).to eq @csv_filename
+
+      original_items = @drive.find_items_by_title(@csv_filename, parent_id: @folder.id)
+      expect(original_items).to have(1).item
+      expect(original_items[0].title).to eq @csv_filename
+
+      @drive.trash_item copy.id
+    end
+
     it 'should find CSV file' do
       items = @drive.find_items_by_title(@csv_filename, parent_id: @folder.id)
       expect(items).to_not be_nil


### PR DESCRIPTION
In setting up Drive tasks for https://jira.ets.berkeley.edu/jira/browse/CLC-5654, I realized that one requirement I forgot to specify was copying a file to a new folder without having to download and re-upload.

The Drive API takes three steps to implement this action (duplicate file, add new parent, remove old parent). Fortunately, the new DriveManager class is nicely built and gives clear patterns to follow.

`find_folders` convenience method also thrown in.