### PR TITLE
CLC-5812, oec:report_diff uses latest (SIS) imports folder by default

### DIFF
--- a/app/models/oec/publish_task.rb
+++ b/app/models/oec/publish_task.rb
@@ -7,7 +7,8 @@ module Oec
       unless @opts[:local_write]
         # SFTP stdout and stderr will go to a log file.
         FileUtils.mkdir_p LOG_DIRECTORY unless Dir.exists? LOG_DIRECTORY
-        filename = "#{self.class.name.demodulize.underscore}_sftp_#{DateTime.now.strftime '%F_%H:%M:%S'}.log"
+        pattern = "#{Oec::Task.date_format}_#{Oec::Task.timestamp_format}"
+        filename = "#{self.class.name.demodulize.underscore}_sftp_#{DateTime.now.strftime pattern}.log"
         sftp_stdout = LOG_DIRECTORY.join(filename).expand_path
         cmd = "#{sftp_command(download_dir)} > #{sftp_stdout} 2>&1"
         system(cmd) ? log(:info, "Successfully ran system command: #{cmd}") : raise(RuntimeError, "System command failed: #{cmd}")

--- a/app/models/oec/report_diff_task.rb
+++ b/app/models/oec/report_diff_task.rb
@@ -46,6 +46,21 @@ module Oec
 
     private
 
+    def default_date_time
+      # Deduce date by parsing the name of the last folder in 'imports', where SIS data lives.
+      parent = @remote_drive.find_nested([@term_code, 'imports'])
+      folders = @remote_drive.find_folders(parent.id)
+      unless (last = folders.sort_by(&:title).last)
+        raise RuntimeError, "The report_diff task requires a non-empty '#{@term_code}/imports' folder"
+      end
+      log :info, "The report_diff task will use SIS data in '#{@term_code}/imports/#{last.title}'"
+      DateTime.strptime(last.title, "#{self.class.date_format} #{self.class.timestamp_format}")
+    rescue => e
+      pattern = "#{Oec::Task.date_format}_#{Oec::Task.timestamp_format}"
+      log :error, "Folder in '#{@term_code}/imports' failed to match '#{pattern}'.\n#{e.message}\n#{e.backtrace.join "\n\t"}"
+      nil
+    end
+
     def create_diff_report(sis_data, dept_data, keys)
       diff_report = Oec::DiffReport.new @opts
       keys.each do |key|

--- a/app/models/oec/task.rb
+++ b/app/models/oec/task.rb
@@ -16,7 +16,7 @@ module Oec
       @log = []
       @remote_drive = Oec::RemoteDrive.new
       @term_code = opts.delete :term_code
-      @date_time = opts[:date_time] || DateTime.now
+      @date_time = opts[:date_time] || default_date_time
       @opts = opts
       @course_code_filter = if opts[:dept_names]
                              {dept_name: opts[:dept_names].split.map { |name| name.tr('_', ' ') }}
@@ -39,6 +39,10 @@ module Oec
     end
 
     private
+
+    def default_date_time
+      DateTime.now
+    end
 
     def copy_file(file, dest_folder)
       return if @opts[:local_write]

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -53,6 +53,23 @@ namespace :oec do
     end
   end
 
+  desc 'Compare department-managed sheets against latest SIS-import sheets'
+  task :report_diff => :environment do
+    term_code = ENV['term_code']
+    raise ArgumentError, 'term_code required' unless term_code
+    opts = {
+      term_code: term_code,
+      local_write: ENV['local_write'].present?,
+      dept_names: ENV['dept_names'],
+      dept_codes: ENV['dept_codes']
+    }
+    success = Oec::ReportDiffTask.new(opts).run
+    unless success
+      Rails.logger.error "#{Oec::ReportDiffTask.class} failed on #{opts}"
+      break
+    end
+  end
+
   desc 'Set up folder structure for new term'
   task :term_setup => :environment do
     raise ArgumentError, 'term_code required' unless ENV['term_code']

--- a/spec/models/oec/report_diff_task_spec.rb
+++ b/spec/models/oec/report_diff_task_spec.rb
@@ -13,7 +13,7 @@ describe Oec::ReportDiffTask do
     }
     let(:now) { DateTime.now }
     let (:fake_remote_drive) { double }
-    subject { Oec::ReportDiffTask.new(term_code: term_code, dept_codes: dept_code_mappings.keys, local_write: true) }
+    subject { Oec::ReportDiffTask.new(term_code: term_code, dept_codes: dept_code_mappings.keys, date_time: DateTime.now, local_write: true) }
 
     before {
       allow(Oec::CourseCode).to receive(:by_dept_code).and_return dept_code_mappings


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5812

Allows for report_diff without generating more sis_imports. We always use most recent SIS data. 