### PR TITLE
CLC-5774 Create Junction API endpoints wrapping OEC tasks

### DIFF
--- a/app/controllers/oec_tasks_controller.rb
+++ b/app/controllers/oec_tasks_controller.rb
@@ -1,0 +1,36 @@
+class OecTasksController < ApplicationController
+  include ClassLogger
+
+  before_action :api_authenticate
+  before_action :authorize_oec_administration
+
+  rescue_from StandardError, with: :handle_api_exception
+  rescue_from Errors::ClientError, with: :handle_client_error
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  def authorize_oec_administration
+    authorize current_user, :can_administer_oec?
+  end
+
+  # GET /api/oec_tasks
+
+  def index
+    departments = Berkeley::Departments.department_map.map { |k,v| {code: k, name: Berkeley::Departments.shortened(v)} }
+    render json: {
+      oecDepartments: departments.sort_by { |dept| dept[:name] },
+      oecTasks: Oec::Task.subclasses.map { |klass| klass.to_s.demodulize },
+      oecTerms: Berkeley::Terms.fetch.campus.values.map { |term| term.to_english }
+    }
+  end
+
+  # POST /api/oec_tasks/:task_name
+
+  def run
+    task_class = "Oec::#{params['task_name']}".constantize
+    params.require('term')
+    task_opts = params.slice('term', 'departmentCode')
+    Oec::ApiTaskWrapper.new(task_class, task_opts).start_in_background
+    render json: {success: true, oecDriveUrl: Oec::RemoteDrive::HUMAN_URL}
+  end
+
+end

--- a/app/models/oec/administrator.rb
+++ b/app/models/oec/administrator.rb
@@ -1,0 +1,9 @@
+module Oec
+  module Administrator
+
+    def self.is_admin?(uid)
+      uid.to_s == Settings.oec.administrator_uid
+    end
+
+  end
+end

--- a/app/models/oec/api_task_wrapper.rb
+++ b/app/models/oec/api_task_wrapper.rb
@@ -1,0 +1,35 @@
+module Oec
+  class ApiTaskWrapper
+    include TorqueBox::Messaging::Backgroundable
+
+    def initialize(task_class, params)
+      @task_class = task_class
+      @params = translate_params(params)
+    end
+
+    def run
+      @task_class.new(@params).run
+    end
+
+    def start_in_background
+      self.background.run
+    end
+
+    private
+
+    def translate_params(params)
+      term_code = Berkeley::TermCodes.from_english params['term']
+      translated_params = {
+        term_code: "#{term_code[:term_yr]}-#{term_code[:term_cd]}"
+      }
+      if params['departmentCode'].present?
+        translated_params.merge!({
+          dept_codes: params['departmentCode'],
+          import_all: true
+        })
+      end
+      translated_params
+    end
+
+  end
+end

--- a/app/models/oec/remote_drive.rb
+++ b/app/models/oec/remote_drive.rb
@@ -1,6 +1,8 @@
 module Oec
   class RemoteDrive < GoogleApps::SheetsManager
 
+    HUMAN_URL = 'https://drive.google.com/drive/my-drive'
+
     def initialize
       super(Settings.oec.google.uid, Settings.oec.google.marshal_dump)
     end

--- a/app/policies/authentication_state_policy.rb
+++ b/app/policies/authentication_state_policy.rb
@@ -26,6 +26,10 @@ class AuthenticationStatePolicy
     can_administrate? || Canvas::Admins.new.admin_user?(@user.user_id)
   end
 
+  def can_administer_oec?
+    can_administrate? || Oec::Administrator.is_admin?(@user.user_id)
+  end
+
   def can_author?
     @user.real_user_auth.active? && (@user.real_user_auth.is_superuser? || @user.real_user_auth.is_author?)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,10 @@ Calcentral::Application.routes.draw do
   post '/api/academics/canvas/mailing_lists/:canvas_course_id/populate' => 'canvas_mailing_lists#populate', :defaults => { :format => 'json' }
   post '/api/academics/canvas/mailing_lists/:canvas_course_id/delete' => 'canvas_mailing_lists#destroy', :defaults => { :format => 'json' }
 
+  # OEC endpoints
+  get '/api/oec_tasks' => 'oec_tasks#index', :defaults => { :format => 'json' }
+  post '/api/oec_tasks/:task_name' => 'oec_tasks#run', :defaults => { :format => 'json' }
+
   # System utility endpoints
   get '/api/cache/clear' => 'cache#clear', :defaults => { :format => 'json' }
   get '/api/cache/delete' => 'cache#delete', :defaults => { :format => 'json' }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -301,6 +301,7 @@ features:
 youtube_splash_id: 'EQ-a7xrfVag'
 
 oec:
+  administrator_uid: ''
   explorance:
     sftp_server: ''
     sftp_port: 22


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5774

Part one:
- creates an `index` endpoint serving task, term and department information useful to the front end;
- creates a `run` endpoint that accepts a slimmed-down set of options and shunts OEC tasks over to a Torquebox background job;
- authorizes these endpoints to superusers or the new `administrator_uid` in YAML, which will be the same as the Google account ID in production but may not be in dev/QA.

Specs to follow.