### PR TITLE
CLC-5865 OEC: Show list of participating departments in control panel

### DIFF
--- a/app/controllers/oec_tasks_controller.rb
+++ b/app/controllers/oec_tasks_controller.rb
@@ -15,10 +15,9 @@ class OecTasksController < ApplicationController
   # GET /api/oec_tasks
 
   def index
-    departments = Berkeley::Departments.department_map.map { |k,v| {code: k, name: Berkeley::Departments.shortened(v)} }
     render json: {
       currentTerm: Berkeley::Terms.fetch.current.to_english,
-      oecDepartments: departments.sort_by { |dept| dept[:name] },
+      oecDepartments: Oec::ApiTaskWrapper.department_list,
       oecTasks: Oec::ApiTaskWrapper::TASK_LIST,
       oecTerms: Berkeley::Terms.fetch.campus.values.map { |term| term.to_english }
     }

--- a/app/models/oec/api_task_wrapper.rb
+++ b/app/models/oec/api_task_wrapper.rb
@@ -47,6 +47,18 @@ module Oec
       }
     ]
 
+    def self.department_list
+      participating_department_codes = Oec::CourseCode.by_dept_code(include_in_oec: true).keys
+      departments = Berkeley::Departments.department_map.map do |k,v|
+        {
+          code: k,
+          name: Berkeley::Departments.shortened(v),
+          participating: participating_department_codes.include?(k)
+        }
+      end
+      departments.sort_by { |dept| dept[:name] }
+    end
+
     def self.generate_task_id
       [Time.now.to_f.to_s.gsub('.', ''), SecureRandom.hex(8)].join '-'
     end

--- a/app/models/oec/course_code.rb
+++ b/app/models/oec/course_code.rb
@@ -14,10 +14,6 @@ module Oec
       @catalog_id_specific_mappings.find { |m| m.dept_name == dept_name && m.catalog_id == catalog_id }
     end
 
-    def self.included_dept_names
-      self.where(include_in_oec: true).select(:dept_name).uniq
-    end
-
     def self.included?(dept_name, catalog_id)
       course_code = find_code(dept_name, catalog_id)
       course_code.present? && course_code.include_in_oec

--- a/app/models/oec/task.rb
+++ b/app/models/oec/task.rb
@@ -38,7 +38,7 @@ module Oec
                            elsif opts[:dept_codes]
                              {dept_code: opts[:dept_codes].split}
                            else
-                             {dept_name: Oec::CourseCode.included_dept_names}
+                             {include_in_oec: true}
                            end
     end
 

--- a/src/assets/stylesheets/_oec.scss
+++ b/src/assets/stylesheets/_oec.scss
@@ -40,6 +40,9 @@
   }
 
   .cc-oec-text {
-    margin: 15px 0;
+    margin-top: 15px;
+    &:last-of-type {
+      margin-bottom: 15px;
+    }
   }
 }

--- a/src/assets/templates/oec.html
+++ b/src/assets/templates/oec.html
@@ -29,20 +29,17 @@
           </div>
         </div>
 
-        <div class="row">
+        <div class="row" data-ng-if="taskParameters.selectedTask.acceptsDepartmentOptions">
           <div class="small-3 columns">
             <label for="cc-page-oec-department" class="cc-oec-label">Department(s):</label>
           </div>
           <div class="small-9 columns">
-            <div class="cc-select" data-ng-if="taskParameters.selectedTask.acceptsDepartmentOptions">
+            <div class="cc-select">
               <select id="cc-page-oec-department"
                       data-ng-model="taskParameters.options.departmentCode"
                       data-ng-options="department.code as department.name for department in oecDepartments">
                 <option value="">All participating departments</option>
               </select>
-            </div>
-            <div class="cc-oec-departments-text" data-ng-if="!taskParameters.selectedTask.acceptsDepartmentOptions">
-              All participating departments
             </div>
           </div>
         </div>
@@ -51,6 +48,13 @@
           <div class="small-9 small-offset-3 columns cc-oec-text" data-ng-if="taskParameters.selectedTask.name">
             <strong data-ng-bind-html="taskParameters.selectedTask.friendlyName"></strong>:
             <span data-ng-bind-html="taskParameters.selectedTask.htmlDescription"></span>
+          </div>
+
+          <div class="small-9 small-offset-3 columns cc-oec-text" data-ng-if="taskParameters.selectedTask.acceptsDepartmentOptions && !taskParameters.options.departmentCode.length">
+            <strong>All participating departments</strong> are selected. The following departments will be included:
+            <ul>
+              <li data-ng-repeat="department in oecDepartments" data-ng-if="department.participating" data-ng-bind="department.name"></li>
+            </ul>
           </div>
         </div>
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5865

The department list from the API gets a `participating` boolean, which is used to display a list of participating departments when the "All participating departments" option is selected.

For tasks that don't accept a department option, the irrelevant "All participating departments" text is removed.

Oec::CourseCode::included_dept_names is a middleman of a method and doesn't need to be in there.