### PR TITLE
CLC-5719, escape Google API query args

### DIFF
--- a/spec/models/oec/remote_drive_spec.rb
+++ b/spec/models/oec/remote_drive_spec.rb
@@ -2,7 +2,7 @@ describe Oec::RemoteDrive do
 
   subject { described_class.new }
   let(:term_code) { '2015-D' }
-  let(:dept_code) { 'LPSPP' }
+  let(:dept_code) { 'SWOME' }
   # DateTime.tomorrow to avoid collision with other testing on today's data
   let(:tomorrow) { DateTime.tomorrow.strftime('%F') }
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5719
Bamboo: https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CJT70-1

[Google API docs](https://developers.google.com/drive/web/search-parameters) say, "Surround with single quotes '. Escape single quotes in queries." I know of no other necessary escaping.

I was able to reproduce the problem using SWOME (Gender and Women's Studies) in oec_remote_drive_spec #real test. That spec is now passing. 