### PR TITLE
CLC-6039, /api/my/status -> hasToolboxTab when superuser, can-view-as

### DIFF
--- a/app/models/user/api.rb
+++ b/app/models/user/api.rb
@@ -146,6 +146,7 @@ module User
           has_instructor_history || has_student_history
         ),
         :hasFinancialsTab => (roles[:student] || roles[:exStudent]),
+        :hasToolboxTab => current_user_policy.can_administrate? || current_user_policy.can_view_as?,
         :hasPhoto => User::Photo.has_photo?(@uid),
         :inEducationAbroadProgram => @oracle_attributes[:education_abroad],
         :googleEmail => google_mail,

--- a/public/dummy/json/status.json
+++ b/public/dummy/json/status.json
@@ -20,6 +20,7 @@
   "hasInstructorHistory": false,
   "hasAcademicsTab": true,
   "hasFinancialsTab": true,
+  "hasToolboxTab": true,
   "googleEmail": "",
   "canvasEmail": "",
   "last_name": "BABTREW",

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -1,9 +1,9 @@
 describe User::Api do
   before(:each) do
     Settings.features.cs_profile = false
-    @random_id = Time.now.to_f.to_s.gsub(".", "")
-    @default_name = "Joe Default"
-    CampusOracle::UserAttributes.stub(:new).and_return(double(get_feed: {
+    @random_id = Time.now.to_f.to_s.gsub('.', '')
+    @default_name = 'Joe Default'
+    allow(CampusOracle::UserAttributes).to receive(:new).and_return double get_feed: {
       'person_name' => @default_name,
       'student_id' => 12345678,
       :roles => {
@@ -12,200 +12,243 @@ describe User::Api do
         :faculty => false,
         :staff => false
       }
-    }))
+    }
   end
 
   after do
     Settings.features.cs_profile = true
   end
 
-  it "should find user with default name" do
+  it 'should find user with default name' do
+    u = User::Api.new @random_id
+    u.init
+    expect(u.preferred_name).to eq @default_name
+  end
+  it 'should override the default name' do
+    u = User::Api.new @random_id
+    u.update_attributes preferred_name: 'Herr Heyer'
+    u = User::Api.new @random_id
+    u.init
+    expect(u.preferred_name).to eq 'Herr Heyer'
+  end
+  it 'should revert to the default name' do
+    u = User::Api.new @random_id
+    u.update_attributes preferred_name: 'Herr Heyer'
+    u = User::Api.new(@random_id)
+    u.update_attributes preferred_name: ''
     u = User::Api.new(@random_id)
     u.init
-    u.preferred_name.should == @default_name
+    expect(u.preferred_name).to eq @default_name
   end
-  it "should override the default name" do
-    u = User::Api.new(@random_id)
-    u.update_attributes(preferred_name: "Herr Heyer")
-    u = User::Api.new(@random_id)
-    u.init
-    u.preferred_name.should == "Herr Heyer"
-  end
-  it "should revert to the default name" do
-    u = User::Api.new(@random_id)
-    u.update_attributes(preferred_name: "Herr Heyer")
-    u = User::Api.new(@random_id)
-    u.update_attributes(preferred_name: "")
-    u = User::Api.new(@random_id)
-    u.init
-    u.preferred_name.should == @default_name
-  end
-  it "should return a user data structure" do
+  it 'should return a user data structure' do
     user_data = User::Api.new(@random_id).get_feed
-    user_data[:preferred_name].should == @default_name
-    user_data[:hasCanvasAccount].should_not be_nil
-    user_data[:isCalendarOptedIn].should_not be_nil
-    user_data[:isCampusSolutionsStudent].should be_falsey
-    user_data[:showSisProfileUI].should be_falsey
+    expect(user_data[:preferred_name]).to eq @default_name
+    expect(user_data[:hasCanvasAccount]).to_not be_nil
+    expect(user_data[:isCalendarOptedIn]).to_not be_nil
+    expect(user_data[:isCampusSolutionsStudent]).to be false
+    expect(user_data[:showSisProfileUI]).to be false
+    expect(user_data[:hasToolboxTab]).to be false
   end
-  it "should return whether the user is registered with Canvas" do
-    Canvas::Proxy.stub(:has_account?).and_return(true, false)
+  it 'should return whether the user is registered with Canvas' do
+    expect(Canvas::Proxy).to receive(:has_account?).and_return(true, false)
     user_data = User::Api.new(@random_id).get_feed
