### PR TITLE
CLC-5926 OEC: Use human-friendly folder names; separate out merged confirmation sheets

### DIFF
--- a/app/models/oec/folder.rb
+++ b/app/models/oec/folder.rb
@@ -2,12 +2,12 @@ module Oec
   module Folder
 
     FOLDER_TITLES = {
-      confirmations: 'departments',
-      merged_confirmations: 'departments',
-      logs: 'logs',
-      overrides: 'overrides',
-      published: 'exports',
-      sis_imports: 'imports'
+      overrides: 'Overrides',
+      sis_imports: 'Step 1: SIS import',
+      confirmations: 'Step 2: department confirmation',
+      merged_confirmations: 'Step 3: preflight merge',
+      published: 'Step 4: publication',
+      logs: 'Task logs'
     }
 
     FOLDER_TITLES.each do |key, title|

--- a/app/models/oec/term_setup_task.rb
+++ b/app/models/oec/term_setup_task.rb
@@ -7,8 +7,6 @@ module Oec
       term_folder = create_folder @term_code
       term_subfolders = {}
       Oec::Folder::FOLDER_TITLES.each do |folder_type, folder_name|
-        # TODO Remove once confirmations and merged_confirmations folders are separated
-        next if folder_type == :merged_confirmations
         term_subfolders[folder_type] = create_folder(folder_name, term_folder)
       end
 

--- a/spec/models/oec/term_setup_task_spec.rb
+++ b/spec/models/oec/term_setup_task_spec.rb
@@ -25,7 +25,7 @@ describe Oec::TermSetupTask do
       expect(fake_remote_drive).to receive(:check_conflicts_and_create_folder)
         .with(term_code, nil, anything).and_return term_folder
 
-      [:confirmations, :logs, :published, :sis_imports].each do |folder_type|
+      [:confirmations, :logs, :merged_confirmations, :published, :sis_imports].each do |folder_type|
         expect(fake_remote_drive).to receive(:check_conflicts_and_create_folder)
           .with(Oec::Folder::FOLDER_TITLES[folder_type], term_folder, anything)
           .and_return mock_google_drive_item(Oec::Folder::FOLDER_TITLES[folder_type])
@@ -35,7 +35,7 @@ describe Oec::TermSetupTask do
         .with(Oec::Folder.overrides, term_folder, anything).and_return overrides_folder
 
       expect(fake_remote_drive).to receive(:copy_item_to_folder)
-        .with(anything, 'departments_id', 'TEMPLATE').and_return mock_google_drive_item
+        .with(anything, "#{Oec::Folder.confirmations}_id", 'TEMPLATE').and_return mock_google_drive_item
 
       %w(courses course_instructors course_supervisors instructors supervisors).each do |sheet|
         expect(fake_remote_drive).to receive(:check_conflicts_and_upload)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5926

Following #4436, the actual renames.