### PR TITLE
CLC-5731 Allow OEC tasks to take department-filter and local-write arguments

### DIFF
--- a/app/models/oec/course_code.rb
+++ b/app/models/oec/course_code.rb
@@ -4,8 +4,8 @@ module Oec
     self.table_name = 'oec_course_codes'
     attr_accessible :dept_name, :catalog_id, :dept_code, :include_in_oec
 
-    def self.included_by_dept_code
-      self.where(dept_name: included_dept_names).group_by { |course_code| course_code.dept_code }
+    def self.by_dept_code(opts)
+      self.where(opts).group_by { |course_code| course_code.dept_code }
     end
 
     def self.included_dept_names

--- a/app/models/oec/courses_import_task.rb
+++ b/app/models/oec/courses_import_task.rb
@@ -1,7 +1,7 @@
 module Oec
   class CoursesImportTask < Task
 
-    def run_internal
+    def run_internal(opts={})
       log :info, "Will import SIS data for term #{@term_code}"
       unless (term_folder = find_folder @term_code) && (imports_folder = find_folder('imports', term_folder))
         raise RuntimeError, 'Could not locate imports folder on remote drive'
@@ -9,7 +9,16 @@ module Oec
       unless (imports_today = find_or_create_folder(datestamp, imports_folder))
         raise RuntimeError, "Could not get imports folder dated #{datestamp} on remote drive"
       end
-      Oec::CourseCode.included_by_dept_code.each do |dept_code, course_codes|
+
+      course_code_filter = if opts[:dept_names]
+                             {dept_name: opts[:dept_names].split}
+                           elsif opts[:dept_codes]
+                             {dept_code: opts[:dept_codes].split}
+                           else
+                             {dept_name: Oec::CourseCode.included_dept_names}
+                           end
+
+      Oec::CourseCode.by_dept_code(course_code_filter).each do |dept_code, course_codes|
         log :info, "Generating #{dept_code}.csv"
         courses = Oec::Courses.new(@tmp_path, dept_code: dept_code)
         import_courses(courses, course_codes)

--- a/app/models/oec/task.rb
+++ b/app/models/oec/task.rb
@@ -6,13 +6,14 @@ module Oec
       @log = []
       uid = Settings.oec.google.uid
       @remote_drive = GoogleApps::SheetsManager.new(uid, Settings.oec.google.marshal_dump)
-      @term_code = opts[:term_code]
+      @term_code = opts.delete :term_code
+      @opts = opts
       @tmp_path = Rails.root.join('tmp', 'oec')
     end
 
     def run
       log :info, "Starting #{self.class.name}"
-      run_internal
+      run_internal @opts
       true
     rescue => e
       log :error, "#{self.class.name} aborted with error: #{e.message}\n#{e.backtrace.join "\n\t"}"
@@ -24,19 +25,21 @@ module Oec
     private
 
     def create_folder(folder_name, parent=nil)
+      return if @opts[:local_write]
       if @remote_drive.find_folders_by_title(folder_name, folder_id(parent)).any?
-        raise RuntimeError, "Folder #{folder_name} with parent #{folder_title(parent)} already exists on remote drive"
+        raise RuntimeError, "Folder '#{folder_name}' with parent '#{folder_title(parent)}' already exists on remote drive"
       else
         create_folder_no_existence_check(folder_name, parent)
       end
     end
 
     def export_sheet(worksheet, dest_folder)
-      worksheet.export
-      log :debug, "Exported worksheet file #{worksheet.output_filename}"
-      upload_to_remote_drive(worksheet, worksheet.base_filename.chomp('.csv'), dest_folder)
-    ensure
-    #  File.delete csv.output_filename
+      if @opts[:local_write]
+        worksheet.export
+        log :debug, "Exported local worksheet file '#{worksheet.output_filename}'"
+      else
+        upload_to_remote_drive(worksheet, worksheet.base_filename.chomp('.csv'), dest_folder)
+      end
     end
 
     def find_or_create_folder(folder_name, parent=nil)
@@ -45,20 +48,20 @@ module Oec
 
     def create_folder_no_existence_check(folder_name, parent=nil)
       unless folder = @remote_drive.create_folder(folder_name, folder_id(parent))
-        raise RuntimeError, "Could not create folder #{folder_name} on remote drive"
+        raise RuntimeError, "Could not create folder '#{folder_name}' on remote drive"
       end
-      log :debug, "Created remote folder \"#{folder_name}\""
+      log :debug, "Created remote folder '#{folder_name}'"
       folder
     end
 
     def copy_file(file, dest_folder)
       if find_item(file.title, dest_folder)
-        raise RuntimeError, "File \"#{file.title}\" already exists in remote drive folder \"#{dest_folder.title}\"; could not copy"
+        raise RuntimeError, "File '#{file.title}' already exists in remote drive folder '#{dest_folder.title}'; could not copy"
       end
       if (@remote_drive.copy_item_to_folder(file, dest_folder.id))
