### PR TITLE
SISRP-8365 Don't allow Post or Delete when user is acting-as

### DIFF
--- a/app/controllers/campus_solutions/address_controller.rb
+++ b/app/controllers/campus_solutions/address_controller.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class AddressController < CampusSolutionsController
 
+    before_filter :exclude_acting_as_users
+
     def post
       post_passthrough CampusSolutions::MyAddress
     end

--- a/app/controllers/campus_solutions/campus_solutions_controller.rb
+++ b/app/controllers/campus_solutions/campus_solutions_controller.rb
@@ -1,5 +1,8 @@
 module CampusSolutions
   class CampusSolutionsController < ApplicationController
+
+    include ClassLogger
+
     before_filter :api_authenticate_401
 
     def json_passthrough(classname, params={})
@@ -14,6 +17,13 @@ module CampusSolutions
     def delete_passthrough(classname)
       model = classname.from_session(session)
       render json: model.delete(params)
+    end
+
+    def exclude_acting_as_users
+      unless current_user.directly_authenticated?
+        logger.warn "ACT-AS: User #{current_user.original_user_id} attempted access to an endpoint which is forbidden while acting-as user #{current_user.user_id}"
+        render :nothing => true, :status => 403
+      end
     end
 
   end

--- a/app/controllers/campus_solutions/email_controller.rb
+++ b/app/controllers/campus_solutions/email_controller.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class EmailController < CampusSolutionsController
 
+    before_filter :exclude_acting_as_users
+
     def post
       post_passthrough CampusSolutions::MyEmail
     end

--- a/app/controllers/campus_solutions/emergency_contact_controller.rb
+++ b/app/controllers/campus_solutions/emergency_contact_controller.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class EmergencyContactController < CampusSolutionsController
 
+    before_filter :exclude_acting_as_users
+
     def post
       post_passthrough CampusSolutions::MyEmergencyContact
     end

--- a/app/controllers/campus_solutions/ethnicity_controller.rb
+++ b/app/controllers/campus_solutions/ethnicity_controller.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class EthnicityController < CampusSolutionsController
 
+    before_filter :exclude_acting_as_users
+
     def post
       post_passthrough CampusSolutions::MyEthnicity
     end

--- a/app/controllers/campus_solutions/language_controller.rb
+++ b/app/controllers/campus_solutions/language_controller.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class LanguageController < CampusSolutionsController
 
+    before_filter :exclude_acting_as_users
+
     def post
       post_passthrough CampusSolutions::MyLanguage
     end

--- a/app/controllers/campus_solutions/person_name_controller.rb
+++ b/app/controllers/campus_solutions/person_name_controller.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class PersonNameController < CampusSolutionsController
 
+    before_filter :exclude_acting_as_users
+
     def post
       post_passthrough CampusSolutions::MyPersonName
     end

--- a/app/controllers/campus_solutions/phone_controller.rb
+++ b/app/controllers/campus_solutions/phone_controller.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class PhoneController < CampusSolutionsController
 
+    before_filter :exclude_acting_as_users
+
     def post
       post_passthrough CampusSolutions::MyPhone
     end

--- a/app/controllers/campus_solutions/sir_response_controller.rb
+++ b/app/controllers/campus_solutions/sir_response_controller.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class SirResponseController < CampusSolutionsController
 
+    before_filter :exclude_acting_as_users
+
     def post
       post_passthrough CampusSolutions::MySirResponse
     end

--- a/app/controllers/campus_solutions/terms_and_conditions_controller.rb
+++ b/app/controllers/campus_solutions/terms_and_conditions_controller.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class TermsAndConditionsController < CampusSolutionsController
 
+    before_filter :exclude_acting_as_users
+
     def post
       model = CampusSolutions::MyTermsAndConditions.from_session(session)
       render json: model.update(request.request_parameters)

--- a/app/controllers/campus_solutions/title4_controller.rb
+++ b/app/controllers/campus_solutions/title4_controller.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class Title4Controller < CampusSolutionsController
 
+    before_filter :exclude_acting_as_users
+
     def post
       model = CampusSolutions::MyTitle4.from_session(session)
       render json: model.update(request.request_parameters)

--- a/app/controllers/campus_solutions/work_experience_controller.rb
+++ b/app/controllers/campus_solutions/work_experience_controller.rb
@@ -1,6 +1,8 @@
 module CampusSolutions
   class WorkExperienceController < CampusSolutionsController
 
+    before_filter :exclude_acting_as_users
+
     def post
       render json: CampusSolutions::MyWorkExperience.from_session(session).update(params)
     end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-8365

Note that as soon as this is merged, you'll have to use a real CalNet login, or else use the basic auth backdoor, whenever you want to test the Profile edit functionality. Profile View still works in act-as mode, however. 