### PR TITLE
CLC-5681 - Hovering a cc-button-link element with an icon doesn't underline the icon

### DIFF
--- a/src/assets/stylesheets/_buttons.scss
+++ b/src/assets/stylesheets/_buttons.scss
@@ -120,6 +120,9 @@ button {
     font-size: 13px;
     font-weight: normal;
   }
+  &:hover i, &:focus i {
+    text-decoration: underline;
+  }
 }
 
 .cc-button-group {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5681