### PR TITLE
CLC-5852 OEC: Show task status and in-progress log in control panel

### DIFF
--- a/app/controllers/oec_tasks_controller.rb
+++ b/app/controllers/oec_tasks_controller.rb
@@ -30,8 +30,21 @@ class OecTasksController < ApplicationController
     task_class = "Oec::#{params['task_name']}".constantize
     params.require('term')
     task_opts = params.slice('term', 'departmentCode')
-    Oec::ApiTaskWrapper.new(task_class, task_opts).start_in_background
-    render json: {success: true, oecDriveUrl: Oec::RemoteDrive::HUMAN_URL}
+    task_status = Oec::ApiTaskWrapper.new(task_class, task_opts).start_in_background
+    render json: {
+      oecDriveUrl: Oec::RemoteDrive::HUMAN_URL,
+      oecTaskStatus: task_status
+    }
+  end
+
+  # GET /api/oec_tasks/status/:task_id
+
+  def task_status
+    task_status = Oec::Task.fetch_from_cache params['task_id']
+    raise Errors::BadRequestError, "OEC task id '#{params['task_id']}' not found" unless task_status
+    render json: {
+      oecTaskStatus: task_status
+    }
   end
 
 end

--- a/app/models/oec/api_task_wrapper.rb
+++ b/app/models/oec/api_task_wrapper.rb
@@ -47,17 +47,27 @@ module Oec
       }
     ]
 
+    def self.generate_task_id
+      [Time.now.to_f.to_s.gsub('.', ''), SecureRandom.hex(8)].join '-'
+    end
+
     def initialize(task_class, params)
       @task_class = task_class
       @params = translate_params(params)
     end
 
-    def run
-      @task_class.new(@params).run
+    def run(task_id)
+      task = @task_class.new @params.merge(api_task_id: task_id, log_to_cache: true)
+      task.run
     end
 
     def start_in_background
-      self.background.run
+      task_id = self.class.generate_task_id
+      self.background.run task_id
+      {
+        id: task_id,
+        status: 'In progress'
+      }
     end
 
     private

--- a/app/models/oec/sis_import_task.rb
+++ b/app/models/oec/sis_import_task.rb
@@ -7,8 +7,8 @@ module Oec
       imports_now = find_or_create_now_subfolder('imports')
       Oec::CourseCode.by_dept_code(@course_code_filter).each do |dept_code, course_codes|
         @term_dates ||= default_term_dates
-        log :info, "Generating #{dept_code}.csv"
         worksheet = Oec::SisImportSheet.new(dept_code: dept_code)
+        log :info, "Generating sheet: '#{worksheet.export_name}'"
         import_courses(worksheet, course_codes)
         export_sheet(worksheet, imports_now)
       end

--- a/app/models/oec/task.rb
+++ b/app/models/oec/task.rb
@@ -1,5 +1,6 @@
 module Oec
   class Task
+    extend Cache::Cacheable
     include ClassLogger
 
     LOG_DIRECTORY = Rails.root.join('tmp', 'oec')
@@ -8,16 +9,24 @@ module Oec
       '%F'
     end
 
+    def self.cache_key(id)
+      "Oec::Task/#{id}"
+    end
+
     def self.timestamp_format
       '%H:%M:%S'
     end
 
     def initialize(opts)
+      @opts = opts
       @log = []
+      @status = 'In progress'
+      @api_task_id = opts.delete :api_task_id
+      write_status_to_cache if opts[:log_to_cache]
+
       @remote_drive = Oec::RemoteDrive.new
       @term_code = opts.delete :term_code
       @date_time = opts[:date_time] || default_date_time
-      @opts = opts
       @course_code_filter = if opts[:dept_names]
                              {dept_name: opts[:dept_names].split.map { |name| name.tr('_', ' ') }}
                            elsif opts[:dept_codes]
@@ -30,12 +39,15 @@ module Oec
     def run
       log :info, "Starting #{self.class.name}"
       run_internal
+      @status = 'Success'
       true
     rescue => e
       log :error, "#{self.class.name} aborted with error: #{e.message}\n#{e.backtrace.join "\n\t"}"
+      @status = 'Error'
       nil
     ensure
       write_log
