### PR TITLE
CLC-5833, user can validate-only or export-and-publish

### DIFF
--- a/app/models/oec/api_task_wrapper.rb
+++ b/app/models/oec/api_task_wrapper.rb
@@ -34,8 +34,8 @@ module Oec
         htmlDescription: 'Run a validation report on merged confirmation sheets. Validation results will appear in a dated subfolder of the <strong>reports</strong> folder.'
       },
       {
-        name: 'PublishTask',
-        friendlyName: 'Export confirmed data',
+        name: 'ExportAndPublishTask',
+        friendlyName: 'Publish confirmed data to Explorance',
         htmlDescription: 'Validate and export merged confirmation sheets. Files will be uploaded to the vendor only if validation passes. A copy of the uploaded data will appear in a timestamped subfolder of the <strong>exports</strong> folder.'
       }
     ]

--- a/app/models/oec/export_and_publish_task.rb
+++ b/app/models/oec/export_and_publish_task.rb
@@ -1,0 +1,14 @@
+module Oec
+  class ExportAndPublishTask < Task
+
+    def run_internal
+      [Oec::ExportTask, Oec::PublishTask].each do |klass|
+        klass.new(
+          term_code: @term_code,
+          local_write: @opts[:local_write]
+        ).run
+      end
+    end
+
+  end
+end

--- a/app/models/oec/export_task.rb
+++ b/app/models/oec/export_task.rb
@@ -88,13 +88,16 @@ module Oec
         end
       end
 
+      skip_export_step = @opts[:validation_without_export]
       if valid?
-        exports_now = find_or_create_now_subfolder 'exports'
-        [instructors, course_instructors, courses, students, course_students, supervisors, course_supervisors].each do |sheet|
-          export_sheet(sheet, exports_now)
+        unless skip_export_step
+          exports_now = find_or_create_now_subfolder 'exports'
+          [instructors, course_instructors, courses, students, course_students, supervisors, course_supervisors].each do |sheet|
+            export_sheet(sheet, exports_now)
+          end
         end
       else
-        log :error, 'Validation failed! No sheets will be exported.'
+        log :error, "Validation failed! #{'No sheets will be exported.' unless skip_export_step}"
         log_validation_errors
       end
     end

--- a/app/models/oec/publish_task.rb
+++ b/app/models/oec/publish_task.rb
@@ -23,8 +23,8 @@ module Oec
         end
         # Now copy the command's output to remote drive.
         sftp_stdout_to_log sftp_stdout
+        FileUtils.rm_rf @tmp_dir
       end
-      FileUtils.rm_rf @tmp_dir
     end
 
     def files_to_publish

--- a/script/run-oec-task.sh
+++ b/script/run-oec-task.sh
@@ -7,7 +7,7 @@ test -f "${PROFILE}" && source "${PROFILE}"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-TASK_OPTIONS=(create_confirmation_sheets export merge_confirmation_sheets publish_to_explorance report_diff sis_import term_setup)
+TASK_OPTIONS=(term_setup sis_import create_confirmation_sheets report_diff merge_confirmation_sheets validate_confirmation_sheets publish_to_explorance)
 TASK="$1"
 
 WORKING_DIR="${PWD}"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5833

* New ExportAndPubish class so ApiWrapper can do both in one task
* 'validation_without_export' opt for ExportTask
* reordering in oec.rake according to real-world workflow
* PublishTask will not remove tmp_dir when local_write 