### PR TITLE
CLC-5835, remove 'datetime_to_publish' from publish task

### DIFF
--- a/app/models/oec/publish_task.rb
+++ b/app/models/oec/publish_task.rb
@@ -34,7 +34,8 @@ module Oec
     private
 
     def download_exports_from_drive
-      datetime_to_publish = @opts[:datetime_to_publish] || date_time_of_most_recent('exports')
+      datetime_to_publish = date_time_of_most_recent('exports')
+      raise RuntimeError, 'The \'exports\' directory is empty; there is nothing to publish.' unless datetime_to_publish
       pattern = "#{Oec::Task.date_format}_%H%M%S"
       download_dir = @tmp_dir.join("publish_#{datetime_to_publish.strftime pattern}")
       FileUtils.mkdir_p download_dir

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -85,8 +85,7 @@ namespace :oec do
     raise ArgumentError, 'term_code required' unless term_code
     Oec::PublishTask.new(
       term_code: term_code,
-      local_write: ENV['local_write'].present?,
-      datetime_to_publish: ENV['datetime_to_publish']
+      local_write: ENV['local_write'].present?
     ).run
   end
 

--- a/spec/models/oec/publish_task_spec.rb
+++ b/spec/models/oec/publish_task_spec.rb
@@ -11,8 +11,6 @@ describe Oec::PublishTask do
       before do
         allow(Oec::RemoteDrive).to receive(:new).and_return fake_remote_drive
         allow(fake_remote_drive).to receive(:find_nested).with(term_code, 'exports') # .and_return (exports_folder = double())
-        # exports_folder_id = double()
-        # allow(exports_folder).to receive(:id) { 'mock_id' }
         allow(fake_remote_drive).to receive(:find_folders).with('mock_id').and_return (exports_folder_listing = double())
         allow(exports_folder_listing).to receive(:sort_by) { exports_folder_listing }
         most_recent_folder = double()

--- a/spec/models/oec/publish_task_spec.rb
+++ b/spec/models/oec/publish_task_spec.rb
@@ -4,12 +4,21 @@ describe Oec::PublishTask do
     let(:term_code) { '2015-B' }
     let(:fake_remote_drive) { double() }
     let(:now) { DateTime.now }
-    let(:task) { Oec::PublishTask.new(term_code: term_code, datetime_to_publish: now) }
+    let(:task) { Oec::PublishTask.new term_code: term_code }
     let(:tmp_publish_directory) { now.strftime "publish_#{Oec::Task.date_format}_%H%M%S" }
 
     context 'sftp command' do
       before do
         allow(Oec::RemoteDrive).to receive(:new).and_return fake_remote_drive
+        allow(fake_remote_drive).to receive(:find_nested).with(term_code, 'exports') # .and_return (exports_folder = double())
+        # exports_folder_id = double()
+        # allow(exports_folder).to receive(:id) { 'mock_id' }
+        allow(fake_remote_drive).to receive(:find_folders).with('mock_id').and_return (exports_folder_listing = double())
+        allow(exports_folder_listing).to receive(:sort_by) { exports_folder_listing }
+        most_recent_folder = double()
+        allow(exports_folder_listing).to receive(:last) { most_recent_folder }
+        allow(most_recent_folder).to receive(:title) { now.strftime  "#{Oec::Task.date_format} #{Oec::Task.timestamp_format}" }
+
         parent_dir = mock_google_drive_item
         allow(fake_remote_drive).to receive(:find_nested).and_return parent_dir
         allow(fake_remote_drive).to receive(:check_conflicts_and_create_folder).and_return mock_google_drive_item


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5835

The 'OEC/Google Drive automated tasks' is updated, too.