### PR TITLE
CLC-5791 CLC-4299 Add Google API scope on demand to existing OAuth2 tokens

### DIFF
--- a/app/controllers/google_auth_controller.rb
+++ b/app/controllers/google_auth_controller.rb
@@ -10,7 +10,10 @@ class GoogleAuthController < ApplicationController
   def request_authorization
     expire
     @scope = Settings.google_proxy.scope
-    @scope += " #{params['scope']}" if params['scope'].present?
+    if params['scope'].present?
+      additional_scope = params['scope'].is_a?(Array) ? params['scope'].join(' ') : params['scope']
+      @scope += " #{additional_scope}"
+    end
     final_redirect = params['final_redirect'] || '/'
     if params['force_domain'].present? && params['force_domain'] == 'false'
       client = get_client(final_redirect, force_domain = false)

--- a/app/models/google_apps/proxy.rb
+++ b/app/models/google_apps/proxy.rb
@@ -156,8 +156,6 @@ module GoogleApps
       Settings.google_proxy.fake || (User::Oauth2Data.get(user_id, APP_ID)["access_token"].present?)
     end
 
-    private
-
     def update_access_tokens!
       if @current_token && @uid && @authorization.access_token != @current_token
         logger.info "Will update token for #{@uid} from #{@current_token} => #{@authorization.access_token}"

--- a/app/models/google_apps/userinfo.rb
+++ b/app/models/google_apps/userinfo.rb
@@ -21,5 +21,21 @@ module GoogleApps
               :params => { 'userId' => 'me'}).first
     end
 
+    def current_scope
+      # Make a real API request to ensure an up-to-date access token.
+      ensure_access = user_info
+      return [] unless ensure_access && ensure_access.response.status == 200
+      access_token = authorization.access_token
+      request_options = {
+        query: {access_token: access_token}
+      }
+      response = get_response('https://www.googleapis.com/oauth2/v1/tokeninfo', request_options)
+      if response['scope'].present?
+        response['scope'].split
+      else
+        []
+      end
+    end
+
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,7 @@ Calcentral::Application.routes.draw do
   # Oauth endpoints: Google
   get '/api/google/request_authorization'=> 'google_auth#request_authorization'
   get '/api/google/handle_callback' => 'google_auth#handle_callback'
+  get '/api/google/current_scope' => 'google_auth#current_scope'
   post '/api/google/remove_authorization' => 'google_auth#remove_authorization', :via => :post
   post '/api/google/dismiss_reminder' => 'google_auth#dismiss_reminder', :defaults => { :format => 'json'}, :via => :post
 

--- a/fixtures/json/google_user_current_scope.json
+++ b/fixtures/json/google_user_current_scope.json
@@ -1,0 +1,10 @@
+{
+ "issued_to": "999.apps.googleusercontent.com",
+ "audience": "999.apps.googleusercontent.com",
+ "user_id": "114856790171836979104",
+ "scope": "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/tasks https://www.googleapis.com/auth/drive.readonly.metadata https://spreadsheets.google.com/feeds https://mail.google.com/mail/feed/atom/",
+ "expires_in": 3098,
+ "email": "tammi.chang.clc@gmail.com",
+ "verified_email": true,
+ "access_type": "offline"
+}

--- a/spec/models/google_apps/userinfo_spec.rb
+++ b/spec/models/google_apps/userinfo_spec.rb
@@ -24,4 +24,18 @@ describe GoogleApps::Userinfo do
     end
     response.data['emails'].first['value'].should be
   end
+
+  it 'should return an API array for the current scope of the Tammi account', :testext => true do
+    userinfo_proxy = GoogleApps::Userinfo.new(
+      {
+        :fake => false,
+        :access_token => Settings.google_proxy.test_user_access_token,
+        :refresh_token => Settings.google_proxy.test_user_refresh_token,
+        :expiration_time => 0
+      })
+    response = userinfo_proxy.current_scope
+    expect(response).to be_an_instance_of Array
+    expect(response).not_to be_empty
+  end
+
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5791
https://jira.ets.berkeley.edu/jira/browse/CLC-4299

* A new API request parameter grants non-standard API authorizations for devs, admins, & SPA account use. The include_granted_scopes option ensures that previously added scopes are not lost.
* A new API endpoint shows the authorization scope for the currently logged-in user. (This is mostly for QA right now, but I can picture later use in the UX.)

See CLC-5791 for a walkthrough and screenshot.