### PR TITLE
CLC-5893, after OEC publish write files to /exports folder as plain test/csv

### DIFF
--- a/app/models/berkeley/terms.rb
+++ b/app/models/berkeley/terms.rb
@@ -77,8 +77,8 @@ module Berkeley
       @current = @running || future_terms.pop
       if (@next = future_terms.pop)
         if (@future = future_terms.pop)
-          if !future_terms.empty?
-            logger.info("Found more than two future terms: #{future_terms}")
+          unless future_terms.empty?
+            logger.info("Found more than two future terms: #{future_terms.map(&:slug).join(', ')}")
             future_terms.each {|t| terms.delete(t.slug)}
           end
         end

--- a/app/models/google_apps/drive_manager.rb
+++ b/app/models/google_apps/drive_manager.rb
@@ -26,6 +26,13 @@ module GoogleApps
       find_items options.merge({ :title => title })
     end
 
+    def download(file)
+      result = get_google_api.execute(:uri => file.download_url)
+      log_response result
+      raise Errors::ProxyError, "Failed to download '#{file.title}' (id: #{file.id}).\nError: #{result.data['error']}" if result.error?
+      result.body
+    end
+
     def find_items(options = {})
       client = get_google_api
       drive_api = client.discovered_api('drive', 'v2')

--- a/app/models/oec/publish_task.rb
+++ b/app/models/oec/publish_task.rb
@@ -40,8 +40,11 @@ module Oec
           sftp_stdout_to_log sftp_stdout
 
           exports_now = find_or_create_now_subfolder 'exports'
-          export_sheets.each do |sheet|
-            export_sheet(sheet, exports_now)
+          # Write files to archive ('exports' folder at Google Drive). No need to use fancy Sheets format.
+          files_to_publish.each do |file_name|
+            path = "#{csv_staging_dir.expand_path}/#{file_name}"
+            raise RuntimeError, "file_to_publish does not exist: #{path}" unless File.exists? path
+            upload_file(path, file_name, 'text/csv', exports_now)
           end
         else
           raise RuntimeError, "System command failed: \n----\n#{cmd}\n----\n"

--- a/app/models/oec/term_setup_task.rb
+++ b/app/models/oec/term_setup_task.rb
@@ -40,7 +40,8 @@ module Oec
         end
         if (previous_exports =  @remote_drive.find_first_matching_folder('exports', previous_term_folder))
           if (most_recent_export = @remote_drive.find_folders(previous_exports.id).sort_by(&:title).last)
-            @previous_term_csvs[Oec::CourseSupervisors] =  @remote_drive.find_first_matching_item('course_supervisors', most_recent_export)
+            csv_file = @remote_drive.find_items_by_title('course_supervisors', parent_id: most_recent_export.id, mime_type: 'text/csv').first
+            @previous_term_csvs[Oec::CourseSupervisors] = Oec::CourseSupervisors.from_csv(csv_file) if csv_file
           end
         end
       end

--- a/app/models/oec/term_setup_task.rb
+++ b/app/models/oec/term_setup_task.rb
@@ -14,8 +14,12 @@ module Oec
       find_previous_term_csvs
 
       [Oec::CourseSupervisors, Oec::Instructors, Oec::Supervisors].each do |worksheet_class|
-        if @previous_term_csvs[worksheet_class]
-          copy_file(@previous_term_csvs[worksheet_class], overrides)
+        file = @previous_term_csvs[worksheet_class]
+        if file && (file.mime_type == 'text/csv') && file.download_url
+          content = StringIO.new @remote_drive.download(file)
+          @remote_drive.upload_to_spreadsheet(file.title.chomp('.csv'), file.description, content, overrides.id)
+        elsif file
+          copy_file(file, overrides)
         else
           log :info, "Could not find previous sheet '#{worksheet_class.export_name}' for copying; will create header-only file"
           export_sheet_headers(worksheet_class, overrides)
@@ -40,8 +44,8 @@ module Oec
         end
         if (previous_exports =  @remote_drive.find_first_matching_folder('exports', previous_term_folder))
           if (most_recent_export = @remote_drive.find_folders(previous_exports.id).sort_by(&:title).last)
-            csv_file = @remote_drive.find_items_by_title('course_supervisors', parent_id: most_recent_export.id, mime_type: 'text/csv').first
-            @previous_term_csvs[Oec::CourseSupervisors] = Oec::CourseSupervisors.from_csv(csv_file) if csv_file
+            item = @remote_drive.find_items_by_title('course_supervisors.csv', parent_id: most_recent_export.id, mime_type: 'text/csv').first
+            @previous_term_csvs[Oec::CourseSupervisors] = item if item
           end
         end
       end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5893
Bamboo: https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-CJT78

The *course_students* sheet has 100-200K rows and Google is unhappy, it exceeds max rows. With this PR, we archive published files to /exports folder as 'text/csv'. It's lightweight and Google is playing nice.
