### PR TITLE
CLC-6021 - Roster photos: printing in Firefox only prints one page

### DIFF
--- a/src/assets/stylesheets/_base.scss
+++ b/src/assets/stylesheets/_base.scss
@@ -17,6 +17,12 @@ body {
   padding: 0;
   position: relative;
 }
+// Make sure printing still works
+@media print {
+  body {
+    overflow-x: visible;
+  }
+}
 
 // HTML & Body
 html, body {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6021