### PR TITLE
CLC-5809, write_log in Oec::Task should always use DateTime.now when write_log

### DIFF
--- a/app/models/oec/task.rb
+++ b/app/models/oec/task.rb
@@ -4,6 +4,14 @@ module Oec
 
     LOG_DIRECTORY = Rails.root.join('tmp', 'oec')
 
+    def self.date_format
+      '%F'
+    end
+
+    def self.timestamp_format
+      '%H:%M:%S'
+    end
+
     def initialize(opts)
       @log = []
       @remote_drive = Oec::RemoteDrive.new
@@ -47,8 +55,8 @@ module Oec
       )
     end
 
-    def datestamp
-      @date_time.strftime '%F'
+    def datestamp(arg = @date_time)
+      arg.strftime self.class.date_format
     end
 
     def export_sheet(worksheet, dest_folder)
@@ -84,10 +92,10 @@ module Oec
       find_or_create_folder("#{datestamp} #{timestamp}", parent)
     end
 
-    def find_or_create_today_subfolder(category_name)
+    def find_or_create_today_subfolder(category_name, date_time = @date_time)
       return if @opts[:local_write]
       parent = @remote_drive.find_nested([@term_code, category_name], on_failure: :error)
-      find_or_create_folder(datestamp, parent)
+      find_or_create_folder(datestamp(date_time), parent)
     end
 
     def get_supplemental_worksheet(klass)
@@ -101,8 +109,8 @@ module Oec
       @log << "[#{Time.now}] #{message}"
     end
 
-    def timestamp
-      @date_time.strftime '%H:%M:%S'
+    def timestamp(arg = @date_time)
+      arg.strftime self.class.timestamp_format
     end
 
     def upload_file(path, remote_name, type, folder)
@@ -116,7 +124,8 @@ module Oec
     end
 
     def write_log
-      log_name = "#{timestamp} #{self.class.name.demodulize.underscore.tr('_', ' ')}.log"
+      now = DateTime.now
+      log_name = "#{timestamp now} #{self.class.name.demodulize.underscore.tr('_', ' ')}.log"
       log :debug, "Exporting log file '#{log_name}'"
       FileUtils.mkdir_p LOG_DIRECTORY unless File.exists? LOG_DIRECTORY
       # Local files need colons taken out of the timestamp, but remote sheets are happy to include them.
@@ -125,7 +134,7 @@ module Oec
       if @opts[:local_write]
         logger.debug "Wrote log file to path #{log_path}"
       else
-        if (reports_today = find_or_create_today_subfolder('reports'))
+        if (reports_today = find_or_create_today_subfolder('reports', now))
           begin
             upload_file(log_path, log_name, 'text/plain', reports_today)
           ensure


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5809

These two will be used in a subsequent PR:
* def self.date_format
* def self.timestamp_format

This gives us more intuitive timestamps on log files.