### PR TITLE
CLC-5654 Implement term setup task

### DIFF
--- a/app/models/oec/course_instructors.rb
+++ b/app/models/oec/course_instructors.rb
@@ -1,0 +1,13 @@
+module Oec
+  class CourseInstructors < Oec::CsvExport
+
+    def headers
+      %w(
+        COURSE_ID
+        LDAP_UID
+        INSTRUCTOR_FUNC
+      )
+    end
+
+  end
+end

--- a/app/models/oec/course_supervisors.rb
+++ b/app/models/oec/course_supervisors.rb
@@ -1,0 +1,13 @@
+module Oec
+  class CourseSupervisors < Oec::CsvExport
+
+    def headers
+      %w(
+        COURSE_ID
+        LDAP_UID
+        DEPT_NAME
+      )
+    end
+
+  end
+end

--- a/app/models/oec/courses.rb
+++ b/app/models/oec/courses.rb
@@ -1,0 +1,32 @@
+module Oec
+  class Courses < Oec::CsvExport
+
+    def headers
+      %w(
+        COURSE_ID
+        COURSE_NAME
+        CROSS_LISTED_FLAG
+        CROSS_LISTED_NAME
+        DEPT_NAME
+        CATALOG_ID
+        INSTRUCTION_FORMAT
+        SECTION_NUM
+        PRIMARY_SECONDARY_CD
+        LDAP_UID
+        SIS_ID
+        FIRST_NAME
+        LAST_NAME
+        EMAIL_ADDRESS
+        INSTRUCTOR_FUNC
+        BLUE_ROLE
+        EVALUATE
+        DEPT_FORM
+        EVALUATION_TYPE
+        MODULAR_COURSE
+        START_DATE
+        END_DATE
+      )
+    end
+
+  end
+end

--- a/app/models/oec/csv_export.rb
+++ b/app/models/oec/csv_export.rb
@@ -1,0 +1,40 @@
+module Oec
+  class CsvExport < ::CsvExport
+
+    def self.base_filename
+      "#{self.name.demodulize.underscore}.csv"
+    end
+
+    def export(overwrite_file = true)
+      file = output_filename
+      output = CSV.open(file, 'wb')
+      output << headers
+      append_records output
+      output.close
+      {
+        filename: file
+      }
+    end
+
+    def output_filename
+      export_directory.join self.class.base_filename
+    end
+
+    def headers
+      # subclasses override
+    end
+
+    def append_records(output_file)
+      # subclasses override
+    end
+
+    def record_to_csv_row(record)
+      row = {}
+      record.keys.each do |key|
+        row[key.upcase] = record[key]
+      end
+      row
+    end
+
+  end
+end

--- a/app/models/oec/instructors.rb
+++ b/app/models/oec/instructors.rb
@@ -1,0 +1,15 @@
+module Oec
+  class Instructors < Oec::CsvExport
+
+    def headers
+      %w(
+        LDAP_UID
+        FIRST_NAME
+        LAST_NAME
+        EMAIL_ADDRESS
+        BLUE_ROLE
+      )
+    end
+
+  end
+end

--- a/app/models/oec/supervisors.rb
+++ b/app/models/oec/supervisors.rb
@@ -1,0 +1,22 @@
+module Oec
+  class Supervisors < Oec::CsvExport
+
+    def headers
+      %w(
+        LDAP_UID
+        FIRST_NAME
+        LAST_NAME
+        EMAIL_ADDRESS
+        SUPERVISOR_GROUP
+        PRIMARY_ADMIN
+        SECONDARY_ADMIN
+        DEPT_NAME_1
+        DEPT_NAME_2
+        DEPT_NAME_3
+        DEPT_NAME_4
+        DEPT_NAME_5
+      )
+    end
+
+  end
+end