-    user_data[:hasCanvasAccount].should be_truthy
+    expect(user_data[:hasCanvasAccount]).to be true
     Rails.cache.clear
     user_data = User::Api.new(@random_id).get_feed
-    user_data[:hasCanvasAccount].should be_falsey
+    expect(user_data[:hasCanvasAccount]).to be false
   end
-  it "should have a null first_login time for a new user" do
+  it 'should have a null first_login time for a new user' do
     user_data = User::Api.new(@random_id).get_feed
-    user_data[:firstLoginAt].should be_nil
+    expect(user_data[:firstLoginAt]).to be_nil
   end
-  it "should properly register a call to record_first_login" do
+  it 'should properly register a call to record_first_login' do
     user_api = User::Api.new(@random_id)
     user_api.get_feed
     user_api.record_first_login
     updated_data = user_api.get_feed
-    updated_data[:firstLoginAt].should_not be_nil
+    expect(updated_data[:firstLoginAt]).to_not be_nil
   end
-  it "should delete a user and all his dependent parts" do
+  it 'should delete a user and all his dependent parts' do
     user_api = User::Api.new @random_id
     user_api.record_first_login
     user_api.get_feed
 
-    User::Oauth2Data.should_receive(:destroy_all)
-    Notifications::Notification.should_receive(:destroy_all)
-    Cache::UserCacheExpiry.should_receive(:notify)
-    Calendar::User.should_receive(:delete_all)
+    expect(User::Oauth2Data).to receive :destroy_all
+    expect(Notifications::Notification).to receive :destroy_all
+    expect(Cache::UserCacheExpiry).to receive :notify
+    expect(Calendar::User).to receive :delete_all
 
     User::Api.delete @random_id
 
-    User::Data.where(:uid => @random_id).should == []
+    expect(User::Data.where :uid => @random_id).to eq []
   end
 
-  it "should say random student gets the academics tab", if: CampusOracle::Queries.test_data? do
+  it 'should say random student gets the academics tab', if: CampusOracle::Queries.test_data? do
     user_data = User::Api.new(@random_id).get_feed
-    user_data[:hasAcademicsTab].should be_truthy
+    expect(user_data[:hasAcademicsTab]).to be true
   end
 
-  it "should say a staff member with no academic history does not get the academics tab", if: CampusOracle::Queries.test_data? do
-    CampusOracle::UserAttributes.stub(:new).and_return(double(get_feed: {
+  it 'should say a staff member with no academic history does not get the academics tab', if: CampusOracle::Queries.test_data? do
+    allow(CampusOracle::UserAttributes).to receive(:new).and_return double get_feed: {
       'person_name' => @default_name,
       :roles => {
         :student => false,
         :faculty => false,
         :staff => true
       }
-    }))
-    fake_instructor_proxy = CampusOracle::UserCourses::HasInstructorHistory.new({:fake => true})
-    fake_instructor_proxy.stub(:has_instructor_history?).and_return(false)
-    CampusOracle::UserCourses::HasInstructorHistory.stub(:new).and_return(fake_instructor_proxy)
-    fake_student_proxy = CampusOracle::UserCourses::HasStudentHistory.new({:fake => true})
-    fake_student_proxy.stub(:has_student_history?).and_return(false)
-    CampusOracle::UserCourses::HasStudentHistory.stub(:new).and_return(fake_student_proxy)
-    user_data = User::Api.new("904715").get_feed
-    user_data[:hasAcademicsTab].should be_falsey
+    }
+    fake_instructor_proxy = CampusOracle::UserCourses::HasInstructorHistory.new :fake => true
+    expect(fake_instructor_proxy).to receive(:has_instructor_history?).and_return false
+    expect(CampusOracle::UserCourses::HasInstructorHistory).to receive(:new).and_return fake_instructor_proxy
+    fake_student_proxy = CampusOracle::UserCourses::HasStudentHistory.new :fake => true
+    expect(fake_student_proxy).to receive(:has_student_history?).and_return false
+    expect(CampusOracle::UserCourses::HasStudentHistory).to receive(:new).and_return fake_student_proxy
+    user_data = User::Api.new('904715').get_feed
   end
 
-  describe "my finances tab" do
-    let(:student_roles) do
+  describe 'My Finances tab' do
+    let(:student_profiles) do
       {
         :active   => { :student => true,  :exStudent => false, :faculty => false, :staff => false },
         :expired  => { :student => false, :exStudent => true,  :faculty => false, :staff => false },
-        :non      => { :student => false, :exStudent => false, :faculty => false, :staff => true },
+        :non      => { :student => false, :exStudent => false, :faculty => false, :staff => true }
       }
     end
     before do
