### PR TITLE
CLC-5720, diff_report worksheet; remote_drive extends generic Google operations

### DIFF
--- a/app/models/oec/diff_report.rb
+++ b/app/models/oec/diff_report.rb
@@ -1,0 +1,23 @@
+module Oec
+  class DiffReport < Worksheet
+
+    def headers
+      %w(
+        +/-
+        KEY
+        LDAP_UID
+        DB_COURSE_NAME
+        COURSE_NAME
+        DB_FIRST_NAME
+        FIRST_NAME
+        DB_LAST_NAME
+        LAST_NAME
+        DB_EMAIL_ADDRESS
+        EMAIL_ADDRESS
+        DB_INSTRUCTOR_FUNC
+        INSTRUCTOR_FUNC
+      )
+    end
+
+  end
+end

--- a/app/models/oec/remote_drive.rb
+++ b/app/models/oec/remote_drive.rb
@@ -1,0 +1,27 @@
+module Oec
+  class RemoteDrive < GoogleApps::SheetsManager
+
+    def initialize
+      super(Settings.oec.google.uid, Settings.oec.google.marshal_dump)
+    end
+
+    def find_dept_courses_spreadsheet(term_code, dept_code)
+      if (term_folder = find_first_matching_folder term_code)
+        dept_title = Berkeley::Departments.get(dept_code, concise: true)
+        dept_folder = find_first_matching_folder(dept_title, term_folder)
+        find_first_matching_item('Courses', dept_folder)
+      else
+        nil
+      end
+    end
+
+    def find_first_matching_folder(title, parent=nil)
+      find_folders_by_title(title, folder_id(parent)).first
+    end
+
+    def find_first_matching_item(title, parent=nil)
+      find_items_by_title(title, parent_id: folder_id(parent)).first
+    end
+
+  end
+end

--- a/app/models/oec/report_diff_task.rb
+++ b/app/models/oec/report_diff_task.rb
@@ -11,6 +11,7 @@ module Oec
 
           dept_title = Berkeley::Departments.get(dept_code, concise: true)
           file_name = "#{timestamp}_#{dept_title.downcase.tr(' ', '_')}_courses_diff"
+          reports_today = find_or_create_today_subfolder('reports')
           @remote_drive.upload_worksheet(file_name, nil, worksheet, reports_today.id)
           log :info, "#{dept_code} diff summary on remote drive: #{@term_code}/reports/#{datestamp}/#{file_name}"
         else

--- a/app/models/oec/report_diff_task.rb
+++ b/app/models/oec/report_diff_task.rb
@@ -2,18 +2,20 @@ module Oec
   class ReportDiffTask < Task
 
     def run_internal
-      unless (reports_today = find_or_create_today_subfolder('reports'))
-        raise RuntimeError, 'Failed to retrieve today\'s reports folder from remote drive'
-      end
       Oec::CourseCode.by_dept_code(@course_code_filter).each do |dept_code, course_codes|
-        dept_title = Berkeley::Departments.get(dept_code, concise: true)
+        spreadsheet = @remote_drive.find_dept_courses_spreadsheet dept_code
+        if spreadsheet
+          worksheet = DiffReport.new('tmp/oec')
 
-        log :info, "Fetch spreadsheet from remote drive: #{@term_code}/departments/#{dept_title}/Courses"
+          # More to come...
 
-        # More to come...
-
-        diff_file = "#{timestamp}_#{dept_title.downcase.tr(' ', '_')}_courses_diff"
-        log :info, "#{dept_title} diff summary on remote drive: #{@term_code}/reports/#{datestamp}/#{diff_file}"
+          dept_title = Berkeley::Departments.get(dept_code, concise: true)
+          file_name = "#{timestamp}_#{dept_title.downcase.tr(' ', '_')}_courses_diff"
+          @remote_drive.upload_worksheet(file_name, nil, worksheet, reports_today.id)
+          log :info, "#{dept_code} diff summary on remote drive: #{@term_code}/reports/#{datestamp}/#{file_name}"
+        else
+          log :info, "No #{@term_code} diff for dept_code=#{dept_code} because dept has no admin-managed spreadsheet."
+        end
       end
     end
 

--- a/app/models/oec/report_diff_task.rb
+++ b/app/models/oec/report_diff_task.rb
@@ -3,7 +3,7 @@ module Oec
 
     def run_internal
       Oec::CourseCode.by_dept_code(@course_code_filter).each do |dept_code, course_codes|
-        spreadsheet = @remote_drive.find_dept_courses_spreadsheet dept_code
+        spreadsheet = @remote_drive.find_dept_courses_spreadsheet(@term_code, dept_code)
         if spreadsheet
           worksheet = DiffReport.new('tmp/oec')
 

--- a/app/models/oec/task.rb
+++ b/app/models/oec/task.rb
@@ -5,7 +5,7 @@ module Oec
     def initialize(opts)
       @log = []
       uid = Settings.oec.google.uid
-      @remote_drive = GoogleApps::SheetsManager.new(uid, Settings.oec.google.marshal_dump)
+      @remote_drive = Oec::RemoteDrive.new
       @term_code = opts.delete :term_code
       @opts = opts
       @tmp_path = Rails.root.join('tmp', 'oec')

--- a/spec/models/oec/report_diff_task_spec.rb
+++ b/spec/models/oec/report_diff_task_spec.rb
@@ -1,3 +1,5 @@
+include OecSpecHelper
+
 describe Oec::ReportDiffTask do
 
   let(:term_code) { '2015-D' }
@@ -24,7 +26,7 @@ describe Oec::ReportDiffTask do
       }
 
       it 'should produce no diff when department spreadsheet not found' do
-        expect(fake_sheets_manager).to receive(:find_dept_courses_spreadsheet).with(dept_code).and_return nil
+        expect(fake_sheets_manager).to receive(:find_dept_courses_spreadsheet).with(term_code, dept_code).and_return nil
         subject.run
       end
     end

--- a/spec/models/oec/report_diff_task_spec.rb
+++ b/spec/models/oec/report_diff_task_spec.rb
@@ -1,0 +1,33 @@
+describe Oec::ReportDiffTask do
+
+  let(:term_code) { '2015-D' }
+  subject { described_class.new(term_code: term_code) }
+
+  let(:fake_sheets_manager) { double }
+  let(:today) { '2015-08-31' }
+  let(:now) { '092222' }
+  let(:logfile) { "#{now}_report_diff_task.log" }
+
+  before(:each) { allow(Oec::RemoteDrive).to receive(:new).and_return fake_sheets_manager }
+
+  describe 'STAT department' do
+
+    context 'no diff to report' do
+      let(:dept_code) { 'PSTAT' }
+      let(:dept_name) { 'STAT' }
+      let(:fake_code_mapping) { [Oec::CourseCode.new(dept_name: dept_name, catalog_id: nil, dept_code: dept_name, include_in_oec: true)] }
+
+      before {
+        allow(Oec::CourseCode).to receive(:by_dept_code).and_return({dept_code => fake_code_mapping})
+        expect(subject).to receive(:write_log)
+        expect(fake_sheets_manager).to_not receive(:upload_worksheet)
+      }
+
+      it 'should produce no diff when department spreadsheet not found' do
+        expect(fake_sheets_manager).to receive(:find_dept_courses_spreadsheet).with(dept_code).and_return nil
+        subject.run
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5720

* Spreadsheets will be built from DiffReport instances.
* Oec::RemoteDrive wraps SheetsManager so we can move helper methods out of Oec::Task
* Specs