--- a/app/models/oec/task.rb
+++ b/app/models/oec/task.rb
@@ -1,0 +1,125 @@
+module Oec
+  class Task
+    include ClassLogger
+
+    def initialize(opts)
+      @log = []
+      @remote_drive = GoogleApps::DriveManager.new GoogleApps::CredentialStore.new(app_name: 'oec')
+      @term_code = opts[:term_code]
+      @tmp_path = Rails.root.join('tmp', 'oec')
+    end
+
+    def run
+      log :info, "Starting #{self.class.name}"
+      run_internal
+      true
+    rescue => e
+      log :error, "#{self.class.name} aborted with error: #{e.message}\n#{e.backtrace.join "\n\t"}"
+      nil
+    ensure
+      write_log
+    end
+
+    private
+
+    def create_folder(folder_name, parent=nil)
+      if @remote_drive.find_folders_by_title(folder_name, folder_id(parent)).any?
+        raise RuntimeError, "Folder #{folder_name} with parent #{folder_title(parent)} already exists on remote drive"
+      else
+        create_folder_no_existence_check(folder_name, parent)
+      end
+    end
+
+    def find_or_create_folder(folder_name, parent=nil)
+      find_folder(folder_name, parent) || create_folder_no_existence_check(folder_name, parent)
+    end
+
+    def create_folder_no_existence_check(folder_name, parent=nil)
+      unless folder = @remote_drive.create_folder(folder_name, folder_id(parent))
+        raise RuntimeError, "Could not create folder #{folder_name} on remote drive"
+      end
+      log :debug, "Created remote folder \"#{folder_name}\""
+      folder
+    end
+
+    def copy_file(file, dest_folder)
+      if find_item(file.title, dest_folder)
+        raise RuntimeError, "File \"#{file.title}\" already exists in remote drive folder \"#{dest_folder.title}\"; could not copy"
+      end
+      if (@remote_drive.copy_item_to_folder(file, dest_folder.id))
+        log :debug, "Copied file \"#{file.title}\" to remote drive folder \"#{dest_folder.title}\""
+      else
+        raise RuntimeError, "Could not copy file \"#{file.title}\" to \"#{dest_folder.title}\""
+      end
+    end
+
+    def datestamp
+      DateTime.now.strftime '%F'
+    end
+
+    def find_folder(title, parent=nil)
+      @remote_drive.find_folders_by_title(title, folder_id(parent)).first
+    end
+
+    def find_folders(parent=nil)
+      @remote_drive.find_folders folder_id(parent)
+    end
+
+    def find_item(title, parent=nil)
+      @remote_drive.find_items_by_title(title, parent_id: folder_id(parent)).first
+    end
+
+    def folder_id(folder)
+      folder ? folder.id : 'root'
+    end
+
+    def folder_title(folder)
+      folder ? folder.title : 'root'
+    end
+
+    def log(level, message)
+      logger.send level, message
+      @log << "[#{Time.now}] #{message}"
+    end
+
+    def timestamp
+      DateTime.now.strftime '%H%M%S'
+    end
+
+    def upload_csv_headers(klass, dest_folder)
+      csv = klass.new(@tmp_path)
+      begin
+        csv.export
+        log :debug, "Created header-only file #{csv.output_filename}"
+        upload_file(csv.output_filename, klass.base_filename, 'text/csv', dest_folder)
+      ensure
+        File.delete csv.output_filename
+      end
+    end
+
+    def upload_file(path, remote_name, type, folder)
+      if @remote_drive.find_items_by_title(remote_name, parent_id: folder.id).any?
+        raise RuntimeError, "File \"#{remote_name}\" already exists in remote drive folder \"#{folder.title}\"; could not upload"
+      end
+      if (!@remote_drive.upload_file(remote_name, '', folder.id, type, path.to_s))
+        raise RuntimeError, "File #{path} could not be uploaded to remote drive folder \"#{folder.title}\""
+      end
+      log :debug, "Uploaded file #{path} to remote drive folder \"#{folder.title}\""
+    end
+
+    def write_log
+      if (term_folder = find_folder @term_code) && (reports_folder = find_folder('reports', term_folder))
+        reports_today = find_or_create_folder(datestamp, reports_folder)
+        log_name = "#{timestamp}_#{self.class.name.demodulize.underscore}.log"
+        begin
+          File.open(@tmp_path.join(log_name), 'wb') { |f| f.puts @log }
+          upload_file(@tmp_path.join(log_name), log_name, 'text/plain', reports_today)
+        ensure
+          File.delete @tmp_path.join(log_name)
+        end
+      end
+    rescue => e
+      logger.error "Could not upload log: #{e.message}\n#{e.backtrace.join "\n\t"}"
+    end
+  end
+end

