### PR TITLE
CLC-5996, front-end wiring for 'Welcome Delegate' page and widget to link accounts

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -318,6 +318,7 @@ features:
   cs_profile_visible_for_legacy_users: true
   show_notifications_archive_link: false
   cs_sir: false
+  cs_delegated_access: false
   slate_checklist: false
   webcast_sign_up_on_calcentral: false
   service_alerts_rss: true

--- a/src/assets/javascripts/angular/configuration/routeConfiguration.js
+++ b/src/assets/javascripts/angular/configuration/routeConfiguration.js
@@ -45,6 +45,10 @@ angular.module('calcentral.config').config(function($routeProvider) {
     controller: 'DashboardController',
     fireUpdatedFeeds: true
   }).
+  when('/welcome_delegate', {
+    templateUrl: 'welcome_delegate.html',
+    controller: 'WelcomeDelegateController'
+  }).
   when('/finances', {
     templateUrl: 'myfinances.html',
     controller: 'MyFinancesController'

--- a/src/assets/javascripts/angular/controllers/pages/welcomeDelegateController.js
+++ b/src/assets/javascripts/angular/controllers/pages/welcomeDelegateController.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var angular = require('angular');
+
+/**
+ * Controller welcomes newly assigned delegate users
+ */
+angular.module('calcentral.controllers').controller('WelcomeDelegateController', function(apiService) {
+  apiService.util.setTitle('Welcome');
+});

--- a/src/assets/javascripts/angular/controllers/widgets/delegateAccountLinkingController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/delegateAccountLinkingController.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var angular = require('angular');
+
+/**
+ * Controller links student account with the requested delegate account
+ */
+angular.module('calcentral.controllers').controller('DelegateAccountLinkingController', function() {
+  var loadDelegateAccountLinkingCard = function() {
+  };
+
+  loadDelegateAccountLinkingCard();
+});
+

--- a/src/assets/stylesheets/_welcome_delegate.scss
+++ b/src/assets/stylesheets/_welcome_delegate.scss
@@ -1,0 +1,8 @@
+.cc-page-welcome-delegate {
+  background: $cc-color-white;
+  h1 {
+    margin: 0 10px;
+    padding-top: 20px;
+  }
+
+}

--- a/src/assets/templates/welcome_delegate.html
+++ b/src/assets/templates/welcome_delegate.html
@@ -1,0 +1,7 @@
+<div class="cc-page-welcome-delegate">
+
+  <div class="cc-widget cc-widget-delegated-access" data-ng-if="api.user.profile.features.cs_delegated_access">
+    <div data-ng-include src="'widgets/delegated_access/link_accounts.html'"></div>
+  </div>
+
+</div>

--- a/src/assets/templates/widgets/delegated_access/link_accounts.html
+++ b/src/assets/templates/widgets/delegated_access/link_accounts.html
@@ -1,0 +1,9 @@
+<div class="cc-widget cc-widget-delegated-access" data-ng-controller="DelegateAccountLinkingController">
+  <div class="cc-widget-title">
+    <h2>Linking Your Account</h2>
+  </div>
+  <div>
+TODO: Build the 'Linking Your Account' widget per https://jira.berkeley.edu/secure/attachment/58061/sis-identity-delegate-s6-v4.pdf
+  </div>
+
+</div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5996
https://jira.ets.berkeley.edu/jira/browse/CLC-5973

The magic URL would be /welcome_delegate The next step is to put some meat on the bones of widgets/delegated_access/link_accounts.html  Plus, 'cs_delegated_access ' feature flag.

(See relevant comments on closed PR #4490) 