+      write_status_to_cache if @opts[:log_to_cache]
     end
 
     private
@@ -140,6 +152,7 @@ module Oec
     def log(level, message)
       logger.send level, message
       @log << "[#{Time.now}] #{message}"
+      write_status_to_cache if @opts[:log_to_cache]
     end
 
     def timestamp(arg = @date_time)
@@ -176,7 +189,14 @@ module Oec
         end
       end
     rescue => e
-      logger.error "Could not write log: #{e.message}\n#{e.backtrace.join "\n\t"}"
+      log :error, "Could not write log: #{e.message}\n#{e.backtrace.join "\n\t"}"
+    end
+
+    def write_status_to_cache
+      self.class.write_cache(
+        {status: @status, log: @log},
+        @api_task_id
+      )
     end
 
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,7 @@ Calcentral::Application.routes.draw do
   # OEC endpoints
   get '/api/oec_tasks' => 'oec_tasks#index', :defaults => { :format => 'json' }
   post '/api/oec_tasks/:task_name' => 'oec_tasks#run', :defaults => { :format => 'json' }
+  get '/api/oec_tasks/status/:task_id' => 'oec_tasks#task_status',  :defaults => { :format => 'json' }
 
   # System utility endpoints
   get '/api/cache/clear' => 'cache#clear', :defaults => { :format => 'json' }

--- a/spec/models/oec/api_task_wrapper_spec.rb
+++ b/spec/models/oec/api_task_wrapper_spec.rb
@@ -25,4 +25,20 @@ describe Oec::ApiTaskWrapper do
     end
   end
 
+  context 'starting background tasks' do
+    let(:wrapper) { Oec::ApiTaskWrapper.new(Oec::TermSetupTask, {'term' => 'Summer 2014'}) }
+
+    before do
+      allow(Oec::RemoteDrive).to receive(:new).and_return double
+      allow(wrapper).to receive(:background).and_return wrapper
+      allow_any_instance_of(Oec::TermSetupTask).to receive(:run)
+    end
+
+    it 'launches tasks with a retrievable id' do
+      task_status = wrapper.start_in_background
+      expect(task_status[:status]).to eq 'In progress'
+      expect(Oec::Task.fetch_from_cache task_status[:id]).to be_present
+    end
+  end
+
 end

--- a/spec/models/oec/term_setup_task_spec.rb
+++ b/spec/models/oec/term_setup_task_spec.rb
@@ -11,7 +11,7 @@ describe Oec::TermSetupTask do
   let (:fake_remote_drive) { double() }
   before { allow(Oec::RemoteDrive).to receive(:new).and_return fake_remote_drive }
 
-  context 'successful term setup' do
+  shared_context 'remote drive interaction' do
     before(:each) do
       allow(fake_remote_drive).to receive(:find_nested).and_return mock_google_drive_item
     end
@@ -20,7 +20,7 @@ describe Oec::TermSetupTask do
     let(:logs_today_folder) { mock_google_drive_item today }
     let(:overrides_folder) { mock_google_drive_item 'overrides' }
 
-    it 'creates folders, uploads sheets, and writes log' do
+    before do
       expect(fake_remote_drive).to receive(:find_folders).with(no_args).and_return []
       expect(fake_remote_drive).to receive(:check_conflicts_and_create_folder)
         .with(term_code, nil, anything).and_return term_folder
@@ -47,8 +47,35 @@ describe Oec::TermSetupTask do
       expect(fake_remote_drive).to receive(:check_conflicts_and_upload)
         .with(kind_of(Pathname), logfile, 'text/plain', logs_today_folder, anything)
         .and_return mock_google_drive_item(logfile)
+    end
+  end
 
+  context 'successful term setup' do
+    include_context 'remote drive interaction'
+    it 'creates folders, uploads sheets, and writes log' do
       subject.run
