### PR TITLE
CLC-5640 OEC: validate export data before output

### DIFF
--- a/app/models/oec/course_instructors.rb
+++ b/app/models/oec/course_instructors.rb
@@ -9,5 +9,7 @@ module Oec
       )
     end
 
+    validate('INSTRUCTOR_FUNC') { |row| 'Unexpected' unless %w(1 2 4).include? row['INSTRUCTOR_FUNC'] }
+
   end
 end

--- a/app/models/oec/courses.rb
+++ b/app/models/oec/courses.rb
@@ -22,5 +22,10 @@ module Oec
       )
     end
 
+    validate('DEPT_FORM') { |row| 'Unexpected for BIOLOGY course:' if row['DEPT_NAME'] == 'BIOLOGY' && !%w(INTEGBI MCELLBI).include?(row['DEPT_FORM']) }
+    validate('COURSE_ID') { |row| 'Invalid' unless row['COURSE_ID'] =~ /\A20\d{2}-[ABCD]-\d{5}(_(A|B|GSI|CHEM|MCB))?\Z/ }
+    validate('COURSE_ID_2') { |row| 'Non-matching' unless row['COURSE_ID'] == row['COURSE_ID_2'] }
+    validate('EVALUATION_TYPE') { |row| 'Unexpected' if row['COURSE_ID'].end_with?('_GSI') && row['EVALUATION_TYPE'] != 'G' }
+
   end
 end

--- a/app/models/oec/export_task.rb
+++ b/app/models/oec/export_task.rb
@@ -1,6 +1,8 @@
 module Oec
   class ExportTask < Task
 
+    include Validator
+
     def run_internal
       merged_course_confirmations = @remote_drive.find_nested [@term_code, 'departments', 'merged_course_confirmations']
       merged_course_confirmations_csv = merged_course_confirmations && @remote_drive.export_csv(merged_course_confirmations)
@@ -22,21 +24,33 @@ module Oec
       ccns = Set.new
       suffixed_ccns = {}
 
-      Oec::SisImportSheet.from_csv(merged_course_confirmations_csv, dept_code: nil).each do |locked_confirmation_row|
-        add_checking_conflicts(courses, locked_confirmation_row, %w(COURSE_ID))
-        add_checking_conflicts(course_instructors, locked_confirmation_row, %w(LDAP_UID COURSE_ID))
-        add_checking_conflicts(instructors, locked_confirmation_row, %w(LDAP_UID))
-
-        supervisors.matching_dept_name(locked_confirmation_row['DEPT_FORM']).each do |supervisor|
-          course_supervisor_row = {
-            'COURSE_ID' => locked_confirmation_row['COURSE_ID'],
-            'LDAP_UID' => supervisor['LDAP_UID'],
-            'DEPT_NAME' => locked_confirmation_row['DEPT_FORM']
-          }
-          add_checking_conflicts(course_supervisors, course_supervisor_row, %w(LDAP_UID COURSE_ID))
+      Oec::SisImportSheet.from_csv(merged_course_confirmations_csv, dept_code: nil).each do |confirmation|
+        validate('courses', confirmation['COURSE_ID']) do |errors|
+          errors.add('Blank instructor LDAP_UID') && next if confirmation['LDAP_UID'].blank?
+          validate_and_add(courses, confirmation, %w(COURSE_ID))
         end
 
-        next unless (ccn = locked_confirmation_row['COURSE_ID'].split('-')[2])
+        if confirmation['LDAP_UID'].present?
+          validate_and_add(instructors, confirmation, %w(LDAP_UID))
+          validate_and_add(course_instructors, confirmation, %w(LDAP_UID COURSE_ID))
+        end
+
+        if confirmation['DEPT_FORM'].present?
+          dept_supervisors = supervisors.matching_dept_name(confirmation['DEPT_FORM'])
+          validate('courses', confirmation['COURSE_ID']) do |errors|
+            errors.add "No supervisors found for DEPT_FORM #{confirmation['DEPT_FORM']}" if dept_supervisors.none?
+            dept_supervisors.each do |supervisor|
+              course_supervisor_row = {
+                'COURSE_ID' => confirmation['COURSE_ID'],
+                'LDAP_UID' => supervisor['LDAP_UID'],
+                'DEPT_NAME' => confirmation['DEPT_FORM']
+              }
+              validate_and_add(course_supervisors, course_supervisor_row, %w(LDAP_UID COURSE_ID))
+            end
+          end
+        end
+
+        next unless (ccn = confirmation['COURSE_ID'].split('-')[2])
         ccn, suffix = ccn.split('_')
         if suffix
           suffixed_ccns[ccn] ||= Set.new
