### PR TITLE
CLC-5667, divorce OEC CredentialStore from bConnected proxy

### DIFF
--- a/app/models/google_apps/client.rb
+++ b/app/models/google_apps/client.rb
@@ -19,23 +19,12 @@ module GoogleApps
         end
       end
 
-      def new_auth(credential_store, options = {})
-        storage = Google::APIClient::Storage.new credential_store
-        auth = storage.authorize
-        if options && options['refresh_token'] && options['expiration_time']
-          auth.refresh_token = options['refresh_token']
-          auth.expires_in = 3600
-          auth.issued_at = Time.at(options['expiration_time'] - 3600)
-        end
-        if auth.nil? || (auth.expired? && auth.refresh_token.nil?)
-          config = credential_store.load_credentials
-          flow = Google::APIClient::InstalledAppFlow.new({
-                                                           :client_id => config.client_id,
-                                                           :client_secret => config.client_secret,
-                                                           :scope => config.scope})
-          auth = flow.authorize storage
-        end
-        auth
+      def new_fake_auth
+        new_auth("fake_access_token")
+      end
+
+      def new_client_auth(token_hash)
+        new_auth(token_hash["access_token"], token_hash)
       end
 
       def generate_request_hash(page_params)
@@ -58,6 +47,20 @@ module GoogleApps
       end
 
       private
+
+      def new_auth(access_token, options={})
+        authorization = client.authorization.dup
+        authorization.client_id = Settings.google_proxy.client_id
+        authorization.client_secret = Settings.google_proxy.client_secret
+        authorization.access_token = access_token
+        ## Not setting these in explicit fake mode will prevent the api_client from attempting to refresh tokens.
+        if options && options["refresh_token"] && options["expiration_time"]
+          authorization.refresh_token = options["refresh_token"]
+          authorization.expires_in = 3600
+          authorization.issued_at = Time.at(options["expiration_time"] - 3600)
+        end
+        authorization
+      end
 
       def discover_version(api)
         client.preferred_version(api).version

--- a/app/models/google_apps/proxy.rb
+++ b/app/models/google_apps/proxy.rb
@@ -8,25 +8,20 @@ module GoogleApps
 
     attr_accessor :authorization, :json_filename
 
-    APP_ID = 'Google'
+    APP_ID = "Google"
 
     def initialize(options = {})
       super(Settings.google_proxy, options)
 
       if @fake
-        options.merge!({ access_token: 'fake_access_token' })
-        credentials = GoogleApps::CredentialStore.new options
-        @authorization = GoogleApps::Client.new_auth credentials
+        @authorization = GoogleApps::Client.new_fake_auth
       elsif options[:user_id]
         token_settings = User::Oauth2Data.get(@uid, APP_ID)
-        options = token_settings || { 'access_token' => '' }
-        credentials = GoogleApps::CredentialStore.new(access_token: options['access_token'])
-        @authorization = GoogleApps::Client.new_auth(credentials, options)
+        @authorization = GoogleApps::Client.new_client_auth token_settings || {"access_token" => ''}
       else
         auth_related_entries = [:access_token, :refresh_token, :expiration_time]
         token_settings = options.select { |k, v| auth_related_entries.include? k }.stringify_keys!
-        credentials = GoogleApps::CredentialStore.new(access_token: token_settings['access_token'])
-        @authorization = GoogleApps::Client.new_auth(credentials, token_settings)
+        @authorization = GoogleApps::Client.new_client_auth token_settings
       end
 
       @fake_options = options[:fake_options] || {}

--- a/spec/models/google_apps/proxy_spec.rb
+++ b/spec/models/google_apps/proxy_spec.rb
@@ -8,47 +8,35 @@ describe GoogleApps::Proxy do
     end
 
     context 'user_id is not nil' do
-      let(:refresh_token) { Settings.google_proxy.test_user_refresh_token }
-      let(:options) { { :user_id => random_id, :refresh_token => refresh_token, :fake => true } }
+      let(:options) { { :user_id => random_id, :fake => true } }
 
       it 'should give precedence to fake access_token during valid user session' do
         expect(auth).to_not be_nil
         expect(auth.client_id).to eq Settings.google_proxy.client_id
         expect(auth.client_secret).to eq Settings.google_proxy.client_secret
-        expect(auth.scope).to match_array Settings.google_proxy.scope.split(' ')
         expect(auth.access_token).to eq 'fake_access_token'
-        expect(auth.refresh_token).to eq refresh_token
         expect(auth.expires_in).to be_nil
         expect(auth.expired?).to be false
       end
     end
 
     context 'user_id is nil' do
-      let(:options) { { :fake => true, :app_name => 'oec' } }
+      let(:options) { { :fake => true } }
 
       it 'should tolerate no session user' do
         expect(auth).to_not be_nil
         expect(auth.access_token).to eq 'fake_access_token'
       end
-
-      it 'should override default client_settings' do
-        expect(auth.client_id).to eq Settings.google_proxy.oec.client_id
-        expect(auth.client_secret).to eq Settings.google_proxy.oec.client_secret
-        expect(auth.scope).to match_array Settings.google_proxy.oec.scope.split(' ')
-      end
     end
 
     context 'test_user tokens' do
-      let(:refresh_token) { Settings.google_proxy.test_user_refresh_token }
       let(:options) { { :fake => true, :access_token => Settings.google_proxy.test_user_access_token,
-                        :refresh_token => refresh_token, :expiration_time => 0 } }
+                        :expiration_time => 0 } }
       it 'should pick up test_user_access_token, minus access_token' do
         expect(auth).to_not be_nil
         expect(auth.client_id).to eq Settings.google_proxy.client_id
         expect(auth.client_secret).to eq Settings.google_proxy.client_secret
-        expect(auth.scope).to match_array Settings.google_proxy.scope.split(' ')
         expect(auth.access_token).to eq 'fake_access_token'
-        expect(auth.refresh_token).to eq refresh_token
       end
     end
 

--- a/spec/models/google_apps/proxy_spec.rb
+++ b/spec/models/google_apps/proxy_spec.rb
@@ -15,8 +15,6 @@ describe GoogleApps::Proxy do
         expect(auth.client_id).to eq Settings.google_proxy.client_id
         expect(auth.client_secret).to eq Settings.google_proxy.client_secret
         expect(auth.access_token).to eq 'fake_access_token'
-        expect(auth.expires_in).to be_nil
-        expect(auth.expired?).to be false
       end
     end
 


### PR DESCRIPTION
DO NOT MERGE until Bamboo is happy: 
https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CJT63-1

https://jira.ets.berkeley.edu/jira/browse/CLC-5667

As I move to put OEC's oauth2 tokens in the db via CredentialStore class, I want to remove risk on the bConnected side. In the future, as Google API work progresses, we can refactor proxy.rb and leverage CredentialStore.