### PR TITLE
CLC-5769 Use template sheets for departmental confirmations

### DIFF
--- a/app/models/google_apps/sheets_manager.rb
+++ b/app/models/google_apps/sheets_manager.rb
@@ -9,9 +9,12 @@ module GoogleApps
     end
 
     def export_csv(file)
-      unless file.exportLinks && (csv_export_uri = file.exportLinks['text/csv'])
-        raise Errors::ProxyError, "No CSV export path found for file ID: #{file.id}"
-      end
+      csv_export_uri = if file.respond_to? :csv_export_url
+                     file.csv_export_url
+                   elsif file.exportLinks && file.exportLinks['text/csv']
+                     file.exportLinks['text/csv']
+                   end
+      raise Errors::ProxyError, "No CSV export path found for file ID: #{file.id}" unless csv_export_uri
       result = @session.execute!(uri: csv_export_uri)
       log_response result
       raise Errors::ProxyError, "export_csv failed with file.id=#{file.id}. Error: #{result.data['error']}" if result.error?
@@ -46,6 +49,52 @@ module GoogleApps
     rescue Google::APIClient::ClientError => e
       logger.error "spreadsheets_by_title failed with query: #{query}. Exception: #{e}"
       nil
+    end
+
+    # An alternative implementation of GoogleDrive::Spreadsheet#save without the expensive XML parsing.
+    def update_worksheet(worksheet, updates)
+      raise Errors::ProxyError, "File #{worksheet.id} is not a Google Sheets worksheet" unless worksheet.is_a? GoogleDrive::Worksheet
+
+      cells_feed_url = CGI.escapeHTML worksheet.cells_feed_url.to_s
+      cells_feed_url_base = cells_feed_url.gsub(/\/private\/full\Z/, '')
+      xml = <<-EOS
+            <feed xmlns="http://www.w3.org/2005/Atom"
+                  xmlns:batch="http://schemas.google.com/gdata/batch"
+                  xmlns:gs="http://schemas.google.com/spreadsheets/2006">
+              <id>#{cells_feed_url}</id>
+      EOS
+
+      updates.each do |coordinates, value|
+        row, col = coordinates
+        safe_value = value ? CGI.escapeHTML(value).gsub("\n", '&#x0a;') : nil
+        xml << <<-EOS
+              <entry>
+                <batch:id>#{row},#{col}</batch:id>
+                <batch:operation type="update"/>
+                <id>#{cells_feed_url_base}/R#{row}C#{col}</id>
+                <link rel="edit" type="application/atom+xml" href="#{cells_feed_url}/R#{row}C#{col}"/>
+                <gs:cell row="#{row}" col="#{col}" inputValue="#{safe_value}"/>
+              </entry>
+        EOS
+      end
+
+      xml << <<-EOS
+            </feed>
+      EOS
+
+      result = @session.execute!(
+        http_method: :post,
+        uri: "#{cells_feed_url}/batch",
+        body: xml,
+        headers: {
+          'Content-Type' => 'application/atom+xml;charset=utf-8',
+          'If-Match' => '*'
+        }
+      )
+      log_response result
+      raise Errors::ProxyError, "update_worksheet failed with file.id=#{file.id}. Error: #{result.data['error']}" if result.error?
+      raise Errors::ProxyError, "update_worksheet failed with file.id=#{file.id}. Error: interrupted" if result.body.include? 'batch:interrupted'
+      result.body
     end
 
     def upload_worksheet(title, description, worksheet, parent_id = 'root', opts={})

--- a/app/models/oec/course_confirmation.rb
+++ b/app/models/oec/course_confirmation.rb
@@ -25,7 +25,5 @@ module Oec
       )
     end
 
-    validate('LDAP_UID') { |row| 'Non-numeric' unless row['LDAP_UID'] =~ /\A\d+\Z/ }
-
   end
 end

--- a/app/models/oec/create_confirmation_sheets_task.rb
+++ b/app/models/oec/create_confirmation_sheets_task.rb
@@ -19,10 +19,39 @@ module Oec
       if valid?
         departments_folder = @remote_drive.find_first_matching_item('departments', term_folder)
         raise RuntimeError, "No departments folder found for term #{@term_code}" unless departments_folder