@@ -47,38 +61,49 @@ module Oec
       end
 
       Oec::Queries.students_for_cntl_nums(@term_code, ccns).each do |student_row|
-        add_checking_conflicts(students, Oec::Worksheet.capitalize_keys(student_row), %w(LDAP_UID))
+        validate_and_add(students, Oec::Worksheet.capitalize_keys(student_row), %w(LDAP_UID))
       end
 
       log :warn, "Getting students for #{ccns.length} non-suffixed CCNs" unless ccns.none?
       Oec::Queries.enrollments_for_cntl_nums(@term_code, ccns).each do |enrollment_row|
-        add_checking_conflicts(course_students, Oec::Worksheet.capitalize_keys(enrollment_row), %w(LDAP_UID COURSE_ID))
+        validate_and_add(course_students, Oec::Worksheet.capitalize_keys(enrollment_row), %w(LDAP_UID COURSE_ID))
       end
 
-      # Any course ID suffixes must match in courses and course_students
+      # Course IDs with suffixes need a little extra wrangling to match up with Oracle queries.
       log :warn, "Getting students for #{suffixed_ccns.length} suffixed CCNs" unless suffixed_ccns.none?
       Oec::Queries.enrollments_for_cntl_nums(@term_code, suffixed_ccns.keys).each do |enrollment_row|
         ccn = enrollment_row['course_id'].split('-')[2].split('_')[0]
         suffixed_ccns[ccn].each do |suffix|
           capitalized_row = Oec::Worksheet.capitalize_keys enrollment_row
           capitalized_row['COURSE_ID'] = "#{capitalized_row['COURSE_ID']}_#{suffix}"
-          add_checking_conflicts(course_students, capitalized_row, %w(LDAP_UID COURSE_ID))
+          validate_and_add(course_students, capitalized_row, %w(LDAP_UID COURSE_ID))
         end
       end
 
-      exports_today = find_or_create_today_subfolder 'exports'
-      [instructors, course_instructors, courses, students, course_students, supervisors, course_supervisors].each do |sheet|
-        export_sheet(sheet, exports_today)
+      if valid?
+        exports_today = find_or_create_today_subfolder 'exports'
+        [instructors, course_instructors, courses, students, course_students, supervisors, course_supervisors].each do |sheet|
+          export_sheet(sheet, exports_today)
+        end
+      else
+        log :error, 'Validation failed! No sheets will be exported.'
+        log_validation_errors
       end
     end
 
-    def add_checking_conflicts(sheet, row, key_columns)
+    def validate_and_add(sheet, row, key_columns)
       key = key_columns.map { |col| row[col] }.join('-')
       candidate_row = row.slice(*sheet.headers)
-      if sheet[key] && (sheet[key] != candidate_row)
-        raise RuntimeError, "Sheet '#{sheet.export_name}' has conflicting values for key '#{key}'; aborting export\n#{sheet[key]}\n#{candidate_row}"
-      else
-        sheet[key] ||= candidate_row
+      validate(sheet.export_name, key) do |errors|
+        sheet.errors_for_row(candidate_row).each { |error| errors.add error }
+        if sheet[key] && (sheet[key] != candidate_row)
+          conflicting_keys = candidate_row.keys.select { |k| candidate_row[k] != sheet[key][k] }
+          conflicting_keys.each do |conflicting_key|
+            errors.add "Conflicting values found under #{conflicting_key}: '#{sheet[key][conflicting_key]}', '#{candidate_row[conflicting_key]}'"
+          end
+        else
+          sheet[key] ||= candidate_row
+        end
       end
     end
 

