### PR TITLE
CLC-5720, round one of ReportDiffTask has diff-marker per dept

### DIFF
--- a/app/models/oec/report_diff_task.rb
+++ b/app/models/oec/report_diff_task.rb
@@ -1,24 +1,77 @@
 module Oec
   class ReportDiffTask < Task
 
+    attr_accessor :dept_with_diff_set
+    attr_accessor :errors_per_dept
+
     def run_internal
-      Oec::CourseCode.by_dept_code(@course_code_filter).each do |dept_code, course_codes|
-        spreadsheet = @remote_drive.find_dept_courses_spreadsheet(@term_code, dept_code)
-        dept_title = Berkeley::Departments.get(dept_code, concise: true)
-        if spreadsheet
-          worksheet = DiffReport.new
+      @dept_with_diff_set = Set.new
+      @errors_per_dept = {}
+      Oec::CourseCode.by_dept_code(@course_code_filter).keys.each { |dept_code| analyze dept_code }
+    end
 
-          # More to come...
-
-          dept_title = Berkeley::Departments.get(dept_code, concise: true)
-          file_name = "#{timestamp}_#{dept_title.downcase.tr(' ', '_')}_courses_diff"
-          reports_today = find_or_create_today_subfolder('reports')
-          upload_worksheet(worksheet, file_name, reports_today)
-          log :info, "#{dept_code} diff summary on remote drive: #{@term_code}/reports/#{datestamp}/#{file_name}"
-        else
-          log :info, "No #{@term_code} diff for #{dept_title} because dept has no admin-managed spreadsheet."
+    def analyze(dept_code)
+      dept_name = Berkeley::Departments.get(dept_code, concise: true)
+      sis_data = csv_row_hash([@term_code, 'imports', datestamp, dept_name], dept_code)
+      log :warn, "#{dept_code} has no #{datestamp} 'imports' spreadsheet" && return unless sis_data.any?
+      dept_data = csv_row_hash([@term_code, 'departments', dept_name, 'Courses'], dept_code)
+      log :warn, "#{dept_name} has no 'Courses' spreadsheet." && return unless dept_data.any?
+      sis_data.keys.each do |key|
+        (@dept_with_diff_set << dept_code) && return unless dept_data.has_key?(key)
+        columns_to_compare.each do |column|
+          (@dept_with_diff_set << dept_code) && return unless (sis_data[key][column].casecmp(dept_data[key][column]) == 0)
         end
       end
+      # TODO: Implement logic below!
+      # file_name = "#{timestamp}_#{Berkeley::Departments.get(dept_code, concise: true).downcase.tr(' ', '_')}_courses_diff"
+      # upload_worksheet(diff_report, diff_file_name(dept_code), find_or_create_today_subfolder('reports'))
+      # log :info, "#{dept_code} diff put to directory: reports/#{datestamp}"
+    end
+
+    private
+
+    def columns_to_compare
+      %w(COURSE_NAME FIRST_NAME LAST_NAME EMAIL_ADDRESS)
+    end
+
+    def hashed(row)
+      id = row['COURSE_ID'].split '-'
+      ccn_plus_tag = id[2].split '_'
+      hash = { term_yr: id[0], term_cd: id[1], ccn: ccn_plus_tag[0] }
+      hash[:annotation] = ccn_plus_tag[1] if ccn_plus_tag.length == 2
+      hash
+    end
+
+    def csv_row_hash(folder_titles, dept_code, opts={})
+      file = @remote_drive.find_nested(folder_titles, opts)
+      return if file.nil?
+      hash = {}
+      csv = @remote_drive.export_csv file
+      Oec::SisImportSheet.from_csv(csv, dept_code: dept_code).each do |row|
+        next unless (id_hash = extract_id(dept_code, row))
+        hash[id_hash] = row
+      end
+      hash
+    end
+
+    def extract_id(dept_code, row)
+      errors = []
+      id = hashed row
+      annotation = id[:annotation]
+      errors << "Invalid CCN annotation: #{annotation}" if (annotation && !%w(A B GSI CHEM MCB).include?(annotation))
+      id[:ldap_uid] = row['LDAP_UID'] unless row['LDAP_UID'].blank?
+      errors << "Invalid ldap_uid: #{id[:ldap_uid]}" if (id[:ldap_uid] && id[:ldap_uid].to_i <= 0)
+      id[:instructor_func] = row['INSTRUCTOR_FUNC'] unless row['INSTRUCTOR_FUNC'].blank?
+      errors << "Invalid instructor_func: #{id[:instructor_func]}" if (id[:instructor_func] && !(0..4).include?(id[:instructor_func].to_i))
+      record_errors(dept_code, id[:ccn], errors)
+      errors.any? ? nil : id
+    end
+
+    def record_errors(dept_code, course_id, errors)
+      return unless errors.any?
+      @errors_per_dept[dept_code] ||= {}
+      @errors_per_dept[dept_code][course_id] ||= []
+      @errors_per_dept[dept_code][course_id].concat errors
     end
 
   end

--- a/app/models/oec/report_diff_task.rb
+++ b/app/models/oec/report_diff_task.rb
@@ -34,14 +34,6 @@ module Oec
       %w(COURSE_NAME FIRST_NAME LAST_NAME EMAIL_ADDRESS)
     end
 
-    def hashed(row)
-      id = row['COURSE_ID'].split '-'
-      ccn_plus_tag = id[2].split '_'
-      hash = { term_yr: id[0], term_cd: id[1], ccn: ccn_plus_tag[0] }
-      hash[:annotation] = ccn_plus_tag[1] if ccn_plus_tag.length == 2
-      hash
-    end
-
     def csv_row_hash(folder_titles, dept_code, opts={})
       file = @remote_drive.find_nested(folder_titles, opts)
       return if file.nil?