--- a/app/models/oec/term_setup_task.rb
+++ b/app/models/oec/term_setup_task.rb
@@ -1,0 +1,46 @@
+module Oec
+  class TermSetupTask < Task
+
+    def run_internal
+      log :info, "Will create initial folders and files for term #{@term_code}"
+
+      term_folder = create_folder @term_code
+      %w(departments exports imports reports).each do |folder_name|
+        create_folder(folder_name, term_folder)
+      end
+      supplemental_sources = create_folder('supplemental_sources', term_folder)
+
+      find_previous_term_csvs
+
+      Oec::CsvExport.subclasses.each do |csv_class|
+        if @previous_term_csvs[csv_class]
+          copy_file(@previous_term_csvs[csv_class], supplemental_sources)
+        else
+          log :info, "Could not find previous #{csv_class.base_filename} for copying; will create header-only file"
+          upload_csv_headers(csv_class, supplemental_sources)
+        end
+      end
+    end
+
+    def find_previous_term_csvs
+      @previous_term_csvs = {}
+      if (previous_term_folder = find_previous_term_folder)
+        if (previous_supplemental_sources = find_folder('supplemental_sources', previous_term_folder))
+          @previous_term_csvs[Oec::Instructors] = find_item('instructors.csv', previous_supplemental_sources)
+          @previous_term_csvs[Oec::Supervisors] = find_item('supervisors.csv', previous_supplemental_sources)
+        end
+        if (previous_exports = find_folder('exports', previous_term_folder))
+          if (most_recent_export = find_folders(previous_exports).sort_by(&:title).last)
+            @previous_term_csvs[Oec::CourseSupervisors] = find_item('course_supervisors.csv', most_recent_export)
+          end
+        end
+      end
+    end
+
+    def find_previous_term_folder
+      if (folders = @remote_drive.find_folders)
+        folders.select { |f| f.title.match(/\d{4}-[A-D]/) && f.title < @term_code }.sort_by(&:title).last
+      end
+    end
+  end
+end