--- a/app/models/oec/instructors.rb
+++ b/app/models/oec/instructors.rb
@@ -11,5 +11,8 @@ module Oec
       )
     end
 
+    validate('BLUE_ROLE') { |row| 'Invalid' if row['BLUE_ROLE'] != '23' }
+    validate('LDAP_UID') { |row| 'Non-numeric' unless row['LDAP_UID'] =~ /\A\d+\Z/ }
+
   end
 end

--- a/app/models/oec/report_diff_task.rb
+++ b/app/models/oec/report_diff_task.rb
@@ -1,12 +1,12 @@
 module Oec
   class ReportDiffTask < Task
 
+    include Validator
+
     attr_accessor :diff_reports_per_dept
-    attr_accessor :errors_per_dept
 
     def run_internal
       @diff_reports_per_dept = {}
-      @errors_per_dept = {}
       Oec::CourseCode.by_dept_code(@course_code_filter).keys.each do |dept_code|
         if (diff_report = analyze dept_code)
           diff_reports_per_dept[dept_code] = diff_report
@@ -15,31 +15,33 @@ module Oec
           log :info, "#{dept_code} diff summary: reports/#{datestamp}/#{file_name}"
         end
       end
-      log_errors
+      log_validation_errors
     end
 
     def analyze(dept_code)
       dept_name = Berkeley::Departments.get(dept_code, concise: true)
-      sis_data = csv_row_hash([@term_code, 'imports', datestamp, dept_name], dept_code)
-      record_error(dept_code, @term_code, "#{dept_name} has no #{datestamp} 'imports' spreadsheet") && return unless sis_data
-      dept_data = csv_row_hash([@term_code, 'departments', dept_name, 'Courses'], dept_code)
-      record_error(dept_code, @term_code, "#{dept_name} has no 'Courses' spreadsheet") && return unless dept_data
-      keys_of_rows_with_diff = []
-      intersection = (sis_keys = sis_data.keys) & (dept_keys = dept_data.keys)
-      (sis_keys | dept_keys).select do |key|
-        if intersection.include? key
-          column_with_diff = columns_to_compare.detect do |column|
-            # Anticipate nil column values
-            sis_value = sis_data[key][column].to_s
-            dept_value = dept_data[key][column].to_s
-            sis_value.casecmp(dept_value) != 0
+      validate(dept_code, @term_code) do |errors|
+        sis_data = csv_row_hash([@term_code, 'imports', datestamp, dept_name], dept_code)
+        errors.add("#{dept_name} has no #{datestamp} 'imports' spreadsheet") && return unless sis_data
+        dept_data = csv_row_hash([@term_code, 'departments', dept_name, 'Courses'], dept_code)
+        errors.add("#{dept_name} has no 'Courses' spreadsheet") && return unless dept_data
+        keys_of_rows_with_diff = []
+        intersection = (sis_keys = sis_data.keys) & (dept_keys = dept_data.keys)
+        (sis_keys | dept_keys).select do |key|
+          if intersection.include? key
+            column_with_diff = columns_to_compare.detect do |column|
+              # Anticipate nil column values
+              sis_value = sis_data[key][column].to_s
+              dept_value = dept_data[key][column].to_s
+              sis_value.casecmp(dept_value) != 0
+            end
+            keys_of_rows_with_diff << key if column_with_diff
+          else
+            keys_of_rows_with_diff << key
           end
-          keys_of_rows_with_diff << key if column_with_diff
-        else
-          keys_of_rows_with_diff << key
         end
+        keys_of_rows_with_diff.any? ? create_diff_report(sis_data, dept_data, keys_of_rows_with_diff) : nil
       end
-      keys_of_rows_with_diff.any? ? create_diff_report(sis_data, dept_data, keys_of_rows_with_diff) : nil
     end
 
     private