@@ -65,6 +57,14 @@ module Oec
       errors << "Invalid instructor_func: #{id[:instructor_func]}" if (id[:instructor_func] && !(0..4).include?(id[:instructor_func].to_i))
       record_errors(dept_code, id[:ccn], errors)
       errors.any? ? nil : id
+    end
+
+    def hashed(row)
+      id = row['COURSE_ID'].split '-'
+      ccn_plus_tag = id[2].split '_'
+      hash = { term_yr: id[0], term_cd: id[1], ccn: ccn_plus_tag[0] }
+      hash[:annotation] = ccn_plus_tag[1] if ccn_plus_tag.length == 2
+      hash
     end
 
     def record_errors(dept_code, course_id, errors)

--- a/app/models/oec/worksheet.rb
+++ b/app/models/oec/worksheet.rb
@@ -15,10 +15,10 @@ module Oec
       self.name.demodulize.underscore
     end
 
-    def self.from_csv(csv)
+    def self.from_csv(csv, opts={})
       return unless csv && (parsed_csv = CSV.parse csv)
       header_row = parsed_csv.shift
-      instance = self.new
+      instance = self.new opts
       raise ArgumentError, "Header mismatch: cannot create instance of #{self.name} from CSV" unless header_row == instance.headers
       parsed_csv.each_with_index { |row, index| instance[index] = Hash[instance.headers.zip row] }
       instance

--- a/spec/models/oec/report_diff_task_spec.rb
+++ b/spec/models/oec/report_diff_task_spec.rb
@@ -1,28 +1,49 @@
 describe Oec::ReportDiffTask do
 
-  context '#fake' do
+  context '#real', testext: true do
     let(:term_code) { '2015-D' }
-    subject { described_class.new(term_code: term_code) }
-
-    let(:fake_remote_drive) { double }
-    let(:today) { '2015-08-31' }
-    let(:now) { '092222' }
-    let(:logfile) { "#{now}_report_diff_task.log" }
-
-    before(:each) { allow(Oec::RemoteDrive).to receive(:new).and_return fake_remote_drive }
     let(:dept_code) { 'PSTAT' }
-    let(:dept_name) { 'STAT' }
-    let(:fake_code_mapping) { [Oec::CourseCode.new(dept_name: dept_name, catalog_id: nil, dept_code: dept_name, include_in_oec: true)] }
+    let(:dept_name) { Berkeley::Departments.get(dept_code, concise: true) }
+    let(:tomorrow) { DateTime.tomorrow }
+    let(:datetime) { tomorrow.strftime('%F') }
+    let(:remote_drive) { Oec::RemoteDrive.new }
 
-    before {
-      allow(Oec::CourseCode).to receive(:by_dept_code).and_return({dept_code => fake_code_mapping})
-      expect(subject).to receive(:write_log)
-      expect(fake_remote_drive).to_not receive(:check_conflicts_and_upload)
-    }
+    context 'Department of Bioengineering diff', :order => :defined do
+      before {
+        # Generate import for tomorrow to avoid conflict with other testing
+        task = Oec::SisImportTask.new(term_code: term_code, dept_codes: dept_code, date_time: tomorrow)
+        task.run_internal
+        # Grab the file we just generated
+        expect(imports = remote_drive.find_nested([term_code, 'imports'])).to_not be_nil
+        expect(@imports_subdir = remote_drive.find_first_matching_folder(datetime, imports)).to_not be_nil
+        dept_name = Berkeley::Departments.get(dept_code, concise: true)
+        import_file_array = remote_drive.spreadsheets_by_title(dept_name, parent_id: @imports_subdir.id)
+        expect(import_file_array).to have(1).item
+        # Copy import spreadsheet to location managed by dept for testing purposes.
+        parent = remote_drive.find_nested [term_code, 'departments']
+        dept_folder = remote_drive.check_conflicts_and_create_folder(dept_name, parent, on_conflict: :return_existing)
+        remote_drive.copy_item_to_folder(import_file_array[0], dept_folder.id, 'Courses')
+      }
 
-    it 'should produce no diff when department spreadsheet not found' do
-      expect(fake_remote_drive).to receive(:find_dept_courses_spreadsheet).with(term_code, dept_code).and_return nil
-      subject.run
+      after {
+        dept_file = remote_drive.find_nested [term_code, 'departments', dept_name]
+        remote_drive.trash_item(dept_file, permanently_delete: true) if dept_file
+        remote_drive.trash_item(@imports_subdir, permanently_delete: true)
+        reports_subdir = remote_drive.find_nested [term_code, 'reports', datetime]
+        remote_drive.trash_item(reports_subdir, permanently_delete: true) if reports_subdir
+      }
+
+      it 'should find department courses spreadsheet' do
+        courses_spreadsheet = remote_drive.find_dept_courses_spreadsheet(term_code, dept_code)
+        expect(courses_spreadsheet).to_not be_nil
+      end
+
+      it 'should report no diff' do
+        task = Oec::ReportDiffTask.new(term_code: term_code, dept_codes: dept_code, date_time: tomorrow)
+        task.run
+        expect(task.dept_with_diff_set).to_not include dept_code
+        expect(task.errors_per_dept).to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5720
DO NOT MERGE until Bamboo passes https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CJT72-1 

Before pushing diff spreadsheets to Google Drive I want to verify basic logic of "is there a diff?". Notice that rows are compared when they align according to id generated by extract_id(). This code still looks out for "annotated" course ids; for example, "2015-D-12345_GSI" in which "GSI" is the annotation.

Follow up tasks:
* https://jira.ets.berkeley.edu/jira/browse/CLC-5718
* Push diff reports to Google Drive