### PR TITLE
CLC-5869 OEC: Do not log stacktrace on non-fatal diff errors

### DIFF
--- a/app/models/oec/report_diff_task.rb
+++ b/app/models/oec/report_diff_task.rb
@@ -106,7 +106,7 @@ module Oec
           hash[id] = row
         rescue => e
           log :error, "\nThis row with bad data in #{folder_titles} will be ignored: \n#{row}."
-          log :error, "We will NOT abort; the error is NOT fatal: #{e.message}\n#{e.backtrace.join "\n\t"}"
+          log :error, "We will NOT abort; the error is NOT fatal: #{e.message}"
         end
       end
       hash


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5869