### PR TITLE
SISRP-9407 Backend logic for profile-fallback 

### DIFF
--- a/app/models/campus_solutions/profile_feature_flagged.rb
+++ b/app/models/campus_solutions/profile_feature_flagged.rb
@@ -5,8 +5,8 @@ module CampusSolutions
     end
     alias_method(:is_cs_profile_feature_enabled, :is_feature_enabled)
 
-    def is_profile_hidden_for_legacy_users
-      Settings.features.cs_profile_hidden_for_legacy_users
+    def is_profile_visible_for_legacy_users
+      Settings.features.cs_profile_visible_for_legacy_users
     end
   end
 end

--- a/app/models/campus_solutions/profile_feature_flagged.rb
+++ b/app/models/campus_solutions/profile_feature_flagged.rb
@@ -4,5 +4,9 @@ module CampusSolutions
       Settings.features.cs_profile
     end
     alias_method(:is_cs_profile_feature_enabled, :is_feature_enabled)
+
+    def is_profile_hidden_for_legacy_users
+      Settings.features.cs_profile_hidden_for_legacy_users
+    end
   end
 end

--- a/app/models/user/api.rb
+++ b/app/models/user/api.rb
@@ -138,7 +138,7 @@ module User
         :uid => @uid,
         :sid => @student_id,
         :isCampusSolutionsStudent => is_campus_solutions_student,
-        :showSisProfileUI => (is_profile_hidden_for_legacy_users ? (is_campus_solutions_student && is_cs_profile_feature_enabled) : is_cs_profile_feature_enabled)
+        :showSisProfileUI => is_cs_profile_feature_enabled && (is_campus_solutions_student || is_profile_visible_for_legacy_users)
       }
     end
 

--- a/app/models/user/api.rb
+++ b/app/models/user/api.rb
@@ -138,7 +138,7 @@ module User
         :uid => @uid,
         :sid => @student_id,
         :isCampusSolutionsStudent => is_campus_solutions_student,
-        :showSisProfileUI => (is_campus_solutions_student && is_cs_profile_feature_enabled)
+        :showSisProfileUI => (is_profile_hidden_for_legacy_users ? (is_campus_solutions_student && is_cs_profile_feature_enabled) : is_cs_profile_feature_enabled)
       }
     end
 

--- a/app/models/user/api.rb
+++ b/app/models/user/api.rb
@@ -137,7 +137,8 @@ module User
         :roles => get_campus_attribute(:roles),
         :uid => @uid,
         :sid => @student_id,
-        :isCampusSolutionsStudent => is_campus_solutions_student
+        :isCampusSolutionsStudent => is_campus_solutions_student,
+        :showSisProfileUI => (is_campus_solutions_student && is_cs_profile_feature_enabled)
       }
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -314,7 +314,7 @@ features:
   manage_site_mailing_lists: false
   cs_fin_aid: false
   cs_profile: false
-  cs_profile_hidden_for_legacy_users: false
+  cs_profile_visible_for_legacy_users: true
   cs_sir: false
   slate_checklist: false
   webcast_sign_up_on_calcentral: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -314,6 +314,7 @@ features:
   manage_site_mailing_lists: false
   cs_fin_aid: false
   cs_profile: false
+  cs_profile_hidden_for_legacy_users: false
   cs_sir: false
   slate_checklist: false
   webcast_sign_up_on_calcentral: false

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -48,6 +48,7 @@ describe User::Api do
     user_data[:hasCanvasAccount].should_not be_nil
     user_data[:isCalendarOptedIn].should_not be_nil
     user_data[:isCampusSolutionsStudent].should be_falsey
+    user_data[:showSisProfileUI].should be_falsey
   end
   it "should return whether the user is registered with Canvas" do
     Canvas::Proxy.stub(:has_account?).and_return(true, false)

--- a/spec/models/user/api_with_campus_solutions_enabled_spec.rb
+++ b/spec/models/user/api_with_campus_solutions_enabled_spec.rb
@@ -45,6 +45,28 @@ describe User::Api do
     user_data[:isCalendarOptedIn].should_not be_nil
     user_data[:sid].should == 1234567890
     user_data[:isCampusSolutionsStudent].should be_truthy
