### PR TITLE
CLC-5841, if standalone ExportTask then implicitly add :validate_without_export

### DIFF
--- a/app/models/oec/api_task_wrapper.rb
+++ b/app/models/oec/api_task_wrapper.rb
@@ -43,6 +43,7 @@ module Oec
     def initialize(task_class, params)
       @task_class = task_class
       @params = translate_params(params)
+      @params[:validate_without_export] = true if task_class == Oec::ExportTask
     end
 
     def run

--- a/spec/models/oec/api_task_wrapper_spec.rb
+++ b/spec/models/oec/api_task_wrapper_spec.rb
@@ -21,6 +21,15 @@ describe Oec::ApiTaskWrapper do
     it 'should translate params to task options' do
       expect(translated_params[:dept_codes]).to eq 'SYPSY'
       expect(translated_params[:import_all]).to eq true
+      expect(translated_params[:validate_without_export]).to be_nil
+    end
+  end
+
+  context 'validate without export' do
+    let(:task_class) { Oec::ExportTask }
+    let(:params) { {'term' => 'Summer 2014', 'departmentCode' => 'SYPSY'} }
+    it 'should implicitly add :validate_without_export' do
+      expect(translated_params[:validate_without_export]).to be true
     end
   end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5841

Clients of ApiTaskWrapper don't need to know about the :validate_without_export config.