+    end
+  end
+
+  context 'logging to cache' do
+    let(:api_task_id) { Oec::ApiTaskWrapper.generate_task_id }
+    subject do
+      described_class.new({
+        api_task_id: api_task_id,
+        log_to_cache: true,
+        term_code: term_code
+      })
+    end
+    include_context 'remote drive interaction'
+
+    it 'allows status and log retrieval by cache key' do
+      subject.run
+      task_status = Oec::Task.fetch_from_cache api_task_id
+      expect(task_status[:status]).to eq 'Success'
+      expect(task_status[:log]).to have_at_least(3).items
+      expect(task_status[:log][0]).to include 'Starting Oec::TermSetupTask'
+      expect(task_status[:log][1]).to include 'Will create initial folders and files'
+      expect(task_status[:log].last).to include 'Exporting log file'
     end
   end
 

--- a/src/assets/javascripts/angular/factories/oecFactory.js
+++ b/src/assets/javascripts/angular/factories/oecFactory.js
@@ -10,12 +10,17 @@ angular.module('calcentral.factories').factory('oecFactory', function($http) {
     return $http.get('/api/oec_tasks');
   };
 
+  var oecTaskStatus = function(oecTaskId) {
+    return $http.get('/api/oec_tasks/status/' + oecTaskId);
+  };
+
   var runOecTask = function(taskName, parameters) {
     return $http.post('/api/oec_tasks/' + taskName, parameters);
   };
 
   return {
     getOecTasks: getOecTasks,
+    oecTaskStatus: oecTaskStatus,
     runOecTask: runOecTask
   };
 });

--- a/src/assets/stylesheets/_oec.scss
+++ b/src/assets/stylesheets/_oec.scss
@@ -22,6 +22,23 @@
     margin-right: 0;
   }
 
+  .cc-oec-log {
+    white-space: pre;
+  }
+
+  .cc-oec-status {
+    background: $cc-color-main-background;
+    border: 1px solid $cc-color-lighter-grey;
+    font-size: 14px;
+    padding: 10px 15px;
+  }
+
+  .cc-oec-status-icon {
+    float: left;
+    font-size: 18px;
+    margin-right: 10px;
+  }
+
   .cc-oec-text {
     margin: 15px 0;
   }

--- a/src/assets/templates/oec.html
+++ b/src/assets/templates/oec.html
@@ -3,7 +3,7 @@
     <h1 class="cc-heading-page-title">OEC Control Panel</h1>
     <div class="cc-oec-content medium-12 columns">
 
-      <form data-ng-if="!taskInProgress" data-ng-submit="runOecTask()">
+      <form data-ng-if="!oecTaskStatus" data-ng-submit="runOecTask()">
 
         <div class="row">
           <div class="small-3 columns">
@@ -63,11 +63,25 @@
         </div>
       </form>
 
-      <div data-ng-if="taskInProgress">
+      <div data-ng-if="oecTaskStatus">
         <div class="cc-oec-text">
-          Your <strong data-ng-bind="taskParameters.selectedTask.friendlyName"></strong> task has started. Watch the action in <a data-ng-href="{{oecDriveUrl}}">your Google Drive account</a>.
+          Your <strong data-ng-bind="taskParameters.selectedTask.friendlyName"></strong> task has started. Results will appear in <a data-ng-href="{{oecDriveUrl}}">your Google Drive account</a>.
         </div>
-        <button class="cc-button cc-button-blue" data-ng-click="initialize()">Start over</button>
+        <div class="cc-oec-status" data-ng-if="oecTaskStatus.status === 'In progress'">
+          In progress...
+        </div>
+        <div class="cc-oec-status" data-ng-if="oecTaskStatus.status !== 'In progress'">
+          <i class="cc-icon fa cc-oec-status-icon"
+             data-ng-class="{true:'fa-check-circle cc-icon-green',false:'fa-exclamation-circle cc-icon-red'}[oecTaskStatus.status==='Success']">
+          </i>
+          <div>
+            <span data-ng-bind="oecTaskStatus.status"></span>.
+          </div>
+        </div>
+        <div class="cc-oec-text">
+          <div class="cc-oec-log" data-ng-repeat="logLine in oecTaskStatus.log" data-ng-bind="logLine"></div>
+        </div>
+        <button class="cc-button cc-button-blue" data-ng-click="initialize()">Back</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5852

This approach is based on our progress-bar wiring for Canvas tasks, but requires less ceremony. When an OEC task is started, the front end receives an ID linked to a cache key. It then polls the back end every two seconds for status and logs until the task is complete, displaying the latest to the user as it goes.