### PR TITLE
SISRP-7380 Workaround for bogus data in responses: force_encoding to UTF-8

### DIFF
--- a/app/models/campus_solutions/list_of_values.rb
+++ b/app/models/campus_solutions/list_of_values.rb
@@ -59,7 +59,7 @@ module CampusSolutions
     def build_feed(response)
       # delivered Campus Solutions API does not give us the xml content-type header that
       # HTTParty needs for auto-parsing, so we must parse it ourselves.
-      parsed = MultiXml.parse response.body
+      parsed = MultiXml.parse response.body.force_encoding('UTF-8')
       if parsed[response_root_xml_node].present?
         # rearrange stupid CS XML (which we can't change, because delivered) into a proper array
         values = []

--- a/app/models/campus_solutions/proxy.rb
+++ b/app/models/campus_solutions/proxy.rb
@@ -45,7 +45,7 @@ module CampusSolutions
       logger.info "Fake = #{@fake}; Making request to #{url} on behalf of user #{@uid}; cache expiration #{self.class.expires_in}"
       logger.debug "Request options = #{request_options}"
       response = get_response(url, request_options)
-      logger.debug "Remote server status #{response.code}, Body = #{response.body}"
+      logger.debug "Remote server status #{response.code}, Body = #{response.body.force_encoding('UTF-8')}"
       feed = build_feed response
       feed = convert_feed_keys(feed)
       if is_errored?(feed)


### PR DESCRIPTION
temporary workaround to https://jira.berkeley.edu/browse/SISRP-7380 

I think this will work, but the problem doesn't manifest for me locally or on Bamboo builds. It only appears in the calcentral-sis-dev environment. I think that has to do with Ruby falling back on the OS default charset, but I'm not sure. Anyway, this PR should be relatively harmless to merge and see if it unblocks @christianv for dev. 