### PR TITLE
CLC-6065, avoid HubEdos::Proxy error for non-student by handling 404 from sis-integration/.../affiliations call

### DIFF
--- a/app/models/hub_edos/proxy.rb
+++ b/app/models/hub_edos/proxy.rb
@@ -61,7 +61,12 @@ module HubEdos
         }
       else
         logger.info "Fake = #{@fake}; Making request to #{url} on behalf of user #{@uid}; cache expiration #{self.class.expires_in}"
-        response = get_response(url, request_options)
+        opts = request_options.merge({
+                                       on_error: {
+                                         rescue_status: 404
+                                       }
+                                     })
+        response = get_response(url, opts)
         logger.debug "Remote server status #{response.code}, Body = #{response.body.force_encoding('UTF-8')}"
         feed = build_feed response
         {

--- a/app/models/hub_edos/student.rb
+++ b/app/models/hub_edos/student.rb
@@ -28,12 +28,14 @@ module HubEdos
 
     def transform_address_keys(response)
       # this should really be done in the Integration Hub, but they won that argument due to time constraints.
-      response['studentResponse']['students']['students'].each do |student|
-        if student['addresses'].present?
-          student['addresses'].each do |address|
-            address['state'] = address.delete('stateCode')
-            address['postal'] = address.delete('postalCode')
-            address['country'] = address.delete('countryCode')
+      if response['studentResponse'].present? && response['studentResponse']['students'].present?
+        response['studentResponse']['students']['students'].each do |student|
+          if student['addresses'].present?
+            student['addresses'].each do |address|
+              address['state'] = address.delete('stateCode')
+              address['postal'] = address.delete('postalCode')
+              address['country'] = address.delete('countryCode')
+            end
           end
         end
       end
@@ -42,10 +44,12 @@ module HubEdos
 
     def redact_sensitive_keys(response)
       # more stuff the Integration Hub should be doing, but the team doesn't have time for.
-      response['studentResponse']['students']['students'].each do |student|
-        SENSITIVE_KEYS.each do |key|
-          if student[key].present?
-            student[key].delete_if { |k| k['uiControl'].present? && k['uiControl']['code'] == 'N' }
+      if response['studentResponse'].present? && response['studentResponse']['students'].present?
+        response['studentResponse']['students']['students'].each do |student|
+          SENSITIVE_KEYS.each do |key|
+            if student[key].present?
+              student[key].delete_if { |k| k['uiControl'].present? && k['uiControl']['code'] == 'N' }
+            end
           end
         end
       end
@@ -58,8 +62,10 @@ module HubEdos
         return response['studentResponse']['students']['students'][0]
       end
       result = {}
-      response['studentResponse']['students']['students'][0].keys.each do |field|
-        result[field] = response['studentResponse']['students']['students'][0][field] if include_fields.include?(field)
+      if response['studentResponse'].present? && response['studentResponse']['students'].present?
+        response['studentResponse']['students']['students'][0].keys.each do |field|
+          result[field] = response['studentResponse']['students']['students'][0][field] if include_fields.include?(field)
+        end
       end
       result
     end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6065

404 status is not an error condition. It's what sis-integration returns to us when user is non-student. Response body:
```
{"StudentResponse":{"source":"UCB-SIS-STUDENT","message":"Student Not Found","students":[""]}} 
```