### PR TITLE
SISRP-10872 Consume student API in chunks rather than /all

### DIFF
--- a/app/models/campus_solutions/person_data_expiry.rb
+++ b/app/models/campus_solutions/person_data_expiry.rb
@@ -1,7 +1,14 @@
 module CampusSolutions
   module PersonDataExpiry
     def self.expire(uid=nil)
-      [HubEdos::Person, HubEdos::Student, HubEdos::MyPerson, HubEdos::MyStudent].each do |klass|
+      [HubEdos::Person, HubEdos::Student, HubEdos::Contacts, HubEdos::Demographics,
+       HubEdos::Affiliations, HubEdos::MyPerson, HubEdos::MyStudent].each do |klass|
+        klass.expire uid
+      end
+    end
+
+    def self.expire_on_profile_change(uid=nil)
+      [HubEdos::Contacts, HubEdos::MyStudent].each do |klass|
         klass.expire uid
       end
     end

--- a/app/models/campus_solutions/person_data_updating_model.rb
+++ b/app/models/campus_solutions/person_data_updating_model.rb
@@ -2,8 +2,9 @@ module CampusSolutions
   module PersonDataUpdatingModel
     def passthrough(model_name, params)
       proxy = model_name.new({user_id: @uid, params: params})
-      PersonDataExpiry.expire @uid
-      proxy.get
+      result = proxy.get
+      PersonDataExpiry.expire_on_profile_change @uid
+      result
     end
   end
 end

--- a/app/models/hub_edos/affiliations.rb
+++ b/app/models/hub_edos/affiliations.rb
@@ -1,0 +1,23 @@
+module HubEdos
+  class Affiliations < Student
+
+    include Cache::UserCacheExpiry
+
+    def initialize(options = {})
+      super(options)
+    end
+
+    def url
+      "#{@settings.base_url}/#{@campus_solutions_id}/affiliation"
+    end
+
+    def json_filename
+      'affiliations.json'
+    end
+
+    def include_fields
+      %w(affiliations)
+    end
+
+  end
+end

--- a/app/models/hub_edos/contacts.rb
+++ b/app/models/hub_edos/contacts.rb
@@ -1,0 +1,23 @@
+module HubEdos
+  class Contacts < Student
+
+    include Cache::UserCacheExpiry
+
+    def initialize(options = {})
+      super(options)
+    end
+
+    def url
+      "#{@settings.base_url}/#{@campus_solutions_id}/contacts"
+    end
+
+    def json_filename
+      'student_contacts.json'
+    end
+
+    def include_fields
+      %w(identifiers names addresses phones emails urls emergencyContacts confidential)
+    end
+
+  end
+end

--- a/app/models/hub_edos/demographics.rb
+++ b/app/models/hub_edos/demographics.rb
@@ -1,0 +1,23 @@
+module HubEdos
+  class Demographics < Student
+
+    include Cache::UserCacheExpiry
+
+    def initialize(options = {})
+      super(options)
+    end
+
+    def url
+      "#{@settings.base_url}/#{@campus_solutions_id}/demographic"
+    end
+
+    def json_filename
+      'demographics.json'
+    end
+
+    def include_fields
+      %w(ethnicities languages usaCountry foreignCountries birth gender)
+    end
+
+  end
+end

--- a/app/models/hub_edos/my_student.rb
+++ b/app/models/hub_edos/my_student.rb
@@ -7,7 +7,23 @@ module HubEdos
     include Cache::JsonAddedCacher
 
     def get_feed_internal
-      HubEdos::Student.new({user_id: @uid}).get
+      merged = {
+        feed: {
+          student: {}
+        },
+        statusCode: 200
+      }
+      [HubEdos::Contacts, HubEdos::Demographics, HubEdos::Affiliations].each do |proxy|
+        feed = proxy.new({user_id: @uid}).get
+        if feed[:statusCode] > 400
+          merged[:statusCode] = 500
+          merged[:errored] = true
+          logger.error("Got errors in merged student feed on #{proxy} for uid #{@uid}")
+        else
+          merged[:feed][:student].merge!(feed[:feed]['student'])
+        end
+      end
+      merged
     end
 
   end

