### PR TITLE
CLC-5667, Get OEC-related OAuth2 tokens in db

### DIFF
--- a/app/models/google_apps/credential_store.rb
+++ b/app/models/google_apps/credential_store.rb
@@ -1,34 +1,73 @@
 module GoogleApps
   class CredentialStore
+    include ClassLogger
 
-    def initialize(options = {})
-      @options = options
+    def initialize(uid, options = {})
+      @uid = uid
+      raise ArgumentError, 'UID is blank' if @uid.blank?
+      @options = options.symbolize_keys
     end
 
     def load_credentials
-      app_name = @options[:app_name]
-      google_configs = Settings.google_proxy.marshal_dump
-      if app_name.nil?
-        # Use default client credentials
-        credentials = google_configs
-      else
-        # Custom clients can be configured via YAML convention: google_proxy.my_app.client_id, etc.
-        key = app_name.to_sym
-        credentials = google_configs[key].marshal_dump if google_configs.has_key? key
+      credentials = load_credentials_from_db
+      if credentials.nil? && @options.has_key?(:access_token) && @options.has_key?(:refresh_token)
+        logger.warn "Writing Google auth tokens to database using values found in options hash. UID: #{@uid}"
+        write_credentials @options
+        credentials = load_credentials_from_db
       end
-      unless credentials.nil?
-        credentials[:token_credential_uri] = 'https://accounts.google.com/o/oauth2/token'
-        # Token override
-        credentials[:access_token] = @options[:access_token] if @options.has_key? :access_token
-        credentials[:refresh_token] = @options[:refresh_token] if @options.has_key? :refresh_token
-      end
+      logger.error "No Google OAuth tokens found where UID=#{@uid}" if credentials.nil?
       credentials
     end
 
-    def write_credentials(credentials_hash = {})
-      # Per http://google-api-python-client.googlecode.com/hg/docs/epy/oauth2client.file.Storage-class.html
-      # Our implementation does not cache (i.e., serialize) OAuth 2 tokens on disk.
-      # See Google::APIClient::FileStore for an alternate strategy.
+    ##
+    # Write the credentials to database.
+    #
+    # @param [Signet::OAuth2::Client] auth
+    def write_credentials(auth = nil)
+      credentials = nil
+      if auth
+        if auth.is_a?(Hash) && auth.has_key?(:access_token) && auth.has_key?(:refresh_token)
+          logger.debug "OAuth tokens in hash, where UID=#{@uid}"
+          credentials = update_tokens(auth[:access_token], auth[:refresh_token], auth[:issued_at], auth[:expires_in], @options)
+        elsif auth.is_a?(Signet::OAuth2::Client) && auth.access_token && auth.refresh_token
+          logger.debug "OAuth tokens in OAuth2 instance, where UID=#{@uid}"
+          credentials = update_tokens(auth.access_token, auth.refresh_token, auth.issued_at, auth.expires_in, @options)
+        end
+      end
+      logger.warn "Google OAuth tokens not found during attempted database update. UID=#{@uid}; auth.class #{auth.class}" if credentials.nil?
+      credentials
+    end
+
+    private
+
+    def update_tokens(access_token, refresh_token, issued_at, expires_in, options = {})
+      tokens_missing = access_token.blank? || refresh_token.blank?
+      raise ArgumentError, "Google 'access_token' and/or 'refresh_token' are blank where UID=#{@uid}" if tokens_missing
+      expiration_time = issued_at.blank? || expires_in.blank? ? 0 : issued_at.to_i + expires_in.to_i
+      logger.debug "Put OAuth tokens to db where UID=#{@uid}"
+      User::Oauth2Data.new_or_update(@uid.to_s, GoogleApps::Proxy::APP_ID, access_token, refresh_token,
+                                     expiration_time, options)
+    end
+
+    def load_credentials_from_db
+      client_id = @options[:client_id] || Settings.google_proxy.client_id
+      client_secret = @options[:client_secret] || Settings.google_proxy.client_secret
+      scope = @options[:scope] || Settings.google_proxy.scope
+      raise ArgumentError "Incomplete Google credential configuration where client_id=#{client_id}" if client_id.blank? || client_secret.blank? || scope.blank?
+      oauth2_data = User::Oauth2Data.get(@uid, GoogleApps::Proxy::APP_ID)
+      credentials = nil
+      if !oauth2_data.nil? && oauth2_data.any?
+        credentials = { :client_id => client_id, :client_secret => client_secret, :scope => scope }
+        credentials.merge! oauth2_data.symbolize_keys
+        # Infer properties wanted by Google
+        unless credentials[:expires_in] && credentials[:issued_at]
+          credentials[:expires_in] = 3600
+          expiration_time = credentials[:expiration_time].to_i
+          credentials[:issued_at] = Time.at(expiration_time - 3600)
+        end
+        credentials[:token_credential_uri] = 'https://accounts.google.com/o/oauth2/token'
+      end
+      credentials
     end
 
   end

