### PR TITLE
CLC-5737 Oec: distinguish normalized and denormalized Courses worksheets

### DIFF
--- a/app/models/oec/courses.rb
+++ b/app/models/oec/courses.rb
@@ -1,15 +1,6 @@
 module Oec
   class Courses < Worksheet
 
-    attr_reader :dept_code
-
-    def initialize(export_dir, opts={})
-      if (@dept_code = opts.delete :dept_code)
-        opts[:filename] = "#{@dept_code}.csv"
-      end
-      super(export_dir, opts)
-    end
-
     def headers
       %w(
         COURSE_ID
@@ -22,13 +13,6 @@ module Oec
         INSTRUCTION_FORMAT
         SECTION_NUM
         PRIMARY_SECONDARY_CD
-        LDAP_UID
-        SIS_ID
-        FIRST_NAME
-        LAST_NAME
-        EMAIL_ADDRESS
-        INSTRUCTOR_FUNC
-        BLUE_ROLE
         EVALUATE
         DEPT_FORM
         EVALUATION_TYPE

--- a/app/models/oec/sis_import_sheet.rb
+++ b/app/models/oec/sis_import_sheet.rb
@@ -1,0 +1,43 @@
+module Oec
+  class SisImportSheet < Worksheet
+
+    attr_reader :dept_code
+
+    def initialize(export_dir, opts={})
+      unless (@dept_code = opts.delete :dept_code)
+        raise ArgumentError, 'dept_code option required'
+      end
+      opts[:filename] = "#{@dept_code}.csv"
+      super(export_dir, opts)
+    end
+
+    def headers
+      %w(
+        COURSE_ID
+        COURSE_ID_2
+        COURSE_NAME
+        CROSS_LISTED_FLAG
+        CROSS_LISTED_NAME
+        DEPT_NAME
+        CATALOG_ID
+        INSTRUCTION_FORMAT
+        SECTION_NUM
+        PRIMARY_SECONDARY_CD
+        LDAP_UID
+        SIS_ID
+        FIRST_NAME
+        LAST_NAME
+        EMAIL_ADDRESS
+        INSTRUCTOR_FUNC
+        BLUE_ROLE
+        EVALUATE
+        DEPT_FORM
+        EVALUATION_TYPE
+        MODULAR_COURSE
+        START_DATE
+        END_DATE
+      )
+    end
+
+  end
+end

--- a/app/models/oec/task.rb
+++ b/app/models/oec/task.rb
@@ -42,8 +42,8 @@ module Oec
 
     def export_sheet(worksheet, dest_folder)
       if @opts[:local_write]
-        worksheet.export
-        log :debug, "Exported local worksheet file '#{worksheet.output_filename}'"
+        worksheet.write_csv
+        log :debug, "Exported worksheet to local file '#{worksheet.output_filename}'"
       else
         upload_to_remote_drive(worksheet, worksheet.base_filename.chomp('.csv'), dest_folder)
       end
@@ -108,8 +108,8 @@ module Oec
     def upload_worksheet_headers(klass, dest_folder)
       worksheet = klass.new(@tmp_path)
       if @opts[:local_write]
-        worksheet.export
-        log :debug, "Exported local header-only file #{worksheet.output_filename}"
+        worksheet.write_csv
+        log :debug, "Exported to header-only local file #{worksheet.output_filename}"
       else
         upload_to_remote_drive(worksheet, klass.name.demodulize.underscore, dest_folder)
       end

--- a/app/models/oec/worksheet.rb
+++ b/app/models/oec/worksheet.rb
@@ -1,5 +1,5 @@
 module Oec
-  class Worksheet < CsvExport
+  class Worksheet
     include Enumerable
 
     def self.base_filename
@@ -13,10 +13,11 @@ module Oec
       end
     end
 
-    def initialize(export_dir, opts={})
+    def initialize(export_directory, opts={})
+      FileUtils.mkdir_p export_directory unless File.exists? export_directory
+      @export_directory = export_directory
+      @opts = opts
       @rows = {}
-      @filename = opts[:filename]
-      super(export_dir)
     end
 
     def [](key)
@@ -32,10 +33,18 @@ module Oec
     end
 
     def base_filename
-      @filename || self.class.base_filename
+      @opts[:filename] || self.class.base_filename
     end
 
-    def export
+    def output_filename
+      @export_directory.join base_filename
+    end
+
+    def headers
+      # subclasses override
+    end
+
+    def write_csv
       if @rows.any?
         output = CSV.open(output_filename, 'wb', headers: headers, write_headers: true)
         @rows.values.each { |row| output << row }
@@ -45,14 +54,5 @@ module Oec
       end
       output.close
     end
-
-    def headers
-      # subclasses override
-    end
-
-    def output_filename
-      export_directory.join base_filename
-    end
-
   end
 end

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -1,10 +1,10 @@
 namespace :oec do
 
   desc 'Import per-department course CSVs, compare with dept spreadsheets and report on non-empty diffs.'
-  task :import_courses => :environment do
+  task :sis_import => :environment do
     term_code = ENV['term_code']
     raise ArgumentError, 'term_code required' unless term_code
-    [Oec::CoursesImportTask, Oec::ReportDiffTask].each do |klass|
+    [Oec::SisImportTask, Oec::ReportDiffTask].each do |klass|
       klass.new(
         term_code: term_code, local_write: ENV['local_write'],
         dept_names: ENV['dept_names'], dept_codes: ENV['dept_codes']).run

--- a/spec/models/google_apps/sheets_manager_spec.rb
+++ b/spec/models/google_apps/sheets_manager_spec.rb
@@ -9,9 +9,9 @@ describe GoogleApps::SheetsManager do
       @folder = @sheet_manager.create_folder "#{GoogleApps::SheetsManager.name} test, #{now}"
       @sheet_title = "Sheet from CSV, #{now}"
       # No CSV files will be created by this test
-      worksheet = Oec::Courses.new Rails.root.join('tmp/oec')
+      worksheet = Oec::SisImportSheet.new Rails.root.join('tmp/oec')
       course_codes = [Oec::CourseCode.new(dept_name: 'SPANISH', catalog_id: '', dept_code: 'LPSPP', include_in_oec: true)]
-      Oec::CoursesImportTask.new(:term_code => '2015-C').import_courses(worksheet, course_codes)
+      Oec::SisImportTask.new(:term_code => '2015-C').import_courses(worksheet, course_codes)
       @spreadsheet = @sheet_manager.upload_worksheet(@sheet_title, "Description #{now}", worksheet, @folder.id)
     end
 

--- a/spec/models/oec/sis_import_task_spec.rb
+++ b/spec/models/oec/sis_import_task_spec.rb
@@ -1,8 +1,8 @@
 include OecSpecHelper
 
-describe Oec::CoursesImportTask do
+describe Oec::SisImportTask do
   let(:term_code) { '2015-B' }
-  let(:task) { Oec::CoursesImportTask.new(term_code: term_code) }
+  let(:task) { Oec::SisImportTask.new(term_code: term_code) }
 
   let(:fake_sheets_manager) { double() }
   before(:each) { allow(GoogleApps::SheetsManager).to receive(:new).and_return fake_sheets_manager }
@@ -10,11 +10,11 @@ describe Oec::CoursesImportTask do
   describe 'CSV export' do
     subject do
       task.import_courses(courses, fake_code_mapping)
-      courses.export
+      courses.write_csv
       CSV.read(courses.output_filename).slice(1..-1).map { |row| Hash[ courses.headers.zip(row) ]}
     end
 
-    let(:courses) { Oec::Courses.new(Rails.root.join('tmp/oec'), dept_code: dept_name) }
+    let(:courses) { Oec::SisImportSheet.new(Rails.root.join('tmp/oec'), dept_code: dept_name) }
     let(:courses_by_ccn) { {} }
     let(:courses_for_dept) { [] }
     let(:additional_cross_listings) { Set.new }
@@ -145,11 +145,11 @@ describe Oec::CoursesImportTask do
     end
 
     describe 'expected network operations' do
-      subject { Oec::CoursesImportTask.new(term_code: term_code) }
+      subject { Oec::SisImportTask.new(term_code: term_code) }
 
       let(:today) { '2015-04-01' }
       let(:now) { '092222' }
-      let(:logfile) { "#{now}_courses_import_task.log" }
+      let(:logfile) { "#{now}_sis_import_task.log" }
       let(:dept_name) { 'MATH' }
       let(:export_file) { "#{dept_name}.csv" }
 
@@ -247,12 +247,12 @@ describe Oec::CoursesImportTask do
 
     it 'filters by course-code department names' do
       expect(Oec::CourseCode).to receive(:by_dept_code).with(dept_name: %w(BIOLOGY MCELLBI)).and_return({})
-      Oec::CoursesImportTask.new(term_code: term_code, dept_names: 'BIOLOGY MCELLBI').run
+      Oec::SisImportTask.new(term_code: term_code, dept_names: 'BIOLOGY MCELLBI').run
     end
 
     it 'filters by department codes' do
       expect(Oec::CourseCode).to receive(:by_dept_code).with(dept_code: %w(IBIBI IMMCB)).and_return({})
-      Oec::CoursesImportTask.new(term_code: term_code, dept_codes: 'IBIBI IMMCB').run
+      Oec::SisImportTask.new(term_code: term_code, dept_codes: 'IBIBI IMMCB').run
     end
   end
 


### PR DESCRIPTION
The previous `Oec::Courses`, which is a format we only expect to use for SIS imports, becomes `Oec::SisImportSheet`. 

`Oec::CoursesImportTask` becomes `Oec::SisImportTask` to signal the close connection between task and sheet format.

The new vanilla `Oec::Courses` includes no instructor-data columns and doesn't need the `dept_code` attribute.

Other cleanup:
  - Remove Oec::Worksheet's inheritance from CsvExport, since that inheritance was giving us nothing but the `export_directory` instance variable;
  - Rename Oec::Worksheet's `export` method to `write_csv`, since CSV output is no longer the usual means of export.