### PR TITLE
CLC-6052 - Fix some things on the toolbox page

### DIFF
--- a/src/assets/stylesheets/_settings.scss
+++ b/src/assets/stylesheets/_settings.scss
@@ -6,7 +6,7 @@
     margin: 40px 0 30px;
   }
   .cc-settings-section {
-    margin-top: 30px;
+    margin-top: 30px !important;
   }
   .cc-settings-service-bconnected-icon {
     background-image: url('../images/icon_bconnected_32x32.png');

--- a/src/assets/stylesheets/_toolbox.scss
+++ b/src/assets/stylesheets/_toolbox.scss
@@ -1,7 +1,35 @@
 .cc-toolbox {
-  background: $cc-color-white;
+  .cc-toolbox-apitest-list {
+    margin-top: 10px;
+    .cc-toolbox-apitest-pending {
+      color: $cc-color-dark-grey;
+    }
+    .cc-toolbox-apitest-failed {
+      color: $cc-color-red;
+    }
+    .cc-toolbox-apitest-success {
+      color: $cc-color-green-plus;
+    }
+    .cc-toolbox-apitest-icon {
+      margin-right: 5px;
+    }
+  }
+  .cc-toolbox-error {
+    margin-bottom: 5px;
+  }
   .cc-toolbox-section {
     margin-top: 30px;
+  }
+  .cc-toolbox-table {
+    margin-top: 20px;
+    td, th {
+      border-bottom: 1px solid $cc-color-widget-background;
+      font-size: 12px;
+      padding: 4px;
+    }
+  }
+  .cc-toolbox-user-section {
+    margin-top: 10px;
   }
   .cc-toolbox-widget {
     background: $cc-color-white;
@@ -15,32 +43,6 @@
         margin: 0;
         text-align: left;
       }
-    }
-  }
-  .cc-toolbox-apitest-list {
-    margin-left: 20px;
-    .cc-toolbox-apitest-pending {
-      color: $cc-color-dark-grey;
-    }
-    .cc-toolbox-apitest-failed {
-      color: $cc-color-red;
-    }
-    .cc-toolbox-apitest-success {
-      color: $cc-color-green-plus;
-    }
-    .cc-toolbox-apitest-icon {
-      width: 5%;
-    }
-  }
-  .cc-toolbox-table {
-    margin: 20px 10px 30px;
-    table {
-      table-layout: fixed;
-    }
-    td, th {
-      border-bottom: 1px solid $cc-color-widget-background;
-      font-size: 12px;
-      padding: 4px;
     }
   }
 }

--- a/src/assets/templates/toolbox.html
+++ b/src/assets/templates/toolbox.html
@@ -9,7 +9,7 @@
     <div class="medium-4 columns" data-ng-if="api.user.profile.isViewer || api.user.profile.isSuperuser">
       <div data-ng-include="'widgets/toolbox/uid_lookup.html'"></div>
     </div>
-    <div class="medium-4 columns" data-ng-if="api.user.profile.isSuperuser">
+    <div class="medium-4 columns cc-column-last" data-ng-if="api.user.profile.isSuperuser">
       <div data-ng-include="'widgets/toolbox/api_test.html'"></div>
     </div>
   </div>

--- a/src/assets/templates/widgets/toolbox/api_test.html
+++ b/src/assets/templates/widgets/toolbox/api_test.html
@@ -1,17 +1,17 @@
-<div class="cc-widget cc-toolbox-widget" data-ng-controller="ApiTestController" data-cc-spinner-directive="apiTest.isLoading">
+<div class="cc-widget cc-toolbox-widget" data-ng-controller="ApiTestController">
   <div class="cc-widget-title">
     <h2>CalCentral API Test</h2>
   </div>
-  <div class="cc-widget-text">
+  <div class="cc-widget-text" data-cc-spinner-directive="apiTest.isLoading">
     <form data-ng-submit="runApiTest()">
       <button class="cc-button cc-button-blue" data-ng-disabled="apiTest.running" type="submit">Run</button>
       <div data-ng-show="apiTest.showTests">
         <ul class="cc-toolbox-apitest-list">
-          <li data-ng-repeat="route in apiTest.data" ng-switch="route.status" class="cc-flex">
-            <i ng-switch-when="success" title="{{route.route}}" class="fa fa-check-circle cc-icon-green cc-toolbox-apitest-icon"></i>
-            <i ng-switch-when="failed" title="{{route.route}}" class="fa fa-check-circle cc-icon-red cc-toolbox-apitest-icon"></i>
-            <i ng-switch-default title="{{route.route}}" class="fa fa-spinner fa-spin cc-toolbox-apitest-icon"></i>
-            <span class="cc-toolbox-apitest-{{route.status}}" data-ng-bind="route.route"></span>
+          <li data-ng-repeat="(route, status) in apiTest.data" ng-switch="status" class="cc-flex cc-flex-align-base">
+            <i ng-switch-when="success" title="Success" class="fa fa-check-circle cc-icon-green cc-toolbox-apitest-icon"></i>
+            <i ng-switch-when="failed" title="Failed" class="fa fa-check-circle cc-icon-red cc-toolbox-apitest-icon"></i>
+            <i ng-switch-default title="Pending" class="fa fa-spinner fa-spin cc-toolbox-apitest-icon"></i>
+            <span data-ng-attr-class="cc-toolbox-apitest-{{status}}" data-ng-bind="route"></span>
           </li>
         </ul>
       </div>