--- a/app/models/google_apps/sheets_manager.rb
+++ b/app/models/google_apps/sheets_manager.rb
@@ -1,10 +1,9 @@
 module GoogleApps
   class SheetsManager < DriveManager
 
-    def initialize(credential_store)
-      super credential_store
+    def initialize(uid, options = {})
+      super uid, options
       auth = get_google_api.authorization
-      auth.fetch_access_token!
       # See https://github.com/gimite/google-drive-ruby
       @session = GoogleDrive::Session.login_with_oauth auth.access_token
     end

--- a/app/models/oec/task.rb
+++ b/app/models/oec/task.rb
@@ -4,7 +4,8 @@ module Oec
 
     def initialize(opts)
       @log = []
-      @remote_drive = GoogleApps::SheetsManager.new GoogleApps::CredentialStore.new(app_name: 'oec')
+      uid = Settings.oec.google.uid
+      @remote_drive = GoogleApps::SheetsManager.new(uid, Settings.oec.google.marshal_dump)
       @term_code = opts[:term_code]
       @tmp_path = Rails.root.join('tmp', 'oec')
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -103,12 +103,6 @@ google_proxy:
   test_user_access_token: "bogusAccessToken"
   test_user_refresh_token: "bogusRefreshToken"
   atom_mail_feed_url: "https://mail.google.com/mail/feed/atom/"
-  oec:
-    client_id: 'oecMumboJumbo'
-    client_secret: 'oecMumboJumbo'
-    access_token: 'tokenThis'
-    refresh_token: 'tokenThat'
-    scope: 'profile email https://mail.google.com/mail/feed/atom/ https://spreadsheets.google.com/feeds/ https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.apps.readonly https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.readonly.metadata https://www.googleapis.com/auth/tasks'
 
 sakai_proxy:
   host: "https://sakai-dev.berkeley.edu"
@@ -313,6 +307,13 @@ features:
 youtube_splash_id: 'EQ-a7xrfVag'
 
 oec:
