### PR TITLE
CLC-5728 OEC: Allow SisImportTask to handle nil terms

### DIFF
--- a/app/models/oec/sis_import_task.rb
+++ b/app/models/oec/sis_import_task.rb
@@ -146,7 +146,7 @@ module Oec
 
     def set_term_dates(worksheet)
       term_slug = Berkeley::TermCodes.to_slug(*@term_code.split('-'))
-      term = Berkeley::Terms.fetch.campus[term_slug]
+      return unless (term = Berkeley::Terms.fetch.campus[term_slug])
       term_dates = {
         'START_DATE' => term.classes_start.strftime('%m-%d-%Y'),
         'END_DATE' => term.instruction_end.strftime('%m-%d-%Y')


### PR DESCRIPTION
Check Bamboo: https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CPT157-3

Follow up to #4188, which caused side-effect failures in specs running Oec::SisImportTask. Our default fake_now is still set to 2013, and Berkeley::Terms won't return information on terms two years in the future.

If a nil term is encountered, output no date information and move on.

