### PR TITLE
CLC-5799 OEC: Include timestamp in imports and exports subfolders

### DIFF
--- a/app/models/oec/export_task.rb
+++ b/app/models/oec/export_task.rb
@@ -81,9 +81,9 @@ module Oec
       end
 
       if valid?
-        exports_today = find_or_create_today_subfolder 'exports'
+        exports_now = find_or_create_now_subfolder 'exports'
         [instructors, course_instructors, courses, students, course_students, supervisors, course_supervisors].each do |sheet|
-          export_sheet(sheet, exports_today)
+          export_sheet(sheet, exports_now)
         end
       else
         log :error, 'Validation failed! No sheets will be exported.'

--- a/app/models/oec/publish_task.rb
+++ b/app/models/oec/publish_task.rb
@@ -21,10 +21,10 @@ module Oec
     private
 
     def download_exports_from_drive
-      date_to_publish = @opts[:date_to_publish] || datestamp
-      tmp_dir = LOG_DIRECTORY.join("publish_#{date_to_publish}")
+      datetime_to_publish = @opts[:datetime_to_publish] || "#{datestamp} #{timestamp}"
+      tmp_dir = LOG_DIRECTORY.join("publish_#{datetime_to_publish.tr(' :', '_')}")
       FileUtils.mkdir_p tmp_dir
