### PR TITLE
SISRP-8275 Adapt to student API payload changes

### DIFF
--- a/app/models/calnet_crosswalk/proxy.rb
+++ b/app/models/calnet_crosswalk/proxy.rb
@@ -70,20 +70,27 @@ module CalnetCrosswalk
     end
 
     def lookup_campus_solutions_id
-      self.class.fetch_from_cache("#{@uid}/campus_solutions_id") do
-        self.class.save_related_cache_key(@uid, self.class.cache_key("#{@uid}/campus_solutions_id"))
-        cs_id = nil
+      lookup_id 'CAMPUS_SOLUTIONS_ID'
+    end
+
+    def lookup_student_id
+      lookup_id 'LEGACY_SIS_STUDENT_ID'
+    end
+
+    def lookup_id(id_type)
+      self.class.fetch_from_cache("#{@uid}/#{id_type}") do
+        self.class.save_related_cache_key(@uid, self.class.cache_key("#{@uid}/#{id_type}"))
+        id = nil
         feed = get[:feed]
         if feed.present?
           feed['Person']['identifiers'].each do |identifier|
-            if identifier['identifierTypeName'] == 'CAMPUS_SOLUTIONS_ID'
-              cs_id = identifier['identifierValue']
-              logger.debug "cs_id is #{cs_id}"
+            if identifier['identifierTypeName'] == id_type
+              id = identifier['identifierValue']
               break
             end
           end
         end
-        cs_id
+        id
       end
     end
 

--- a/app/models/hub_edos/student.rb
+++ b/app/models/hub_edos/student.rb
@@ -19,7 +19,7 @@ module HubEdos
     def build_feed(response)
       raw_response = response.parsed_response
       {
-        'student' => raw_response['StudentResponse']['students'][0]
+        'student' => raw_response['studentResponse']['students']['students'][0]
       }
     end
 

--- a/app/models/user/student.rb
+++ b/app/models/user/student.rb
@@ -8,5 +8,9 @@ module User
     def lookup_campus_solutions_id
       CalnetCrosswalk::Proxy.new(user_id: @uid).lookup_campus_solutions_id
     end
+
+    def lookup_student_id_from_crosswalk
+      CalnetCrosswalk::Proxy.new(user_id: @uid).lookup_student_id
+    end
   end
 end

