### PR TITLE
CLC-5969, UITEST needs the Xvfb check before the 'if' block

### DIFF
--- a/script/bamboo-tests.sh
+++ b/script/bamboo-tests.sh
@@ -21,6 +21,12 @@ rvm gemset use $GEMSET
 bundle install --local --retry 3 || { echo "WARNING: bundle install --local failed, running bundle install"; bundle install --retry 3 || { echo "ERROR: bundle install failed"; exit 1; } }
 bundle package --all || { echo "WARNING: bundle package failed"; exit 1; }
 
+# set up Xvfb for headless browser testing
+if [ ! -f /tmp/.X99-lock ];
+then
+    Xvfb :99 -screen 0 1440x900x16 &
+fi
+
 # run the tests
 if [ "$2" == "uitest" ]; then
   # run UI tests if we've been given a second arg
@@ -30,12 +36,6 @@ if [ "$2" == "uitest" ]; then
 else
   # run regular testext tests
   echo "Running testext tests"
-
-  # set up Xvfb for headless browser testing
-  if [ ! -f /tmp/.X99-lock ];
-  then
-      Xvfb :99 -screen 0 1440x900x16 &
-  fi
 
   bundle exec rake assets:clean db:reset spec:xml
 fi


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5969

```bamboo-tests.sh``` is used by Bamboo to run testext or run testext + uitests. See comments in CLC-5969 that highlight the oddity Xvfb placement. This change guarantees that Xvfb check happens when uitests are run. 