@@ -84,16 +86,16 @@ module Oec
     end
 
     def extract_id(dept_code, row)
-      errors = []
       id = hashed row
-      annotation = id[:annotation]
-      errors << "Invalid CCN annotation: #{annotation}" if (annotation && !%w(A B GSI CHEM MCB).include?(annotation))
-      id[:ldap_uid] = row['LDAP_UID'] unless row['LDAP_UID'].blank?
-      errors << "Invalid ldap_uid: #{id[:ldap_uid]}" if (id[:ldap_uid] && id[:ldap_uid].to_i <= 0)
-      # instructor_func is NOT part of composite key but we do validate.
-      instructor_func = row['INSTRUCTOR_FUNC'] unless row['INSTRUCTOR_FUNC'].blank?
-      errors << "Invalid instructor_func: #{instructor_func}" if (instructor_func && !(0..4).include?(instructor_func.to_i))
-      errors.each { |error| record_error(dept_code, id[:ccn], error) }
+      validate(dept_code, id[:ccn]) do |errors|
+        annotation = id[:annotation]
+        errors.add "Invalid CCN annotation: #{annotation}" if (annotation && !%w(A B GSI CHEM MCB).include?(annotation))
+        id[:ldap_uid] = row['LDAP_UID'] unless row['LDAP_UID'].blank?
+        errors.add "Invalid ldap_uid: #{id[:ldap_uid]}" if (id[:ldap_uid] && id[:ldap_uid].to_i <= 0)
+        # instructor_func is NOT part of composite key but we do validate.
+        instructor_func = row['INSTRUCTOR_FUNC'] unless row['INSTRUCTOR_FUNC'].blank?
+        errors.add "Invalid instructor_func: #{instructor_func}" if (instructor_func && !(0..4).include?(instructor_func.to_i))
+      end
       id
     end
 
@@ -103,30 +105,6 @@ module Oec
       hash = { term_yr: id[0], term_cd: id[1], ccn: ccn_plus_tag[0] }
       hash[:annotation] = ccn_plus_tag[1] if ccn_plus_tag.length == 2
       hash
-    end
-
-    def record_error(dept_code, ccn, error)
-      return unless error
-      @errors_per_dept[dept_code] ||= {}
-      @errors_per_dept[dept_code][ccn] ||= []
-      @errors_per_dept[dept_code][ccn] << error
-    end
-
-    def log_errors
-      message = ''
-      @errors_per_dept.each do |dept_code, errors_hash|
-        message.concat <<-summary
-
-#{Berkeley::Departments.get(dept_code)} errors
-        summary
-        errors_hash.each do |id, errors|
-          message.concat <<-summary
-  #{id}:
-    #{errors.join("\n    ").concat "\n"}
-          summary
-        end
-      end
-      log :error, message unless message.blank?
     end
 
   end

--- a/app/models/oec/students.rb
+++ b/app/models/oec/students.rb
@@ -11,5 +11,7 @@ module Oec
       )
     end
 
+    validate('SIS_ID') { |row| 'Unexpected' unless row['SIS_ID'] == "UID:#{row['LDAP_UID']}" || row['SIS_ID'] =~ /\A\d+\Z/ }
+
   end
 end

--- a/app/models/oec/supervisors.rb
+++ b/app/models/oec/supervisors.rb
@@ -25,5 +25,7 @@ module Oec
       end
     end
 
+    validate('LDAP_UID') { |row| 'Non-numeric' unless row['LDAP_UID'] =~ /\A\d+\Z/ }
+
   end
 end

--- a/app/models/oec/validation_error_counter.rb
+++ b/app/models/oec/validation_error_counter.rb
@@ -1,0 +1,22 @@
+module Oec
+  class ValidationErrorCounter
+
+    def initialize(validator, keys)
+      @validator = validator
+      @keys = keys
+    end
+
+    def add(error)
+      @error_counter ||= error_counter_for_keys
+      @error_counter[error] ||= 0
+      @error_counter[error] += 1
+    end
+
+    def error_counter_for_keys
+      @keys.inject(@validator.errors) do |hash, key|
+        hash[key] ||= {}
+      end
+    end
+
+  end
+end

