### PR TITLE
CLC-5907 OEC: Omit timestamps in skipped-course logs, keep them out of the browser

### DIFF
--- a/app/models/oec/api_task_wrapper.rb
+++ b/app/models/oec/api_task_wrapper.rb
@@ -12,37 +12,37 @@ module Oec
       {
         name: 'SisImportTask',
         friendlyName: 'SIS data import',
-        htmlDescription: 'Import course and instructor data for one or more campus departments. Imported data will appear in a new, timestamped subfolder of the <strong>imports</strong> folder.',
+        htmlDescription: "Import course and instructor data for one or more campus departments. Imported data will appear in a new, timestamped subfolder of the <strong>#{Oec::Folder.sis_imports}</strong> folder.",
         acceptsDepartmentOptions: true
       },
       {
         name: 'CreateConfirmationSheetsTask',
         friendlyName: 'Create confirmation sheets',
-        htmlDescription: 'Create confirmation sheets for review and edits by department administrators. Sheets will appear under the <strong>departments</strong> folder. If that folder contains a sheet named <strong>TEMPLATE</strong>, it will be used as a model for the confirmation sheets.',
+        htmlDescription: "Create confirmation sheets for review and edits by department administrators. Sheets will appear under the <strong>#{Oec::Folder.confirmations}</strong> folder. If that folder contains a sheet named <strong>TEMPLATE</strong>, it will be used as a model for the confirmation sheets.",
         acceptsDepartmentOptions: true
       },
       {
         name: 'ReportDiffTask',
         friendlyName: 'Diff confirmation sheets',
-        htmlDescription: 'Compare department confirmation sheets to the most recent SIS import data and report on differences. The diff report will appear as a new sheet in the <strong>departments</strong> folder, and will replace any previous diff report.',
+        htmlDescription: "Compare department confirmation sheets to the most recent SIS import data and report on differences. The diff report will appear as a new sheet in the <strong>#{Oec::Folder.confirmations}</strong> folder, and will replace any previous diff report.",
         acceptsDepartmentOptions: true
       },
       {
         name: 'MergeConfirmationSheetsTask',
         friendlyName: 'Merge confirmation sheets',
-        htmlDescription: 'Merge department confirmation sheets into master sheets for preflight review. Two new sheets will be created in the <strong>departments</strong> folder: <strong>Merged course confirmations</strong> and <strong>Merged supervisor confirmations</strong>.',
+        htmlDescription: "Merge department confirmation sheets into master sheets for preflight review. Two new sheets will be created in the <strong>#{Oec::Folder.merged_confirmations}</strong> folder: <strong>Merged course confirmations</strong> and <strong>Merged supervisor confirmations</strong>.",
         acceptsDepartmentOptions: false
       },
       {
         name: 'ValidationTask',
         friendlyName: 'Validate confirmed data',
-        htmlDescription: 'Run a validation report on merged confirmation sheets. Validation results will appear in a dated subfolder of the <strong>logs</strong> folder.',
+        htmlDescription: "Run a validation report on merged confirmation sheets. Validation results will appear in a dated subfolder of the <strong>#{Oec::Folder.logs}</strong> folder.",
         acceptsDepartmentOptions: false
       },
       {
         name: 'PublishTask',
         friendlyName: 'Publish confirmed data to Explorance',
-        htmlDescription: 'Validate and export merged confirmation sheets. Files will be uploaded to the vendor only if validation passes. A copy of the uploaded data will appear in a timestamped subfolder of the <strong>exports</strong> folder.',
+        htmlDescription: "Validate and export merged confirmation sheets. Files will be uploaded to the vendor only if validation passes. A copy of the uploaded data will appear in a timestamped subfolder of the <strong>#{Oec::Folder.published}</strong> folder.",
         acceptsDepartmentOptions: false
       }
     ]


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5907

See issue comments for the motivation behind taking out some timestamps.

Also generally improve logging on the import task, and update the contextual help.