### PR TITLE
CLC-5724, upload_worksheet() brings abstraction to GoogleApps::SheetsManager

### DIFF
--- a/app/models/oec/term_setup_task.rb
+++ b/app/models/oec/term_setup_task.rb
@@ -17,7 +17,7 @@ module Oec
           copy_file(@previous_term_csvs[csv_class], supplemental_sources)
         else
           log :info, "Could not find previous #{csv_class.base_filename} for copying; will create header-only file"
-          upload_csv_headers(csv_class, supplemental_sources)
+          upload_worksheet_headers(csv_class, supplemental_sources)
         end
       end
     end

--- a/spec/models/google_apps/sheets_manager_spec.rb
+++ b/spec/models/google_apps/sheets_manager_spec.rb
@@ -6,9 +6,13 @@ describe GoogleApps::SheetsManager do
       settings = Settings.oec.google.marshal_dump
       @sheet_manager = GoogleApps::SheetsManager.new settings[:uid], settings
       now = DateTime.now.strftime('%m/%d/%Y at %I:%M%p')
-      @folder = @sheet_manager.create_folder "GoogleApps::SheetsManager tested on #{now}"
+      @folder = @sheet_manager.create_folder "#{GoogleApps::SheetsManager.name} test, #{now}"
       @sheet_title = "Sheet from CSV, #{now}"
-      @spreadsheet = @sheet_manager.upload_csv_to_spreadsheet(@sheet_title, "Description #{now}", 'fixtures/oec_legacy/courses.csv', @folder.id)
+      # No CSV files will be created by this test
+      worksheet = Oec::Courses.new Rails.root.join('tmp/oec')
+      course_codes = [Oec::CourseCode.new(dept_name: 'SPANISH', catalog_id: '', dept_code: 'LPSPP', include_in_oec: true)]
+      Oec::CoursesImportTask.new(:term_code => '2015-C').import_courses(worksheet, course_codes)
+      @spreadsheet = @sheet_manager.upload_worksheet(@sheet_title, "Description #{now}", worksheet, @folder.id)
     end
 
     after(:all) do

--- a/spec/support/oec_spec_helper.rb
+++ b/spec/support/oec_spec_helper.rb
@@ -37,8 +37,8 @@ module OecSpecHelper
     expect(fake_sheets_manager).to receive(:find_items_by_title)
       .with(file_name.chomp('.csv'), parent_id: mock_file(parent_name).id)
       .and_return []
-    expect(fake_sheets_manager).to receive(:upload_csv_to_spreadsheet)
-      .with(file_name.chomp('.csv'), '', Rails.root.join('tmp', 'oec', file_name).to_s, mock_file(parent_name).id)
+    expect(fake_sheets_manager).to receive(:upload_worksheet)
+      .with(file_name.chomp('.csv'), '', kind_of(Oec::Worksheet), mock_file(parent_name).id)
       .and_return(mock_file(file_name))
   end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5724

A worksheet object might wrap a CSV file read from disk or a hash in memory. Our GoogleApps::SheetsManager doesn't care and thus the abstraction. 