-      allow(CampusOracle::UserAttributes).to receive(:new).and_return(double(get_feed: {
-        roles: test_roles
-      }))
+      allow(CampusOracle::UserAttributes).to receive(:new).and_return double get_feed: { roles: user_roles }
     end
-    subject {User::Api.new(@random_id).get_feed[:hasFinancialsTab]}
-    context 'an active student' do
-      let(:test_roles) {student_roles[:active]}
-      it {should be_truthy}
+    subject { User::Api.new(@random_id).get_feed[:hasFinancialsTab] }
+    context 'active student' do
+      let(:user_roles) { student_profiles[:active] }
+      it { should be true }
     end
-    context 'a non-student' do
-      let(:test_roles) {student_roles[:non]}
-      it {should be_falsey}
+    context 'non-student' do
+      let(:user_roles) { student_profiles[:non] }
+      it { should be false }
     end
-    context 'an ex-student' do
-      let(:test_roles) {student_roles[:expired]}
-      it {should be_truthy}
+    context 'ex-student' do
+      let(:user_roles) { student_profiles[:expired] }
+      it { should be true }
     end
   end
 
-
-  it "should not explode when CampusOracle returns empty feeds" do
-    CampusOracle::UserAttributes.stub(:new).and_return(double(get_feed: {
-    }))
-    fake_instructor_proxy = CampusOracle::UserCourses::HasInstructorHistory.new({:fake => true})
-    fake_instructor_proxy.stub(:has_instructor_history?).and_return(false)
-    CampusOracle::UserCourses::HasInstructorHistory.stub(:new).and_return(fake_instructor_proxy)
-    fake_student_proxy = CampusOracle::UserCourses::HasStudentHistory.new({:fake => true})
-    fake_student_proxy.stub(:has_student_history?).and_return(false)
-    CampusOracle::UserCourses::HasStudentHistory.stub(:new).and_return(fake_student_proxy)
-    user_data = User::Api.new("904715").get_feed
-    user_data[:hasAcademicsTab].should_not be_truthy
+  describe 'My Toolbox tab' do
+    context 'superuser' do
+      before { User::Auth.new_or_update_superuser! @random_id }
+      it 'should show My Toolbox tab' do
+        user_api = User::Api.new(@random_id)
+        expect(user_api.get_feed[:hasToolboxTab]).to be true
+      end
+    end
+    context 'can_view_as' do
+      before {
+        user = User::Auth.new uid: @random_id
+        user.is_viewer = true
+        user.active = true
+        user.save
+      }
+      subject { User::Api.new(@random_id).get_feed[:hasToolboxTab] }
+      it { should be true }
+    end
+    context 'ordinary profiles' do
+      let(:profiles) do
+        {
+          :student   => { :student => true,  :exStudent => false, :faculty => false, :staff => false },
+          :faculty   => { :student => false, :exStudent => false, :faculty => true,  :staff => false },
+          :staff     => { :student => false, :exStudent => false, :faculty => true,  :staff => true }
+        }
+      end
+      before do
+        allow(CampusOracle::UserAttributes).to receive(:new).and_return double get_feed: {
+          roles: user_roles
+        }
+      end
+      subject { User::Api.new(@random_id).get_feed[:hasToolboxTab] }
+      context 'student' do
+        let(:user_roles) { profiles[:student] }
+        it { should be false }
+      end
+      context 'faculty' do
+        let(:user_roles) { profiles[:faculty] }
+        it { should be false }
+      end
+      context 'staff' do
+        let(:user_roles) { profiles[:staff] }
+        it { should be false }
+      end
+    end
   end
 
-  context "proper cache handling" do
+  it 'should not explode when CampusOracle returns empty feeds' do
+    expect(CampusOracle::UserAttributes).to receive(:new).and_return double(get_feed: {})
+    fake_instructor_proxy = CampusOracle::UserCourses::HasInstructorHistory.new :fake => true
+    expect(fake_instructor_proxy).to receive(:has_instructor_history?).and_return false
+    expect(CampusOracle::UserCourses::HasInstructorHistory).to receive(:new).and_return fake_instructor_proxy
+    fake_student_proxy = CampusOracle::UserCourses::HasStudentHistory.new :fake => true
+    expect(fake_student_proxy).to receive(:has_student_history?).and_return false
+    expect(CampusOracle::UserCourses::HasStudentHistory).to receive(:new).and_return fake_student_proxy
+    user_data = User::Api.new('904715').get_feed
+  end
 
