### PR TITLE
CLC-5882, google spec testext must not collide with other testing

### DIFF
--- a/spec/models/google_apps/drive_manager_spec.rb
+++ b/spec/models/google_apps/drive_manager_spec.rb
@@ -6,7 +6,7 @@ describe GoogleApps::DriveManager do
       settings = Settings.oec.google.marshal_dump
       @drive = GoogleApps::DriveManager.new Settings.oec.google.uid, settings
       now = DateTime.now.strftime('%m/%d/%Y at %I:%M%p')
-      title = "GoogleDriveInsert tested on #{now}"
+      title = "#{described_class} tested on #{now}"
       csv_file = 'fixtures/oec_legacy/courses.csv'
       text_file = 'fixtures/jms_recordings/ist_jms.txt'
       @folder = @drive.create_folder title

--- a/spec/models/oec/remote_drive_spec.rb
+++ b/spec/models/oec/remote_drive_spec.rb
@@ -30,6 +30,7 @@ describe Oec::RemoteDrive do
       before {
         worksheet = Oec::SisImportSheet.new(dept_code: dept_code)
         course_codes = [Oec::CourseCode.new(dept_name: 'SPANISH', catalog_id: '', dept_code: dept_code, include_in_oec: true)]
+        # Import of '2015-D' is intentional because we want valid data as input.
         Oec::SisImportTask.new(:term_code => '2015-D').import_courses(worksheet, course_codes)
         @folder = subject.create_folder transient_folder_name
         subject.check_conflicts_and_upload(worksheet, dept_code, Oec::Worksheet, @folder)

--- a/spec/models/oec/remote_drive_spec.rb
+++ b/spec/models/oec/remote_drive_spec.rb
@@ -1,48 +1,46 @@
 describe Oec::RemoteDrive do
 
   subject { described_class.new }
-  let(:term_code) { '2015-D' }
+  let(:william_the_conqueror_term_code) { '1066-D' }
   let(:dept_code) { 'IQBBB' }
-  # DateTime.tomorrow to avoid collision with other testing on today's data
-  let(:tomorrow) { DateTime.tomorrow.strftime('%F') }
+  let(:now) { DateTime.now }
 
   context '#real', testext: true, :order => :defined do
 
     context 'find no match' do
       it 'should return nil when term not found' do
-        spreadsheet = subject.find_dept_courses_spreadsheet('2008-B', dept_code)
+        spreadsheet = subject.find_dept_courses_spreadsheet(william_the_conqueror_term_code, dept_code)
         expect(spreadsheet).to be_nil
       end
 
       it 'should return nil when dept \'Courses\' spreadsheet is not found' do
-        spreadsheet = subject.find_dept_courses_spreadsheet(term_code, dept_code)
+        spreadsheet = subject.find_dept_courses_spreadsheet(william_the_conqueror_term_code, dept_code)
         expect(spreadsheet).to be_nil
       end
 
       it 'should return nil when dept not found' do
-        spreadsheet = subject.find_nested [term_code, 'imports', tomorrow, dept_code]
+        spreadsheet = subject.find_nested [william_the_conqueror_term_code, 'imports', now.strftime('%F'), dept_code]
         expect(spreadsheet).to be_nil
       end
     end
 
     context 'imports folder', :order => :defined do
+      let(:transient_folder_name) { "#{described_class} tested on #{now.strftime '%m/%d/%Y at %I:%M%p'}" }
+
       before {
         worksheet = Oec::SisImportSheet.new(dept_code: dept_code)
         course_codes = [Oec::CourseCode.new(dept_name: 'SPANISH', catalog_id: '', dept_code: dept_code, include_in_oec: true)]
-        Oec::SisImportTask.new(:term_code => term_code).import_courses(worksheet, course_codes)
-        @imports = subject.find_nested([term_code, 'imports'], on_failure: :error)
-        tomorrow_folder = subject.find_first_matching_folder(tomorrow, @imports) ||
-          subject.create_folder(tomorrow, @imports.id)
-        @dept_import = subject.check_conflicts_and_upload(worksheet, dept_code, Oec::Worksheet, tomorrow_folder)
+        Oec::SisImportTask.new(:term_code => '2015-D').import_courses(worksheet, course_codes)
+        @folder = subject.create_folder transient_folder_name
+        subject.check_conflicts_and_upload(worksheet, dept_code, Oec::Worksheet, @folder)
       }
 
       after {
-        now_import_folder = subject.find_first_matching_folder(tomorrow, @imports)
-        subject.trash_item(now_import_folder, permanently_delete: true) if now_import_folder
+        subject.trash_item(@folder, permanently_delete: true)
       }
 
       it 'should find newly created department import' do
-        spreadsheet = subject.find_nested [term_code, 'imports', tomorrow, dept_code]
+        spreadsheet = subject.find_nested [transient_folder_name, dept_code]
         expect(spreadsheet).to_not be_nil
       end
     end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5882
Bamboo passed: https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CJT75-2

Before I retire the 'ets.course.eval.qa' account and point textext specs at 'course-eval' I want to guarantee that test-data (e.g., term_date = 1066-D) does not collide with manual testing of QA dept.