### PR TITLE
CLC-5726 Allow SheetsManager to export sheets as CSV

### DIFF
--- a/app/models/google_apps/drive_manager.rb
+++ b/app/models/google_apps/drive_manager.rb
@@ -188,7 +188,12 @@ module GoogleApps
     end
 
     def log_response(api_response)
-      logger.debug "Google Drive API request #{api_response.request.api_method.id} #{api_response.request.parameters} returned status #{api_response.status}"
+      request_description = if api_response.request.api_method
+        "#{api_response.request.api_method.id} #{api_response.request.parameters}"
+      else
+        api_response.request.uri
+      end
+      logger.debug "Google Drive API request #{request_description} returned status #{api_response.status}"
     end
 
   end

--- a/app/models/google_apps/sheets_manager.rb
+++ b/app/models/google_apps/sheets_manager.rb
@@ -8,6 +8,20 @@ module GoogleApps
       @session = GoogleDrive::Session.login_with_oauth auth.access_token
     end
 
+    def export_csv(file)
+      unless file.exportLinks && (csv_export_uri = file.exportLinks['text/csv'])
+        raise Errors::ProxyError, "No CSV export path found for file ID: #{file.id}"
+      end
+      api_response = @session.execute!(uri: csv_export_uri)
+      log_response api_response
+      case api_response.status
+        when 200
+          api_response.body
+        else
+          raise Errors::ProxyError, "Error in export_csv, file ID (#{file.id}): #{api_response.data['error']['message']}"
+      end
+    end
+
     def spreadsheet_by_id(id)
       api_response = @session.execute!(:api_method => @session.drive.files.get, :parameters => { :fileId => id })
       log_response api_response


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5726

For the sake of speed, this gives us the option to bypass the Sheets API entirely and get a CSV export straight from a Google Drive file object.

Bamboo is chugging: https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CPT152-7