### PR TITLE
CLC-5926 OEC: Avoid repetitively hardcoding folder names

### DIFF
--- a/app/models/oec/folder.rb
+++ b/app/models/oec/folder.rb
@@ -1,0 +1,18 @@
+module Oec
+  module Folder
+
+    FOLDER_TITLES = {
+      confirmations: 'departments',
+      merged_confirmations: 'departments',
+      logs: 'logs',
+      overrides: 'overrides',
+      published: 'exports',
+      sis_imports: 'imports'
+    }
+
+    FOLDER_TITLES.each do |key, title|
+      define_singleton_method(key) { title }
+    end
+
+  end
+end

--- a/app/models/oec/merged_sheet_validation.rb
+++ b/app/models/oec/merged_sheet_validation.rb
@@ -4,10 +4,10 @@ module Oec
     include Validator
 
     def build_and_validate_export_sheets
-      course_confirmations_file = @remote_drive.find_nested [@term_code, 'departments', 'Merged course confirmations'], on_failure: :error
+      course_confirmations_file = @remote_drive.find_nested [@term_code, Oec::Folder.merged_confirmations, 'Merged course confirmations'], on_failure: :error
       course_confirmations = Oec::SisImportSheet.from_csv(@remote_drive.export_csv(course_confirmations_file), dept_code: nil)
 
-      supervisor_confirmations_file = @remote_drive.find_nested [@term_code, 'departments', 'Merged supervisor confirmations'], on_failure: :error
+      supervisor_confirmations_file = @remote_drive.find_nested [@term_code, Oec::Folder.merged_confirmations, 'Merged supervisor confirmations'], on_failure: :error
       supervisor_confirmations = Oec::Supervisors.from_csv @remote_drive.export_csv(supervisor_confirmations_file)
 
       instructors = Oec::Instructors.new
@@ -17,7 +17,7 @@ module Oec
       course_students = Oec::CourseStudents.new
       supervisors = Oec::Supervisors.new
 
-      if (previous_course_supervisors = @remote_drive.find_nested [@term_code, 'overrides', 'course_supervisors'])
+      if (previous_course_supervisors = @remote_drive.find_nested [@term_code, Oec::Folder.overrides, 'course_supervisors'])
         course_supervisors = Oec::CourseSupervisors.from_csv @remote_drive.export_csv(previous_course_supervisors)
       else
         course_supervisors = Oec::CourseSupervisors.new

--- a/app/models/oec/publish_task.rb
+++ b/app/models/oec/publish_task.rb
@@ -39,7 +39,7 @@ module Oec
           # Now copy the command's output to remote drive.
           sftp_stdout_to_log sftp_stdout
 
-          exports_now = find_or_create_now_subfolder 'exports'
+          exports_now = find_or_create_now_subfolder Oec::Folder.published
           # Write files to archive ('exports' folder at Google Drive). No need to use fancy Sheets format.
           files_to_publish.each do |file_name|
             path = "#{csv_staging_dir.expand_path}/#{file_name}"

--- a/app/models/oec/remote_drive.rb
+++ b/app/models/oec/remote_drive.rb
@@ -48,11 +48,6 @@ module Oec
       item
     end
 
-    def find_dept_courses_spreadsheet(term_code, dept_code)
-      dept_name = Berkeley::Departments.get(dept_code, concise: true)
-      find_nested [term_code, 'departments', dept_name, 'Courses']
-    end
-
     def find_first_matching_folder(title, parent=nil)
       find_folders_by_title(title, folder_id(parent)).first
     end

--- a/app/models/oec/sis_import_task.rb
+++ b/app/models/oec/sis_import_task.rb
@@ -6,7 +6,7 @@ module Oec
     def run_internal
       @dept_forms = {}
       log :info, "Will import SIS data for term #{@term_code}"
-      imports_now = find_or_create_now_subfolder('imports')
+      imports_now = find_or_create_now_subfolder Oec::Folder.sis_imports
       Oec::CourseCode.by_dept_code(@course_code_filter).each do |dept_code, course_codes|
         @term_dates ||= default_term_dates
         worksheet = Oec::SisImportSheet.new(dept_code: dept_code)

--- a/app/models/oec/task.rb
+++ b/app/models/oec/task.rb
@@ -136,7 +136,7 @@ module Oec
     end
 
     def get_overrides_worksheet(klass)
-      if (overrides_sheet = @remote_drive.find_nested [@term_code, 'overrides', klass.export_name])
+      if (overrides_sheet = @remote_drive.find_nested [@term_code, Oec::Folder.overrides, klass.export_name])
         klass.from_csv @remote_drive.export_csv overrides_sheet
       end
     end