+  google:
+    uid: ''
+    client_id: 'oecClientId'
+    client_secret: 'oecClientSecret'
+    access_token: 'oecAccessToken'
+    refresh_token: 'oecRefreshToken'
+    scope: 'profile email https://mail.google.com/mail/feed/atom/ https://spreadsheets.google.com/feeds/ https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.apps.readonly https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.readonly.metadata https://www.googleapis.com/auth/tasks'
   current_terms_codes: [{
     year: 2015,
     code: "C"

--- a/spec/models/google_apps/credential_store_spec.rb
+++ b/spec/models/google_apps/credential_store_spec.rb
@@ -91,7 +91,7 @@ describe GoogleApps::CredentialStore do
       existing_data = User::Oauth2Data.get(@uid, @app_id)
       raise 'The random and very large id matches real data. Abort!' if existing_data.any?
       # Values in options hash will be written to the database
-      GoogleApps::CredentialStore.new(@uid, options).write_credentials
+      GoogleApps::CredentialStore.new(@uid, options).write_credentials options
     end
 
     after do

--- a/spec/models/google_apps/credential_store_spec.rb
+++ b/spec/models/google_apps/credential_store_spec.rb
@@ -1,34 +1,113 @@
 describe GoogleApps::CredentialStore do
 
-  context '#load_credentials' do
-    it 'should load default calcentral credentials' do
-      custom_token = 'custom_access_token'
-      store = GoogleApps::CredentialStore.new(access_token: custom_token)
-      credentials = store.load_credentials
-      expect(credentials[:client_id]).to_not be_nil
-      expect(credentials[:token_credential_uri]).to_not be_nil
-      expect(credentials[:access_token]).to eq custom_token
+  context '#fake' do
+    let(:client_id) { Settings.google_proxy.client_id }
+    let(:client_secret) { Settings.google_proxy.client_secret }
+    let(:scope) { Settings.google_proxy.scope }
+    let(:oauth2_data) {
+      {
+        :access_token => "access_token-#{rand(999999)}",
+        :refresh_token => "refresh_token-#{rand(999999)}",
+        :expiration_time => 1
+      }
+    }
+
+    context 'uid has access and refresh token in the database' do
+      let(:uid) { random_id }
+      let(:store) { GoogleApps::CredentialStore.new(uid) }
+      before {
+        allow(User::Oauth2Data).to receive(:get).with(uid, GoogleApps::Proxy::APP_ID).and_return oauth2_data
+      }
+
+      it 'should load default calcentral credentials' do
+        c = store.load_credentials
+        expect(c[:client_id]).to eq client_id
+        expect(c[:client_secret]).to eq client_secret
+        expect(c[:token_credential_uri]).to_not be_nil
+        expect(c[:access_token]).to eq oauth2_data[:access_token]
+        expect(c[:refresh_token]).to eq oauth2_data[:refresh_token]
+        expect(c[:expires_in]).to_not be_nil
+        expect(c[:issued_at]).to_not be_nil
+        expect(c[:scope]).to eq scope
+      end
     end
 
-    it 'should load custom credentials' do
-      store = GoogleApps::CredentialStore.new(app_name: 'oec')
-      credentials = store.load_credentials
-      expect(credentials[:client_id]).to_not be_nil
-      expect(credentials[:token_credential_uri]).to_not be_nil
-      expect(credentials[:access_token]).to_not be_nil
+    context 'options' do
+      let(:user_does_not_exist) { random_id }
+      let(:store) { GoogleApps::CredentialStore.new(user_does_not_exist, options) }
+      before {
+        allow(User::Oauth2Data).to receive(:get).with(user_does_not_exist, GoogleApps::Proxy::APP_ID).and_return({})
+      }
+
+      context 'override access and refresh token' do
+        let(:options) {
+          {
+            'access_token' => "access_token_#{DateTime.now.strftime('%m/%d/%Y at %I:%M%p')}",
+            'refresh_token' => "refresh_token_#{DateTime.now.strftime('%m/%d/%Y at %I:%M%p')}"
+          }
+        }
+
+        it 'should not load credentials when UID not found' do
+          expect(store.load_credentials).to be_nil
+        end
+      end
+
+      context 'Google auth scope' do
+        it 'OEC scope should be a superset of default scope' do
+          oec_scope = Settings.oec.google.scope.split(' ')
+          default_scope = Settings.google_proxy.scope.split(' ')
+          expect(oec_scope).to include *default_scope
+        end
+
+      end
     end
 
-    it 'should return nil when no such key mapping exists' do
-      store = GoogleApps::CredentialStore.new(app_name: 'no_such_key')
-      expect(store.load_credentials).to be_nil
+    context 'error conditions' do
+      it 'should raise error when UID is blank' do
+        expect{ GoogleApps::CredentialStore.new('  ') }.to raise_error ArgumentError
+      end
+
+      it 'should raise error when client configs are incomplete' do
+        store = GoogleApps::CredentialStore.new(random_id, {client_id: 'someClientId', client_secret: ' '})
+        expect{ store.load_credentials }.to raise_error
+      end
     end
   end
 
-  context '#scope' do
-    it 'should always expand on default scope, never narrow it' do
-      default_scope = GoogleApps::CredentialStore.new.load_credentials[:scope].split(' ')
-      oec_scope = GoogleApps::CredentialStore.new(app_name: 'oec').load_credentials[:scope].split(' ')
-      expect(oec_scope).to include *default_scope
+  context '#real', testext: true, :order => :defined do
+    let(:options) {
+      {
+        access_token: "access_token_#{DateTime.now.strftime('%m/%d/%Y at %I:%M%p')}",
+        refresh_token: "refresh_token_#{DateTime.now.strftime('%m/%d/%Y at %I:%M%p')}",
+        issued_at: 1440628381,
+        expires_in: 3600,
+        app_data: 'johndoe@berkeley.edu'
+      }
+    }
+
+    before do
+      @uid = 99999.to_s
+      @app_id = GoogleApps::Proxy::APP_ID
+      existing_data = User::Oauth2Data.get(@uid, @app_id)
+      raise 'The random and very large id matches real data. Abort!' if existing_data.any?
+      # Values in options hash will be written to the database
+      GoogleApps::CredentialStore.new(@uid, options).write_credentials
+    end
+
+    after do
+      User::Oauth2Data.remove(@uid, @app_id)
+    end
+
+    it 'should find no match in oauth2_data' do
+      c = GoogleApps::CredentialStore.new(@uid).load_credentials
+      expect(c).to_not be_nil
+      expect(c[:access_token]).to eq options[:access_token]
+      expect(c[:refresh_token]).to eq options[:refresh_token]
+      expect(c[:expiration_time]).to_not be_nil
+      expect(c[:expires_in]).to eq 3600
+      expect(c[:client_id]).to eq Settings.google_proxy.client_id
+      expect(c[:client_secret]).to eq Settings.google_proxy.client_secret
+      expect(c[:scope]).to eq Settings.google_proxy.scope
     end
   end
 

--- a/spec/models/google_apps/drive_manager_spec.rb
+++ b/spec/models/google_apps/drive_manager_spec.rb
@@ -3,7 +3,15 @@ describe GoogleApps::DriveManager do
   context '#real', testext: true, :order => :defined do
 
     before(:all) do
-      @drive = GoogleApps::DriveManager.new GoogleApps::CredentialStore.new(app_name: 'oec')
+      app_data = {:email => 'ets.quality@gmail.com'}
+      store = GoogleApps::CredentialStore.new(1055799, {
+        :access_token => 'ya29.0gHs7gafsWRe3oOunAP2SIRGpLTbXcQzPZ40nbmU_JHqWHr73IEZlRogxFVyLBUpfN2e',
+        :refresh_token => '1/uw9QGBqRCroObKKtysnfI_DH5kgEn97bnuGLdogGsZtIgOrJDtdun6zK6XiATCKT',
+        :expires_in => 3600,
+        :app_data => app_data})
+      store.write_credentials
+      settings = Settings.oec.google.marshal_dump
+      @drive = GoogleApps::DriveManager.new settings[:uid], settings
       now = DateTime.now.strftime('%m/%d/%Y at %I:%M%p')
       title = "GoogleDriveInsert tested on #{now}"
       csv_file = 'fixtures/oec_legacy/courses.csv'

--- a/spec/models/google_apps/drive_manager_spec.rb
+++ b/spec/models/google_apps/drive_manager_spec.rb
@@ -3,15 +3,8 @@ describe GoogleApps::DriveManager do
   context '#real', testext: true, :order => :defined do
 
     before(:all) do
-      app_data = {:email => 'ets.quality@gmail.com'}
-      store = GoogleApps::CredentialStore.new(1055799, {
-        :access_token => 'ya29.0gHs7gafsWRe3oOunAP2SIRGpLTbXcQzPZ40nbmU_JHqWHr73IEZlRogxFVyLBUpfN2e',
-        :refresh_token => '1/uw9QGBqRCroObKKtysnfI_DH5kgEn97bnuGLdogGsZtIgOrJDtdun6zK6XiATCKT',
-        :expires_in => 3600,
-        :app_data => app_data})
-      store.write_credentials
       settings = Settings.oec.google.marshal_dump
-      @drive = GoogleApps::DriveManager.new settings[:uid], settings
+      @drive = GoogleApps::DriveManager.new Settings.oec.google.uid, settings
       now = DateTime.now.strftime('%m/%d/%Y at %I:%M%p')
       title = "GoogleDriveInsert tested on #{now}"
       csv_file = 'fixtures/oec_legacy/courses.csv'

--- a/spec/models/google_apps/sheets_manager_spec.rb
+++ b/spec/models/google_apps/sheets_manager_spec.rb
@@ -3,7 +3,8 @@ describe GoogleApps::SheetsManager do
   context '#real', testext: true, :order => :defined do
 
     before(:all) do
-      @sheet_manager = GoogleApps::SheetsManager.new GoogleApps::CredentialStore.new(app_name: 'oec')
+      settings = Settings.oec.google.marshal_dump
+      @sheet_manager = GoogleApps::SheetsManager.new settings[:uid], settings
       now = DateTime.now.strftime('%m/%d/%Y at %I:%M%p')
       @folder = @sheet_manager.create_folder "GoogleApps::SheetsManager tested on #{now}"
       @sheet_title = "Sheet from CSV, #{now}"


### PR DESCRIPTION
DO NOT MERGE until https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CJT64-2 succeeds

* CredentialStore now wraps *oauth2_data* db table. https://jira.ets.berkeley.edu/jira/browse/CLC-5667
* New OEC spa account *ets.course.eval.qa@gmail.com*: https://jira.ets.berkeley.edu/jira/browse/CLC-5632
* OEC/OAuth configs moved under existing 'oec' in yml. 
* Once tokens are in database we can remove *access_token* and *refresh_token* from yml. That removal will happen w/ release after next.