--- a/fixtures/json/affiliations.json
+++ b/fixtures/json/affiliations.json
@@ -1,0 +1,33 @@
+{
+  "studentResponse": {
+    "correlationId": "d1b3e543-a7a2-4bde-a753-c638a415125e",
+    "source": "UCB-SIS-STUDENT",
+    "students": {
+      "students": [
+        {
+          "identifiers": [
+            {
+              "type": "student-id",
+              "id": "CC00000001",
+              "primary": true,
+              "disclose": false
+            }
+          ],
+          "affiliations": [
+            {
+              "type": {
+                "code": "APPLICANT",
+                "description": "Applicant"
+              },
+              "statusCode": "INA",
+              "statusDescription": "Inactive",
+              "fromDate": "2015-10-02",
+              "toDate": "2015-10-28"
+            }
+          ],
+          "confidential": false
+        }
+      ]
+    }
+  }
+}

--- a/fixtures/json/demographics.json
+++ b/fixtures/json/demographics.json
@@ -1,0 +1,91 @@
+{
+  "studentResponse": {
+    "correlationId": "46ecc88c-82d7-48ed-b935-c318e83f43e6",
+    "source": "UCB-SIS-STUDENT",
+    "students": {
+      "students": [
+        {
+          "identifiers": [
+            {
+              "type": "student-id",
+              "id": "11667051",
+              "disclose": false
+            },
+            {
+              "type": "DB2",
+              "id": "11667051",
+              "disclose": false,
+              "fromDate": "1902-02-01"
+            }
+          ],
+          "names": [
+            {
+              "type": {
+                "code": "PRF",
+                "description": "Preferred"
+              },
+              "familyName": "Bear",
+              "givenName": "René",
+              "middleName": "",
+              "prefixName": "",
+              "suffixName": "",
+              "formattedName": "René  Bear ",
+              "preferred": true,
+              "disclose": false,
+              "uiControl": {
+                "code": "U",
+                "description": "Edit - No Delete"
+              },
+              "fromDate": "2015-11-06"
+            },
+            {
+              "type": {
+                "code": "PRI",
+                "description": "Primary"
+              },
+              "familyName": "Bear",
+              "givenName": "Oski",
+              "middleName": "",
+              "prefixName": "",
+              "suffixName": "",
+              "formattedName": "Oski  Bear ",
+              "preferred": false,
+              "disclose": false,
+              "uiControl": {
+                "code": "D",
+                "description": "Display Only"
+              },
+              "fromDate": "1902-02-01"
+            }
+          ],
+          "ethnicities": [
+            {
+              "group": {
+                "code": "2",
+                "description": "Black/African American"
+              },
+              "hispanicLatino": false,
+              "detail": {
+                "code": "BLACK",
+                "description": "African American/Black"
+              }
+            }
+          ],
+          "languages": [],
+          "usaCountry": {
+            "citizenshipStatus": {
+              "code": "1",
+              "description": "Native"
+            },
+            "militaryStatus": {
+              "code": "",
+              "description": "",
+              "fromDate": "1902-02-01"
+            }
+          },
+          "confidential": false
+        }
+      ]
+    }
+  }
+}

