### PR TITLE
CLC-3181 Use campus DB first_name and last_name instead of person_name

### DIFF
--- a/app/models/campus_oracle/queries.rb
+++ b/app/models/campus_oracle/queries.rb
@@ -26,7 +26,7 @@ module CampusOracle
       result = []
       use_pooled_connection {
         sql = <<-SQL
-        select pi.ldap_uid, trim(pi.first_name) as first_name, trim(pi.last_name) as last_name, pi.person_name, pi.email_address, pi.student_id, pi.affiliations
+        select pi.ldap_uid, trim(pi.first_name) as first_name, trim(pi.last_name) as last_name, pi.email_address, pi.student_id, pi.affiliations
         from calcentral_person_info_vw pi
         where pi.ldap_uid in (#{up_to_1000_ldap_uids.collect { |id| id.to_i }.join(', ')})
         SQL

--- a/app/models/canvas_csv/base.rb
+++ b/app/models/canvas_csv/base.rb
@@ -22,7 +22,7 @@ module CanvasCsv
         'user_id' => derive_sis_user_id(campus_user),
         'login_id' => campus_user['ldap_uid'].to_s,
         'password' => nil,
-        'full_name' => campus_user['person_name'],
+        'full_name' => "#{campus_user['first_name']} #{campus_user['last_name']}",
         'email' => campus_user['email_address'],
         'status' => 'active'
       }

--- a/app/models/mailing_lists/site_mailing_list.rb
+++ b/app/models/mailing_lists/site_mailing_list.rb
@@ -251,7 +251,7 @@ module MailingLists
             unless list_address_set.include? user_address
               population_results[:add][:total] += 1
               logger.debug "Adding address #{user_address}"
-              proxy_response = add_member_proxy.add_member(self.list_name, user_address, user['person_name'])
+              proxy_response = add_member_proxy.add_member(self.list_name, user_address, "#{user['first_name']} #{user['last_name']}")
               if proxy_response[:response] && proxy_response[:response][:added]
                 population_results[:add][:success] += 1
               else

--- a/spec/models/canvas_csv/add_new_users_spec.rb
+++ b/spec/models/canvas_csv/add_new_users_spec.rb
@@ -17,8 +17,8 @@ describe CanvasCsv::AddNewUsers do
   let(:sis_active_uids) { %w(946122 946123 946124 946125 946126 946127).to_set }
   let(:sis_active_people) do
     [
-      {'ldap_uid'=>'946122', 'person_name'=>'Charmaine D\'Silva', 'email_address'=>'charmainedsilva@example.com', 'student_id'=>'22729405'},
-      {'ldap_uid'=>'946127', 'person_name'=>'Dwight Schrute', 'email_address'=>'dschrute@schrutefarms.com', 'student_id'=>nil},
+      {'ldap_uid'=>'946122', 'first_name'=>'Charmaine', 'last_name'=>'D\'Silva', 'email_address'=>'charmainedsilva@example.com', 'student_id'=>'22729405'},
+      {'ldap_uid'=>'946127', 'first_name'=>'Dwight', 'last_name'=>'Schrute', 'email_address'=>'dschrute@schrutefarms.com', 'student_id'=>nil},
     ]
   end
 
@@ -124,9 +124,11 @@ describe CanvasCsv::AddNewUsers do
       expect(loaded_users[0]).to be_an_instance_of Hash
       expect(loaded_users[1]).to be_an_instance_of Hash
       expect(loaded_users[0]['ldap_uid']).to eq '946122'
-      expect(loaded_users[0]['person_name']).to eq 'Charmaine D\'Silva'
+      expect(loaded_users[0]['first_name']).to eq 'Charmaine'
+      expect(loaded_users[0]['last_name']).to eq 'D\'Silva'
       expect(loaded_users[1]['ldap_uid']).to eq '946127'
-      expect(loaded_users[1]['person_name']).to eq 'Dwight Schrute'
+      expect(loaded_users[1]['first_name']).to eq 'Dwight'
+      expect(loaded_users[1]['last_name']).to eq 'Schrute'
     end
 
     it 'loads empty array when no new active users' do

--- a/spec/models/canvas_csv/base_spec.rb
+++ b/spec/models/canvas_csv/base_spec.rb
@@ -6,8 +6,8 @@ describe CanvasCsv::Base do
     context 'when all users known' do
       before do
         people_attributes = [
-          { 'ldap_uid'=>'1234', 'first_name'=>'John', 'last_name'=>'Smith', 'person_name'=> 'John Smith', 'email_address'=>'johnsmith@example.com', 'student_id'=>nil, 'affiliations'=>'EMPLOYEE-TYPE-ACADEMIC' },
-          { 'ldap_uid'=>'1235', 'first_name'=>'Jane', 'last_name'=>'Smith', 'person_name' => 'Jane Smith', 'email_address'=>'janesmith@example.com', 'student_id'=>nil, 'affiliations'=>'EMPLOYEE-TYPE-ACADEMIC' },
+          { 'ldap_uid'=>'1234', 'first_name'=>'John', 'last_name'=>'Smith',  'email_address'=>'johnsmith@example.com', 'student_id'=>nil, 'affiliations'=>'EMPLOYEE-TYPE-ACADEMIC' },
+          { 'ldap_uid'=>'1235', 'first_name'=>'Jane', 'last_name'=>'Smith', 'email_address'=>'janesmith@example.com', 'student_id'=>nil, 'affiliations'=>'EMPLOYEE-TYPE-ACADEMIC' },
         ]
         expect(CampusOracle::Queries).to receive(:get_basic_people_attributes).with(['1234','1235']).and_return people_attributes
       end

--- a/spec/models/canvas_csv/maintain_users_spec.rb
+++ b/spec/models/canvas_csv/maintain_users_spec.rb
@@ -22,7 +22,8 @@ describe CanvasCsv::MaintainUsers do
       let(:campus_rows) { [
         {
           'ldap_uid' => uid.to_i,
-          'person_name' => 'Ema Ilcha',
+          'first_name' => 'Ema',
+          'last_name' => 'Ilcha',
           'email_address' => 'new@example.edu',
           'affiliations' => 'EMPLOYEE-TYPE-STAFF'
         }
@@ -53,7 +54,8 @@ describe CanvasCsv::MaintainUsers do
       let(:campus_rows) { [
         {
           'ldap_uid' => changed_sis_id_uid.to_i,
-          'person_name' => 'Sissy Changer',
+          'first_name' => 'Sissy',
+          'last_name' => 'Changer',
           'email_address' => "#{changed_sis_id_uid}@example.edu",
           'affiliations' => 'EMPLOYEE-TYPE-STAFF,STUDENT-TYPE-REGISTERED',
           'student_id' => changed_sis_id_student_id.to_i
@@ -82,7 +84,8 @@ describe CanvasCsv::MaintainUsers do
       let(:campus_rows) { [
         {
           'ldap_uid' => uid.to_i,
-          'person_name' => 'Noam Changey',
+          'first_name' => 'Noam',
+          'last_name' => 'Changey',
           'email_address' => "#{uid}@example.edu",
           'affiliations' => 'EMPLOYEE-TYPE-STAFF,STUDENT-STATUS-EXPIRED',
           'student_id' => 9999999
@@ -95,16 +98,16 @@ describe CanvasCsv::MaintainUsers do
       end
     end
 
-    context 'when full name matches but first name does not' do
+    context 'when Canvas full_name matches campus first_name and last_name but Canvas first_name does not match campus first_name' do
       let(:uid) { rand(999999).to_s }
       let(:existing_account) {
         {
           'canvas_user_id' => rand(999999).to_s,
           'user_id' => "UID:#{uid}",
           'login_id' => uid,
-          'first_name' => 'Outerbridge',
-          'last_name' => 'Horsey',
-          'full_name' => 'Outerbridge Horsey III',
+          'first_name' => 'Eugene',
+          'last_name' => 'Debs',
+          'full_name' => 'Eugene V Debs',
           'email' => "#{uid}@example.edu",
           'status' => 'active'
         }
@@ -112,9 +115,8 @@ describe CanvasCsv::MaintainUsers do
       let(:campus_rows) { [
         {
           'ldap_uid' => uid.to_i,
-          'first_name' => 'Outerbridge III',
-          'last_name' => 'Horsey',
-          'person_name' => 'Outerbridge Horsey III',
+          'first_name' => 'Eugene V',
+          'last_name' => 'Debs',
           'email_address' => "#{uid}@example.edu",
           'affiliations' => 'EMPLOYEE-TYPE-STAFF,STUDENT-STATUS-EXPIRED',
           'student_id' => 9999999
@@ -142,7 +144,8 @@ describe CanvasCsv::MaintainUsers do
       let(:campus_rows) { [
         {
           'ldap_uid' => 0,
-          'person_name' => 'Sumotha Match',
+          'first_name' => 'Sumotha',
+          'last_name' => 'Match',
           'email_address' => 'zero@example.edu',
           'affiliations' => 'STUDENT-TYPE-REGISTERED',
           'student_id' => 9999999

--- a/spec/models/mailing_lists/site_mailing_list_spec.rb
+++ b/spec/models/mailing_lists/site_mailing_list_spec.rb
@@ -170,9 +170,9 @@ describe MailingLists::SiteMailingList do
         let(:fake_add_proxy) { Calmail::AddListMember.new(fake: true) }
         let(:fake_remove_proxy) { Calmail::RemoveListMember.new(fake: true) }
 
-        let(:oliver) { {'login_id' => '12345', 'person_name' => 'Oliver Heyer', 'email_address' => 'oheyer@berkeley.edu'}  }
-        let(:ray) { {'login_id' => '67890', 'person_name' => 'Ray Davis', 'email_address' => 'raydavis@berkeley.edu'}  }
-        let(:paul) { {'login_id' => '65536', 'person_name' => 'Paul Kerschen', 'email_address' => 'kerschen@berkeley.edu'}  }
+        let(:oliver) { {'login_id' => '12345', 'first_name' => 'Oliver', 'last_name' => 'Heyer', 'email_address' => 'oheyer@berkeley.edu'}  }
+        let(:ray) { {'login_id' => '67890', 'first_name' => 'Ray', 'last_name' => 'Davis', 'email_address' => 'raydavis@berkeley.edu'}  }
+        let(:paul) { {'login_id' => '65536', 'first_name' => 'Paul', 'last_name' => 'Kerschen', 'email_address' => 'kerschen@berkeley.edu'}  }
 
         before do
           allow(Canvas::CourseUsers).to receive(:new).and_return course_users


### PR DESCRIPTION
Partial revert of #4060, going back to `first_name` and `last_name` from campus data in place of `person_name`.

See comments to https://jira.ets.berkeley.edu/jira/browse/CLC-3181 for motivation.