### PR TITLE
CLC-5748 Surface user-friendly department names where possible

### DIFF
--- a/app/models/berkeley/departments.rb
+++ b/app/models/berkeley/departments.rb
@@ -8,7 +8,7 @@ module Berkeley
     end
 
     def self.shortened(name)
-      name.sub(/^[OCDSP][a-z]+ (of|for|in) /, '').sub(/ (Department|Institute|Academic Program|Programs?)$/, '')
+      name.sub(/^[OCDSP][\w\s]+ (of|for|in) /, '').sub(/ (Department|Institute|Academic Program|Programs?)$/, '')
     end
 
     #L4 codes from http://www.bai.berkeley.edu/BFS/BudgetGL/treeReports/UCBDTREE.HTM

--- a/app/models/google_apps/drive_manager.rb
+++ b/app/models/google_apps/drive_manager.rb
@@ -60,7 +60,7 @@ module GoogleApps
       client = get_google_api
       drive_api = client.discovered_api('drive', 'v2')
       metadata = {
-        :title => escape(title),
+        :title => title,
         :mimeType => 'application/vnd.google-apps.folder'
       }
       dir = drive_api.files.insert.request_schema.new metadata
@@ -75,8 +75,8 @@ module GoogleApps
       client = get_google_api
       drive_api = client.discovered_api('drive', 'v2')
       metadata = {
-        :title => escape(title),
-        :description => escape(description),
+        :title => title,
+        :description => description,
         :mimeType => mime_type
       }
       file = drive_api.files.insert.request_schema.new metadata
@@ -124,7 +124,7 @@ module GoogleApps
     def copy_item(id, copy_title)
       client = get_google_api
       drive_api = client.discovered_api('drive', 'v2')
-      copy_schema = drive_api.files.copy.request_schema.new({'title' => escape(copy_title)})
+      copy_schema = drive_api.files.copy.request_schema.new({'title' => copy_title})
       result = client.execute(
         :api_method => drive_api.files.copy,
         :body_object => copy_schema,

--- a/app/models/google_apps/sheets_manager.rb
+++ b/app/models/google_apps/sheets_manager.rb
@@ -61,7 +61,7 @@ module GoogleApps
       client = get_google_api
       drive_api = client.discovered_api('drive', 'v2')
       media = Google::APIClient::UploadIO.new(path_or_io, 'text/csv')
-      metadata = { :title => escape(title), :description => escape(description) }
+      metadata = { :title => title, :description => description }
       file = drive_api.files.insert.request_schema.new metadata
       file.parents = [{ :id => parent_id }]
       result = @session.execute!(

--- a/app/models/oec/sis_import_sheet.rb
+++ b/app/models/oec/sis_import_sheet.rb
@@ -7,7 +7,7 @@ module Oec
       unless (@dept_code = opts.delete :dept_code)
         raise ArgumentError, 'dept_code option required'
       end
-      opts[:export_name] = @dept_code
+      opts[:export_name] = Berkeley::Departments.get(@dept_code, concise: true)
       super(opts)
     end
 

--- a/app/models/oec/sis_import_task.rb
+++ b/app/models/oec/sis_import_task.rb
@@ -51,7 +51,7 @@ module Oec
           false
         else
           course['course_id_2'] = course['course_id']
-          course['dept_form'] = worksheet.dept_code unless course['cross_listed_flag'].present?
+          course['dept_form'] = worksheet.export_name.upcase unless course['cross_listed_flag'].present?
           roles = Berkeley::UserRoles.roles_from_campus_row course
           course['evaluation_type'] = if roles[:student]
                                         'G'

--- a/spec/models/berkeley/departments_spec.rb
+++ b/spec/models/berkeley/departments_spec.rb
@@ -19,6 +19,7 @@ describe Berkeley::Departments do
     expect(Berkeley::Departments.get('QLROT', concise: true)).to eq 'Military Affairs'
     expect(Berkeley::Departments.get('QKCWP', concise: true)).to eq 'College Writing'
     expect(Berkeley::Departments.get('QIIAS', concise: true)).to eq 'International and Area Studies'
+    expect(Berkeley::Departments.get('SPOLS', concise: true)).to eq 'Political Science'
   end
 
   it 'should never trim \'Haas School of Business\' and similar' do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5748

Also tweaks the concise-name regex to catch "Charles and Louise Travers Department of Political Science", and rolls back some of the apostrophe escaping on Google API calls. (It turns out that you do need the escaping when building a query string, but that escaping metadata parameters in the Ruby API will add an extra backslash. Obviously....)