### PR TITLE
CLC-5759 CLC-5858 OEC: Allow tasks to define their own follow-ups

### DIFF
--- a/app/models/oec/sis_import_task.rb
+++ b/app/models/oec/sis_import_task.rb
@@ -1,6 +1,8 @@
 module Oec
   class SisImportTask < Task
 
+    on_success_run Oec::ReportDiffTask, if: proc { !@opts[:local_write] }
+
     def run_internal
       @dept_forms = {}
       log :info, "Will import SIS data for term #{@term_code}"

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -14,20 +14,14 @@ namespace :oec do
     term_code = ENV['term_code']
     raise ArgumentError, 'term_code required' unless term_code
     date_time = DateTime.now
-    [Oec::SisImportTask, Oec::ReportDiffTask].each do |klass|
-      success = klass.new(
-        term_code: term_code,
-        date_time: date_time,
-        local_write: ENV['local_write'].present?,
-        import_all: ENV['import_all'].present?,
-        dept_names: ENV['dept_names'],
-        dept_codes: ENV['dept_codes']
-      ).run
-      unless success
-        Rails.logger.error "Abort due to fatal error in #{klass}. Any remaining tasks will not run."
-        break
-      end
-    end
+    Oec::SisImportTask.new(
+      term_code: term_code,
+      date_time: date_time,
+      local_write: ENV['local_write'].present?,
+      import_all: ENV['import_all'].present?,
+      dept_names: ENV['dept_names'],
+      dept_codes: ENV['dept_codes']
+    ).run
   end
 
   desc 'Generate SIS data sheets, one per dept_code, to be shared with department admins'

--- a/spec/models/oec/sis_import_task_spec.rb
+++ b/spec/models/oec/sis_import_task_spec.rb
@@ -1,6 +1,6 @@
 describe Oec::SisImportTask do
   let(:term_code) { '2015-B' }
-  let(:task) { Oec::SisImportTask.new(term_code: term_code, local_write: true) }
+  let(:task) { Oec::SisImportTask.new(term_code: term_code, local_write: local_write) }
 
   let(:fake_remote_drive) { double() }
   let(:course_overrides_row) { Oec::Courses.new.headers.join(',') }
@@ -17,6 +17,23 @@ describe Oec::SisImportTask do
     allow(fake_remote_drive).to receive(:export_csv).with(instructor_overrides).and_return instructor_overrides_row
 
     allow(Settings.terms).to receive(:fake_now).and_return DateTime.parse('2015-03-09')
+  end
+
+  shared_context 'local-write mode and no follow-up diff' do
+    let(:local_write) { true }
+    before do
+      expect(Oec::ReportDiffTask).not_to receive(:new)
+    end
+  end
+
+  shared_context 'follow-up diff and no local-write mode' do
+    let(:local_write) { false }
+    before do
+      expect(Oec::ReportDiffTask).to receive(:new).and_call_original
+      expect(fake_remote_drive).to receive(:check_conflicts_and_upload)
+        .with(kind_of(Pathname), report_diff_logfile, 'text/plain', logs_today_folder, anything)
+        .and_return mock_google_drive_item(report_diff_logfile)
+    end
   end
 
   describe 'CSV export' do
@@ -71,6 +88,8 @@ describe Oec::SisImportTask do
     end
 
     shared_examples 'expected CSV structure' do
+      include_context 'local-write mode and no follow-up diff'
+
       it { expect(course_id_column).to contain_exactly(*expected_ids) }
       it 'should include dept_form only for non-crosslisted courses' do
         subject.each do |row|
@@ -235,9 +254,12 @@ describe Oec::SisImportTask do
     describe 'expected network operations' do
       subject { Oec::SisImportTask.new(term_code: term_code) }
 
+      include_context 'follow-up diff and no local-write mode'
+
       let(:today) { '2015-04-01' }
       let(:now) { '09:22:22' }
-      let(:logfile) { "#{now} sis import task.log" }
+      let(:sis_import_logfile) { "#{now} sis import task.log" }
+      let(:report_diff_logfile) { "#{now} report diff task.log" }
       let(:dept_name) { 'MATH' }
       let(:sheet_name) { 'Mathematics' }
 
@@ -257,13 +279,14 @@ describe Oec::SisImportTask do
           .and_return(imports_today_folder)
         expect(fake_remote_drive).to receive(:check_conflicts_and_create_folder)
           .with(today, anything, anything)
+          .at_least(1).times
           .and_return(logs_today_folder)
         expect(fake_remote_drive).to receive(:check_conflicts_and_upload)
           .with(kind_of(Oec::Worksheet), sheet_name, (Oec::Worksheet), imports_today_folder, anything)
           .and_return mock_google_drive_item(sheet_name)
         expect(fake_remote_drive).to receive(:check_conflicts_and_upload)
-          .with(kind_of(Pathname), logfile, 'text/plain', logs_today_folder, anything)
-          .and_return mock_google_drive_item(logfile)
+          .with(kind_of(Pathname), sis_import_logfile, 'text/plain', logs_today_folder, anything)
+          .and_return mock_google_drive_item(sis_import_logfile)
         subject.run
       end
     end
@@ -275,6 +298,8 @@ describe Oec::SisImportTask do
       task.set_cross_listed_values([ course ], course_codes)
       course['CROSS_LISTED_NAME']
     end
+
+    include_context 'local-write mode and no follow-up diff'
 
     context 'departments sharing catalog id and section code' do
       let(:course_codes) do
@@ -343,14 +368,16 @@ describe Oec::SisImportTask do
     let(:null_sheets_manager) { double.as_null_object }
     before(:each) { allow(Oec::RemoteDrive).to receive(:new).and_return null_sheets_manager }
 
+    include_context 'local-write mode and no follow-up diff'
+
     it 'filters by course-code department names' do
       expect(Oec::CourseCode).to receive(:by_dept_code).with(dept_name: %w(BIOLOGY MCELLBI)).and_return({})
-      Oec::SisImportTask.new(term_code: term_code, dept_names: 'BIOLOGY MCELLBI').run
+      Oec::SisImportTask.new(term_code: term_code, dept_names: 'BIOLOGY MCELLBI', local_write: true).run
     end
 
     it 'filters by department codes' do
       expect(Oec::CourseCode).to receive(:by_dept_code).with(dept_code: %w(IBIBI IMMCB)).and_return({})
-      Oec::SisImportTask.new(term_code: term_code, dept_codes: 'IBIBI IMMCB').run
+      Oec::SisImportTask.new(term_code: term_code, dept_codes: 'IBIBI IMMCB', local_write: true).run
     end
   end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5858

Oec::Task subclasses can define a follow-up task to run on success. This allows consistent behavior between the command-line and browser interfaces.

A task passes its own option set to the follow-up, as well as its own log under a `:previous_task_log` option. This allows the follow-up to seamlessly append its own logs in the control panel UI, but keep logfiles separate for upload to Drive. 

This PR also addresses https://jira.ets.berkeley.edu/jira/browse/CLC-5759 by having SisImportTask call ReportDiffTask only when `local_write` is turned off.