### PR TITLE
CLC-5906, dynamically flip key configurations without redeploy/restart

### DIFF
--- a/app/controllers/yaml_settings_controller.rb
+++ b/app/controllers/yaml_settings_controller.rb
@@ -13,7 +13,7 @@ class YamlSettingsController < ApplicationController
       feature_flags_after = Settings.features.marshal_dump
       msg = (feature_flags_before.to_a - feature_flags_after.to_a).any? ?
         'Settings reloaded. Please consider clearing the cache.' :
-        'Warning: No change detected in feature flags. Please verify that your settings changes loaded.'
+        'Warning: No change detected in feature flags. Please verify that your settings were loaded.'
       # Give user a snippet of the settings for the sake of his/her own verification
       json = {
         message: msg,

--- a/app/controllers/yaml_settings_controller.rb
+++ b/app/controllers/yaml_settings_controller.rb
@@ -6,17 +6,30 @@ class YamlSettingsController < ApplicationController
   def reload
     authorize(current_user, :can_reload_yaml_settings?)
     begin
-      is_success = CalcentralConfig.reload_settings
-      # Give user a snippet of the settings
-      json = { reloaded: is_success }
-      json[:snippet] = { features: Settings.features.marshal_dump } unless !is_success || Settings.features.nil?
-      # 400 code: Bad request, impossible to satisfy
-      render :json => json, :status => (is_success ? 200 : 400)
+      # Feature flag diff is our litmus test: Were settings actually reloaded?
+      feature_flags_before = Settings.features.marshal_dump
+      # Reload happens here
+      CalcentralConfig.reload_settings
+      feature_flags_after = Settings.features.marshal_dump
+      msg = (feature_flags_before.to_a - feature_flags_after.to_a).any? ?
+        'Settings reloaded. Please consider clearing the cache.' :
+        'Warning: No change detected in feature flags. Please verify that your settings changes loaded.'
+      # Give user a snippet of the settings for the sake of his/her own verification
+      json = {
+        message: msg,
+        snippet: {
+          features: feature_flags_after
+        }
+      }
+      response_code = 200
     rescue => e
-      logger.fatal 'Failed to reload YAML file. PLEASE consider a server restart because the state of the system is unknown.'
-      logger.fatal "#{e.message}\n#{e.backtrace.join "\n\t"}"
-      render :json => {reloaded: false}, :status => 500
+      logger.fatal msg = %Q(Failed to reload YAML file. PLEASE consider a server restart because the state of the system is unknown.
+#{e.message}
+#{e.backtrace.join "\n\t"})
+      json = { message: msg }
+      response_code = 500
     end
+    render :json => json, :status => response_code
   end
 
 end

--- a/lib/calcentral_config.rb
+++ b/lib/calcentral_config.rb
@@ -14,8 +14,8 @@ module CalcentralConfig
   end
 
   def reload_settings
-    new_settings = load_settings
     if Kernel.const_defined? :Settings
+      new_settings = load_settings
       Rails.logger.warn 'Preparing to reload application settings via Kernel'
       Kernel.const_set(:Settings, new_settings)
       new_level = Log4r::LNAMES.index Settings.logger.level
@@ -31,7 +31,6 @@ module CalcentralConfig
       Rails.logger.warn 'YAML settings reloaded. Ask yourself, should I clear the cache?'
     end
   end
-
 
   def deep_open_struct(hash_recursive)
     require 'ostruct'

--- a/lib/calcentral_config.rb
+++ b/lib/calcentral_config.rb
@@ -18,16 +18,7 @@ module CalcentralConfig
       new_settings = load_settings
       Rails.logger.warn 'Preparing to reload application settings via Kernel'
       Kernel.const_set(:Settings, new_settings)
-      new_level = Log4r::LNAMES.index Settings.logger.level
-      old_level = Rails.logger.level
-      if new_level.nil?
-        Rails.logger.warn "The new logger level is invalid: #{Settings.logger.level}"
-      elsif new_level == old_level
-        Rails.logger.warn "No change to logger level: #{Log4r::LNAMES[Rails.logger.level]}"
-      else
-        Rails.logger.level = new_level
-        Rails.logger.warn "Logger level changed (old -> new): #{Log4r::LNAMES[old_level]} -> #{Log4r::LNAMES[Rails.logger.level]}"
-      end
+      update_rails_logger_level Settings.logger.level
       Rails.logger.warn 'YAML settings reloaded. Ask yourself, should I clear the cache?'
     end
   end
@@ -64,6 +55,8 @@ module CalcentralConfig
     File.exists?(dir) ? File.expand_path(dir) : nil
   end
 
+  private
+
   def calcentral_settings_files(standard_dir, extension)
     files = [
         Rails.root.join('config', "settings.#{extension}"),
@@ -79,4 +72,18 @@ module CalcentralConfig
     end
     files
   end
+
+  def update_rails_logger_level(level_name)
+    new_level = Log4r::LNAMES.index level_name
+    old_level = Rails.logger.level
+    if new_level.nil?
+      Rails.logger.warn "The new logger level is invalid: #{Settings.logger.level}"
+    elsif new_level == old_level
+      Rails.logger.warn "No change to logger level: #{Log4r::LNAMES[Rails.logger.level]}"
+    else
+      Rails.logger.level = new_level
+      Rails.logger.warn "Logger level changed (old -> new): #{Log4r::LNAMES[old_level]} -> #{Log4r::LNAMES[Rails.logger.level]}"
+    end
+  end
+
 end

--- a/spec/controllers/yaml_settings_controller_spec.rb
+++ b/spec/controllers/yaml_settings_controller_spec.rb
@@ -27,6 +27,8 @@ describe YamlSettingsController do
         expect(Kernel).to receive(:const_set).with(anything, anything).and_raise RuntimeError
         get :reload, { :format => 'json' }
         expect(response.status).to eq 500
+        json = JSON.parse response.body
+        expect(json['message']).to include 'RuntimeError'
       end
     end
 

--- a/spec/controllers/yaml_settings_controller_spec.rb
+++ b/spec/controllers/yaml_settings_controller_spec.rb
@@ -20,37 +20,37 @@ describe YamlSettingsController do
 
   context 'authorized user' do
     let(:user_auth) { User::Auth.new(uid: @user_id, is_superuser: true, active: true) }
-    before {
-      settings = OpenStruct.new(
-        {
-          logger: OpenStruct.new(
-            {
-              level: log_level
-            }
-          )
-        }
-      )
-      expect(CalcentralConfig).to receive(:load_settings).and_return(settings)
-    }
 
-    context 'corrupt settings' do
-      let(:log_level) { 'invalid_log_level' }
-
+    context 'Kernel raises error' do
       it 'should abort the reload action if settings are corrupt' do
+        Rails.logger.warn 'EXPECT this test to generate RuntimeError in logs'
+        expect(Kernel).to receive(:const_set).with(anything, anything).and_raise RuntimeError
         get :reload, { :format => 'json' }
-        expect(response.status).to eq 400
+        expect(response.status).to eq 500
       end
     end
 
     context 'valid settings' do
-      let(:log_level) { 2 }
+      context 'settings change not detected' do
+        it 'should warn user of a possible problem' do
+          get :reload, { :format => 'json' }
+          expect(response.status).to eq 200
+          json = JSON.parse response.body
+          expect(json['message']).to include 'Warning: No change detected in feature flags'
+        end
+      end
 
-      it 'should succeed in changing the log level' do
-        allow(Rails.logger).to receive(:level).and_return 1
-        get :reload, { :format => 'json' }
-        expect(response.status).to eq 200
-        json = JSON.parse response.body
-        expect(json['reloaded']).to be true
+      context 'settings change detected' do
+        before {
+          Settings.features.textbooks = !Settings.features.textbooks
+        }
+
+        it 'should succeed' do
+          get :reload, { :format => 'json' }
+          expect(response.status).to eq 200
+          json = JSON.parse response.body
+          expect(json['message']).to include 'Settings reloaded'
+        end
       end
     end
   end

--- a/spec/controllers/yaml_settings_controller_spec.rb
+++ b/spec/controllers/yaml_settings_controller_spec.rb
@@ -43,8 +43,9 @@ describe YamlSettingsController do
       end
 
       context 'settings change detected' do
+        let(:original_textbooks_value) { Settings.features.textbooks }
         before {
-          Settings.features.textbooks = !Settings.features.textbooks
+          Settings.features.textbooks = !original_textbooks_value
         }
 
         it 'should succeed' do
@@ -52,6 +53,8 @@ describe YamlSettingsController do
           expect(response.status).to eq 200
           json = JSON.parse response.body
           expect(json['message']).to include 'Settings reloaded'
+          # Was the value actually restored?
+          expect(Settings.features.textbooks).to eq original_textbooks_value
         end
       end
     end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5906

Note:
* Code does before and after diff on feature flags (litmus test)
* Message to the user guesses at success / failure. Ultimately, user must verify success with his/her own smoke-testing.
* Overhauled the spec