### PR TITLE
SISRP-9984 Don't treat 404 from work experience API as an error

### DIFF
--- a/app/models/hub_edos/work_experience.rb
+++ b/app/models/hub_edos/work_experience.rb
@@ -21,5 +21,9 @@ module HubEdos
       }
     end
 
+    def request_options
+      super.merge({on_error: {rescue_status: 404}})
+    end
+
   end
 end

--- a/app/models/hub_edos/work_experience.rb
+++ b/app/models/hub_edos/work_experience.rb
@@ -15,10 +15,15 @@ module HubEdos
     end
 
     def build_feed(response)
-      {
-        # yes, the array structure really is this weird.
-        'workExperiences' => response.parsed_response['studentResponse']['students']['students'][0]['workExperiences']['workExperiences']
-      }
+      resp = response.parsed_response
+      if resp['studentResponse'].present? && resp['studentResponse']['students'].present? && resp['studentResponse']['students'].length > 0
+        {
+          # yes, the array structure really is this weird.
+          'workExperiences' => response.parsed_response['studentResponse']['students']['students'][0]['workExperiences']['workExperiences']
+        }
+      else
+        {}
+      end
     end
 
     def request_options


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-9984

Missing data will appear to the client UI as a 404 but won't get logged as an error in the app log. 