--- a/spec/models/oec/term_setup_task_spec.rb
+++ b/spec/models/oec/term_setup_task_spec.rb
@@ -1,0 +1,159 @@
+describe Oec::TermSetupTask do
+
+  let(:term_code) { '2015-D' }
+  subject { described_class.new(term_code: term_code) }
+
+  let(:fake_drive_manager) { double() }
+  before { allow(GoogleApps::DriveManager).to receive(:new).and_return fake_drive_manager }
+
+  def mock_file(file_name)
+    if file_name == 'root'
+      double(title: nil, id: 'root')
+    else
+      double(title: file_name, id: "#{file_name}_id")
+    end
+  end
+
+  def expect_folder_creation(folder_name, parent_name, opts={})
+    expect(fake_drive_manager).to receive(:create_folder)
+      .with(folder_name, mock_file(parent_name).id)
+      .and_return mock_file(folder_name)
+    if opts[:read_after_creation]
+      expect(fake_drive_manager).to receive(:find_folders_by_title)
+        .at_least(2).times
+        .with(folder_name, mock_file(parent_name).id)
+        .and_return([], [mock_file(folder_name)])
+    else
+      expect(fake_drive_manager).to receive(:find_folders_by_title)
+        .at_least(1).times
+        .with(folder_name, mock_file(parent_name).id)
+        .and_return([])
+    end
+  end
+
+  def expect_file_upload(file_name, parent_name)
+    expect(fake_drive_manager).to receive(:find_items_by_title)
+      .with(file_name, parent_id: mock_file(parent_name).id)
+      .and_return []
+    expect(fake_drive_manager).to receive(:upload_file)
+      .with(file_name, '', mock_file(parent_name).id, 'text/csv', Rails.root.join('tmp', 'oec', file_name).to_s)
+      .and_return(mock_file(file_name))
+  end
+
+  shared_context 'expecting folder creation' do
+    before do
+      expect_folder_creation(term_code, 'root', read_after_creation: true)
+      %w(departments exports imports supplemental_sources).each do |folder_name|
+        expect_folder_creation(folder_name, term_code)
+      end
+    end
+  end
+
+  shared_context 'expecting logging' do
+    let(:today) { '2015-08-31' }
+    let(:now) { '092222' }
+    let(:logfile) { "#{now}_term_setup_task.log" }
+
+    before do
+      allow(DateTime).to receive(:now).and_return DateTime.strptime("#{today} #{now}", '%F %H%M%S')
+      expect_folder_creation('reports', term_code, read_after_creation: true)
+      expect_folder_creation(today, 'reports')
+      expect(fake_drive_manager).to receive(:find_items_by_title)
+        .with(logfile, parent_id: mock_file(today).id)
+        .and_return []
+      expect(fake_drive_manager).to receive(:upload_file)
+        .with(logfile, '', mock_file(today).id, 'text/plain', Rails.root.join('tmp', 'oec', logfile).to_s)
+        .and_return mock_file(logfile)
+    end
+  end
+
+  context 'when no previous term data is found in remote drive' do
+    include_context 'expecting folder creation'
+    include_context 'expecting logging'
+
+    before { allow(fake_drive_manager).to receive(:find_folders).with(no_args).and_return [] }
+
+    it 'checks CSV existence and uploads header-only CSVs as supplemental sources' do
+      %w(course_instructors.csv course_supervisors.csv courses.csv instructors.csv supervisors.csv).each do |csv_name|
+        expect_file_upload(csv_name, 'supplemental_sources')
+      end
+      subject.run
+    end
+
+    context 'when existing files would be overwritten' do
+      before do
+        %w(course_instructors.csv course_supervisors.csv courses.csv instructors.csv supervisors.csv).each do |csv_name|
+          allow(fake_drive_manager).to receive(:find_items_by_title)
+            .with(csv_name, parent_id: mock_file('supplemental_sources').id)
+            .and_return [mock_file(csv_name)]
+          end
+      end
+      it 'aborts the task and logs error' do
+        expect(Rails.logger).to receive(:error) do |error_message|
+          expect(error_message.lines.first).to match /Oec::TermSetupTask aborted with error.*already exists.*could not upload/
+        end
+        subject.run
+      end
+    end
+  end
+
+  context 'when previous term data is found in remote drive' do
+    include_context 'expecting folder creation'
+    include_context 'expecting logging'
+
+    before do
+      @mock_existing_csvs = {}
+      %w(course_supervisors.csv instructors.csv supervisors.csv).each do |csv_name|
+        @mock_existing_csvs[csv_name] = mock_file(csv_name)
+      end
+      expect(fake_drive_manager).to receive(:find_folders).with(no_args).and_return [mock_file('2015-B'), mock_file('2015-C')]
+      %w(supplemental_sources exports).each do |folder_name|
+        expect(fake_drive_manager).to receive(:find_folders_by_title)
+          .with(folder_name, mock_file('2015-C').id)
+          .and_return [mock_file(folder_name)]
+      end
+      expect(fake_drive_manager).to receive(:find_folders)
+        .with(mock_file('exports').id)
+        .and_return [mock_file('2015-06-04'), mock_file('2015-06-22')]
+      expect(fake_drive_manager).to receive(:find_items_by_title)
+        .with('course_supervisors.csv', parent_id: mock_file('2015-06-22').id)
+        .and_return [@mock_existing_csvs['course_supervisors.csv']]
+    end
+
+    it 'copies existing files and uploads others' do
+      %w(instructors.csv supervisors.csv).each do |csv_name|
+        expect(fake_drive_manager).to receive(:find_items_by_title)
+          .with(csv_name, parent_id: mock_file('supplemental_sources').id)
+          .at_least(2).times
+          .and_return([@mock_existing_csvs[csv_name]], [])
+        expect(fake_drive_manager).to receive(:copy_item_to_folder)
+          .with(@mock_existing_csvs[csv_name], mock_file('supplemental_sources').id)
+          .and_return @mock_existing_csvs[csv_name]
+      end
+      expect(fake_drive_manager).to receive(:find_items_by_title)
+        .with('course_supervisors.csv', parent_id: mock_file('supplemental_sources').id)
+        .and_return []
+      expect(fake_drive_manager).to receive(:copy_item_to_folder)
+        .with(@mock_existing_csvs['course_supervisors.csv'], mock_file('supplemental_sources').id)
+        .and_return @mock_existing_csvs['course_supervisors.csv']
+      %w(course_instructors.csv courses.csv).each do |csv_name|
+        expect_file_upload(csv_name, 'supplemental_sources')
+      end
+      subject.run
+    end
+  end
+
+  context 'Google Drive connection error' do
+    before do
+      expect(fake_drive_manager).to receive(:find_folders_by_title)
+        .at_least(1).times
+        .and_raise Errors::ProxyError, 'A confounding error'
+    end
+    it 'logs errors' do
+      expect(Rails.logger).to receive(:error).at_least(1).times do |error_message|
+        expect(error_message.lines.first).to include 'A confounding error'
+      end
+      subject.run
+    end
+  end
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5654

- Oec::TermSetupTask inherits from Oec::Task, which holds a lot of lower-level logic expected to be shared between tasks.
- Different CSV formats are defined as skeletal subclasses of Oec::CsvExport.
- DriveManager gets some logging and exception handling. Since it's quite a different animal from our usual proxies, there was unfortunately no good way to test the term setup task other than a lot of fiddly expectation-setting on a mock object. 