### PR TITLE
CLC-6021 - Roster photos: printing in Firefox only prints one page

### DIFF
--- a/src/assets/stylesheets/_canvas_roster.scss
+++ b/src/assets/stylesheets/_canvas_roster.scss
@@ -67,6 +67,7 @@
   }
 
   @media print {
+    overflow: visible;
     padding: 0;
 
     .cc-page-roster-image-unavailable:before {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6021

This PR should also fix the FireFox issue