--- a/fixtures/json/student_api_via_hub.json
+++ b/fixtures/json/student_api_via_hub.json
@@ -1,256 +1,248 @@
 {
-  "StudentResponse": {
-    "correlationId": "e517f0a5-9703-4e13-980a-8dce77d9e041",
+  "studentResponse": {
+    "correlationId": "e0f7bb33-daa5-4ec9-9e45-61819d8a8612",
     "source": "UCB-SIS-STUDENT",
-    "students": [
-      {
-        "identifiers": [
-          {
-            "type": "Student ID",
-            "id": 11667051,
-            "disclose": false
-          },
-          {
-            "type": "CalNet UID",
-            "id": "61889",
-            "disclose": false
-          },
-          {
-            "type": "Social Security Number",
-            "id": "XXXXXXXXX",
-            "disclose": false
-          },
-          {
-            "type": "SIS",
-            "id": 11667051,
-            "disclose": false,
-            "fromDate": "1902-02-01"
-          }
-        ],
-        "names": [
-          {
-            "type": {
-              "code": "PRF",
-              "description": "Preferred"
+    "students": {
+      "students": [
+        {
+          "identifiers": [
+            {
+              "type": "student-id",
+              "disclose": false
             },
-            "familyName": "Bear",
-            "givenName": "Osk",
-            "middleName": "",
-            "prefixName": "",
-            "suffixName": "",
-            "formattedName": "Osk Bear",
-            "preferred": true,
-            "disclose": false,
-            "uiControl": {
-              "code": "U",
-              "description": "Edit - No Delete"
+            {
+              "type": "campus-uid",
+              "disclose": false
             },
-            "fromDate": "2015-10-02"
-          },
-          {
-            "type": {
-              "code": "PRI",
-              "description": "Primary"
+            {
+              "type": "Social-Security-Number",
+              "id": "XXXXXXXXX",
+              "disclose": false
             },
-            "familyName": "Bear",
-            "givenName": "Oski",
-            "middleName": "",
-            "prefixName": "",
-            "suffixName": "",
-            "formattedName": "Oski Bear",
-            "preferred": false,
-            "disclose": false,
-            "uiControl": {
-              "code": "D",
-              "description": "Display Only"
-            },
-            "fromDate": "1902-02-01"
-          }
-        ],
-        "gender": {
-          "genderOfRecord": {
-            "code": "M",
-            "description": "Male"
-          },
-          "discloseGenderOfRecord": false,
-          "sexAtBirth": {
-            "code": "",
-            "description": ""
-          },
-          "discloseSexAtBirth": false,
-          "genderIdentity": {
-            "code": "",
-            "description": ""
-          },
-          "discloseGenderIdentity": false,
-          "fromDate": "1902-02-01"
-        },
-        "addresses": [
-          {
-            "type": {
-              "code": "DIPL",
-              "description": "Diploma"
-            },
-            "address1": "1234 56TH ST",
-            "address2": "APT 789, BOX 101112",
-            "address3": "",
-            "num1": "",
-            "num2": "",
-            "addrField1": "",
-            "addrField2": "",
-            "addrField3": "",
-            "houseType": "",
-            "city": "BERKELEY",
-            "county": "",
-            "stateCode": "CA",
-            "postalCode": 94708,
-            "countryCode": "USA",
-            "formattedAddress": "1234 56TH ST\nAPT 789, BOX 101112\nBERKELEY, CA 94708",
-            "disclose": false,
-            "uiControl": {
-              "code": "N",
-              "description": "Do Not Display"
-            },
-            "fromDate": "2015-01-12"
-          },
-          {
-            "type": {
-              "code": "HOME",
-              "description": "Home"
-            },
-            "address1": "2111 BANCROFT WAY  #550",
-            "address2": "",
-            "address3": "",
-            "num1": "",
-            "num2": "",
-            "addrField1": "",
-            "addrField2": "",
-            "addrField3": "",
-            "houseType": "",
-            "city": "BERKELEY",
-            "county": "",
-            "stateCode": "CA",
-            "postalCode": 94720,
-            "countryCode": "USA",
-            "formattedAddress": "2111 BANCROFT WAY  #550\nBERKELEY, CA 94720",
-            "disclose": false,
-            "uiControl": {
-              "code": "U",
-              "description": "Edit - No Delete"
-            },
-            "fromDate": "2013-10-31"
-          },
-          {
-            "type": {
-              "code": "LOCL",
-              "description": "Local"
-            },
-            "address1": "120 SPROUL HALL",
-            "address2": "",
-            "address3": "",
-            "num1": "",
-            "num2": "",
-            "addrField1": "",
-            "addrField2": "",
-            "addrField3": "",
-            "houseType": "",
-            "city": "BERKELEY",
-            "county": "",
-            "stateCode": "CA",
-            "postalCode": 94720,
-            "countryCode": "USA",
-            "formattedAddress": "120 SPROUL HALL\nBERKELEY, CA 94720",
-            "disclose": false,
-            "uiControl": {
-              "code": "F",
-              "description": "Full Edit"
-            },
-            "fromDate": "2014-08-18"
-          }
-        ],
-        "phones": [
-          {
-            "type": {
-              "code": "CELL",
-              "description": "Mobile"
-            },
-            "number": "415/123-4567",
-            "countryCode": "",
-            "extension": 123,
-            "primary": true,
-            "disclose": false,
-            "uiControl": {
-              "code": "D",
-              "description": "Display Only"
+            {
+              "type": "SIS",
+              "id": "11667051",
+              "disclose": false,
+              "fromDate": "1902-02-01"
             }
-          },
-          {
-            "type": {
-              "code": "HOME",
-              "description": "Home/Permanent"
+          ],
+          "names": [
+            {
+              "type": {
+                "code": "PRF",
+                "description": "Preferred"
+              },
+              "familyName": "Bear",
+              "givenName": "Osk",
+              "middleName": "",
+              "prefixName": "",
+              "suffixName": "",
+              "formattedName": "Osk Bear",
+              "preferred": true,
+              "disclose": false,
+              "uiControl": {
+                "code": "U",
+                "description": "Edit - No Delete"
+              },
+              "fromDate": "2015-10-02"
             },
-            "number": "510/642-9507",
-            "countryCode": "",
-            "extension": 101,
-            "primary": false,
-            "disclose": false,
-            "uiControl": {
-              "code": "U",
-              "description": "Edit - No Delete"
+            {
+              "type": {
+                "code": "PRI",
+                "description": "Primary"
+              },
+              "familyName": "Bear",
+              "givenName": "Oski",
+              "middleName": "",
+              "prefixName": "",
+              "suffixName": "",
+              "formattedName": "Oski Bear",
+              "preferred": false,
+              "disclose": false,
+              "uiControl": {
+                "code": "D",
+                "description": "Display Only"
+              },
+              "fromDate": "1902-02-01"
             }
-          }
-        ],
-        "emails": [
-          {
-            "type": {
-              "code": "OTHR",
-              "description": "Other"
+          ],
+          "gender": {
+            "genderOfRecord": {
+              "code": "M",
+              "description": "Male"
             },
-            "emailAddress": "oski@berkeley.edu",
-            "primary": true,
-            "disclose": false,
-            "uiControl": {
-              "code": "F",
-              "description": "Full Edit"
-            }
-          }
-        ],
-        "ethnicities": [
-          {
-            "group": {
-              "code": 2,
-              "description": "Black/African American"
+            "discloseGenderOfRecord": false,
+            "sexAtBirth": {
+              "code": "",
+              "description": ""
             },
-            "hispanicLatino": false,
-            "detail": {
-              "code": "BLACK",
-              "description": "African American/ Black"
-            }
-          }
-        ],
-        "usaCountry": {
-          "citizenshipStatus": {
-            "code": 1,
-            "description": "Native"
-          },
-          "militaryStatus": {
-            "code": "",
-            "description": "",
+            "discloseSexAtBirth": false,
+            "genderIdentity": {
+              "code": "",
+              "description": ""
+            },
+            "discloseGenderIdentity": false,
             "fromDate": "1902-02-01"
           },
-          "passport": "",
-          "visa": ""
-        },
-        "birth": {
-          "date": "1975-02-05",
-          "description": "United States",
-          "locality": "YOSEMITE,CA",
-          "stateCode": "",
-          "countryCode": "USA"
-        },
-        "death": "",
-        "confidential": false
-      }
-    ]
+          "affiliations": [],
+          "addresses": [
+            {
+              "type": {
+                "code": "DIPL",
+                "description": "Diploma"
+              },
+              "address1": "1234 56TH ST",
+              "address2": "APT 789, BOX 101112",
+              "address3": "",
+              "address4": "",
+              "num1": "",
+              "num2": "",
+              "addrField1": "",
+              "addrField2": "",
+              "addrField3": "",
+              "houseType": "",
+              "city": "BERKELEY",
+              "county": "",
+              "stateCode": "CA",
+              "postalCode": "94708",
+              "countryCode": "USA",
+              "formattedAddress": "1234 56TH ST\nAPT 789, BOX 101112\nBERKELEY, CA 94708",
+              "disclose": false,
+              "uiControl": {
+                "code": "N",
+                "description": "Do Not Display"
+              },
+              "fromDate": "2015-01-12"
+            },
+            {
+              "type": {
+                "code": "HOME",
+                "description": "Home"
+              },
+              "address1": "2111 BANCROFT WAY  #550",
+              "address2": "",
+              "address3": "",
+              "address4": "",
+              "num1": "",
+              "num2": "",
+              "addrField1": "",
+              "addrField2": "",
+              "addrField3": "",
+              "houseType": "",
+              "city": "BERKELEY",
+              "county": "",
+              "stateCode": "CA",
+              "postalCode": "94720",
+              "countryCode": "USA",
+              "formattedAddress": "2111 BANCROFT WAY  #550\nBERKELEY, CA 94720",
+              "disclose": false,
+              "uiControl": {
+                "code": "U",
+                "description": "Edit - No Delete"
+              },
+              "fromDate": "2013-10-31"
+            },
+            {
+              "type": {
+                "code": "LOCL",
+                "description": "Local"
+              },
+              "address1": "Test",
+              "address2": "",
+              "address3": "",
+              "address4": "",
+              "num1": "",
+              "num2": "",
+              "addrField1": "",
+              "addrField2": "",
+              "addrField3": "",
+              "houseType": "",
+              "city": "",
+              "county": "",
+              "stateCode": "",
+              "postalCode": "0",
+              "countryCode": "WAL",
+              "formattedAddress": "",
+              "disclose": false,
+              "uiControl": {
+                "code": "F",
+                "description": "Full Edit"
+              },
+              "fromDate": "2015-10-06"
+            }
+          ],
+          "phones": [
+            {
+              "type": {
+                "code": "CELL",
+                "description": "Mobile"
+              },
+              "number": "415/123-4567",
+              "countryCode": "",
+              "extension": "123",
+              "primary": false,
+              "disclose": false,
+              "uiControl": {
+                "code": "D",
+                "description": "Display Only"
+              }
+            },
+            {
+              "type": {
+                "code": "HOME",
+                "description": "Home/Permanent"
+              },
+              "number": "510/642-9505",
+              "countryCode": "",
+              "extension": "",
+              "primary": true,
+              "disclose": false,
+              "uiControl": {
+                "code": "U",
+                "description": "Edit - No Delete"
+              }
+            }
+          ],
+          "emails": [
+            {
+              "type": {
+                "code": "CAMP",
+                "description": "Campus"
+              },
+              "emailAddress": "oski@berkeley.edu",
+              "primary": true,
+              "disclose": false,
+              "uiControl": {
+                "code": "D",
+                "description": "Display Only"
+              }
+            }
+          ],
+          "urls": [],
+          "ethnicities": [],
+          "languages": [],
+          "usaCountry": {
+            "citizenshipStatus": {
+              "code": "1",
+              "description": "Native"
+            },
+            "militaryStatus": {
+              "code": "",
+              "description": "",
+              "fromDate": "1902-02-01"
+            }
+          },
+          "emergencyContacts": [],
+          "birth": {
+            "date": "1975-02-05",
+            "description": "United States",
+            "locality": "YOSEMITE,CA",
+            "stateCode": "",
+            "countryCode": "USA"
+          },
+          "confidential": false
+        }
+      ]
+    }
   }
 }

--- a/spec/models/calnet_crosswalk/proxy_spec.rb
+++ b/spec/models/calnet_crosswalk/proxy_spec.rb
@@ -9,6 +9,22 @@ describe CalnetCrosswalk::Proxy do
     end
   end
 
+  shared_context 'looking up ids' do
+    context 'looking up cs id' do
+      subject { proxy.lookup_campus_solutions_id }
+      it 'should return the CS ID' do
+        expect(subject).to eq '11667051'
+      end
+    end
+
+    context 'looking up student id' do
+      subject { proxy.lookup_student_id }
+      it 'should return the Student ID' do
+        expect(subject).to eq '11667051'
+      end
+    end
+  end
+
   context 'mock proxy' do
     let(:proxy) { CalnetCrosswalk::Proxy.new(user_id: '61889', fake: true) }
     let(:feed) { proxy.get[:feed] }
@@ -18,12 +34,14 @@ describe CalnetCrosswalk::Proxy do
       response = proxy.get
       expect(response[:errored]).to eq true
     end
+    include_context 'looking up ids'
   end
 
   context 'real proxy', testext: true do
     let(:proxy) { CalnetCrosswalk::Proxy.new(user_id: '61889', fake: false) }
     let(:feed) { proxy.get[:feed] }
     it_behaves_like 'a proxy that returns data'
+    include_context 'looking up ids'
   end
 
 end

--- a/spec/models/hub_edos/student_spec.rb
+++ b/spec/models/hub_edos/student_spec.rb
@@ -11,11 +11,11 @@ describe HubEdos::Student do
 
     it 'returns data with the expected structure' do
       expect(subject[:feed]['student']).to be
-      expect(subject[:feed]['student']['identifiers'][0]['id']).to be
+      expect(subject[:feed]['student']['identifiers'][0]['type']).to be
     end
   end
 
-  context 'real proxy', testext: true do 
+  context 'real proxy', testext: true do
     let(:proxy) { HubEdos::Student.new(fake: false, user_id: '61889') }
     subject { proxy.get }
 
@@ -24,7 +24,7 @@ describe HubEdos::Student do
 
     it 'returns data with the expected structure' do
       expect(subject[:feed]['student']).to be
-      expect(subject[:feed]['student']['identifiers'][0]['id']).to be
+      expect(subject[:feed]['student']['identifiers'][0]['type']).to be
     end
 
   end

--- a/spec/models/hub_edos/user_attributes_spec.rb
+++ b/spec/models/hub_edos/user_attributes_spec.rb
@@ -6,12 +6,12 @@ describe HubEdos::UserAttributes do
   subject { HubEdos::UserAttributes.new(user_id: user_id).get }
   it 'should provide the converted person data structure' do
     expect(subject[:ldap_uid]).to eq '61889'
-    expect(subject[:student_id]).to eq 11667051
+    expect(subject[:student_id]).to eq '11667051'
     expect(subject[:first_name]).to eq 'Osk'
     expect(subject[:last_name]).to eq 'Bear'
     expect(subject[:person_name]).to eq 'Osk Bear'
     expect(subject[:email_address]).to eq 'oski@berkeley.edu'
-    expect(subject[:official_bmail_address]).to be_nil
+    expect(subject[:official_bmail_address]).to eq 'oski@berkeley.edu'
     expect(subject[:names]).to be
     expect(subject[:addresses]).to be
   end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-8275

Student API payload changed slightly, so I made those adjustments. 

It no longer sends us student ID or LDAP UID, so we now look in the crosswalk for the student ID, and make use of the UID that we already have anyway. 