### PR TITLE
CLC-5840 Distribute LTI Usage / TurnItIn reports through Google Drive

### DIFF
--- a/app/models/canvas_csv/base.rb
+++ b/app/models/canvas_csv/base.rb
@@ -6,6 +6,7 @@ module CanvasCsv
 
     def initialize
       super(Settings.canvas_proxy.export_directory)
+      @reporter_uid = Settings.canvas_proxy.reporter_uid
     end
 
     def accumulate_user_data(user_ids)
@@ -85,6 +86,16 @@ module CanvasCsv
 
     def csv_count(csv_filename)
       CSV.read(csv_filename, {headers: true}).length
+    end
+
+    def sheets_manager
+      @sheets_manager ||=  @reporter_uid.present? ? GoogleApps::SheetsManager.new(@reporter_uid) : nil
+    end
+
+    def reports_folder
+      @reports_folder ||= sheets_manager.present? ?
+        sheets_manager.find_folders_by_title('bCourses Reports').first || sheets_manager.find_folders_by_title('bCourses Reports', shared: true).first :
+        nil
     end
 
   end

--- a/app/models/oec/create_confirmation_sheets_task.rb
+++ b/app/models/oec/create_confirmation_sheets_task.rb
@@ -43,7 +43,7 @@ module Oec
               raise RuntimeError, "Could not find worksheet 'Report Viewers' in template copy '#{dept_sheet.title}'" unless report_viewers_worksheet
             else
               log :debug, "No template confirmation sheet found, will create blank '#{dept_name}' confirmation sheet"
-              dept_sheet = @remote_drive.upload_to_spreadsheet(dept_name, '', StringIO.new(dept_confirmations[:courses].headers.join(',')), departments_folder.id)
+              dept_sheet = @remote_drive.upload_to_spreadsheet(dept_name, StringIO.new(dept_confirmations[:courses].headers.join(',')), departments_folder.id)
               courses_worksheet = dept_sheet.worksheets.first
               report_viewers_worksheet = dept_sheet.add_worksheet('Report Viewers', 100, dept_confirmations[:supervisors].headers.count)
               dept_confirmations[:supervisors].headers.each_with_index { |header, i| report_viewers_worksheet[1, i+1] = header }

--- a/app/models/oec/remote_drive.rb
+++ b/app/models/oec/remote_drive.rb
@@ -39,7 +39,7 @@ module Oec
         raise RuntimeError, "Item '#{title}' already exists in remote drive folder '#{folder.title}'; could not upload"
       end
       upload_operation = (type == Oec::Worksheet) ?
-        upload_worksheet(title, '', item, folder_id(folder), format_numbers: :text) :
+        upload_to_spreadsheet(title, item.to_io, folder_id(folder)) :
         upload_file(title, '', folder_id(folder), type, item.to_s)
       unless upload_operation
         raise RuntimeError, "Item '#{title}' could not be uploaded to remote drive folder '#{folder.title}'"

--- a/app/models/oec/term_setup_task.rb
+++ b/app/models/oec/term_setup_task.rb
@@ -16,7 +16,7 @@ module Oec
         file = @previous_term_csvs[worksheet_class]
         if file && (file.mime_type == 'text/csv') && file.download_url
           content = StringIO.new @remote_drive.download(file)
-          @remote_drive.upload_to_spreadsheet(file.title.chomp('.csv'), file.description, content, term_subfolders[:overrides].id)
+          @remote_drive.upload_to_spreadsheet(file.title.chomp('.csv'), content, term_subfolders[:overrides].id)
         elsif file
           copy_file(file, term_subfolders[:overrides])
         else

--- a/app/models/oec/worksheet.rb
+++ b/app/models/oec/worksheet.rb
@@ -113,6 +113,24 @@ module Oec
       @rows.values
     end
 
