### PR TITLE
CLC-5700, enhance publish_task; no more sftp_password

### DIFF
--- a/app/models/oec/report_diff_task.rb
+++ b/app/models/oec/report_diff_task.rb
@@ -54,18 +54,7 @@ module Oec
     end
 
     def default_date_time
-      # Deduce date by parsing the name of the last folder in 'imports', where SIS data lives.
-      parent = @remote_drive.find_nested([@term_code, 'imports'])
-      folders = @remote_drive.find_folders(parent.id)
-      unless (last = folders.sort_by(&:title).last)
-        raise RuntimeError, "The report_diff task requires a non-empty '#{@term_code}/imports' folder"
-      end
-      log :info, "The report_diff task will use SIS data in '#{@term_code}/imports/#{last.title}'"
-      DateTime.strptime(last.title, "#{self.class.date_format} #{self.class.timestamp_format}")
-    rescue => e
-      pattern = "#{Oec::Task.date_format}_#{Oec::Task.timestamp_format}"
-      log :error, "Folder in '#{@term_code}/imports' failed to match '#{pattern}'.\n#{e.message}\n#{e.backtrace.join "\n\t"}"
-      nil
+      date_time_of_most_recent 'imports'
     end
 
     def report_diff(dept_code, sis_data, dept_data, keys)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -305,7 +305,6 @@ oec:
     sftp_server: ''
     sftp_port: 22
     sftp_user: ''
-    sftp_password: ''
   google:
     uid: ''
     client_id: 'oecClientId'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5793

* reuse the logic in report_diff: publish_task now defaults to *date_time_of_most_recent 'exports'* 
* tidy up logging
* strictly ssh keys in dev, qa and prod – no more sftp_password