### PR TITLE
SISRP-10872 Followup - use the merged MyStudent feed from UserAttributes

### DIFF
--- a/app/models/hub_edos/user_attributes.rb
+++ b/app/models/hub_edos/user_attributes.rb
@@ -17,10 +17,10 @@ module HubEdos
     end
 
     def get_internal
-      edo_feed = Student.new(user_id: @uid).get
+      edo_feed = MyStudent.new(user_id: @uid).get_feed
       result = {}
       if (feed = edo_feed[:feed])
-        edo = HashConverter.symbolize feed['student'] # TODO will have to dynamically switch student/person EDO somehow
+        edo = HashConverter.symbolize feed[:student] # TODO will have to dynamically switch student/person EDO somehow
         set_ids(result)
         extract_passthrough_elements(edo, result)
         extract_names(edo, result)

--- a/spec/models/hub_edos/user_attributes_spec.rb
+++ b/spec/models/hub_edos/user_attributes_spec.rb
@@ -1,18 +1,25 @@
+# encoding: UTF-8
 describe HubEdos::UserAttributes do
 
   let(:user_id) { '61889' }
-  let(:fake_student_proxy) { HubEdos::Student.new(user_id: user_id) }
-  before { allow(HubEdos::Student).to receive(:new).and_return fake_student_proxy }
+  let(:fake_contact_proxy) { HubEdos::Contacts.new(user_id: user_id) }
+  before { allow(HubEdos::Contacts).to receive(:new).and_return fake_contact_proxy }
+
+  let(:fake_demographics_proxy) { HubEdos::Demographics.new(user_id: user_id) }
+  before { allow(HubEdos::Demographics).to receive(:new).and_return fake_demographics_proxy }
+
+  let(:fake_affiliations_proxy) { HubEdos::Affiliations.new(user_id: user_id) }
+  before { allow(HubEdos::Affiliations).to receive(:new).and_return fake_affiliations_proxy }
 
   subject { HubEdos::UserAttributes.new(user_id: user_id).get }
 
   it 'should provide the converted person data structure' do
     expect(subject[:ldap_uid]).to eq '61889'
     expect(subject[:student_id]).to eq '11667051'
-    expect(subject[:first_name]).to eq 'Osk'
+    expect(subject[:first_name]).to eq 'René'
     expect(subject[:last_name]).to eq 'Bear'
-    expect(subject[:person_name]).to eq 'Osk Bear'
-    expect(subject[:email_address]).to eq 'oski@berkeley.edu'
+    expect(subject[:person_name]).to eq 'René  Bear '
+    expect(subject[:email_address]).to eq 'oski@gmail.com'
     expect(subject[:official_bmail_address]).to eq 'oski@berkeley.edu'
     expect(subject[:names]).to be
     expect(subject[:addresses]).to be
@@ -20,7 +27,7 @@ describe HubEdos::UserAttributes do
 
   context 'role transformation' do
     before do
-      fake_student_proxy.override_json { |json| json['studentResponse']['students']['students'][0]['affiliations'] = affiliations }
+      fake_affiliations_proxy.override_json { |json| json['studentResponse']['students']['students'][0]['affiliations'] = affiliations }
     end
 
     context 'undergraduate student' do


### PR DESCRIPTION
Followup for https://jira.berkeley.edu/browse/SISRP-10872 eliminates the last usage of /students/all. 