### PR TITLE
CLC-5604, new proxy_spec and better fake data handling in CredentialStore

### DIFF
--- a/app/models/google_apps/credential_store.rb
+++ b/app/models/google_apps/credential_store.rb
@@ -2,24 +2,25 @@ module GoogleApps
   class CredentialStore
 
     def initialize(options = {})
-      @app_name = options[:app_name]
-      # Access token override
-      @access_token = options[:access_token]
+      @options = options
     end
 
     def load_credentials
+      app_name = @options[:app_name]
       google_configs = Settings.google_proxy.marshal_dump
-      if @app_name.nil?
+      if app_name.nil?
         # Use default client credentials
         credentials = google_configs
       else
         # Custom clients can be configured via YAML convention: google_proxy.my_app.client_id, etc.
-        key = @app_name.to_sym
+        key = app_name.to_sym
         credentials = google_configs[key].marshal_dump if google_configs.has_key? key
       end
       unless credentials.nil?
-        credentials[:access_token] = @access_token unless @access_token.nil?
         credentials[:token_credential_uri] = 'https://accounts.google.com/o/oauth2/token'
+        # Token override
+        credentials[:access_token] = @options[:access_token] if @options.has_key? :access_token
+        credentials[:refresh_token] = @options[:refresh_token] if @options.has_key? :refresh_token
       end
       credentials
     end

--- a/app/models/google_apps/proxy.rb
+++ b/app/models/google_apps/proxy.rb
@@ -14,7 +14,8 @@ module GoogleApps
       super(Settings.google_proxy, options)
 
       if @fake
-        credentials = GoogleApps::CredentialStore.new(access_token: 'fake_access_token')
+        options.merge!({ access_token: 'fake_access_token' })
+        credentials = GoogleApps::CredentialStore.new options
         @authorization = GoogleApps::Client.new_auth credentials
       elsif options[:user_id]
         token_settings = User::Oauth2Data.get(@uid, APP_ID)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -96,12 +96,12 @@ ldap:
   application_password: 'someMumboJumbo'
 google_proxy:
   client_id: 1
-  client_secret: 'someMumboJumbo'
+  client_secret: 'bogusClientSecret'
   scope: 'profile email https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/tasks https://www.googleapis.com/auth/drive.readonly.metadata https://mail.google.com/mail/feed/atom/'
   fake: false
   #Maps to tammi.chang.clc@gmail.com. Used for testing + recording responses
-  test_user_access_token: "someMumboJumbo"
-  test_user_refresh_token: "someMumboJumbo"
+  test_user_access_token: "bogusAccessToken"
+  test_user_refresh_token: "bogusRefreshToken"
   atom_mail_feed_url: "https://mail.google.com/mail/feed/atom/"
   oec:
     client_id: 'moreMumboJumbo'

--- a/spec/models/google_apps/proxy_spec.rb
+++ b/spec/models/google_apps/proxy_spec.rb
@@ -1,0 +1,55 @@
+describe GoogleApps::Proxy do
+
+  let(:auth) { GoogleApps::Proxy.new(options).authorization }
+
+  context '#fake' do
+    before do
+      allow(User::Oauth2Data).to receive(:new).never
+    end
+
+    context 'user_id is not nil' do
+      let(:refresh_token) { Settings.google_proxy.test_user_refresh_token }
+      let(:options) { { :user_id => random_id, :refresh_token => refresh_token, :fake => true } }
+
+      it 'should give precedence to fake access_token during valid user session' do
+        expect(auth).to_not be_nil
+        expect(auth.client_id).to eq Settings.google_proxy.client_id
+        expect(auth.client_secret).to eq Settings.google_proxy.client_secret
+        expect(auth.scope).to match_array Settings.google_proxy.scope.split(' ')
+        expect(auth.access_token).to eq 'fake_access_token'
+        expect(auth.refresh_token).to eq refresh_token
+        expect(auth.expires_in).to be_nil
+        expect(auth.expired?).to be false
+      end
+    end
+
+    context 'user_id is nil' do
+      let(:options) { { :fake => true, :app_name => 'oec' } }
+
+      it 'should tolerate no session user' do
+        expect(auth).to_not be_nil
+        expect(auth.access_token).to eq 'fake_access_token'
+      end
+
+      it 'should override default client_settings' do
+        expect(auth.client_id).to eq Settings.google_proxy.oec.client_id
+        expect(auth.client_secret).to eq Settings.google_proxy.oec.client_secret
+        expect(auth.scope).to match_array Settings.google_proxy.oec.scope.split(' ')
+      end
+    end
+
+    context 'test_user tokens' do
+      let(:refresh_token) { Settings.google_proxy.test_user_refresh_token }
+      let(:options) { { :access_token => Settings.google_proxy.test_user_access_token, :refresh_token => refresh_token, :expiration_time => 0 } }
+      it 'should pick up test_user_access_token, minus access_token' do
+        expect(auth).to_not be_nil
+        expect(auth.client_id).to eq Settings.google_proxy.client_id
+        expect(auth.client_secret).to eq Settings.google_proxy.client_secret
+        expect(auth.scope).to match_array Settings.google_proxy.scope.split(' ')
+        expect(auth.access_token).to eq 'fake_access_token'
+        expect(auth.refresh_token).to eq refresh_token
+      end
+    end
+
+  end
+end

--- a/spec/models/google_apps/proxy_spec.rb
+++ b/spec/models/google_apps/proxy_spec.rb
@@ -40,7 +40,8 @@ describe GoogleApps::Proxy do
 
     context 'test_user tokens' do
       let(:refresh_token) { Settings.google_proxy.test_user_refresh_token }
-      let(:options) { { :access_token => Settings.google_proxy.test_user_access_token, :refresh_token => refresh_token, :expiration_time => 0 } }
+      let(:options) { { :fake => true, :access_token => Settings.google_proxy.test_user_access_token,
+                        :refresh_token => refresh_token, :expiration_time => 0 } }
       it 'should pick up test_user_access_token, minus access_token' do
         expect(auth).to_not be_nil
         expect(auth.client_id).to eq Settings.google_proxy.client_id


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5604
Bamboo: https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CJT60-2

Includes:
* More test coverage
* fake data: *refresh_token* override to go with existing *access_token* override