+    def to_csv_string
+      CSV.generate do |csv|
+        csv << headers
+        each_sorted do |row|
+          csv_row = headers.map do |header|
+            # A trick to force plaintext formatting in Google Sheets.
+            # TODO Why not use the CSV :force_quotes option?
+            row[header] =~ /\A\d+\Z/ ? "'#{row[header]}" : row[header]
+          end
+          csv << csv_row
+        end
+      end
+    end
+
+    def to_io
+      StringIO.new(to_csv_string)
+    end
+
     def write_csv
       if @rows.any?
         output = CSV.open(csv_export_path, 'wb', headers: headers, write_headers: true)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -91,6 +91,8 @@ canvas_proxy:
   test_admin_id:
   test_servers:
   test_cas_url: 'https://auth-test.berkeley.edu/cas'
+  # If reports are provided through Google Drive, this is the UID that creates them.
+  reporter_uid:
 ldap:
   host: 'nds.berkeley.edu'
   port: 636

--- a/lib/tasks/canvas.rake
+++ b/lib/tasks/canvas.rake
@@ -112,18 +112,12 @@ namespace :canvas do
 
   desc 'Report TurnItIn usage for a term'
   task :report_turnitin => :environment do
-    CanvasCsv::TurnitinReporter.print_term_report(ENV['TERM_ID'])
+    CanvasCsv::TurnitinReporter.new(ENV['TERM_ID']).run
   end
 
   desc 'Report LTI Apps enabled for a term'
   task :report_lti_usage => :environment do
-    sis_term_id = ENV["TERM_ID"]
-    if sis_term_id.blank?
-      sis_term_id = Canvas::Terms.current_sis_term_ids.first
-    end
-    Rails.logger.warn "Beginning report on LTI configurations in #{sis_term_id}"
-    CanvasCsv::LtiUsageReporter.new(sis_term_id).run
-    Rails.logger.warn "Reports on LTI configurations in #{sis_term_id} generated"
+    CanvasCsv::LtiUsageReporter.new(ENV["TERM_ID"]).run
   end
 
 end

--- a/spec/models/canvas_csv/turnitin_reporter_spec.rb
+++ b/spec/models/canvas_csv/turnitin_reporter_spec.rb
@@ -62,19 +62,19 @@ describe CanvasCsv::TurnitinReporter do
     context 'at the very beginning of a term' do
       let(:fake_now) {DateTime.parse('2014-06-10')}
       it 'picks the previous term' do
-        expect(described_class.default_term_id).to eq 'TERM:2014-B'
+        expect(subject.default_term_id).to eq 'TERM:2014-B'
       end
     end
     context 'between terms' do
       let(:fake_now) {DateTime.parse('2014-05-16')}
       it 'picks the previous term' do
-        expect(described_class.default_term_id).to eq 'TERM:2014-B'
+        expect(subject.default_term_id).to eq 'TERM:2014-B'
       end
     end
     context 'within a term' do
       let(:fake_now) {DateTime.parse('2014-06-30')}
       it 'picks the running term' do
-        expect(described_class.default_term_id).to eq 'TERM:2014-C'
+        expect(subject.default_term_id).to eq 'TERM:2014-C'
       end
     end
   end

--- a/spec/models/google_apps/sheets_manager_spec.rb
+++ b/spec/models/google_apps/sheets_manager_spec.rb
@@ -36,7 +36,7 @@ describe GoogleApps::SheetsManager do
     end
 
     it 'should output the same CSV values that were put in' do
-      spreadsheet_file = @sheet_manager.find_items(id: @spreadsheet.id, parent_id: @folder.id).first
+      spreadsheet_file = @sheet_manager.find_items(parent_id: @folder.id).first
       csv_export = @sheet_manager.export_csv spreadsheet_file
       parsed_csv = CSV.parse csv_export
       expect(parsed_csv[0]).to eq @sis_import_sheet.headers
@@ -47,7 +47,7 @@ describe GoogleApps::SheetsManager do
     end
 
     it 'should update cells in batch' do