@@ -193,7 +193,7 @@ module Oec
       if @opts[:local_write]
         logger.debug "Wrote log file to path #{log_path}"
       else
-        if (logs_today = find_or_create_today_subfolder('logs', now))
+        if (logs_today = find_or_create_today_subfolder(Oec::Folder.logs, now))
           begin
             upload_file(log_path, log_name, 'text/plain', logs_today)
           ensure

--- a/spec/models/oec/create_confirmation_sheets_task_spec.rb
+++ b/spec/models/oec/create_confirmation_sheets_task_spec.rb
@@ -23,7 +23,7 @@ describe Oec::CreateConfirmationSheetsTask do
     allow(fake_remote_drive).to receive(:get_items_in_folder).and_return [import_sheet]
 
     allow(fake_remote_drive).to receive(:find_first_matching_item).and_return mock_google_drive_item
-    allow(fake_remote_drive).to receive(:find_first_matching_item).with('departments', anything).and_return departments_folder
+    allow(fake_remote_drive).to receive(:find_first_matching_item).with(Oec::Folder.confirmations, anything).and_return departments_folder
     allow(fake_remote_drive).to receive(:find_first_matching_item).with('Molecular and Cell Biology', departments_folder).and_return nil
     allow(fake_remote_drive).to receive(:find_first_matching_item).with('supervisors', anything).and_return supervisors_sheet
 

--- a/spec/models/oec/merge_confirmation_sheets_task_spec.rb
+++ b/spec/models/oec/merge_confirmation_sheets_task_spec.rb
@@ -57,7 +57,7 @@ describe Oec::MergeConfirmationSheetsTask do
     allow(gws_confirmation_spreadsheet).to receive(:worksheets).and_return [gws_course_confirmation[:sheet], gws_supervisor_confirmation[:sheet]]
     allow(mcellbi_confirmation_spreadsheet).to receive(:worksheets).and_return [mcellbi_course_confirmation[:sheet], mcellbi_supervisor_confirmation[:sheet]]
 
-    allow(fake_remote_drive).to receive(:find_first_matching_item).with('departments', anything).and_return departments_folder
+    allow(fake_remote_drive).to receive(:find_first_matching_item).with(Oec::Folder.confirmations, anything).and_return departments_folder
     allow(fake_remote_drive).to receive(:find_first_matching_item).with('supervisors', anything).and_return supervisors[:sheet]
     allow(fake_remote_drive).to receive(:find_first_matching_item).with('Gender and Women\'s Studies', last_import_folder).and_return gws_import[:sheet]
     allow(fake_remote_drive).to receive(:find_first_matching_item).with('Molecular and Cell Biology', last_import_folder).and_return mcellbi_import[:sheet]

--- a/spec/models/oec/remote_drive_spec.rb
+++ b/spec/models/oec/remote_drive_spec.rb
@@ -9,17 +9,17 @@ describe Oec::RemoteDrive do
 
     context 'find no match' do
       it 'should return nil when term not found' do
-        spreadsheet = subject.find_dept_courses_spreadsheet(william_the_conqueror_term_code, dept_code)
+        spreadsheet = subject.find_nested ['1000-A', Oec::Folder.confirmations, dept_code]
         expect(spreadsheet).to be_nil
       end
 
-      it 'should return nil when dept \'Courses\' spreadsheet is not found' do
-        spreadsheet = subject.find_dept_courses_spreadsheet(william_the_conqueror_term_code, dept_code)
+      it 'should return nil when department confirmation spreadsheet is not found' do
+        spreadsheet = subject.find_nested [william_the_conqueror_term_code, Oec::Folder.confirmations, dept_code]
         expect(spreadsheet).to be_nil
       end
 
       it 'should return nil when dept not found' do
-        spreadsheet = subject.find_nested [william_the_conqueror_term_code, 'imports', now.strftime('%F'), dept_code]
+        spreadsheet = subject.find_nested [william_the_conqueror_term_code, Oec::Folder.sis_imports, now.strftime('%F'), dept_code]
         expect(spreadsheet).to be_nil
       end
     end

--- a/spec/models/oec/report_diff_task_spec.rb
+++ b/spec/models/oec/report_diff_task_spec.rb
@@ -30,15 +30,15 @@ describe Oec::ReportDiffTask do
         fake_csv_hash[dept_name] = [ sis_data, dept_data]
       end
       # Behave as if there is no previous diff report on remote drive
