### PR TITLE
Make CalCentral use the SAML Assertion from CAS to retrieve IDs where it can

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,9 +26,9 @@ gem 'activerecord-jdbch2-adapter', '~> 1.3.16'
 # http://flori.github.com/json/
 gem 'json', '~> 1.8.0'
 
-# CAS Strategy for OmniAuth
-# https://rubygems.org/gems/omniauth-cas
-gem 'omniauth-cas', '~> 1.1.0'
+# CAS Strategy for OmniAuth. ETS maintains its own fork with SAML Ticket Validator capability,
+# provided by Steven Hansen.
+gem 'omniauth-cas', '~> 1.1.0', git: 'https://github.com/ets-berkeley-edu/omniauth-cas.git'
 
 # LDAP
 gem 'net-ldap', '~> 0.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/ets-berkeley-edu/omniauth-cas.git
+  revision: 0c740de3a3c8b297df88453ec89a3875301d5458
+  specs:
+    omniauth-cas (1.1.0)
+      addressable (~> 2.3)
+      nokogiri (~> 1.5)
+      omniauth (~> 1.2.0)
+
+GIT
   remote: https://github.com/instructure/ims-lti.git
   revision: 016adac413022a451f722b25fb6574cc4f9899ae
   specs:
@@ -180,7 +189,7 @@ GEM
       spork (>= 0.8.4)
     haml (4.0.5)
       tilt
-    hashie (3.3.1)
+    hashie (3.4.2)
     headless (1.0.2)
     highline (1.6.21)
     hike (1.2.3)
@@ -254,10 +263,6 @@ GEM
     omniauth (1.2.2)
       hashie (>= 1.2, < 4)
       rack (~> 1.0)
-    omniauth-cas (1.1.0)
-      addressable (~> 2.3)
-      nokogiri (~> 1.5)
-      omniauth (~> 1.2.0)
     page-object (1.1.0)
       page_navigation (>= 0.9)
       selenium-webdriver (>= 2.44.0)
@@ -481,7 +486,7 @@ DEPENDENCIES
   minitest-reporters (~> 1.0.8)
   net-ldap (~> 0.11.0)
   nokogiri (~> 1.5.9)
-  omniauth-cas (~> 1.1.0)
+  omniauth-cas (~> 1.1.0)!
   page-object (~> 1.1.0)
   protected_attributes (~> 1.0.8)
   pundit (~> 0.3.0)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,16 +9,17 @@ class SessionsController < ApplicationController
 
     # Save crosswalk some work by caching critical IDs if they were asserted to us via SAML.
     if auth.respond_to?(:extra)
-      logger.error "Omniauth extra = #{auth.extra.inspect}"
+      logger.debug "Omniauth extra from SAML = #{auth.extra.inspect}"
       crosswalk = CalnetCrosswalk::Proxy.new(user_id: auth_uid)
       sid = auth.extra['berkeleyEduStuID']
-      cs_id = auth.extra['campusSolutionsID']
+      cs_id = auth.extra['berkeleyEduStuCSID']
       if sid.present?
-        logger.error "Caching student ID #{sid} for UID #{auth_uid} based on SAML assertion"
+        logger.debug "Caching student ID #{sid} for UID #{auth_uid} based on SAML assertion"
         crosswalk.cache_student_id sid
       end
       if cs_id.present?
-        logger.error "Caching Campus Solutions ID #{cs_id} for UID #{auth_uid} based on SAML assertion"
+        # TODO reduce this log level once CAS reliably sends us the CS ID
+        logger.warn "Caching Campus Solutions ID #{cs_id} for UID #{auth_uid} based on SAML assertion"
         crosswalk.cache_campus_solutions_id cs_id
       end
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,6 +6,23 @@ class SessionsController < ApplicationController
   def lookup
     auth = request.env["omniauth.auth"]
     auth_uid = auth['uid']
+
+    # Save crosswalk some work by caching critical IDs if they were asserted to us via SAML.
+    if auth.respond_to?(:extra)
+      logger.error "Omniauth extra = #{auth.extra.inspect}"
+      crosswalk = CalnetCrosswalk::Proxy.new(user_id: auth_uid)
+      sid = auth.extra['berkeleyEduStuID']
+      cs_id = auth.extra['campusSolutionsID']
+      if sid.present?
+        logger.error "Caching student ID #{sid} for UID #{auth_uid} based on SAML assertion"
+        crosswalk.cache_student_id sid
+      end
+      if cs_id.present?
+        logger.error "Caching Campus Solutions ID #{cs_id} for UID #{auth_uid} based on SAML assertion"
+        crosswalk.cache_campus_solutions_id cs_id
+      end
+    end
+
     if params['renew'] == 'true'
       # If we're reauthenticating due to view-as, then the CAS-provided UID should match
       # the session's "original_user_id".

--- a/app/models/calnet_crosswalk/proxy.rb
+++ b/app/models/calnet_crosswalk/proxy.rb
@@ -2,9 +2,7 @@ module CalnetCrosswalk
   class Proxy < BaseProxy
 
     include ClassLogger
-    include Cache::UserCacheExpiry
     include Proxies::Mockable
-    include Cache::RelatedCacheKeyTracker
 
     APP_ID = 'calnetcrosswalk'
     APP_NAME = 'Calnet Crosswalk'
@@ -73,13 +71,20 @@ module CalnetCrosswalk
       lookup_id 'CAMPUS_SOLUTIONS_ID'
     end
 
+    def cache_campus_solutions_id(value)
+      cache_id('CAMPUS_SOLUTIONS_ID', value)
+    end
+
     def lookup_student_id
       lookup_id 'LEGACY_SIS_STUDENT_ID'
     end
 
+    def cache_student_id(value)
+      cache_id('LEGACY_SIS_STUDENT_ID', value)
+    end
+
     def lookup_id(id_type)
       self.class.fetch_from_cache("#{@uid}/#{id_type}") do
-        self.class.save_related_cache_key(@uid, self.class.cache_key("#{@uid}/#{id_type}"))
         id = nil
         feed = get[:feed]
         if feed.present?
@@ -91,6 +96,12 @@ module CalnetCrosswalk
           end
         end
         id
+      end
+    end
+
+    def cache_id(id_type, id_value)
+      self.class.fetch_from_cache("#{@uid}/#{id_type}", true) do
+        id_value
       end
     end
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,7 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :cas, url: Settings.cas_server
+  provider :cas,
+           url: Settings.cas_server,
+           service_validate_url: '/samlValidate'
 end
 
 # More configurable logging.


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-9421

We use a fork of omniauth-cas (https://github.com/ets-berkeley-edu/omniauth-cas) that was graciously provided by Steve Hansen to wrangle the SAML assertion into a form we can use. 

If the SAML assertion gave us a student ID and/or CS EMPLID, we store them in cache, which will reduce the load on the crosswalk service. 

Before merging, the team should duly consider the risk involved in maintaining our own fork of omniauth-cas, and weigh it against the benefits. 