--- a/app/models/oec/validator.rb
+++ b/app/models/oec/validator.rb
@@ -1,0 +1,36 @@
+module Oec
+  module Validator
+
+    attr_accessor :errors
+
+    def validate(*keys)
+      @errors ||= {}
+      yield ValidationErrorCounter.new(self, keys)
+    end
+
+    def valid?(*keys)
+      errors_for_keys = keys.inject(@errors) { |errors, key| errors[key] if errors }
+      errors_for_keys.blank?
+    end
+
+    def log_validation_errors
+      message = ''
+      @errors.each do |sheet_name, errors_by_key|
+        message.concat <<-summary
+
+#{Berkeley::Departments.get(sheet_name)} errors:
+        summary
+        errors_by_key.each do |key, errors|
+          message << "\n#{key.present? ? key : '[Blank key]'}:"
+          errors.each do |error_message, count|
+            message << "\n    #{error_message}"
+            message << " (#{count} rows)" if count > 1
+          end
+          message << "\n"
+        end
+      end
+      log :error, message unless message.blank?
+    end
+
+  end
+end

--- a/spec/models/oec/export_task_spec.rb
+++ b/spec/models/oec/export_task_spec.rb
@@ -115,7 +115,7 @@ describe Oec::ExportTask do
   context 'data with suffixed course IDs' do
     before do
       merged_course_confirmations_csv.concat(
-        '2015-B-34821_GSI,2015-B-34821_GSI,LGBT C146A LEC 001 REP SEXUALITY/LIT,Y,GWS/LGBT C146A LEC 001,LGBT,C146A,LEC,001,P,562283,10945601,Clarice,Cccc,cccc@berkeley.edu,1,23,,,G,,01-26-2015,05-11-2015')
+        '2015-B-34821_GSI,2015-B-34821_GSI,LGBT C146A LEC 001 REP SEXUALITY/LIT,Y,GWS/LGBT C146A LEC 001,LGBT,C146A,LEC,001,P,562283,10945601,Clarice,Cccc,cccc@berkeley.edu,1,23,,LGBT,G,,01-26-2015,05-11-2015')
       expect(Oec::Queries).to receive(:enrollments_for_cntl_nums)
         .with(term_code, ['34821'])
         .and_return student_ids.map { |id| {'course_id' => '2015-B-34821', 'ldap_uid' => id} }
@@ -133,17 +133,96 @@ describe Oec::ExportTask do
     end
   end
 
+  shared_examples 'validation error logging' do
+    it 'should log error' do
+      merged_course_confirmations_csv.concat invalid_row
+      expect(task).not_to receive :export_sheet
+      task.run
+      expect(task.errors[sheet_name][key].keys.first).to eq expected_message
+    end
+  end
+
   context 'conflicting data' do
