### PR TITLE
CLC-5700, publish_task invokes sftp to push to Explorance

### DIFF
--- a/app/models/oec/publish_task.rb
+++ b/app/models/oec/publish_task.rb
@@ -1,0 +1,66 @@
+module Oec
+  class PublishTask < Task
+
+    def run_internal
+      download_dir = download_exports_from_drive
+      # SFTP stdout and stderr will go to a log file.
+      FileUtils.mkdir_p LOG_DIRECTORY unless Dir.exists? LOG_DIRECTORY
+      sftp_stdout = LOG_DIRECTORY.join("sftp_#{DateTime.now.strftime '%F_%H:%M:%S'}.log").expand_path
+      cmd = "#{sftp_command(download_dir)} > #{sftp_stdout} 2>&1"
+      log :info, "Preparing to run system command:\n#{cmd}\n"
+      system cmd
+      # Now copy the command's output to remote drive.
+      sftp_stdout_to_log sftp_stdout
+      FileUtils.rm_rf download_dir
+    end
+
+    private
+
+    def files_to_publish
+      %w(courses.csv course_instructors.csv course_students.csv course_supervisors.csv instructors.csv students.csv supervisors.csv)
+    end
+
+    def download_exports_from_drive
+      date_to_publish = @opts[:date_to_publish] || datestamp
+      tmp_dir = LOG_DIRECTORY.join("publish_#{date_to_publish}")
+      FileUtils.mkdir_p tmp_dir
+      parent = @remote_drive.find_nested([@term_code, 'exports', date_to_publish], on_failure: :error)
+      files_to_publish.each do |filename|
+        remote_content = @remote_drive.find_first_matching_item(filename.chomp('.csv'), parent)
+        open(tmp_dir.join(filename), 'w') { |f|
+          f << @remote_drive.export_csv(remote_content)
+          f << "\n"
+        }
+      end
+      tmp_dir.to_s
+    end
+
+    def sftp_command(download_dir)
+      e = Settings.oec.explorance
+      cmd = "lftp sftp://#{e.sftp_user}"
+      # If password is blank then SSH key-based auth
+      cmd.concat ":#{e.sftp_password}" unless e.sftp_password.blank?
+      cmd.concat "@#{e.sftp_server}:#{e.sftp_port} -e '#{sftp_script download_dir}'"
+      cmd
+    end
+
+    def sftp_script(download_dir)
+      download_dir.chomp!('/')
+      put_files = files_to_publish.map { |file| "put #{download_dir}/#{file}" }.join("\n")
+      %(
+        #{put_files}
+        exit
+      )
+    end
+
+    def sftp_stdout_to_log(sftp_output)
+      if File.exists? sftp_output
+        log = File.open(sftp_output, 'rb').read.gsub(/\r\n?/, "\n")
+        log.each_line { |line| log(:info, line) }
+      else
+        log(:error, "SFTP log file not found: #{sftp_output}")
+      end
+    end
+
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -308,6 +308,11 @@ features:
 youtube_splash_id: 'EQ-a7xrfVag'
 
 oec:
+  explorance:
+    sftp_server: ''
+    sftp_port: 22
+    sftp_user: ''
+    sftp_password: ''
   google:
     uid: ''
     client_id: 'oecClientId'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5788
https://jira.ets.berkeley.edu/jira/browse/CLC-5787

Notes:
* Publish task pulls exports from remote drive, SFTPs them to Explorance and writes stdout/stderr to log file in remote drive 'reports' dir.
* I'm using *LFTP* (see https://en.wikipedia.org/wiki/Lftp) which gives more options in using *SFTP*. For example, scriptable way of providing password.
* If password is blank in yml the code will assume ssh keys are at work and exclude password from command line script.