+    user_data[:showSisProfileUI].should be_truthy
+  end
+  context "with a legacy student" do
+    before do
+      HubEdos::UserAttributes.stub(:new).and_return(
+        double(
+        get: {
+          :person_name => @default_name,
+          :student_id => 12345678,    # note: 8-digit ID means legacy
+          :roles => {
+            :student => true,
+            :exStudent => false,
+            :faculty => false,
+            :staff => false
+          }
+        }))
+    end
+    it "should hide SIS profile for legacy students" do
+      user_data = User::Api.new(@random_id).get_feed
+      user_data[:isCampusSolutionsStudent].should be_falsey
+      user_data[:showSisProfileUI].should be_falsey
+    end
   end
   it "should return whether the user is registered with Canvas" do
     Canvas::Proxy.stub(:has_account?).and_return(true, false)

--- a/spec/models/user/api_with_campus_solutions_enabled_spec.rb
+++ b/spec/models/user/api_with_campus_solutions_enabled_spec.rb
@@ -47,7 +47,7 @@ describe User::Api do
     user_data[:isCampusSolutionsStudent].should be_truthy
     user_data[:showSisProfileUI].should be_truthy
   end
-  context "with a legacy student" do
+  context 'with a legacy student' do
     before do
       HubEdos::UserAttributes.stub(:new).and_return(
         double(
@@ -62,10 +62,25 @@ describe User::Api do
           }
         }))
     end
-    it "should hide SIS profile for legacy students" do
-      user_data = User::Api.new(@random_id).get_feed
-      user_data[:isCampusSolutionsStudent].should be_falsey
-      user_data[:showSisProfileUI].should be_falsey
+    context 'with the fallback enabled' do
+      before do
+        allow(Settings.features).to receive(:cs_profile_hidden_for_legacy_users).and_return(true)
+      end
+      it "should hide SIS profile for legacy students" do
+        user_data = User::Api.new(@random_id).get_feed
+        user_data[:isCampusSolutionsStudent].should be_falsey
+        user_data[:showSisProfileUI].should be_falsey
+      end
+    end
+    context 'with the fallback disabled' do
+      before do
+        allow(Settings.features).to receive(:cs_profile_hidden_for_legacy_users).and_return(false)
+      end
+      it "should show SIS profile for legacy students" do
+        user_data = User::Api.new(@random_id).get_feed
+        user_data[:isCampusSolutionsStudent].should be_falsey
+        user_data[:showSisProfileUI].should be_truthy
+      end
     end
   end
   it "should return whether the user is registered with Canvas" do

--- a/spec/models/user/api_with_campus_solutions_enabled_spec.rb
+++ b/spec/models/user/api_with_campus_solutions_enabled_spec.rb
@@ -64,7 +64,7 @@ describe User::Api do
     end
     context 'with the fallback enabled' do
       before do
-        allow(Settings.features).to receive(:cs_profile_hidden_for_legacy_users).and_return(true)
+        allow(Settings.features).to receive(:cs_profile_visible_for_legacy_users).and_return(false)
       end
       it "should hide SIS profile for legacy students" do
         user_data = User::Api.new(@random_id).get_feed
@@ -74,7 +74,7 @@ describe User::Api do
     end
     context 'with the fallback disabled' do
       before do
-        allow(Settings.features).to receive(:cs_profile_hidden_for_legacy_users).and_return(false)
+        allow(Settings.features).to receive(:cs_profile_visible_for_legacy_users).and_return(true)
       end
       it "should show SIS profile for legacy students" do
         user_data = User::Api.new(@random_id).get_feed


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-9407

New feature flag, cs_profile_visible_for_legacy_users, does what it says. When the flag is true (the default), everyone gets the profile feature. When false, only new students in CS get it. 

@christianv will need to followup with the front-end changes for this: Hide Profile UI when showSisProfileUI is false in the /api/my/status feed. 