-    before do
-      merged_course_confirmations_csv.concat(
-        '2015-B-32960,2015-B-32960,GWS 103 LEC 001 IDENTITY ACROSS DIF,,,GWS,103,LEC,001,P,104033,UID:104033,BAD_FIRST_NAME,Ffff,ffff@berkeley.edu,1,23,,GWS,F,,01-26-2015,05-11-2015')
+    let(:invalid_row) { '2015-B-32960,2015-B-32960,GWS 103 LEC 001 IDENTITY ACROSS DIF,,,GWS,103,LEC,001,P,104033,UID:104033,BAD_FIRST_NAME,Ffff,ffff@berkeley.edu,1,23,,GWS,F,,01-26-2015,05-11-2015' }
+    let(:sheet_name) { 'instructors' }
+    let(:key) { '104033' }
+    let(:expected_message) { "Conflicting values found under FIRST_NAME: 'Flora', 'BAD_FIRST_NAME'" }
+    include_examples 'validation error logging'
+  end
+
+  context 'invalid instructor_func' do
+    let(:invalid_row) { '2015-B-99999,2015-B-99999,GWS 150 LEC 001 VINDICATION OF RIGHTS,,,GWS,150,LEC,001,P,155555,UID:155555,Zachary,Zzzz,zzzz@berkeley.edu,6,23,,GWS,F,,01-26-2015,05-11-2015' }
+    let(:sheet_name) { 'course_instructors' }
+    let(:key) { '155555-2015-B-99999' }
+    let(:expected_message) { 'Unexpected INSTRUCTOR_FUNC 6' }
+    include_examples 'validation error logging'
+  end
+
+  context 'courses sheet validations' do
+    let(:sheet_name) { 'courses' }
+    let(:key) { '2015-B-99999' }
+
+    context 'blank field' do
+      let(:invalid_row) { '2015-B-99999,2015-B-99999,BIOLOGY 150 LEC 001 VINDICATION OF RIGHTS,,,BIOLOGY,150,LEC,001,P,155555,UID:155555,Zachary,Zzzz,zzzz@berkeley.edu,1,23,,,F,,01-26-2015,05-11-2015' }
+      let(:expected_message) { 'Blank DEPT_FORM' }
+      include_examples 'validation error logging'
     end
 
-    it 'should log error and abort' do
-      expect(Rails.logger).to receive(:error).at_least(1).times do |error_message|
-        expect(error_message.lines.first).to include "Sheet 'instructors' has conflicting values for key '104033'"
-      end
+    context 'invalid BIOLOGY department form' do
+      let(:invalid_row) { '2015-B-99999,2015-B-99999,BIOLOGY 150 LEC 001 VINDICATION OF RIGHTS,,,BIOLOGY,150,LEC,001,P,155555,UID:155555,Zachary,Zzzz,zzzz@berkeley.edu,1,23,,SPANISH,F,,01-26-2015,05-11-2015' }
+      let(:expected_message) { 'Unexpected for BIOLOGY course: DEPT_FORM SPANISH' }
+      include_examples 'validation error logging'
+    end
+
+    context 'invalid course id' do
+      let(:invalid_row) { '2015-B-999991,2015-B-999991,GWS 150 LEC 001 VINDICATION OF RIGHTS,,,GWS,150,LEC,001,P,155555,UID:155555,Zachary,Zzzz,zzzz@berkeley.edu,1,23,,GWS,F,,01-26-2015,05-11-2015' }
+      let(:key) { '2015-B-999991' }
+      let(:expected_message) { 'Invalid COURSE_ID 2015-B-999991' }
+      include_examples 'validation error logging'
+    end
+
+    context 'non-matching COURSE_ID_2' do
+      let(:invalid_row) { '2015-B-99999,2015-B-99998,GWS 150 LEC 001 VINDICATION OF RIGHTS,,,GWS,150,LEC,001,P,155555,UID:155555,Zachary,Zzzz,zzzz@berkeley.edu,1,23,,GWS,F,,01-26-2015,05-11-2015' }
+      let(:expected_message) { 'Non-matching COURSE_ID_2 2015-B-99998' }
+      include_examples 'validation error logging'
+    end
+
+    context 'unexpected GSI evaluation type' do
+      let(:key) { '2015-B-99999_GSI' }
+      let(:invalid_row) { '2015-B-99999_GSI,2015-B-99999_GSI,GWS 150 LEC 001 VINDICATION OF RIGHTS,,,GWS,150,LEC,001,P,155555,UID:155555,Zachary,Zzzz,zzzz@berkeley.edu,1,23,,GWS,F,,01-26-2015,05-11-2015' }
+      let(:expected_message) { 'Unexpected EVALUATION_TYPE F' }
+      include_examples 'validation error logging'
+    end
+  end
+
+  context 'instructors sheet validations' do
+    let(:sheet_name) { 'instructors' }
+
+    context 'invalid BLUE_ROLE' do
+      let(:key) { '155555' }
+      let(:invalid_row) { '2015-B-99999_GSI,2015-B-99999_GSI,GWS 150 LEC 001 VINDICATION OF RIGHTS,,,GWS,150,LEC,001,P,155555,UID:155555,Zachary,Zzzz,zzzz@berkeley.edu,1,24,,GWS,F,,01-26-2015,05-11-2015' }
+      let(:expected_message) { 'Invalid BLUE_ROLE 24' }
+      include_examples 'validation error logging'
+    end
+
+    context 'non-numeric UID' do
+      let(:key) { '155555Z' }
+      let(:invalid_row) { '2015-B-99999,2015-B-99999,GWS 150 LEC 001 VINDICATION OF RIGHTS,,,GWS,150,LEC,001,P,155555Z,UID:155555Z,Zachary,Zzzz,zzzz@berkeley.edu,1,23,,GWS,F,,01-26-2015,05-11-2015' }
+      let(:expected_message) { 'Non-numeric LDAP_UID 155555Z' }
+      include_examples 'validation error logging'
+    end
+  end
+
+  context 'repeated errors' do
+    before do
+      merged_course_confirmations_csv.concat "2015-B-99999,2015-B-99999,GWS 150 LEC 001 VINDICATION OF RIGHTS,,,GWS,150,LEC,001,P,155555Z,UID:155555Z,Zachary,Zzzz,zzzz@berkeley.edu,1,23,,GWS,F,,01-26-2015,05-11-2015\n"
+      merged_course_confirmations_csv.concat "2015-B-99999,2015-B-99999,GWS 150 DIS 001 VINDICATION OF RIGHTS,,,GWS,150,LEC,001,P,155555Z,UID:155555Z,Zachary,Zzzz,zzzz@berkeley.edu,1,23,,GWS,F,,01-26-2015,05-11-2015\n"
+      expect(task).not_to receive :export_sheet
+    end
+
+    it 'should record a row count' do
       task.run