-    it "should update the last modified hash when content changes" do
-      user_api = User::Api.new(@random_id)
+  context 'proper cache handling' do
+
+    it 'should update the last modified hash when content changes' do
+      user_api = User::Api.new @random_id
       user_api.get_feed
-      original_last_modified = User::Api.get_last_modified(@random_id)
+      original_last_modified = User::Api.get_last_modified @random_id
       old_hash = original_last_modified[:hash]
       old_timestamp = original_last_modified[:timestamp]
 
       sleep 1
 
-      user_api.preferred_name="New Name"
+      user_api.preferred_name = 'New Name'
       user_api.save
       feed = user_api.get_feed
-      new_last_modified = User::Api.get_last_modified(@random_id)
-      new_last_modified[:hash].should_not == old_hash
-      new_last_modified[:timestamp].should_not == old_timestamp
-      new_last_modified[:timestamp][:epoch].should == feed[:lastModified][:timestamp][:epoch]
+      new_last_modified = User::Api.get_last_modified @random_id
+      expect(new_last_modified[:hash]).to_not eq old_hash
+      expect(new_last_modified[:timestamp]).to_not eq old_timestamp
+      expect(new_last_modified[:timestamp][:epoch]).to eq feed[:lastModified][:timestamp][:epoch]
     end
 
-    it "should not update the last modified hash when content hasn't changed" do
-      user_api = User::Api.new(@random_id)
+    it 'should not update the last modified hash when content has not changed' do
+      user_api = User::Api.new @random_id
       user_api.get_feed
-      original_last_modified = User::Api.get_last_modified(@random_id)
+      original_last_modified = User::Api.get_last_modified @random_id
 
       sleep 1
 
       Cache::UserCacheExpiry.notify @random_id
       feed = user_api.get_feed
-      unchanged_last_modified = User::Api.get_last_modified(@random_id)
-      original_last_modified.should == unchanged_last_modified
-      original_last_modified[:timestamp][:epoch].should == feed[:lastModified][:timestamp][:epoch]
+      unchanged_last_modified = User::Api.get_last_modified @random_id
+      expect(original_last_modified).to eq unchanged_last_modified
+      expect(original_last_modified[:timestamp][:epoch]).to eq feed[:lastModified][:timestamp][:epoch]
     end
 
   end
 
-  context "proper handling of superuser permissions" do
-    before { User::Auth.new_or_update_superuser!(@random_id) }
+  context 'proper handling of superuser permissions' do
+    before { User::Auth.new_or_update_superuser! @random_id }
     subject { User::Api.new(@random_id).get_feed }
-    it "should pass the superuser status" do
-      subject[:isSuperuser].should be_truthy
-      subject[:isViewer].should be_truthy
+    it 'should pass the superuser status' do
+      expect(subject[:isSuperuser]).to be true
+      expect(subject[:isViewer]).to be true
+      expect(subject[:hasToolboxTab]).to be true
     end
   end
 
-  context "proper handling of viewer permissions" do
+  context 'proper handling of viewer permissions' do
     before {
-      user = User::Auth.new(uid: @random_id)
+      user = User::Auth.new uid: @random_id
       user.is_viewer = true
       user.active = true
       user.save
     }
     subject { User::Api.new(@random_id).get_feed }
-    it "should pass the viewer status" do
-      subject[:isSuperuser].should be_falsey
-      subject[:isViewer].should be_truthy
+    it 'should pass the viewer status' do
+      expect(subject[:isSuperuser]).to be false
+      expect(subject[:isViewer]).to be true
+      expect(subject[:hasToolboxTab]).to be true
     end
   end
 
 end
-

--- a/spec/ui_selenium/pages/api_my_status_page.rb
+++ b/spec/ui_selenium/pages/api_my_status_page.rb
@@ -66,4 +66,8 @@ class ApiMyStatusPage
     @parsed['hasFinancialsTab']
   end
 
+  def has_toolbox_tab?
+    @parsed['hasToolboxTab']
+  end
+
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6039

Nothing surfaces on the UI yet. This is purely putting hasToolboxTab in the /api/my/status feed when user is "super" or can-view-as. Eventually, this tab will have view-as features and other admin-ish type cards.