### PR TITLE
CLC-5802 Feature-flag bCourses user inactivation to deal with unreliable campus data

### DIFF
--- a/app/models/canvas_csv/maintain_users.rb
+++ b/app/models/canvas_csv/maintain_users.rb
@@ -134,6 +134,7 @@ module CanvasCsv
           @known_uids << login_id
           new_account_data = canvas_user_from_campus_row(campus_row)
         else
+          return unless Settings.canvas_proxy.inactivate_expired_users
           # This LDAP UID no longer appears in campus data. Mark the Canvas user account as inactive.
           logger.warn "Inactivating account for LDAP UID #{ldap_uid}" unless inactive_account
           if old_account_data['email'].present?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -83,6 +83,8 @@ canvas_proxy:
   dry_run_import: <%= ENV['CANVAS_DRY_RUN_IMPORT'] || '' %>
   # Set to false to disable synchronization of obfuscated names in Dev/QA.
   maintain_user_names: true
+  # Set to false to disable user account inactivation based on campus data.
+  inactivate_expired_users: true
   # Set to false if Canvas permissions block our ability to delete an invalid email address.
   delete_bad_emails: true
   # URL for scripts to point to CalCentral/Junction


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5802

Our database continues to miss many active accounts. And even after it's fixed, we know that what Oracle has done before, Oracle will someday do again.