### PR TITLE
CLC-5654 Explicitly list Oec::CsvExport subclasses

### DIFF
--- a/app/models/oec/term_setup_task.rb
+++ b/app/models/oec/term_setup_task.rb
@@ -12,7 +12,7 @@ module Oec
 
       find_previous_term_csvs
 
-      Oec::CsvExport.subclasses.each do |csv_class|
+      [Oec::CourseInstructors, Oec::CourseSupervisors, Oec::Courses, Oec::Instructors, Oec::Supervisors].each do |csv_class|
         if @previous_term_csvs[csv_class]
           copy_file(@previous_term_csvs[csv_class], supplemental_sources)
         else


### PR DESCRIPTION
Follow-up for https://jira.ets.berkeley.edu/jira/browse/CLC-5654.

For obscure constant-loading reasons, the handy ActiveSupport `subclasses` method is returning an array of subclasses when run in the console or as part of a test, but an empty array when run as part of a Rake task. Work around for the moment by listing subclasses explicitly.