+        template = @remote_drive.find_first_matching_item('TEMPLATE', departments_folder)
+
         confirmations.each do |dept_name, dept_confirmations|
-          department_folder = find_or_create_folder(dept_name, departments_folder)
-          export_sheet(dept_confirmations[:courses], department_folder)
-          export_sheet(dept_confirmations[:supervisors], department_folder)
+          if @remote_drive.find_first_matching_item(dept_name, departments_folder)
+            log :warn, "File '#{dept_name}' exists in departments folder, will not create confirmation sheet"
+            next
+          end
+
+          if @opts[:local_write]
+            dept_confirmations[:courses].write_csv
+            log :debug, "Exported to local file #{dept_confirmations[:courses].csv_export_path}"
+            dept_confirmations[:supervisors].write_csv
+            log :debug, "Exported to local file #{dept_confirmations[:supervisors].csv_export_path}"
+          else
+            if template && template.mime_type == 'application/vnd.google-apps.spreadsheet'
+              log :debug, "Will copy new '#{dept_name}' confirmation sheet from template"
+              dept_sheet = (template_copy = @remote_drive.copy_item(template.id, dept_name)) && @remote_drive.spreadsheet_by_id(template_copy.id)
+              dept_worksheets = dept_sheet.worksheets
+              courses_worksheet = dept_worksheets.find { |w| w.title == 'Courses' }
+              raise RuntimeError, "Could not find worksheet 'Courses' in template copy '#{dept_sheet.title}'" unless courses_worksheet
+              report_viewers_worksheet = dept_worksheets.find { |w| w.title == 'Report Viewers' }
+              raise RuntimeError, "Could not find worksheet 'Report Viewers' in template copy '#{dept_sheet.title}'" unless report_viewers_worksheet
+            else
+              log :debug, "No template confirmation sheet found, will create blank '#{dept_name}' confirmation sheet"
+              dept_sheet = @remote_drive.upload_to_spreadsheet(dept_name, '', StringIO.new(dept_confirmations[:courses].headers.join(',')), departments_folder.id)
+              courses_worksheet = dept_sheet.worksheets.first
+              report_viewers_worksheet = dept_sheet.add_worksheet('Report Viewers', 100, dept_confirmations[:supervisors].headers.count)
+              dept_confirmations[:supervisors].headers.each_with_index { |header, i| report_viewers_worksheet[1, i+1] = header }
+              report_viewers_worksheet.save
+            end
+            update_worksheet(courses_worksheet, dept_confirmations[:courses])
+            update_worksheet(report_viewers_worksheet, dept_confirmations[:supervisors])
+          end
         end
       else
         log :error, 'Validation failed! Confirmation sheets will not be created.'
@@ -32,9 +61,10 @@ module Oec
 
     def generate_confirmations(imports, supervisors)
       confirmations = {}
+      import_items = @remote_drive.get_items_in_folder imports.id
       Oec::CourseCode.by_dept_code(@course_code_filter).each do |dept_code, course_codes|
         dept_name = Berkeley::Departments.get(dept_code, concise: true)
-        unless (dept_import_sheet = @remote_drive.find_first_matching_item(dept_name, imports))
+        unless (dept_import_sheet = import_items.find { |f| f.title == dept_name })
           log :warn, "No sheet found for #{dept_name} in import folder '#{imports.title}'; skipping confirmation sheet creation."
           next
         end
@@ -63,6 +93,21 @@ module Oec
         end
       end
       supervisor_confirmation
+    end
+
+    def update_worksheet(remote_sheet, local_sheet)
+      headers = remote_sheet.rows.last
+      offset = remote_sheet.rows.count + 1
+      cell_updates = {}
+      local_sheet.each_with_index do |local_sheet_row, y|
+        headers.each_with_index { |header, x| cell_updates[[y+offset, x+1]] = local_sheet_row[header] }
+      end
+      begin
+        @remote_drive.update_worksheet(remote_sheet, cell_updates)
+        log :debug, "Exported confirmation data to '#{remote_sheet.title}' worksheet"
+      rescue Errors::ProxyError => e
+        log :error, "Export of confirmation data to '#{remote_sheet.title}' failed: #{e}"
+      end
     end
 
   end

