### PR TITLE
CLC-5793, toss out lftp; publish_task is always SSH

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -305,6 +305,7 @@ oec:
     sftp_server: ''
     sftp_port: 22
     sftp_user: ''
+    ssh_private_key_file: ''
   google:
     uid: ''
     client_id: 'oecClientId'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5793

Changes:
* dev and qa environments use SSH keys so the code can stop relying on *lftp*
* we use sftp's batch-mode
* name of ssh_private_key_file must be explicit (see Settings.oec) because other apps might have a need for other keys in ~/.ssh
