### PR TITLE
CLC-5743 OEC: Better handling for non-participating departments

### DIFF
--- a/app/models/oec/sis_import_task.rb
+++ b/app/models/oec/sis_import_task.rb
@@ -15,7 +15,7 @@ module Oec
     def import_courses(worksheet, course_codes)
       course_codes_by_ccn = {}
       cross_listed_ccns = Set.new
-      Oec::Queries.courses_for_codes(@term_code, course_codes).each do |course_row|
+      Oec::Queries.courses_for_codes(@term_code, course_codes, @opts[:import_all]).each do |course_row|
         if import_course(worksheet, course_row)
           course_codes_by_ccn[course_row['course_cntl_num']] ||= course_row.slice('dept_name', 'catalog_id', 'instruction_format', 'section_num')
           cross_listed_ccns.merge [course_row['cross_listed_ccns'], course_row['co_scheduled_ccns']].join(',').split(',').reject(&:blank?)

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -6,17 +6,22 @@ namespace :oec do
     raise ArgumentError, 'term_code required' unless term_code
     [Oec::SisImportTask, Oec::ReportDiffTask].each do |klass|
       klass.new(
-        term_code: term_code, local_write: ENV['local_write'],
-        dept_names: ENV['dept_names'], dept_codes: ENV['dept_codes']).run
+        term_code: term_code,
+        local_write: ENV['local_write'].present?,
+        import_all: ENV['import_all'].present?,
+        dept_names: ENV['dept_names'],
+        dept_codes: ENV['dept_codes']
+      ).run
     end
   end
 
   desc 'Set up folder structure for new term'
   task :term_setup => :environment do
     raise ArgumentError, 'term_code required' unless ENV['term_code']
-    task = Oec::TermSetupTask.new(
-      term_code: ENV['term_code'], local_write: ENV['local_write'])
-    task.run
+    Oec::TermSetupTask.new(
+      term_code: ENV['term_code'],
+      local_write: ENV['local_write']
+    ).run
   end
 
   # Legacy tasks below this line

--- a/spec/models/oec/queries_spec.rb
+++ b/spec/models/oec/queries_spec.rb
@@ -8,7 +8,8 @@ describe Oec::Queries do
   end
 
   context 'department-specific queries' do
-    subject { Oec::Queries.depts_clause('c', course_codes) }
+    subject { Oec::Queries.depts_clause('c', course_codes, import_all) }
+    let(:import_all) { false }
 
     context 'limiting query by department code' do
       let(:course_codes) do
@@ -22,6 +23,11 @@ describe Oec::Queries do
       it { should include("(c.dept_name = 'CATALAN')", "(c.dept_name = 'PORTUG')", "(c.dept_name = 'SPANISH')") }
       it { should_not include "(c.dept_name = 'ILA')" }
       it { should_not include 'NOT' }
+
+      context 'with import_all flag' do
+        let(:import_all) { true }
+        it { should include "(c.dept_name = 'ILA')" }
+      end
     end
 
     context 'limiting query by course code' do
@@ -81,6 +87,26 @@ describe Oec::Queries do
       )
     end
     include_examples 'expected result structure'
+  end
+
+  context 'a department not participating in OEC', testext: true do
+    subject do
+      Oec::Queries.courses_for_codes(
+        term_code,
+        [Oec::CourseCode.new(dept_name: 'FRENCH', catalog_id: nil, dept_code: 'HFREN', include_in_oec: false)],
+        import_all
+      )
+    end
+
+    context 'without import_all flag' do
+      let (:import_all) { false }
+      it { should be_empty }
+    end
+
+    context 'with import_all flag' do
+      let (:import_all) { true }
+      include_examples 'expected result structure'
+    end
   end
 
   context 'course lookup by ccn', testext: true do

--- a/spec/models/oec/sis_import_task_spec.rb
+++ b/spec/models/oec/sis_import_task_spec.rb
@@ -45,7 +45,7 @@ describe Oec::SisImportTask do
     before(:each) do
       load_fixture_courses
       expect(Oec::Queries).to receive(:courses_for_codes)
-        .with(term_code, fake_code_mapping).exactly(1).times
+        .with(term_code, fake_code_mapping, nil).exactly(1).times
         .and_return courses_for_dept
       expect(Oec::Queries).to receive(:courses_for_cntl_nums)
         .with(term_code, additional_cross_listings.to_a).exactly(1).times


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5743

Oec::SisImportTask is getting a lot of options, but I think we want the ability to toggle this one.

When `import_all` is switched off (the default), a query on a non-participating department will return an empty array instead of blowing up.

When `import_all` is switched on, the `include_in_oec` flag in our database is ignored, and a full course listing is returned.