### PR TITLE
[QA] CLC-6016 Finaid-related Campus Solutions user models should observe finaid flag

### DIFF
--- a/app/models/campus_solutions/my_aid_years.rb
+++ b/app/models/campus_solutions/my_aid_years.rb
@@ -4,10 +4,10 @@ module CampusSolutions
     include Cache::LiveUpdatesEnabled
     include Cache::FreshenOnWarm
     include Cache::JsonAddedCacher
-    include CampusSolutions::ProfileFeatureFlagged
+    include CampusSolutions::FinaidFeatureFlagged
 
     def get_feed_internal
-      return {} unless is_cs_profile_feature_enabled
+      return {} unless is_feature_enabled
       CampusSolutions::AidYears.new({user_id: @uid}).get
     end
 

--- a/app/models/campus_solutions/my_financial_aid_data.rb
+++ b/app/models/campus_solutions/my_financial_aid_data.rb
@@ -6,12 +6,12 @@ module CampusSolutions
     include Cache::FreshenOnWarm
     include Cache::JsonAddedCacher
     include Cache::RelatedCacheKeyTracker
-    include CampusSolutions::ProfileFeatureFlagged
+    include CampusSolutions::FinaidFeatureFlagged
 
     attr_accessor :aid_year
 
     def get_feed_internal
-      return {} unless is_cs_profile_feature_enabled
+      return {} unless is_feature_enabled
       logger.debug "User #{@uid}; aid year #{aid_year}"
       CampusSolutions::FinancialAidData.new({user_id: @uid, aid_year: aid_year}).get
     end


### PR DESCRIPTION
I hope this is my last QA PR under https://jira.ets.berkeley.edu/jira/browse/CLC-6016.

A couple of Finaid-related models are switched from the CS profile flag (which I hastily put in yesterday) to the CS finaid flag. Using the wrong flag would presumably have created a separate leak between GL3 and GL4 ("...the _Titanic_ and her sister ship _Olympic_ were built with a cellular double bottom and divided into 16 major watertight compartments with 15 transverse watertight bulkheads that ran clear across the ship...").

Bamboo has built at https://bamboo.ets.berkeley.edu/bamboo/browse/CPB-CPT216-1. I believe the failures, including the CampusSolutions::AidYears failure, are red herrings; they're triggered by Campus Solutions errors farther down the stack and are showing up on all our branches at present.

(Parts one and two are at #4527 and #4528; if this last PR checks out, a squashed PR of all three into master will follow).