### PR TITLE
CLC-6024 Present filtered My Academics to delegate viewers

### DIFF
--- a/app/controllers/my_academics_controller.rb
+++ b/app/controllers/my_academics_controller.rb
@@ -3,7 +3,11 @@ class MyAcademicsController < ApplicationController
   before_filter :api_authenticate
 
   def get_feed
-    render :json => MyAcademics::Merged.from_session(session).get_feed_as_json
+    if current_user.authenticated_as_delegate?
+      render json: MyAcademics::FilteredForDelegate.from_session(session).get_feed_as_json
+    else
+      render json: MyAcademics::Merged.from_session(session).get_feed_as_json
+    end
   end
 
 end

--- a/app/models/campus_oracle/user_courses/all.rb
+++ b/app/models/campus_oracle/user_courses/all.rb
@@ -27,6 +27,14 @@ module CampusOracle
         end
       end
 
+      def get_enrollments_summary
+        self.class.fetch_from_cache "summary-#{@uid}" do
+          campus_classes = {}
+          merge_enrollments campus_classes
+          Hash[campus_classes.sort.reverse]
+        end
+      end
+
     end
   end
 end

--- a/app/models/my_academics/filtered_for_delegate.rb
+++ b/app/models/my_academics/filtered_for_delegate.rb
@@ -1,0 +1,55 @@
+module MyAcademics
+  class FilteredForDelegate < UserSpecificModel
+
+    include Cache::LiveUpdatesEnabled
+    include Cache::FreshenOnWarm
+    include Cache::JsonAddedCacher
+    include MergedModel
+
+    def self.providers
+      [
+        CollegeAndLevel,
+        TransitionTerm,
+        GpaUnits,
+        Semesters
+      ]
+    end
+
+    def get_feed_as_json(force_cache_write=false)
+      if show_grades?
+        super(force_cache_write)
+      else
+        feed = get_feed(force_cache_write)
+        filter_grades(feed).to_json
+      end
+    end
+
+    def get_feed_internal
+      feed = {
+        filteredForDelegate: true
+      }
+      handling_provider_exceptions(feed, self.class.providers) do |provider|
+        provider.new(@uid).merge feed
+      end
+      feed
+    end
+
+    private
+
+    def filter_grades(feed)
+      feed[:semesters].each do |semester|
+        semester[:classes].each do |course|
+          [:sections, :transcript].each do |key|
+            course[key].each { |section| section.delete :grade } if course[key]
+          end
+        end
+      end
+      feed[:gpaUnits].delete :cumulativeGpa
+      feed
+    end
+
+    def show_grades?
+      delegate_permissions.include? 'View grades'
+    end
+  end
+end

--- a/app/models/my_academics/gpa_units.rb
+++ b/app/models/my_academics/gpa_units.rb
@@ -1,16 +1,20 @@
 module MyAcademics
   class GpaUnits
+    extend Cache::Cacheable
     include AcademicsModule
+    include ClassLogger
+    include Cache::UserCacheExpiry
 
     def merge(data)
-      student_info = CampusOracle::Queries.get_student_info(@uid) || {}
-      return data if student_info.nil?
-
-      data[:gpaUnits] = {
-        cumulativeGpa: student_info['cum_gpa'].nil? ? nil: student_info['cum_gpa'].to_s,
-        totalUnits: student_info['tot_units'].nil? ? nil : student_info['tot_units'].to_f,
-        totalUnitsAttempted: student_info['lgr_tot_attempt_unit'].nil? ? nil : student_info['lgr_tot_attempt_unit'].to_f
-      }
+      gpa_units = self.class.fetch_from_cache(@uid) do
+        student_info = CampusOracle::Queries.get_student_info(@uid) || {}
+        {
+          cumulativeGpa: student_info['cum_gpa'].nil? ? nil: student_info['cum_gpa'].to_s,
+          totalUnits: student_info['tot_units'].nil? ? nil : student_info['tot_units'].to_f,
+          totalUnitsAttempted: student_info['lgr_tot_attempt_unit'].nil? ? nil : student_info['lgr_tot_attempt_unit'].to_f
+        }
+      end
+      data[:gpaUnits] = gpa_units
     end
   end
 end

--- a/app/models/my_academics/transition_term.rb
+++ b/app/models/my_academics/transition_term.rb
@@ -1,11 +1,17 @@
 module MyAcademics
   class TransitionTerm