--- a/app/models/oec/report_diff_task.rb
+++ b/app/models/oec/report_diff_task.rb
@@ -23,8 +23,8 @@ module Oec
       validate(dept_code, @term_code) do |errors|
         sis_data = csv_row_hash([@term_code, 'imports', "#{datestamp} #{timestamp}", dept_name], dept_code, Oec::SisImportSheet)
         errors.add("#{dept_name} has no 'imports' '#{datestamp} #{timestamp}' spreadsheet") && return unless sis_data
-        dept_data = csv_row_hash([@term_code, 'departments', dept_name, 'Courses'], dept_code, Oec::CourseConfirmation)
-        errors.add("#{dept_name} has no 'Courses' spreadsheet") && return unless dept_data
+        dept_data = csv_row_hash([@term_code, 'departments', dept_name], dept_code, Oec::CourseConfirmation)
+        errors.add("#{dept_name} has no department confirmation spreadsheet") && return unless dept_data
         keys_of_rows_with_diff = []
         intersection = (sis_keys = sis_data.keys) & (dept_keys = dept_data.keys)
         (sis_keys | dept_keys).select do |key|

--- a/app/models/oec/worksheet.rb
+++ b/app/models/oec/worksheet.rb
@@ -33,9 +33,9 @@ module Oec
 
     def self.from_csv(csv, opts={})
       return unless csv && (parsed_csv = CSV.parse csv)
-      header_row = parsed_csv.shift
       instance = self.new opts
-      raise ArgumentError, "Header mismatch: cannot create instance of #{self.name} from CSV" unless header_row == instance.headers
+      (header_row = parsed_csv.shift) until (header_row == instance.headers || parsed_csv.empty?)
+      raise ArgumentError, "Header mismatch: cannot create instance of #{self.name} from CSV" unless header_row
       parsed_csv.each_with_index { |row, index| instance[index] = Hash[instance.headers.zip row] }
       instance
     end

--- a/spec/models/oec/report_diff_task_spec.rb
+++ b/spec/models/oec/report_diff_task_spec.rb
@@ -34,7 +34,7 @@ describe Oec::ReportDiffTask do
         if dept_name.nil?
           expect(fake_remote_drive).to receive(:find_nested).with(imports_path, anything).and_return nil
         else
-          courses_path = [term_code, 'departments', friendly_name, 'Courses']
+          courses_path = [term_code, 'departments', friendly_name]
           sheet_classes = [Oec::SisImportSheet, Oec::CourseConfirmation]
           [ imports_path, courses_path ].each_with_index do |path, index|
             expect(fake_remote_drive).to receive(:find_nested).with(path, anything).and_return (remote_file = double)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5769

- Departmental confirmation sheets are now a single Google Sheet with multiple worksheets. Oec::CreateConfirmationSheetsTask will look for a 'TEMPLATE' sheet in the departmental folder and copy over its styling and validation for departmental sheets. If the 'TEMPLATE' sheet is not found, it will create a new Google Sheet without styling or validation.
- Updating cells in place is accomplished with the new SheetsManager#update_worksheet, re-implementing the functionality of GoogleDrive::Spreadsheet#save with acceptable performance.
- Other tasks are changed to expect a multi-worksheet confirmation sheet. Calling the CSV export URL for a multi-worksheet Google Sheet will generate a CSV for the first worksheet only. As it happens, this is what ReportDiffTask requires anyway ("Courses," not "Report Viewers"), so that code had to change very little. MergeConfirmationSheetsTask requires both worksheets and has to be explicitly told to pull them both out.
- Oec::Worksheet#from_csv now discards decorative header rows, such as we get from the fancy-formatted department sheets, until it reaches a row with the header data that it's expecting.
- A misplaced validation is taken out of Oec::CourseConfirmation. (As written, that validation prevents any rows without instructor data from being written to confirmation sheets, even though the whole point of the confirmation sheets is to fill in blank data).
- https://jira.ets.berkeley.edu/jira/browse/CLC-5808 is also addressed.