--- a/src/assets/templates/widgets/toolbox/uid_lookup.html
+++ b/src/assets/templates/widgets/toolbox/uid_lookup.html
@@ -3,35 +3,34 @@
     <h2>UID/SID Lookup</h2>
   </div>
   <div class="cc-widget-text">
-    <div>
-      <div class="cc-text-red" data-ng-if="admin.viewAsErrorStatus">
-        <i class="cc-icon-red fa fa-exclamation-circle"></i>
-        <span data-ng-bind="admin.viewAsErrorStatus"></span>
-      </div>
+    <div class="cc-toolbox-error" data-ng-if="admin.lookupErrorStatus">
+      <i class="cc-icon-red fa fa-exclamation-circle"></i>
+      <span class="cc-text-red" data-ng-bind="admin.lookupErrorStatus"></span>
     </div>
     <form data-ng-submit="admin.lookupUser()">
       <div>
-        <div>
-          <input id="cc-toolbox-id" data-ng-pattern="api.util.uidPattern" placeholder="Enter UID or SID here" data-ng-model="admin.id" type="text" data-cc-select-on-click-directive />
-        </div>
+        <label for="cc-toolbox-id">UID/SID</label>
+        <input id="cc-toolbox-id" data-ng-pattern="api.util.uidPattern" placeholder="Enter UID or SID here" data-ng-model="admin.id" type="text" data-cc-select-on-click-directive />
       </div>
       <div>
         <button class="cc-button cc-button-blue" data-ng-disabled="!admin.id" type="submit">Look Up</button>
       </div>
-      <table class="cc-toolbox-table" data-ng-if="admin.users">
-        <thead>
-          <tr>
-            <th width="50%" scope="col">UID</th>
-            <th width="50%" scope="col">SID</th>
-          </tr>
-        </thead>
-        <tbody data-ng-repeat="user in admin.users">
-          <tr>
-            <td data-ng-bind="user.ldap_uid"></td>
-            <td data-ng-bind="user.student_id || 'This user has no SID'"></td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="cc-table cc-toolbox-table" data-ng-if="admin.users.length">
+        <table>
+          <thead>
+            <tr>
+              <th width="50%" scope="col">UID</th>
+              <th width="50%" scope="col">SID</th>
+            </tr>
+          </thead>
+          <tbody data-ng-repeat="user in admin.users">
+            <tr>
+              <td data-ng-bind="user.ldap_uid"></td>
+              <td data-ng-bind="user.student_id || 'This user has no SID'"></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </form>
   </div>
 </div>

--- a/src/assets/templates/widgets/toolbox/view_as.html
+++ b/src/assets/templates/widgets/toolbox/view_as.html
@@ -3,11 +3,9 @@
     <h2>View as</h2>
   </div>
   <div class="cc-widget-text">
-    <div>
-      <div class="cc-text-red" data-ng-if="admin.actAsErrorStatus">
-        <i class="cc-icon-red fa fa-exclamation-circle"></i>
-        <span data-ng-bind="admin.actAsErrorStatus"></span>
-      </div>
+    <div class="cc-toolbox-error" data-ng-if="admin.actAsErrorStatus">
+      <i class="cc-icon-red fa fa-exclamation-circle"></i>
+      <span class="cc-text-red" data-ng-bind="admin.actAsErrorStatus"></span>
     </div>
     <form data-ng-submit="admin.actAsUser()">
       <div>
@@ -19,7 +17,7 @@
       <div>
         <button class="cc-button cc-button-blue" data-ng-disabled="!admin.actAs.id" type="submit">Submit</button>
       </div>
-      <div>
+      <div class="cc-toolbox-user-section">
         <ul data-ng-repeat="user in admin.userPool" data-ng-if="admin.userPool">
           <li>
             UID: <button class="cc-button-link" data-ng-bind="user.ldap_uid" data-ng-click="admin.actAsUser(user)"></button>
@@ -27,7 +25,7 @@
           </li>
         </ul>
       </div>
-      <div data-ng-repeat="block in admin.userBlocks">
+      <div data-ng-repeat="block in admin.userBlocks" class="cc-toolbox-user-section">
         <div data-ng-if="block.users.length">
           <strong data-ng-bind="block.title"></strong>
           (<button type="button" class="cc-button-link" data-ng-click="block.clearAllUsers()">clear all</button>)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6052

* Fix spacing on the settings page
* Fix spacing for the last column on the toolbox page
* Fix background color on the toolbox page (we shouldn't make it white as soon as we have a `cc-widget` on it.
* Bring back the error messages (like `That does not appear to be a valid UID or SID.`) for the UID / SID Lookup
* Add `label` to `UID/SID Lookup` for accessibility reasons
* Fix weird spinner behavior on Chrome when running the CalCentral API Test
* Fix alignment of check & spinner icons with their text next to it (flex-base)
* Allow for re-running the API tests
* Fix the main spinner for `CalCentral API Test` (only hide the contents on the widget, not the widget container)
* Refactor `CalCentral API Test` - and fix the dependency on the counter / index.
* Use data-ng-attr for dynamic items