### PR TITLE
CLC-5878 Do not show date and timezone in per-line log timestamps

### DIFF
--- a/app/models/oec/task.rb
+++ b/app/models/oec/task.rb
@@ -151,7 +151,7 @@ module Oec
 
     def log(level, message)
       logger.send level, message
-      @log << "[#{Time.now}] #{message}"
+      @log << "[#{Time.now.strftime '%T'}] #{message}"
       write_status_to_cache if @opts[:log_to_cache]
     end
 

--- a/src/assets/templates/oec.html
+++ b/src/assets/templates/oec.html
@@ -79,7 +79,7 @@
           </div>
         </div>
         <div class="cc-oec-text">
-          <div class="cc-oec-log" data-ng-repeat="logLine in oecTaskStatus.log" data-ng-bind="logLine"></div>
+          <div class="cc-oec-log" data-ng-repeat="logLine in oecTaskStatus.log track by $index" data-ng-bind="logLine"></div>
         </div>
         <button class="cc-button cc-button-blue" data-ng-click="initialize()">Back</button>
       </div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5878

Also adds an Angular track-by to avoid errors on duplicate lines.