-      parent = @remote_drive.find_nested([@term_code, 'exports', date_to_publish], on_failure: :error)
+      parent = @remote_drive.find_nested([@term_code, 'exports', datetime_to_publish], on_failure: :error)
       files_to_publish.each do |filename|
         remote_content = @remote_drive.find_first_matching_item(filename.chomp('.csv'), parent)
         open(tmp_dir.join(filename), 'w') { |f|

--- a/app/models/oec/report_diff_task.rb
+++ b/app/models/oec/report_diff_task.rb
@@ -10,7 +10,7 @@ module Oec
       Oec::CourseCode.by_dept_code(@course_code_filter).keys.each do |dept_code|
         if (diff_report = analyze dept_code)
           diff_reports_per_dept[dept_code] = diff_report
-          file_name = "#{timestamp}_#{Berkeley::Departments.get(dept_code, concise: true).downcase.tr(' ', '_')}_courses_diff"
+          file_name = "#{timestamp} #{Berkeley::Departments.get(dept_code, concise: true)} courses diff"
           upload_worksheet(diff_report, file_name, find_or_create_today_subfolder('reports'))
           log :info, "#{dept_code} diff summary: reports/#{datestamp}/#{file_name}"
         end
@@ -21,8 +21,8 @@ module Oec
     def analyze(dept_code)
       dept_name = Berkeley::Departments.get(dept_code, concise: true)
       validate(dept_code, @term_code) do |errors|
-        sis_data = csv_row_hash([@term_code, 'imports', datestamp, dept_name], dept_code, Oec::SisImportSheet)
-        errors.add("#{dept_name} has no #{datestamp} 'imports' spreadsheet") && return unless sis_data
+        sis_data = csv_row_hash([@term_code, 'imports', "#{datestamp} #{timestamp}", dept_name], dept_code, Oec::SisImportSheet)
+        errors.add("#{dept_name} has no 'imports' '#{datestamp} #{timestamp}' spreadsheet") && return unless sis_data
         dept_data = csv_row_hash([@term_code, 'departments', dept_name, 'Courses'], dept_code, Oec::CourseConfirmation)
         errors.add("#{dept_name} has no 'Courses' spreadsheet") && return unless dept_data
         keys_of_rows_with_diff = []

--- a/app/models/oec/sis_import_task.rb
+++ b/app/models/oec/sis_import_task.rb
@@ -4,12 +4,12 @@ module Oec
     def run_internal
       @dept_forms = {}
       log :info, "Will import SIS data for term #{@term_code}"
-      imports_today = find_or_create_today_subfolder('imports')
+      imports_now = find_or_create_now_subfolder('imports')
       Oec::CourseCode.by_dept_code(@course_code_filter).each do |dept_code, course_codes|
         log :info, "Generating #{dept_code}.csv"
         worksheet = Oec::SisImportSheet.new(dept_code: dept_code)
         import_courses(worksheet, course_codes)
-        export_sheet(worksheet, imports_today)
+        export_sheet(worksheet, imports_now)
       end
     end
 

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -25,9 +25,11 @@ namespace :oec do
   task :sis_import => :environment do
     term_code = ENV['term_code']
     raise ArgumentError, 'term_code required' unless term_code
+    date_time = DateTime.now
     [Oec::SisImportTask, Oec::ReportDiffTask].each do |klass|
       success = klass.new(
         term_code: term_code,
+        date_time: date_time,
         local_write: ENV['local_write'].present?,
         import_all: ENV['import_all'].present?,
         dept_names: ENV['dept_names'],
@@ -56,7 +58,7 @@ namespace :oec do
     Oec::PublishTask.new(
       term_code: term_code,
       local_write: ENV['local_write'].present?,
-      date_to_publish: ENV['date_to_publish']
+      datetime_to_publish: ENV['datetime_to_publish']
     ).run
   end
 

--- a/spec/models/oec/export_task_spec.rb
+++ b/spec/models/oec/export_task_spec.rb
@@ -39,7 +39,7 @@ describe Oec::ExportTask do
     allow(fake_remote_drive).to receive(:find_nested).and_return mock_google_drive_item
     allow(fake_remote_drive).to receive(:export_csv)
       .and_return(merged_course_confirmations_csv, merged_supervisor_confirmations_csv)
-    allow(Settings.terms).to receive(:fake_now).and_return DateTime.parse('2015-03-09')
+    allow(Settings.terms).to receive(:fake_now).and_return DateTime.parse('2015-03-09 12:00:00')
 
     allow(Oec::Queries).to receive(:students_for_cntl_nums).and_return student_data_rows
     allow(Oec::Queries).to receive(:enrollments_for_cntl_nums).and_return(enrollment_data_rows, suffixed_enrollment_data_rows)

--- a/spec/models/oec/publish_task_spec.rb
+++ b/spec/models/oec/publish_task_spec.rb
@@ -3,8 +3,8 @@ describe Oec::PublishTask do
   describe 'Publish' do
     let(:term_code) { '2015-B' }
     let(:fake_remote_drive) { double() }
-    let(:target_date) { '2015-09-18' }
-    let(:task) { Oec::PublishTask.new(term_code: term_code, date_to_publish: target_date, local_write: true) }
+    let(:target_date) { '2015-09-18 12:00:00' }
+    let(:task) { Oec::PublishTask.new(term_code: term_code, datetime_to_publish: target_date, local_write: true) }
 
     context 'sftp command' do
       before do
@@ -21,13 +21,13 @@ describe Oec::PublishTask do
 
       after do
         Dir.glob(Rails.root.join 'tmp', 'oec', "*#{Oec::PublishTask.name.demodulize.underscore}.log").each do |file|
-          expect(File.open(file, 'rb').read).to include "#{target_date}/courses.csv", 'sftp://'
+          expect(File.open(file, 'rb').read).to include "#{target_date.tr(' :', '_')}/courses.csv", 'sftp://'
           FileUtils.rm_rf file
         end
       end
 
-      it 'should run system command with date_to_publish in path' do
-        expect(task).to receive(:system).with(/publish_2015-09-18\/courses.csv/).and_return true
+      it 'should run system command with datetime_to_publish in path' do
+        expect(task).to receive(:system).with(/publish_2015-09-18_12_00_00\/courses.csv/).and_return true
         expect(task.run).to be true
       end
 

--- a/spec/models/oec/report_diff_task_spec.rb
+++ b/spec/models/oec/report_diff_task_spec.rb
@@ -30,7 +30,7 @@ describe Oec::ReportDiffTask do
       end
       dept_code_mappings.each do |dept_code, dept_name|
         friendly_name = Berkeley::Departments.get(dept_code, concise: true)
-        imports_path = [term_code, 'imports', now.strftime('%F'), friendly_name]
+        imports_path = [term_code, 'imports', now.strftime('%F %H:%M:%S'), friendly_name]
         if dept_name.nil?
           expect(fake_remote_drive).to receive(:find_nested).with(imports_path, anything).and_return nil
         else

--- a/spec/models/oec/sis_import_task_spec.rb
+++ b/spec/models/oec/sis_import_task_spec.rb
@@ -219,8 +219,8 @@ describe Oec::SisImportTask do
       subject { Oec::SisImportTask.new(term_code: term_code) }
 
       let(:today) { '2015-04-01' }
-      let(:now) { '092222' }
-      let(:logfile) { "#{now}_sis_import_task.log" }
+      let(:now) { '09:22:22' }
+      let(:logfile) { "#{now} sis import task.log" }
       let(:dept_name) { 'MATH' }
       let(:sheet_name) { 'Mathematics' }
 
@@ -228,14 +228,17 @@ describe Oec::SisImportTask do
       let(:reports_today_folder) { mock_google_drive_item today }
 
       before do
-        allow(DateTime).to receive(:now).and_return DateTime.strptime("#{today} #{now}", '%F %H%M%S')
+        allow(DateTime).to receive(:now).and_return DateTime.strptime("#{today} #{now}", '%F %H:%M:%S')
         allow(Oec::CourseCode).to receive(:by_dept_code).and_return({l4_codes[dept_name] => fake_code_mapping})
       end
 
       it 'should upload a department csv and a log file' do
         expect(fake_remote_drive).to receive(:check_conflicts_and_create_folder)
+          .with("#{today} #{now}", anything, anything)
+          .and_return(imports_today_folder)
+        expect(fake_remote_drive).to receive(:check_conflicts_and_create_folder)
           .with(today, anything, anything)
-          .and_return(imports_today_folder, reports_today_folder)
+          .and_return(reports_today_folder)
         expect(fake_remote_drive).to receive(:check_conflicts_and_upload)
           .with(kind_of(Oec::Worksheet), sheet_name, (Oec::Worksheet), imports_today_folder, anything)
           .and_return mock_google_drive_item(sheet_name)

--- a/spec/models/oec/term_setup_task_spec.rb
+++ b/spec/models/oec/term_setup_task_spec.rb
@@ -2,9 +2,9 @@ describe Oec::TermSetupTask do
 
   let(:term_code) { 'fake_term' }
   let(:today) { '2015-08-31' }
-  let(:now) { '092222' }
-  let(:logfile) { "#{now}_term_setup_task.log" }
-  before { allow(DateTime).to receive(:now).and_return DateTime.strptime("#{today} #{now}", '%F %H%M%S') }
+  let(:now) { '09:22:22' }
+  let(:logfile) { "#{now} term setup task.log" }
+  before { allow(DateTime).to receive(:now).and_return DateTime.strptime("#{today} #{now}", '%F %H:%M:%S') }
 
   subject { described_class.new(term_code: term_code) }
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5799

Happily, #4191 already gave Oec::Task a configurable DateTime, which lets us match timestamps between folder names and report/log files.

With all these timestamps now about, spaces and colons are preferred in remote item names where feasible.
