### PR TITLE
CLC-5839 OEC control panel: hide departments dropdown when not relevant

### DIFF
--- a/app/models/oec/api_task_wrapper.rb
+++ b/app/models/oec/api_task_wrapper.rb
@@ -6,37 +6,44 @@ module Oec
       {
         name: 'TermSetupTask',
         friendlyName: 'Term setup',
-        htmlDescription: 'Create a Google Drive folder under a new term code (e.g., <strong>2015-D</strong>) and populate it with initial folders and files.'
+        htmlDescription: 'Create a Google Drive folder under a new term code (e.g., <strong>2015-D</strong>) and populate it with initial folders and files.',
+        acceptsDepartmentOptions: false
       },
       {
         name: 'SisImportTask',
         friendlyName: 'SIS data import',
-        htmlDescription: 'Import course and instructor data for one or more campus departments. Imported data will appear in a new, timestamped subfolder of the <strong>imports</strong> folder.'
+        htmlDescription: 'Import course and instructor data for one or more campus departments. Imported data will appear in a new, timestamped subfolder of the <strong>imports</strong> folder.',
+        acceptsDepartmentOptions: true
       },
       {
         name: 'CreateConfirmationSheetsTask',
         friendlyName: 'Create confirmation sheets',
-        htmlDescription: 'Create confirmation sheets for review and edits by department administrators. Sheets will appear under the <strong>departments</strong> folder. If that folder contains a sheet named <strong>TEMPLATE</strong>, it will be used as a model for the confirmation sheets.'
+        htmlDescription: 'Create confirmation sheets for review and edits by department administrators. Sheets will appear under the <strong>departments</strong> folder. If that folder contains a sheet named <strong>TEMPLATE</strong>, it will be used as a model for the confirmation sheets.',
+        acceptsDepartmentOptions: true
       },
       {
         name: 'ReportDiffTask',
         friendlyName: 'Diff confirmation sheets',
-        htmlDescription: 'Compare department confirmation sheets to the most recent SIS import data and report on differences. The diff report will appear as a new sheet in the <strong>departments</strong> folder, and will replace any previous diff report.'
+        htmlDescription: 'Compare department confirmation sheets to the most recent SIS import data and report on differences. The diff report will appear as a new sheet in the <strong>departments</strong> folder, and will replace any previous diff report.',
+        acceptsDepartmentOptions: true
       },
       {
         name: 'MergeConfirmationSheetsTask',
         friendlyName: 'Merge confirmation sheets',
-        htmlDescription: 'Merge department confirmation sheets into master sheets for preflight review. Two new sheets will be created in the <strong>departments</strong> folder: <strong>Merged course confirmations</strong> and <strong>Merged supervisor confirmations</strong>.'
+        htmlDescription: 'Merge department confirmation sheets into master sheets for preflight review. Two new sheets will be created in the <strong>departments</strong> folder: <strong>Merged course confirmations</strong> and <strong>Merged supervisor confirmations</strong>.',
+        acceptsDepartmentOptions: false
       },
       {
         name: 'ValidationTask',
         friendlyName: 'Validate confirmed data',
-        htmlDescription: 'Run a validation report on merged confirmation sheets. Validation results will appear in a dated subfolder of the <strong>reports</strong> folder.'
+        htmlDescription: 'Run a validation report on merged confirmation sheets. Validation results will appear in a dated subfolder of the <strong>reports</strong> folder.',
+        acceptsDepartmentOptions: false
       },
       {
         name: 'PublishTask',
         friendlyName: 'Publish confirmed data to Explorance',
-        htmlDescription: 'Validate and export merged confirmation sheets. Files will be uploaded to the vendor only if validation passes. A copy of the uploaded data will appear in a timestamped subfolder of the <strong>exports</strong> folder.'
+        htmlDescription: 'Validate and export merged confirmation sheets. Files will be uploaded to the vendor only if validation passes. A copy of the uploaded data will appear in a timestamped subfolder of the <strong>exports</strong> folder.',
+        acceptsDepartmentOptions: false
       }
     ]
 

--- a/src/assets/javascripts/angular/controllers/pages/oecController.js
+++ b/src/assets/javascripts/angular/controllers/pages/oecController.js
@@ -30,7 +30,14 @@ angular.module('calcentral.controllers').controller('OecController', function(ap
     });
   };
 
+  var sanitizeTaskOptions = function() {
+    if (!$scope.taskParameters.selectedTask.acceptsDepartmentOptions) {
+      $scope.taskParameters.options.departmentCode = null;
+    }
+  };
+
   $scope.runOecTask = function() {
+    sanitizeTaskOptions();
     return oecFactory.runOecTask($scope.taskParameters.selectedTask.name, $scope.taskParameters.options).success(function(data) {
       if (data.success) {
         $scope.taskInProgress = true;

--- a/src/assets/stylesheets/_oec.scss
+++ b/src/assets/stylesheets/_oec.scss
@@ -13,6 +13,11 @@
     }
   }
 
+  .cc-oec-departments-text {
+    font-size: 12px;
+    margin: 5px 0 0 5px;
+  }
+
   .cc-oec-label {
     margin-right: 0;
   }

--- a/src/assets/templates/oec.html
+++ b/src/assets/templates/oec.html
@@ -34,10 +34,15 @@
             <label for="cc-page-oec-department" class="cc-oec-label">Department(s):</label>
           </div>
           <div class="small-9 columns">
-            <div class="cc-select">
-              <select id="cc-page-oec-department" data-ng-model="taskParameters.options.departmentCode" data-ng-options="department.code as department.name for department in oecDepartments">
+            <div class="cc-select" data-ng-if="taskParameters.selectedTask.acceptsDepartmentOptions">
+              <select id="cc-page-oec-department"
+                      data-ng-model="taskParameters.options.departmentCode"
+                      data-ng-options="department.code as department.name for department in oecDepartments">
                 <option value="">All participating departments</option>
               </select>
+            </div>
+            <div class="cc-oec-departments-text" data-ng-if="!taskParameters.selectedTask.acceptsDepartmentOptions">
+              All participating departments
             </div>
           </div>
         </div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5839

For tasks where department selection has no effect:
- Show text "All participating departments" in place of dropdown;
- If the departmentCode option was previously set, strip it on submit.