### PR TITLE
CLC-5832 OEC: Add new validations on export

### DIFF
--- a/app/models/oec/courses.rb
+++ b/app/models/oec/courses.rb
@@ -26,6 +26,7 @@ module Oec
     validate('COURSE_ID') { |row| 'Invalid' unless row['COURSE_ID'] =~ /\A20\d{2}-[ABCD]-\d{5}(_(A|B|GSI|CHEM|MCB))?\Z/ }
     validate('COURSE_ID_2') { |row| 'Non-matching' unless row['COURSE_ID'] == row['COURSE_ID_2'] }
     validate('EVALUATION_TYPE') { |row| 'Unexpected' if row['COURSE_ID'].end_with?('_GSI') && row['EVALUATION_TYPE'] != 'G' }
+    validate('EVALUATION_TYPE') { |row| 'Unexpected' unless %w(F G LANG LECT SEMI WRIT).include? row['EVALUATION_TYPE'] }
     validate('END_DATE') do |row|
       start_date = Date.strptime(row['START_DATE'], WORKSHEET_DATE_FORMAT)
       end_date = Date.strptime(row['END_DATE'], WORKSHEET_DATE_FORMAT)

--- a/app/models/oec/sis_import_task.rb
+++ b/app/models/oec/sis_import_task.rb
@@ -161,20 +161,8 @@ module Oec
         end
       end
 
-      set_term_dates(worksheet, supplemental_course_sheet)
-    end
-
-    def set_term_dates(worksheet, supplemental_course_sheet)
-      default_term_dates = supplemental_course_sheet.find do |row|
-        row['DEPT_NAME'].blank? &&
-        row['CATALOG_ID'].blank? &&
-        row['INSTRUCTION_FORMAT'].blank? &&
-        row['SECTION_NUM'].blank? &&
-        row['START_DATE'].present? &&
-        row['END_DATE'].present?
-      end
       if default_term_dates
-        worksheet.each { |row| row.update(default_term_dates.slice('START_DATE', 'END_DATE')) unless row['MODULAR_COURSE'].present? }
+        worksheet.each { |row| row.update(default_term_dates) unless row['MODULAR_COURSE'].present? }
       end
     end
 

--- a/app/models/oec/task.rb
+++ b/app/models/oec/task.rb
@@ -63,6 +63,20 @@ module Oec
       arg.strftime self.class.date_format
     end
 
+    def default_term_dates
+      if (supplemental_course_sheet = get_supplemental_worksheet Oec::Courses)
+        default_term_dates_row = supplemental_course_sheet.find do |row|
+          row['DEPT_NAME'].blank? &&
+            row['CATALOG_ID'].blank? &&
+            row['INSTRUCTION_FORMAT'].blank? &&
+            row['SECTION_NUM'].blank? &&
+            row['START_DATE'].present? &&
+            row['END_DATE'].present?
+        end
+        default_term_dates_row.slice('START_DATE', 'END_DATE') if default_term_dates_row
+      end
+    end
+
     def export_sheet(worksheet, dest_folder)
       if @opts[:local_write]
         worksheet.write_csv


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5832

Code to pull default term dates from supplemental_sources/courses is extracted into the base Oec::Task class so that validations can check against it. Also constrains values on MODULAR_COURSE and EVALUATION_TYPE.