-        log :debug, "Copied file \"#{file.title}\" to remote drive folder \"#{dest_folder.title}\""
+        log :debug, "Copied file '#{file.title}' to remote drive folder '#{dest_folder.title}'"
       else
-        raise RuntimeError, "Could not copy file \"#{file.title}\" to \"#{dest_folder.title}\""
+        raise RuntimeError, "Could not copy file '#{file.title}' to '#{dest_folder.title}'"
       end
     end
 
@@ -97,49 +100,49 @@ module Oec
 
     def upload_worksheet_headers(klass, dest_folder)
       worksheet = klass.new(@tmp_path)
-      begin
+      if @opts[:local_write]
         worksheet.export
-        log :debug, "Created header-only file #{worksheet.output_filename}"
+        log :debug, "Exported local header-only file #{worksheet.output_filename}"
+      else
         upload_to_remote_drive(worksheet, klass.name.demodulize.underscore, dest_folder)
-      ensure
-        File.delete worksheet.output_filename
       end
     end
 
     def upload_to_remote_drive(worksheet, title, folder)
       if @remote_drive.find_items_by_title(title, parent_id: folder.id).any?
-        raise RuntimeError, "File \"#{title}\" already exists in remote drive folder \"#{folder.title}\"; could not upload"
+        raise RuntimeError, "Item '#{title}' already exists in remote drive folder '#{folder.title}'; could not upload sheet"
       end
-      path = worksheet.output_filename
       if (!@remote_drive.upload_worksheet(title, '', worksheet, folder.id))
-        raise RuntimeError, "File #{path} could not be uploaded as sheet '#{title}' to remote drive folder \"#{folder.title}\""
+        raise RuntimeError, "Sheet '#{title}' could not be uploaded to remote drive folder '#{folder.title}'"
       end
-      log :debug, "Uploaded file #{path} as sheet '#{title}' to remote drive folder '#{folder.title}'"
+      log :debug, "Uploaded sheet '#{title}' to remote drive folder '#{folder.title}'"
     end
 
     def upload_file(path, remote_name, type, folder)
       if @remote_drive.find_items_by_title(remote_name, parent_id: folder.id).any?
-        raise RuntimeError, "File \"#{remote_name}\" already exists in remote drive folder \"#{folder.title}\"; could not upload"
+        raise RuntimeError, "Item '#{remote_name}' already exists in remote drive folder '#{folder.title}'; could not upload"
       end
       if (!@remote_drive.upload_file(remote_name, '', folder.id, type, path.to_s))
-        raise RuntimeError, "File #{path} could not be uploaded to remote drive folder \"#{folder.title}\""
+        raise RuntimeError, "File #{path} could not be uploaded to remote drive folder '#{folder.title}'"
       end
-      log :debug, "Uploaded file #{path} to remote drive folder \"#{folder.title}\""
+      log :debug, "Uploaded file #{path} to remote drive folder '#{folder.title}'"
     end
 
     def write_log
       if (term_folder = find_folder @term_code) && (reports_folder = find_folder('reports', term_folder))
         reports_today = find_or_create_folder(datestamp, reports_folder)
         log_name = "#{timestamp}_#{self.class.name.demodulize.underscore}.log"
-        begin
-          File.open(@tmp_path.join(log_name), 'wb') { |f| f.puts @log }
-          upload_file(@tmp_path.join(log_name), log_name, 'text/plain', reports_today)
-        ensure
-          File.delete @tmp_path.join(log_name)
+        File.open(@tmp_path.join(log_name), 'wb') { |f| f.puts @log }
+        unless @opts[:local_write]
+          begin
+            upload_file(@tmp_path.join(log_name), log_name, 'text/plain', reports_today)
+          ensure
+            File.delete @tmp_path.join(log_name)
+          end
         end
       end
     rescue => e
-      logger.error "Could not upload log: #{e.message}\n#{e.backtrace.join "\n\t"}"
+      logger.error "Could not write log: #{e.message}\n#{e.backtrace.join "\n\t"}"
     end
   end
 end

--- a/app/models/oec/term_setup_task.rb
+++ b/app/models/oec/term_setup_task.rb
@@ -1,7 +1,7 @@
 module Oec
   class TermSetupTask < Task
 
-    def run_internal
+    def run_internal(opts={})
       log :info, "Will create initial folders and files for term #{@term_code}"
 
       term_folder = create_folder @term_code

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -3,13 +3,18 @@ namespace :oec do
   desc 'Import per-department course CSVs'
   task :import_courses => :environment do
     raise ArgumentError, "term_code required" unless ENV['term_code']
