### PR TITLE
CLC-5341 Keep "129182,129410" from displaying as "129,182,129,410"

### DIFF
--- a/app/models/canvas_csv/lti_usage_reporter.rb
+++ b/app/models/canvas_csv/lti_usage_reporter.rb
@@ -52,7 +52,7 @@ module CanvasCsv
         csv << {
           'Tool' => summary[:label],
           'URL' => summary[:url],
-          'Accounts' => summary[:accounts].join(','),
+          'Accounts' => summary[:accounts].join(', '),
           'Courses Visible' => courses_count
         }
       end

--- a/spec/models/canvas_csv/lti_usage_reporter_spec.rb
+++ b/spec/models/canvas_csv/lti_usage_reporter_spec.rb
@@ -104,6 +104,13 @@ canvas_course_id,course_id,short_name,long_name,canvas_account_id,account_id,can
       expect(tool_row['URL']).to be_present
       expect(tool_row['Courses Visible'].to_s).to eq '1'
     end
+    it 'keeps Excel from interpreting a list of account IDs as one spectacularly large number' do
+      subject.tool_url_to_summary = {
+        'acme.com' => {label: 'Acme Quality', url: 'acme.com', accounts: [12345,67890], nbr_courses_visible: 13}
+      }
+      subject.generate_summary_report
+      expect(summary_report.first['Accounts']).to eq '12345, 67890'
+    end
   end
 
   describe '#courses_report' do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5341

Why do you think they call it Excel?