+      expect(task.errors['instructors']['155555Z'].first).to eq ['Non-numeric LDAP_UID 155555Z', 2]
     end
   end
 

--- a/spec/models/oec/report_diff_task_spec.rb
+++ b/spec/models/oec/report_diff_task_spec.rb
@@ -47,14 +47,13 @@ describe Oec::ReportDiffTask do
     }
 
     it 'should log errors' do
-      expect(subject.errors_per_dept).to have(2).items
-      expect(subject.errors_per_dept['FOO']).to have(1).item
-      expect(subject.errors_per_dept['PSTAT']).to have(2).item
-      expect(subject.errors_per_dept['PSTAT']['99999']).to have(2).item
-      expect(subject.errors_per_dept['PSTAT']['99999'][0]).to include 'Invalid CCN annotation'
-      expect(subject.errors_per_dept['PSTAT']['99999'][1]).to include 'Invalid ldap_uid'
-      expect(subject.errors_per_dept['PSTAT']['11111']).to have(1).items
-      expect(subject.errors_per_dept['PSTAT']['11111'][0]).to include 'Invalid instructor_func'
+      expect(subject.errors).to have(2).items
+      expect(subject.errors['FOO']).to have(1).item
+      expect(subject.errors['PSTAT']).to have(2).item
+      expect(subject.errors['PSTAT']['99999']).to have(2).item
+      expect(subject.errors['PSTAT']['99999'].keys).to match_array ['Invalid CCN annotation: wrong', 'Invalid ldap_uid: bad_data']
+      expect(subject.errors['PSTAT']['11111']).to have(1).items
+      expect(subject.errors['PSTAT']['11111'].keys.first).to include 'Invalid instructor_func'
     end
 
     it 'should report STAT diff' do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5640

Validation for exported data, as demoed this morning.

The pretty formatting in Oec::ReportDiffTask is extracted to Oec::Validator for reusability. Error message collections are changed from arrays to hashes with an integer count as value, making it easier to log repeated errors compactly.

A bit of metaprogramming in Oec::Worksheet allows its subclasses to set their own validation rules with ActiveRecord-style macros.