### PR TITLE
CLC-6007 Mention term in blinkered My Academics Profile

### DIFF
--- a/src/assets/templates/academics_student_profile.html
+++ b/src/assets/templates/academics_student_profile.html
@@ -42,7 +42,9 @@
             for the most current information.
           </div>
           <div data-ng-if="!api.user.profile.roles.registered" class="cc-widget-profile-message-text">
-            You are not currently registered as a student.
+            You are not registered as a student for the <span data-ng-bind="collegeAndLevel.termName"></span> term. Please
+            check <a href="https://sis.berkeley.edu/bearfacts/student/studentMain.do?bfaction=welcome">Bear Facts</a>
+            for information on other terms.
           </div>
         </div>
         <div class="cc-academics-nocontent-container" data-ng-if="!isAcademicInfoAvailable">


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6007

Aside from single-quote and Rspec cleanup, the changes are:
- Ensure that MyAcademics::CollegeAndLevel always returns a `termName` value, falling back to the CalCentral current term if it can't extract a term from Bearfacts;
- Surface a more detailed message in the profile template, including term name, when a student is considered active but not registered.