### PR TITLE
CLC-6051, hide /toolbox when view-as; card styling

### DIFF
--- a/app/models/user/api.rb
+++ b/app/models/user/api.rb
@@ -146,7 +146,7 @@ module User
           has_instructor_history || has_student_history
         ),
         :hasFinancialsTab => (roles[:student] || roles[:exStudent]),
-        :hasToolboxTab => current_user_policy.can_administrate? || current_user_policy.can_view_as?,
+        :hasToolboxTab => current_user_policy.has_toolbox_tab?,
         :hasPhoto => User::Photo.has_photo?(@uid),
         :inEducationAbroadProgram => @oracle_attributes[:education_abroad],
         :googleEmail => google_mail,

--- a/app/policies/authentication_state_policy.rb
+++ b/app/policies/authentication_state_policy.rb
@@ -68,4 +68,8 @@ class AuthenticationStatePolicy
     feature_flag = Settings.features.webcast_sign_up_on_calcentral
     feature_flag.present? && feature_flag && (can_administrate? || can_view_as? || can_add_current_official_sections?)
   end
+
+  def has_toolbox_tab?
+    can_administrate? || (@user.user_auth.active? && @user.user_auth.is_viewer?)
+  end
 end

--- a/src/assets/javascripts/angular/controllers/widgets/adminController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/adminController.js
@@ -112,7 +112,7 @@ angular.module('calcentral.controllers').controller('AdminController', function(
   var actAsUser = function(user) {
     return adminFactory.actAs({
       uid: user.ldap_uid
-    }).success(apiService.util.redirectToToolbox);
+    }).success(apiService.util.redirectToHome);
   };
 
   $scope.admin.actAsUser = function(user) {

--- a/src/assets/javascripts/angular/services/utilService.js
+++ b/src/assets/javascripts/angular/services/utilService.js
@@ -75,6 +75,13 @@ angular.module('calcentral.services').service('utilService', function($cacheFact
   };
 
   /**
+   * Redirect to base URL
+   */
+  var redirectToHome = function() {
+    window.location = '/';
+  };
+
+  /**
    * Prevent a click event from bubbling up to its parents
    */
   var preventBubble = function($event) {
@@ -218,6 +225,7 @@ angular.module('calcentral.services').service('utilService', function($cacheFact
     printPage: printPage,
     redirect: redirect,
     redirectToToolbox: redirectToToolbox,
+    redirectToHome: redirectToHome,
     setTitle: setTitle,
     supportsLocalStorage: supportsLocalStorage,
     uidPattern: uidPattern

--- a/src/assets/stylesheets/_toolbox.scss
+++ b/src/assets/stylesheets/_toolbox.scss
@@ -3,6 +3,20 @@
   .cc-toolbox-section {
     margin-top: 30px;
   }
+  .cc-toolbox-widget {
+    background: $cc-color-white;
+    form {
+      background: transparent;
+      border: 0;
+      margin: 0;
+      padding: 0;
+      label {
+        display: inline-block;
+        margin: 0;
+        text-align: left;
+      }
+    }
+  }
   .cc-toolbox-apitest-list {
     margin-left: 20px;
     .cc-toolbox-apitest-pending {
@@ -28,8 +42,5 @@
       font-size: 12px;
       padding: 4px;
     }
-  }
-  .cc-toolbox-recent-uids {
-    margin-top: 7px;
   }
 }

--- a/src/assets/templates/toolbox.html
+++ b/src/assets/templates/toolbox.html
@@ -1,16 +1,17 @@
-<div class="cc-toolbox">
-  <div class="column">
-    <h1 class="cc-heading-page-title">My Toolbox</h1>
+<div class="cc-toolbox" data-ng-if="api.user.profile.hasToolboxTab">
+  <div class="row collapse">
+    <div class="column">
+      <h1 class="cc-heading-page-title">My Toolbox</h1>
+    </div>
+    <div class="medium-4 columns" data-ng-if="api.user.profile.isViewer || api.user.profile.isSuperuser">
+      <div data-ng-include="'widgets/toolbox/view_as.html'"></div>
+    </div>
+    <div class="medium-4 columns" data-ng-if="api.user.profile.isViewer || api.user.profile.isSuperuser">
+      <div data-ng-include="'widgets/toolbox/uid_lookup.html'"></div>
+    </div>
+    <div class="medium-4 columns" data-ng-if="api.user.profile.isSuperuser">
+      <div data-ng-include="'widgets/toolbox/api_test.html'"></div>
+    </div>
   </div>
-
-  <div class="medium-4 columns" data-ng-if="api.user.profile.isViewer || api.user.profile.actingAsUid">
-    <div data-ng-include="'widgets/toolbox/view_as.html'"></div>
-  </div>
-  <div class="medium-4 columns">
-    <div data-ng-include="'widgets/toolbox/uid_lookup.html'"></div>
-  </div>
-  <div class="medium-4 columns" data-ng-if="api.user.profile.isSuperuser">
-    <div data-ng-include="'widgets/toolbox/api_test.html'"></div>
-  </div>
-
 </div>
+<div data-ng-include="'404.html'" data-ng-if="!api.user.profile.hasToolboxTab"></div>

--- a/src/assets/templates/widgets/toolbox/api_test.html
+++ b/src/assets/templates/widgets/toolbox/api_test.html
@@ -1,18 +1,20 @@
-<div data-ng-controller="ApiTestController"
-     data-cc-spinner-directive="apiTest.isLoading"
->
-  <h2>CalCentral API Test</h2>
-  <form data-ng-submit="runApiTest()">
-    <button class="cc-button cc-button-blue" data-ng-disabled="apiTest.running" type="submit">Run test</button>
-    <div data-ng-show="apiTest.showTests">
-      <ul class="cc-toolbox-apitest-list">
-        <li data-ng-repeat="route in apiTest.data" ng-switch="route.status" class="cc-flex">
-          <i ng-switch-when="success" title="{{route.route}}" class="fa fa-check-circle cc-icon-green cc-toolbox-apitest-icon"></i>
-          <i ng-switch-when="failed" title="{{route.route}}" class="fa fa-check-circle cc-icon-red cc-toolbox-apitest-icon"></i>
-          <i ng-switch-default title="{{route.route}}" class="fa fa-spinner fa-spin cc-toolbox-apitest-icon"></i>
-          <span class="cc-toolbox-apitest-{{route.status}}" data-ng-bind="route.route"></span>
-        </li>
-      </ul>
-    </div>
-  </form>
+<div class="cc-widget cc-toolbox-widget" data-ng-controller="ApiTestController" data-cc-spinner-directive="apiTest.isLoading">
+  <div class="cc-widget-title">
+    <h2>CalCentral API Test</h2>
+  </div>
+  <div class="cc-widget-text">
+    <form data-ng-submit="runApiTest()">
+      <button class="cc-button cc-button-blue" data-ng-disabled="apiTest.running" type="submit">Run</button>
+      <div data-ng-show="apiTest.showTests">
+        <ul class="cc-toolbox-apitest-list">
+          <li data-ng-repeat="route in apiTest.data" ng-switch="route.status" class="cc-flex">
+            <i ng-switch-when="success" title="{{route.route}}" class="fa fa-check-circle cc-icon-green cc-toolbox-apitest-icon"></i>
+            <i ng-switch-when="failed" title="{{route.route}}" class="fa fa-check-circle cc-icon-red cc-toolbox-apitest-icon"></i>
+            <i ng-switch-default title="{{route.route}}" class="fa fa-spinner fa-spin cc-toolbox-apitest-icon"></i>
+            <span class="cc-toolbox-apitest-{{route.status}}" data-ng-bind="route.route"></span>
+          </li>
+        </ul>
+      </div>
+    </form>
+  </div>
 </div>

--- a/src/assets/templates/widgets/toolbox/uid_lookup.html
+++ b/src/assets/templates/widgets/toolbox/uid_lookup.html
@@ -1,39 +1,37 @@
-<h3>UID/SID Lookup</h3>
-<form data-ng-submit="admin.lookupUser()">
-  <div class="row">
-    <div class="small-9 small-offset-3 columns">
-      <input id="cc-toolbox-id" data-ng-pattern="api.util.uidPattern" placeholder="Enter UID or SID here" data-ng-model="admin.id" type="text" data-cc-select-on-click-directive />
-    </div>
+<div class="cc-widget cc-toolbox-widget" data-ng-controller="AdminController">
+  <div class="cc-widget-title">
+    <h2>UID/SID Lookup</h2>
   </div>
-  <div class="row">
-    <div class="small-9 small-offset-3 columns">
-      <button
-        class="cc-button cc-button-blue"
-        data-ng-disabled="!admin.id"
-        type="submit">Look Up</button>
+  <div class="cc-widget-text">
+    <div>
+      <div class="cc-text-red" data-ng-if="admin.viewAsErrorStatus">
+        <i class="cc-icon-red fa fa-exclamation-circle"></i>
+        <span data-ng-bind="admin.viewAsErrorStatus"></span>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="small-8 small-offset-3 columns">
-      <span data-ng-bind="admin.lookupErrorStatus"></span>
-    </div>
-  </div>
-  <div data-ng-if="admin.users" class="row">
-    <div class="small-6 small-offset-3 columns cc-table">
-      <table class="cc-toolbox-table">
+    <form data-ng-submit="admin.lookupUser()">
+      <div>
+        <div>
+          <input id="cc-toolbox-id" data-ng-pattern="api.util.uidPattern" placeholder="Enter UID or SID here" data-ng-model="admin.id" type="text" data-cc-select-on-click-directive />
+        </div>
+      </div>
+      <div>
+        <button class="cc-button cc-button-blue" data-ng-disabled="!admin.id" type="submit">Look Up</button>
+      </div>
+      <table class="cc-toolbox-table" data-ng-if="admin.users">
         <thead>
-        <tr>
-          <th width="50%" scope="col">UID</th>
-          <th width="50%" scope="col">SID</th>
-        </tr>
+          <tr>
+            <th width="50%" scope="col">UID</th>
+            <th width="50%" scope="col">SID</th>
+          </tr>
         </thead>
         <tbody data-ng-repeat="user in admin.users">
-        <tr>
-          <td data-ng-bind="user.ldap_uid"></td>
-          <td data-ng-bind="user.student_id || 'This user has no SID'"></td>
-        </tr>
+          <tr>
+            <td data-ng-bind="user.ldap_uid"></td>
+            <td data-ng-bind="user.student_id || 'This user has no SID'"></td>
+          </tr>
         </tbody>
       </table>
-    </div>
+    </form>
   </div>
-</form>
+</div>

--- a/src/assets/templates/widgets/toolbox/view_as.html
+++ b/src/assets/templates/widgets/toolbox/view_as.html
@@ -1,54 +1,48 @@
-<div data-ng-controller="AdminController"
-     data-cc-spinner-directive="admin.isLoading"
->
-  <h3>View as</h3>
-  <form data-ng-submit="admin.actAsUser()">
-    <div class="row">
-      <div class="small-3 columns">
-        <label for="cc-toolbox-act-as-uid">UID/SID</label>
-      </div>
-      <div class="small-9 columns">
-        <input id="cc-toolbox-act-as-uid" data-ng-model="admin.actAs.id" data-ng-pattern="api.util.uidPattern" placeholder="Enter UID or SID here" type="text" data-cc-select-on-click-directive />
-      </div>
-    </div>
-    <div class="row">
-      <div class="small-9 small-offset-3 columns">
-        <button
-          class="cc-button cc-button-blue"
-          data-ng-disabled="!admin.actAs.id"
-          type="submit">Submit</button>
-      </div>
-    </div>
-    <div class="row">
-      <div class="small-9 small-offset-3 columns">
+<div class="cc-widget cc-toolbox-widget" data-ng-controller="AdminController" data-cc-spinner-directive="admin.isLoading">
+  <div class="cc-widget-title">
+    <h2>View as</h2>
+  </div>
+  <div class="cc-widget-text">
+    <div>
+      <div class="cc-text-red" data-ng-if="admin.actAsErrorStatus">
+        <i class="cc-icon-red fa fa-exclamation-circle"></i>
         <span data-ng-bind="admin.actAsErrorStatus"></span>
       </div>
     </div>
-    <div class="row" data-ng-if="admin.userPool">
-      <div class="small-9 small-offset-3 columns">
-        <ul data-ng-repeat="user in admin.userPool">
+    <form data-ng-submit="admin.actAsUser()">
+      <div>
+        <label for="cc-toolbox-view-as-uid">UID/SID</label>
+      </div>
+      <div>
+        <input id="cc-toolbox-view-as-uid" data-ng-model="admin.actAs.id" data-ng-pattern="api.util.uidPattern" placeholder="Enter UID or SID here" type="text" data-cc-select-on-click-directive />
+      </div>
+      <div>
+        <button class="cc-button cc-button-blue" data-ng-disabled="!admin.actAs.id" type="submit">Submit</button>
+      </div>
+      <div>
+        <ul data-ng-repeat="user in admin.userPool" data-ng-if="admin.userPool">
           <li>
             UID: <button class="cc-button-link" data-ng-bind="user.ldap_uid" data-ng-click="admin.actAsUser(user)"></button>
             (SID: <span data-ng-bind="user.student_id || 'none'"></span>)
           </li>
         </ul>
       </div>
-    </div>
-
-    <div class="row cc-toolbox-recent-uids" data-ng-repeat="block in admin.userBlocks">
-      <div class="small-9 small-offset-3 columns" data-ng-if="block.users.length">
-        <h4><span data-ng-bind="block.title"></span> (<button type="button" class="cc-button-link" data-ng-click="block.clearAllUsers()">clear all</button>)</h4>
-        <ul>
-          <li data-ng-repeat="user in block.users track by $index">
-              <span>
-                UID: <button type="submit" class="cc-button-link" data-ng-click="admin.updateIDField(user.ldap_uid)" data-ng-bind="user.ldap_uid"></button>
-                (SID: <span data-ng-bind="user.student_id || 'none'"></span>)
-              </span>
-            <span data-ng-if="block.storeUser && !user.saved">(<button type="button" class="cc-button-link" data-ng-click="block.storeUser(user)">save</button>)</span>
-            <span data-ng-if="block.clearUser">(<button type="button" class="cc-button-link" data-ng-click="block.clearUser(user)">delete</button>)</span>
-          </li>
-        </ul>
+      <div data-ng-repeat="block in admin.userBlocks">
+        <div data-ng-if="block.users.length">
+          <strong data-ng-bind="block.title"></strong>
+          (<button type="button" class="cc-button-link" data-ng-click="block.clearAllUsers()">clear all</button>)
+          <ul>
+            <li data-ng-repeat="user in block.users track by $index">
+                <span>
+                  UID: <button type="submit" class="cc-button-link" data-ng-click="admin.updateIDField(user.ldap_uid)" data-ng-bind="user.ldap_uid"></button>
+                  (SID: <span data-ng-bind="user.student_id || 'none'"></span>)
+                </span>
+              <span data-ng-if="block.storeUser && !user.saved">(<button type="button" class="cc-button-link" data-ng-click="block.storeUser(user)">save</button>)</span>
+              <span data-ng-if="block.clearUser">(<button type="button" class="cc-button-link" data-ng-click="block.clearUser(user)">delete</button>)</span>
+            </li>
+          </ul>
+        </div>
       </div>
-    </div>
-  </form>
+    </form>
+  </div>
 </div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6051
https://jira.ets.berkeley.edu/jira/browse/CLC-6040

Includes:
* My Toolbox widgets look like proper cards
* Remove extraneous styles
* While you view-as, the My Toolbox tab behaves per target user privileges 
* When you click to view-as you are sent to '/'  (ie, Dashboard)

Note: spec will come in future PR - https://jira.ets.berkeley.edu/jira/browse/CLC-6053