--- a/fixtures/json/student_contacts.json
+++ b/fixtures/json/student_contacts.json
@@ -1,0 +1,205 @@
+{
+  "studentResponse": {
+    "correlationId": "f684c25b-9505-40e1-b695-227d3fe5d876",
+    "source": "UCB-SIS-STUDENT",
+    "students": {
+      "students": [
+        {
+          "identifiers": [
+            {
+              "type": "student-id",
+              "id": "11667051",
+              "disclose": false
+            },
+            {
+              "type": "DB2",
+              "id": "11667051",
+              "disclose": false,
+              "fromDate": "1902-02-01"
+            }
+          ],
+          "names": [
+            {
+              "type": {
+                "code": "PRF",
+                "description": "Preferred"
+              },
+              "familyName": "Bear",
+              "givenName": "René",
+              "middleName": "",
+              "prefixName": "",
+              "suffixName": "",
+              "formattedName": "René  Bear ",
+              "preferred": true,
+              "disclose": false,
+              "uiControl": {
+                "code": "U",
+                "description": "Edit - No Delete"
+              },
+              "fromDate": "2015-11-06"
+            },
+            {
+              "type": {
+                "code": "PRI",
+                "description": "Primary"
+              },
+              "familyName": "Bear",
+              "givenName": "Oski",
+              "middleName": "",
+              "prefixName": "",
+              "suffixName": "",
+              "formattedName": "Oski  Bear ",
+              "preferred": false,
+              "disclose": false,
+              "uiControl": {
+                "code": "D",
+                "description": "Display Only"
+              },
+              "fromDate": "1902-02-01"
+            }
+          ],
+          "addresses": [
+            {
+              "type": {
+                "code": "DIPL",
+                "description": "Diploma"
+              },
+              "address1": "1234 56TH ST",
+              "address2": "APT 789, BOX 101112",
+              "address3": "",
+              "address4": "",
+              "num1": "",
+              "num2": "",
+              "addrField1": "",
+              "addrField2": "",
+              "addrField3": "",
+              "houseType": "",
+              "city": "BERKELEY",
+              "county": "",
+              "stateCode": "CA",
+              "stateName": "California",
+              "postalCode": "94708",
+              "countryCode": "USA",
+              "countryName": "United States",
+              "formattedAddress": "1234 56TH ST\nAPT 789, BOX 101112\nBERKELEY, California 94708",
+              "disclose": false,
+              "uiControl": {
+                "code": "N",
+                "description": "Do Not Display"
+              },
+              "fromDate": "2015-01-12"
+            },
+            {
+              "type": {
+                "code": "HOME",
+                "description": "Home"
+              },
+              "address1": "2111 BANCROFT WAY  #550",
+              "address2": "",
+              "address3": "",
+              "address4": "",
+              "num1": "",
+              "num2": "",
+              "addrField1": "",
+              "addrField2": "",
+              "addrField3": "",
+              "houseType": "",
+              "city": "BERKELEY",
+              "county": "",
+              "stateCode": "CA",
+              "stateName": "California",
+              "postalCode": "94720",
+              "countryCode": "USA",
+              "countryName": "United States",
+              "formattedAddress": "2111 BANCROFT WAY  #550\nBERKELEY, California 94720",
+              "disclose": false,
+              "uiControl": {
+                "code": "U",
+                "description": "Edit - No Delete"
+              },
+              "fromDate": "2013-10-31"
+            },
+            {
+              "type": {
+                "code": "LOCL",
+                "description": "Local"
+              },
+              "address1": "200 SPROUL HALL",
+              "address2": "",
+              "address3": "",
+              "address4": "",
+              "num1": "",
+              "num2": "",
+              "addrField1": "",
+              "addrField2": "",
+              "addrField3": "",
+              "houseType": "",
+              "city": "BERKELEY",
+              "county": "",
+              "stateCode": "CA",
+              "stateName": "California",
+              "postalCode": "94720",
+              "countryCode": "USA",
+              "countryName": "United States",
+              "formattedAddress": "200 SPROUL HALL\nBERKELEY, California 94720",
+              "disclose": false,
+              "uiControl": {
+                "code": "U",
+                "description": "Edit - No Delete"
+              },
+              "fromDate": "2015-07-20"
+            }
+          ],
+          "phones": [
+            {
+              "type": {
+                "code": "HOME",
+                "description": "Home/Permanent"
+              },
+              "number": "44 01698 12345",
+              "countryCode": "",
+              "extension": "888",
+              "primary": true,
+              "disclose": false,
+              "uiControl": {
+                "code": "F",
+                "description": "Full Edit"
+              }
+            }
+          ],
+          "emails": [
+            {
+              "type": {
+                "code": "OTHR",
+                "description": "Other"
+              },
+              "emailAddress": "oski@gmail.com",
+              "primary": true,
+              "disclose": false,
+              "uiControl": {
+                "code": "F",
+                "description": "Full Edit"
+              }
+            },
+            {
+              "type": {
+                "code": "CAMP",
+                "description": "Campus"
+              },
+              "emailAddress": "oski@berkeley.edu",
+              "primary": false,
+              "disclose": false,
+              "uiControl": {
+                "code": "F",
+                "description": "Full Edit"
+              }
+            }
+          ],
+          "urls": [],
+          "emergencyContacts": [],
+          "confidential": false
+        }
+      ]
+    }
+  }
+}

--- a/spec/models/hub_edos/affiliations_spec.rb
+++ b/spec/models/hub_edos/affiliations_spec.rb
@@ -1,0 +1,28 @@
+describe HubEdos::Affiliations do
+
+  context 'mock proxy' do
+    let(:proxy) { HubEdos::Affiliations.new(fake: true, user_id: '61889') }
+    subject { proxy.get }
+
+    it_behaves_like 'a proxy that properly observes the profile feature flag'
+    it_should_behave_like 'a simple proxy that returns errors'
+
+    it 'returns data with the expected structure' do
+      expect(subject[:feed]['student']).to be
+      expect(subject[:feed]['student']['affiliations'].length).to eq 1
+    end
+  end
+
+  context 'real proxy', testext: true do
+    let(:proxy) { HubEdos::Affiliations.new(fake: false, user_id: '61889') }
+    subject { proxy.get }
+
+    it_behaves_like 'a proxy that properly observes the profile feature flag'
+
+    it 'returns data with the expected structure' do
+      expect(subject[:feed]['student']).to be
+      expect(subject[:feed]['student']['affiliations']).to be
+    end
+
+  end
+end