-    Oec::CoursesImportTask.new(term_code: ENV['term_code']).run
+    task = Oec::CoursesImportTask.new(
+      term_code: ENV['term_code'], local_write: ENV['local_write'],
+      dept_names: ENV['dept_name'], dept_codes: ENV['dept_codes'])
+    task.run
   end
 
   desc 'Set up folder structure for new term'
   task :term_setup => :environment do
     raise ArgumentError, "term_code required" unless ENV['term_code']
-    Oec::TermSetupTask.new(term_code: ENV['term_code']).run
+    task = Oec::TermSetupTask.new(
+      term_code: ENV['term_code'], local_write: ENV['local_write'])
+    task.run
   end
 
   # Legacy tasks below this line

--- a/spec/models/oec/courses_import_task_spec.rb
+++ b/spec/models/oec/courses_import_task_spec.rb
@@ -139,7 +139,7 @@ describe Oec::CoursesImportTask do
 
       before do
         allow(DateTime).to receive(:now).and_return DateTime.strptime("#{today} #{now}", '%F %H%M%S')
-        allow(Oec::CourseCode).to receive(:included_by_dept_code).and_return({dept_name => fake_code_mapping})
+        allow(Oec::CourseCode).to receive(:by_dept_code).and_return({dept_name => fake_code_mapping})
       end
 
       it 'should upload a department csv and a log file' do
@@ -224,4 +224,20 @@ describe Oec::CoursesImportTask do
       it { should eq 'MATH/STAT C51, MATH C151 LEC 001, STAT C151 VOL 001' }
     end
   end
+
+  context 'department-specific filters' do
+    let(:null_sheets_manager) { double.as_null_object }
+    before(:each) { allow(GoogleApps::SheetsManager).to receive(:new).and_return null_sheets_manager }
+
+    it 'filters by course-code department names' do
+      expect(Oec::CourseCode).to receive(:by_dept_code).with(dept_name: %w(BIOLOGY MCELLBI)).and_return({})
+      Oec::CoursesImportTask.new(term_code: term_code, dept_names: 'BIOLOGY MCELLBI').run
+    end
+
+    it 'filters by department codes' do
+      expect(Oec::CourseCode).to receive(:by_dept_code).with(dept_code: %w(IBIBI IMMCB)).and_return({})
+      Oec::CoursesImportTask.new(term_code: term_code, dept_codes: 'IBIBI IMMCB').run
+    end
+  end
+
 end

--- a/spec/models/oec/term_setup_task_spec.rb
+++ b/spec/models/oec/term_setup_task_spec.rb
@@ -8,6 +8,11 @@ describe Oec::TermSetupTask do
   let(:fake_sheets_manager) { double() }
   before { allow(GoogleApps::SheetsManager).to receive(:new).and_return fake_sheets_manager }
 
+  let(:today) { '2015-08-31' }
+  let(:now) { '092222' }
+  let(:logfile) { "#{now}_term_setup_task.log" }
+  before { allow(DateTime).to receive(:now).and_return DateTime.strptime("#{today} #{now}", '%F %H%M%S') }
+
   shared_context 'expecting folder creation' do
     before do
       expect_folder_creation(term_code, 'root', read_after_creation: true)
@@ -18,12 +23,7 @@ describe Oec::TermSetupTask do
   end
 
   shared_context 'expecting logging' do
-    let(:today) { '2015-08-31' }
-    let(:now) { '092222' }
-    let(:logfile) { "#{now}_term_setup_task.log" }
-
     before do
-      allow(DateTime).to receive(:now).and_return DateTime.strptime("#{today} #{now}", '%F %H%M%S')
       expect_folder_creation('reports', term_code, read_after_creation: true)
       expect_folder_creation(today, 'reports')
       expect(fake_sheets_manager).to receive(:find_items_by_title)
@@ -121,6 +121,20 @@ describe Oec::TermSetupTask do
       expect(Rails.logger).to receive(:error).at_least(1).times do |error_message|
         expect(error_message.lines.first).to include 'A confounding error'
       end
+      subject.run
+    end
+  end
+
+  context 'local-write mode' do
+    subject { described_class.new(term_code: term_code, local_write: 'Y') }
+
+    it 'reads from but does not write to remote drive' do
+      expect_folder_lookup(term_code, 'root')
+      expect_folder_lookup('reports', term_code)
+      expect_folder_lookup(today, 'reports')
+      expect(fake_sheets_manager).to receive(:find_folders).with(no_args).and_return []
+
+      expect(fake_sheets_manager).not_to receive(:upload_file)
       subject.run
     end
   end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5731

Oec::CoursesImportTask can now filter by either friendly course-code "department names" (SPANISH, CATALAN) or unfriendly department codes (IBIBI, LPPSP). 

On all tasks, a `local_write` option can be set to any truthy value in order to skip Google Drive upload and instead output local CSVs and logfiles for debugging purposes. Otherwise local output-and-delete is skipped entirely in favor of the Better Way from #4148.

Task logging is standardized a bit.