### PR TITLE
CLC-5846, if OEC uid=12004714 is obsolete then delete oauth2_data

### DIFF
--- a/db/migrate/20151002183441_remove_obsolete_oauth_oec.rb
+++ b/db/migrate/20151002183441_remove_obsolete_oauth_oec.rb
@@ -1,0 +1,10 @@
+class RemoveObsoleteOauthOec < ActiveRecord::Migration
+  def change
+    uid = '12004714'
+    if Settings.oec.google.uid == uid
+      Rails.logger.warn "Do NOT delete oauth2_data where uid='#{uid}' because, according to YAML, #{uid} is still used. "
+    else
+      User::Oauth2Data.where(:uid => uid).delete_all
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150813225141) do
+ActiveRecord::Schema.define(version: 20151002183441) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5846

* Environments still using uid=12004714: local, testext, dev, qa 
* Prod will use a new uid based on yaml settings (prepared prior to v66 release) 