-      expect(fake_remote_drive).to receive(:find_nested).with([term_code, 'departments']).and_return (departments_folder = double)
+      expect(fake_remote_drive).to receive(:find_nested).with([term_code, Oec::Folder.confirmations]).and_return (departments_folder = double)
       expect(fake_remote_drive).to receive(:find_first_matching_item).with('2015-D diff report', departments_folder).and_return nil
       dept_code_mappings.each do |dept_code, dept_name|
         friendly_name = Berkeley::Departments.get(dept_code, concise: true)
-        imports_path = [term_code, 'imports', now.strftime('%F %H:%M:%S'), friendly_name]
+        imports_path = [term_code, Oec::Folder.sis_imports, now.strftime('%F %H:%M:%S'), friendly_name]
         if dept_name.nil?
           expect(fake_remote_drive).to receive(:find_nested).with(imports_path, anything).and_return nil
         else
-          courses_path = [term_code, 'departments', friendly_name]
+          courses_path = [term_code, Oec::Folder.confirmations, friendly_name]
           sheet_classes = [Oec::SisImportSheet, Oec::CourseConfirmation]
           [ imports_path, courses_path ].each_with_index do |path, index|
             expect(fake_remote_drive).to receive(:find_nested).with(path, anything).and_return (remote_file = double)

--- a/spec/models/oec/sis_import_task_spec.rb
+++ b/spec/models/oec/sis_import_task_spec.rb
@@ -9,11 +9,11 @@ describe Oec::SisImportTask do
   before(:each) do
     allow(Oec::RemoteDrive).to receive(:new).and_return fake_remote_drive
     course_overrides = mock_google_drive_item 'course_overrides'
-    allow(fake_remote_drive).to receive(:find_nested).with([term_code, 'overrides', Oec::Courses.export_name]).and_return course_overrides
+    allow(fake_remote_drive).to receive(:find_nested).with([term_code, Oec::Folder.overrides, Oec::Courses.export_name]).and_return course_overrides
     allow(fake_remote_drive).to receive(:export_csv).with(course_overrides).and_return course_overrides_row
 
     instructor_overrides = mock_google_drive_item 'instructor_overrides'
-    allow(fake_remote_drive).to receive(:find_nested).with([term_code, 'overrides', Oec::Instructors.export_name]).and_return instructor_overrides
+    allow(fake_remote_drive).to receive(:find_nested).with([term_code, Oec::Folder.overrides, Oec::Instructors.export_name]).and_return instructor_overrides
     allow(fake_remote_drive).to receive(:export_csv).with(instructor_overrides).and_return instructor_overrides_row
 
     allow(Settings.terms).to receive(:fake_now).and_return DateTime.parse('2015-03-09')

--- a/spec/models/oec/term_setup_task_spec.rb
+++ b/spec/models/oec/term_setup_task_spec.rb
@@ -18,20 +18,21 @@ describe Oec::TermSetupTask do
 
     let(:term_folder) { mock_google_drive_item term_code }
     let(:logs_today_folder) { mock_google_drive_item today }
-    let(:overrides_folder) { mock_google_drive_item 'overrides' }
+    let(:overrides_folder) { mock_google_drive_item Oec::Folder.overrides }
 
     before do
       expect(fake_remote_drive).to receive(:find_folders).with(no_args).and_return []
       expect(fake_remote_drive).to receive(:check_conflicts_and_create_folder)
         .with(term_code, nil, anything).and_return term_folder
 
-      %w(departments exports imports logs).each do |title|
+      [:confirmations, :logs, :published, :sis_imports].each do |folder_type|
         expect(fake_remote_drive).to receive(:check_conflicts_and_create_folder)
-          .with(title, term_folder, anything).and_return mock_google_drive_item(title)
+          .with(Oec::Folder::FOLDER_TITLES[folder_type], term_folder, anything)
+          .and_return mock_google_drive_item(Oec::Folder::FOLDER_TITLES[folder_type])
       end
 
       expect(fake_remote_drive).to receive(:check_conflicts_and_create_folder)
-        .with('overrides', term_folder, anything).and_return overrides_folder
+        .with(Oec::Folder.overrides, term_folder, anything).and_return overrides_folder
 
       expect(fake_remote_drive).to receive(:copy_item_to_folder)
         .with(anything, 'departments_id', 'TEMPLATE').and_return mock_google_drive_item


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5926

This part-one PR does no renaming of folders but centralizes folder names in a constant Hash. Once this is cleared, part two will switch the names over.