-      spreadsheet_file = @sheet_manager.find_items(id: @spreadsheet.id, parent_id: @folder.id).first
+      spreadsheet_file = @sheet_manager.find_items(parent_id: @folder.id).first
       worksheet = @sheet_manager.spreadsheet_by_id(@spreadsheet.id).worksheets.first
       @sheet_manager.update_worksheet(worksheet, {
         [2, 2] => 'Kilroy',
@@ -67,8 +67,7 @@ describe GoogleApps::SheetsManager do
     end
 
     it 'should have named the worksheet as well as the Sheets file' do
-      spreadsheet_file = @sheet_manager.find_items(id: @spreadsheet.id, parent_id: @folder.id).first
-      worksheet = spreadsheet_file.worksheets.first
+      worksheet = @sheet_manager.spreadsheet_by_id(@spreadsheet.id).worksheets.first
       expect(worksheet.title).to eq @worksheet_title
     end
 

--- a/spec/models/google_apps/sheets_manager_spec.rb
+++ b/spec/models/google_apps/sheets_manager_spec.rb
@@ -7,12 +7,13 @@ describe GoogleApps::SheetsManager do
       @sheet_manager = GoogleApps::SheetsManager.new settings[:uid], settings
       now = DateTime.now.strftime('%m/%d/%Y at %I:%M%p')
       @folder = @sheet_manager.create_folder "#{GoogleApps::SheetsManager.name} test, #{now}"
-      @sheet_title = "Sheet from CSV, #{now}"
+      @spreadsheet_title = "Sheet from CSV, #{now}"
+      @worksheet_title = "Primary worksheet, #{now}"
       # No CSV files will be created by this test
       @sis_import_sheet = Oec::SisImportSheet.new(dept_code: 'LPSPP')
       course_codes = [Oec::CourseCode.new(dept_name: 'SPANISH', catalog_id: '', dept_code: 'LPSPP', include_in_oec: true)]
       Oec::SisImportTask.new(:term_code => '2015-C').import_courses(@sis_import_sheet, course_codes)
-      @spreadsheet = @sheet_manager.upload_worksheet(@sheet_title, "Description #{now}", @sis_import_sheet, @folder.id)
+      @spreadsheet = @sheet_manager.upload_to_spreadsheet(@spreadsheet_title, @sis_import_sheet.to_io, @folder.id, @worksheet_title)
     end
 
     after(:all) do
@@ -26,7 +27,7 @@ describe GoogleApps::SheetsManager do
     it 'should get spreadsheet by id' do
       sheet_by_id = @sheet_manager.spreadsheet_by_id @spreadsheet.id
       expect(sheet_by_id).to_not be nil
-      spreadsheets = @sheet_manager.spreadsheets_by_title @sheet_title
+      spreadsheets = @sheet_manager.spreadsheets_by_title @spreadsheet_title
       expect(spreadsheets).to have(1).item
       sheet_by_title = spreadsheets[0]
       expect(sheet_by_title).to_not be nil
@@ -63,6 +64,12 @@ describe GoogleApps::SheetsManager do
       @sis_import_sheet.each_sorted_with_index do |row, i|
         expect(parsed_csv[i+1][0]).to eq row['COURSE_ID']
       end
+    end
+
+    it 'should have named the worksheet as well as the Sheets file' do
+      spreadsheet_file = @sheet_manager.find_items(id: @spreadsheet.id, parent_id: @folder.id).first
+      worksheet = spreadsheet_file.worksheets.first
+      expect(worksheet.title).to eq @worksheet_title
     end
 
     it 'should find no spreadsheet mapped to bogus id' do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5840

The first commit untangles OEC-specific classes from the more generic GoogleApps module, allows SPA accounts (for example) to find shared folders, and adds a convenient upload-to-a-worksheet method.

The second commit uploads LTI and TurnItIn usage reports to a folder shared between PDG and TLS.

The third fixes my new textext test and removes some confusingly ignored arguments from existing ones.