-    include AcademicsModule, ClassLogger
+    extend Cache::Cacheable
+    include AcademicsModule
+    include ClassLogger
+    include Cache::UserCacheExpiry
 
     def merge(data)
       college_and_level = data[:collegeAndLevel]
       if college_and_level && !college_and_level[:empty] && !college_and_level[:noStudentId]
-        data[:transitionTerm] = transition_term college_and_level
+        term = self.class.fetch_from_cache @uid do
+          transition_term college_and_level
+        end
+        data[:transitionTerm] = term
       end
     end
 

--- a/app/models/user_specific_model.rb
+++ b/app/models/user_specific_model.rb
@@ -24,4 +24,8 @@ class UserSpecificModel
     @authentication_state.directly_authenticated?
   end
 
+  def delegate_permissions
+    @authentication_state.delegate_permissions || []
+  end
+
 end

--- a/app/policies/authentication_state.rb
+++ b/app/policies/authentication_state.rb
@@ -10,6 +10,16 @@ class AuthenticationState
     @lti_authenticated_only = session['lti_authenticated_only']
   end
 
+  def authenticated_as_delegate?
+    #TODO implement me
+    false
+  end
+
+  def delegate_permissions
+    #TODO implement me
+    nil
+  end
+
   def directly_authenticated?
     user_id && !lti_authenticated_only &&
       (original_user_id.blank? ||

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -227,6 +227,10 @@ cache:
     CanvasLti::Lti: <%= 5.minutes %>
     Advising::MyAdvising: <%= 2.hours %>
 
+    MyAcademics::CollegeAndLevel: NEXT_08_00
+    MyAcademics::GpaUnits: NEXT_08_00
+    MyAcademics::TransitionTerm: NEXT_08_00
+
     Berkeley::Terms: NEXT_08_00
     Finaid::TimeRange: <%= 4.hours %>
 

--- a/spec/controllers/my_academics_controller_spec.rb
+++ b/spec/controllers/my_academics_controller_spec.rb
@@ -1,18 +1,58 @@
-require "support/shared_examples"
-
 describe MyAcademicsController do
 
-  context "when serving academics feed" do
-    it_should_behave_like "a user authenticated api endpoint" do
-      let(:make_request) { get :get_feed }
-    end
-
-    it "should get a non-empty feed for an authenticated (but fake) user" do
-      session['user_id'] = "0"
-      get :get_feed
-      json_response = JSON.parse(response.body)
-      json_response["regblocks"]["noStudentId"].should be_truthy
-    end
+  it_should_behave_like 'a user authenticated api endpoint' do
+    let(:make_request) { get :get_feed }
   end
 
+  it 'should get a non-empty feed for an authenticated (but fake) user' do
+    session['user_id'] = '0'
+    get :get_feed
+    json_response = JSON.parse(response.body)
+    expect(json_response['regblocks']['noStudentId']).to eq true
+  end
+
+  context 'fake campus data', if: CampusOracle::Connection.test_data? do
+    let(:uid) { '61889' }
+    before do
+      fake_classes = Bearfacts::Proxy.subclasses + [ Regstatus::Proxy ]
+      fake_classes.each do |klass|
+        allow(klass).to receive(:new).and_return klass.new(user_id: uid, fake: true)
+      end
+      session['user_id'] = uid
+    end
+
+    it 'should get a feed full of content' do
+      get :get_feed
+      json_response = JSON.parse(response.body)
+      expect(json_response['feedName']).to eq 'MyAcademics::Merged'
+      expect(json_response['examSchedule']).to have(3).items
+      expect(json_response['gpaUnits']).to include 'cumulativeGpa'
+      expect(json_response['otherSiteMemberships']).to be_present
+      expect(json_response['regblocks']).to be_present
+      expect(json_response['requirements']).to be_present
+      expect(json_response['semesters']).to have(24).items
+      expect(json_response['semesters'][0]['slug']).to be_present
+      expect(json_response['semesters'][1]['classes'][0]['transcript'][0]['grade']).to be_present
+      expect(json_response['transitionTerm']).to be_present
+    end
+
+    context 'delegate view' do
+      before { allow_any_instance_of(AuthenticationState).to receive(:authenticated_as_delegate?).and_return true }
+
+      it 'should get a filtered feed' do
+        get :get_feed
+        json_response = JSON.parse(response.body)
+        expect(json_response['feedName']).to eq 'MyAcademics::FilteredForDelegate'
+        expect(json_response).not_to include 'examSchedule'
+        expect(json_response['gpaUnits']).not_to include 'cumulativeGpa'
+        expect(json_response).not_to include 'otherSiteMemberships'
+        expect(json_response).not_to include 'regblocks'
+        expect(json_response).not_to include 'requirements'
+        expect(json_response['semesters']).to have(24).items
+        expect(json_response['semesters'][0]).not_to include 'slug'
+        expect(json_response['semesters'][1]['classes'][0]['transcript'][0]).not_to include 'grade'
+        expect(json_response['transitionTerm']).to be_present
+      end
+    end
+  end
 end

--- a/spec/models/campus_oracle/user_courses/all_spec.rb
+++ b/spec/models/campus_oracle/user_courses/all_spec.rb
@@ -100,4 +100,22 @@ describe CampusOracle::UserCourses::All do
     course_primary[:enroll_limit].to_s.should == '5000'
   end
 
+  it 'should return a shallower summary of enrollment data on request', :if => CampusOracle::Connection.test_data? do
+    client = CampusOracle::UserCourses::All.new({user_id: '300939'})
+    summary = client.get_enrollments_summary
+    expect(summary.keys).to match_array %w(2014-C 2014-B 2013-D 2012-B)
+    expect(summary['2013-D']).to have(2).items
+    summary['2013-D'].each do |course|
+      expect(course[:id]).to be_present
+      expect(course[:course_code]).to be_present
+      expect(course[:role]).to eq 'Student'
+      course[:sections].each do |section|
+        expect(section[:ccn]).to be_present
+        expect(section[:section_label]).to be_present
+        expect(section).not_to include :instructors
+        expect(section).not_to include :schedules
+      end
+    end
+  end
+
 end

--- a/spec/models/my_academics/filtered_for_delegate_spec.rb
+++ b/spec/models/my_academics/filtered_for_delegate_spec.rb
@@ -1,0 +1,56 @@
+describe MyAcademics::FilteredForDelegate do
+  let(:provider_classes) do
+    [
+      MyAcademics::CollegeAndLevel,
+      MyAcademics::TransitionTerm,
+      MyAcademics::GpaUnits,
+      MyAcademics::Semesters
+    ]
+  end
+
+  let(:uid) { '61889' }
+  before do
+    fake_classes = Bearfacts::Proxy.subclasses + [ Regstatus::Proxy ]
+    fake_classes.each do |klass|
+      allow(klass).to receive(:new).and_return klass.new(user_id: uid, fake: true)
+    end
+    allow_any_instance_of(AuthenticationState).to receive(:delegate_permissions).and_return fake_delegate_permissions
+  end
+  let(:feed) { JSON.parse described_class.new(uid).get_feed_as_json }
+
+  shared_examples 'filtered feed' do
+    it 'should include expected components' do
+      expect(feed['collegeAndLevel']).to be_present
+      expect(feed['transitionTerm']).to be_present
+      expect(feed['semesters']).to be_present
+    end
+  end
+
+  context 'when delegate permissions include grades', if: CampusOracle::Connection.test_data?  do
+    let(:fake_delegate_permissions) { ['View grades', 'View enrollments'] }
+    include_examples 'filtered feed'
+
+    it 'should return grades' do
+      expect(feed['gpaUnits']).to include 'cumulativeGpa'
+      feed['semesters'].each do |semester|
+        semester['classes'].each do |course|
+          expect(course['transcript'].first).to include 'grade'
+        end
+      end
+    end
+  end
+
+  context 'when delegate permissions do not include grades', if: CampusOracle::Connection.test_data? do
+    let(:fake_delegate_permissions) { ['View enrollments', 'View finances'] }
+    include_examples 'filtered feed'
+
+    it 'should not return grades' do
+      expect(feed['gpaUnits']).not_to include 'cumulativeGpa'
+      feed['semesters'].each do |semester|
+        semester['classes'].each do |course|
+          expect(course['transcript'].first).not_to include 'grade'
+        end
+      end
+    end
+  end
+end

--- a/src/assets/templates/academics.html
+++ b/src/assets/templates/academics.html
@@ -13,7 +13,7 @@
 
     <div class="medium-4 columns cc-academics-row-margin" data-ng-if="api.user.profile.hasStudentHistory || api.user.profile.roles.student">
       <div data-ng-include src="'academics_student_profile.html'"></div>
-      <div data-ng-include src="'academics_status_and_blocks.html'"></div>
+      <div data-ng-include src="'academics_status_and_blocks.html'" data-ng-if="showStatusAndBlocks"></div>
     </div>
 
     <div class="medium-4 columns cc-academics-row-margin">
@@ -26,7 +26,7 @@
 
       <div data-ng-include="'academics_final_exam_schedule.html'" data-ng-if="examSchedule.length"></div>
 
-      <div data-ng-include="'academics_ls_advising.html'" data-ng-if="api.user.profile.features.advising && isLSStudent"></div>
+      <div data-ng-include="'academics_ls_advising.html'" data-ng-if="showAdvising"></div>
 
       <div data-ng-include="'academics_university_requirements.html'" data-ng-if="requirements && isUndergraduate"></div>
     </div>

--- a/src/assets/templates/academics_semesters.html
+++ b/src/assets/templates/academics_semesters.html
@@ -1,7 +1,7 @@
 <div class="cc-widget">
   <div class="cc-widget-title">
     <h2 class="cc-left">Semesters</h2>
-    <a data-ng-href="{{transcriptLink}}" class="cc-right cc-widget-title-link">
+    <a data-ng-href="{{transcriptLink}}" class="cc-right cc-widget-title-link" data-ng-if="transcriptLink">
       <strong>Order Transcripts</strong>
     </a>
   </div>
@@ -9,10 +9,10 @@
   <div class="cc-academics-semesters">
     <div class="cc-table cc-academics-semester cc-academics-semester-{{semester.timeBucket}}" data-ng-repeat="semester in semesters | limitTo:pastSemestersLimit">
       <div>
-        <h3 data-ng-if="semester.hasEnrollmentData"><a class="cc-left" data-ng-href="/academics/semester/{{semester.slug}}" data-ng-bind="semester.name"></a></h3>
-        <h3 data-ng-if="!semester.hasEnrollmentData" data-ng-bind="semester.name"></h3>
+        <h3 data-ng-if="semester.hasEnrollmentData && semester.slug"><a class="cc-left" data-ng-href="/academics/semester/{{semester.slug}}" data-ng-bind="semester.name"></a></h3>
+        <h3 data-ng-if="!semester.hasEnrollmentData || !semester.slug" data-ng-bind="semester.name"></h3>
         <h4 data-ng-if="semester.notation" data-ng-bind="semester.notation"></h4>
-        <a class="cc-right cc-academics-semester-title-link" data-ng-href="/academics/booklist/{{semester.slug}}" data-ng-if="semester.hasEnrollmentData && semester.timeBucket !== 'past'">Book List</a>
+        <a class="cc-right cc-academics-semester-title-link" data-ng-href="/academics/booklist/{{semester.slug}}" data-ng-if="semester.hasEnrollmentData && semester.slug && semester.timeBucket !== 'past'">Book List</a>
         <table>
           <thead>
             <tr>

--- a/src/assets/templates/academics_status_and_blocks.html
+++ b/src/assets/templates/academics_status_and_blocks.html
@@ -1,4 +1,4 @@
-<div class="cc-widget cc-academics-status-and-blocks" data-ng-if="!regblocks.noStudentId || studentInfo.regStatus.code !== null || studentInfo.californiaResidency">
+<div class="cc-widget cc-academics-status-and-blocks">
 
   <div class="cc-widget-title">
     <h2><span data-ng-if="studentInfo.regStatus.code !== null || studentInfo.californiaResidency">Status and </span>Blocks</h2>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6024

Road map:
- In general, stuff to be hidden from delegates is so deeply intertwined in the My Academics feed that it seemed best to construct an entirely new feed rather than diving deep into the existing structure and unmerging all the merged components. Hence the new MyAcademics::FilteredForDelegate.
- Fortunately, the two flavors of MyAcademics::FilteredForDelegate (with and without grades) are similar enough that additional grade filtering can use the same filter-for-view-as logic that already exists in My Badges and elsewhere.
- MyAcademics::Merged and MyAcademics::FilteredForDelegate are cached separately. Feed components that supply both without alteration (CollegeAndLevel, GpaUnits, and TransitionTerm) are now individually cached as well, though this is still a far cry from the fine-grained separation we'd like to set up in the My Academics feed.
- All decisions depend on a couple of to-be-implemented methods in AuthenticationState. My assumption is that this class will be used to return delegate status and permissions from session state, as we currently do with View-As. This is the major bit of wiring that remains outstanding for the delegated access feature.