--- a/spec/models/hub_edos/contacts_spec.rb
+++ b/spec/models/hub_edos/contacts_spec.rb
@@ -1,0 +1,33 @@
+describe HubEdos::Contacts do
+
+  context 'mock proxy' do
+    let(:proxy) { HubEdos::Contacts.new(fake: true, user_id: '61889') }
+    subject { proxy.get }
+
+    it_behaves_like 'a proxy that properly observes the profile feature flag'
+    it_should_behave_like 'a simple proxy that returns errors'
+
+    it 'returns data with the expected structure' do
+      expect(subject[:feed]['student']).to be
+      expect(subject[:feed]['student']['identifiers'][0]['type']).to be
+      expect(subject[:feed]['student']['addresses'][0]['state']).to eq 'CA'
+      expect(subject[:feed]['student']['addresses'][0]['postal']).to eq '94720'
+      expect(subject[:feed]['student']['addresses'][0]['country']).to eq 'USA'
+      expect(subject[:feed]['student']['addresses'][0]['formattedAddress']).to eq "2111 BANCROFT WAY  #550\nBERKELEY, California 94720"
+      expect(subject[:feed]['student']['phones'].length).to eq 1
+    end
+  end
+
+  context 'real proxy', testext: true do
+    let(:proxy) { HubEdos::Contacts.new(fake: false, user_id: '61889') }
+    subject { proxy.get }
+
+    it_behaves_like 'a proxy that properly observes the profile feature flag'
+
+    it 'returns data with the expected structure' do
+      expect(subject[:feed]['student']).to be
+      expect(subject[:feed]['student']['identifiers'][0]['type']).to be
+    end
+
+  end
+end

--- a/spec/models/hub_edos/demographics_spec.rb
+++ b/spec/models/hub_edos/demographics_spec.rb
@@ -1,0 +1,29 @@
+describe HubEdos::Demographics do
+
+  context 'mock proxy' do
+    let(:proxy) { HubEdos::Demographics.new(fake: true, user_id: '61889') }
+    subject { proxy.get }
+
+    it_behaves_like 'a proxy that properly observes the profile feature flag'
+    it_should_behave_like 'a simple proxy that returns errors'
+
+    it 'returns data with the expected structure' do
+      expect(subject[:feed]['student']).to be
+      expect(subject[:feed]['student']['ethnicities'][0]['group']['code']).to eq '2'
+      expect(subject[:feed]['student']['usaCountry']).to be
+    end
+  end
+
+  context 'real proxy', testext: true do
+    let(:proxy) { HubEdos::Demographics.new(fake: false, user_id: '61889') }
+    subject { proxy.get }
+
+    it_behaves_like 'a proxy that properly observes the profile feature flag'
+
+    it 'returns data with the expected structure' do
+      expect(subject[:feed]['student']).to be
+      expect(subject[:feed]['student']['ethnicities'][0]).to be
+    end
+
+  end
+end


### PR DESCRIPTION
NOTE for Christian: The /students/demographic Hub endpoint doesn't yet include birth and gender, but it will shortly (Faiza promised that it's easy). As soon as it does, this code will pick it up. The /students/affiliation endpoint already existed, so now I take advantage of it. 

Squashed commit of the following:

commit b6b2a1fde158f0617b68f5b476f06acf2d3e0547
Author: Chris Tweney <chris@media.berkeley.edu>
Date:   Fri Nov 13 07:09:37 2015 -0800

    SISRP-10872 Add birth, gender, and affiliation

commit 68502b02cfe845d4f50223525c47b1019948c373
Author: Chris Tweney <chris@media.berkeley.edu>
Date:   Thu Nov 12 10:46:57 2015 -0800

    SISRP-10872 Fix test failure

commit 8e4c5901cf523e23611a3c48f20c9225617e74b7
Author: Chris Tweney <chris@media.berkeley.edu>
Date:   Thu Nov 12 10:27:31 2015 -0800

    SISRP-10872 Fetch student data piecemeal instead of via /students/all