### PR TITLE
SISRP-10824 Use Crosswalk for view-as admin lookup

### DIFF
--- a/app/controllers/act_as_controller.rb
+++ b/app/controllers/act_as_controller.rb
@@ -47,9 +47,17 @@ class ActAsController < ApplicationController
     end
 
     # Ensure uid is in our database
-    if CampusOracle::Queries.find_people_by_uid(act_as_uid).blank?
-      logger.warn "ACT-AS: User #{current_user.real_user_id} FAILED to login to #{act_as_uid}, act_as_uid not found"
-      return false
+    if Settings.features.cs_profile
+      ldap_uid = CalnetCrosswalk::ByUid.new(user_id: act_as_uid).lookup_ldap_uid
+      if ldap_uid.blank?
+        logger.warn "ACT-AS: User #{current_user.real_user_id} FAILED to login to #{act_as_uid}, act_as_uid not found"
+        return false
+      end
+    else
+      if CampusOracle::Queries.find_people_by_uid(act_as_uid).blank?
+        logger.warn "ACT-AS: User #{current_user.real_user_id} FAILED to login to #{act_as_uid}, act_as_uid not found"
+        return false
+      end
     end
     true
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,7 +10,7 @@ class SessionsController < ApplicationController
     # Save crosswalk some work by caching critical IDs if they were asserted to us via SAML.
     if auth.respond_to?(:extra)
       logger.warn "Omniauth extra from SAML = #{auth.extra.inspect}"
-      crosswalk = CalnetCrosswalk::Proxy.new(user_id: auth_uid)
+      crosswalk = CalnetCrosswalk::ByUid.new(user_id: auth_uid)
       sid = auth.extra['berkeleyEduStuID']
       cs_id = auth.extra['berkeleyEduCSID']
       if sid.present?

--- a/app/models/calnet_crosswalk/by_sid.rb
+++ b/app/models/calnet_crosswalk/by_sid.rb
@@ -1,0 +1,13 @@
+module CalnetCrosswalk
+  class BySid < Proxy
+
+    def url
+      "#{@settings.base_url}/LEGACY_SIS_STUDENT_ID/#{@uid}"
+    end
+
+    def mock_request
+      super.merge(uri_matching: "#{@settings.base_url}/LEGACY_SIS_STUDENT_ID/#{@uid}")
+    end
+
+  end
+end

--- a/app/models/calnet_crosswalk/by_uid.rb
+++ b/app/models/calnet_crosswalk/by_uid.rb
@@ -1,0 +1,13 @@
+module CalnetCrosswalk
+  class ByUid < Proxy
+
+    def url
+      "#{@settings.base_url}/UID/#{@uid}"
+    end
+
+    def mock_request
+      super.merge(uri_matching: "#{@settings.base_url}/UID/#{@uid}")
+    end
+
+  end
+end

--- a/app/models/hub_edos/proxy.rb
+++ b/app/models/hub_edos/proxy.rb
@@ -13,6 +13,7 @@ module HubEdos
 
     def initialize(settings, options)
       super
+      p "@uid = #{@uid}"
       if @fake
         @campus_solutions_id = lookup_campus_solutions_id
         initialize_mocks

--- a/app/models/hub_edos/proxy.rb
+++ b/app/models/hub_edos/proxy.rb
@@ -13,7 +13,6 @@ module HubEdos
 
     def initialize(settings, options)
       super
-      p "@uid = #{@uid}"
       if @fake
         @campus_solutions_id = lookup_campus_solutions_id
         initialize_mocks

--- a/app/models/user/search_users.rb
+++ b/app/models/user/search_users.rb
@@ -8,9 +8,25 @@ module User
 
     def search_users
       self.class.fetch_from_cache "#{@id}" do
-        users_uid = User::SearchUsersByUid.new(id: @id).search_users_by_uid
-        users_sid = User::SearchUsersBySid.new(id: @id).search_users_by_sid
-        users_uid + users_sid
+        if Settings.features.cs_profile
+          results = []
+          [CalnetCrosswalk::ByUid, CalnetCrosswalk::BySid].each do |proxy_class|
+            proxy = proxy_class.new(user_id: @id)
+            sid = proxy.lookup_student_id
+            uid = proxy.lookup_ldap_uid
+            if sid.present? || uid.present?
+              results << {
+                'ldap_uid' => uid,
+                'student_id' => sid
+              }
+            end
+          end
+          results
+        else
+          users_uid = User::SearchUsersByUid.new(id: @id).search_users_by_uid
+          users_sid = User::SearchUsersBySid.new(id: @id).search_users_by_sid
+          users_uid + users_sid
+        end
       end
     end
 

--- a/app/models/user/stored_users.rb
+++ b/app/models/user/stored_users.rb
@@ -22,7 +22,9 @@ module User
 
       return users unless all_uids.present?
 
-      # TODO SISRP-10824 find a way to replace this batch user query with Crosswalk (which doesn't offer multi-user lookup, or names)
+      # TODO SISRP-10824 / SISRP-11917: Have to find a way to replace this batch user query with Crosswalk
+      # (which doesn't offer multi-user lookup, or names)
+      # Until that's done, act-as search history will only be saved for users who are present in Oracle.
       users_found = User::SearchUsersByUid.new(:ids => all_uids).search_users_by_uid_batch
       uid_hash = {}
 

--- a/app/models/user/stored_users.rb
+++ b/app/models/user/stored_users.rb
@@ -22,6 +22,7 @@ module User
 
       return users unless all_uids.present?
 
+      # TODO SISRP-10824 find a way to replace this batch user query with Crosswalk (which doesn't offer multi-user lookup, or names)
       users_found = User::SearchUsersByUid.new(:ids => all_uids).search_users_by_uid_batch
       uid_hash = {}
 

--- a/app/models/user/student.rb
+++ b/app/models/user/student.rb
@@ -6,11 +6,11 @@ module User
     end
 
     def lookup_campus_solutions_id
-      CalnetCrosswalk::Proxy.new(user_id: @uid).lookup_campus_solutions_id
+      CalnetCrosswalk::ByUid.new(user_id: @uid).lookup_campus_solutions_id
     end
 
     def lookup_student_id_from_crosswalk
-      CalnetCrosswalk::Proxy.new(user_id: @uid).lookup_student_id
+      CalnetCrosswalk::ByUid.new(user_id: @uid).lookup_student_id
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -273,9 +273,9 @@ cache:
     CampusSolutions::Translate: <%= 24.hours %>
     CampusSolutions::DashboardUrl: <%= 29.days %>
 
-    CalnetCrosswalk::Proxy: <%= 29.days %>
-    CalnetCrosswalk::ByUid: <%= 29.days %>
-    CalnetCrosswalk::BySid: <%= 29.days %>
+    CalnetCrosswalk::Proxy: <%= 24.hours %>
+    CalnetCrosswalk::ByUid: <%= 24.hours %>
+    CalnetCrosswalk::BySid: <%= 24.hours %>
 
 # Cache warmer settings
 cache_warmer:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -274,6 +274,8 @@ cache:
     CampusSolutions::DashboardUrl: <%= 29.days %>
 
     CalnetCrosswalk::Proxy: <%= 29.days %>
+    CalnetCrosswalk::ByUid: <%= 29.days %>
+    CalnetCrosswalk::BySid: <%= 29.days %>
 
 # Cache warmer settings
 cache_warmer:
@@ -409,6 +411,6 @@ hub_edos_proxy:
 
 calnet_crosswalk_proxy:
   fake: true
-  base_url: 'https://registry-d1.calnet.1918.berkeley.edu:8453/registry-service/api/v1/identifiers/UID'
+  base_url: 'https://registry-d1.calnet.1918.berkeley.edu:8453/registry-service/api/v1/identifiers'
   username: secret
   password: secret

--- a/spec/models/calnet_crosswalk/by_uid_spec.rb
+++ b/spec/models/calnet_crosswalk/by_uid_spec.rb
@@ -1,4 +1,4 @@
-describe CalnetCrosswalk::Proxy do
+describe CalnetCrosswalk::ByUid do
 
   shared_examples 'a proxy that returns data' do
     it 'returns data with the expected structure' do
@@ -24,7 +24,7 @@ describe CalnetCrosswalk::Proxy do
   end
 
   context 'mock proxy' do
-    let(:proxy) { CalnetCrosswalk::Proxy.new(user_id: '61889', fake: true) }
+    let(:proxy) { CalnetCrosswalk::ByUid.new(user_id: '61889', fake: true) }
     let(:feed) { proxy.get[:feed] }
     it_behaves_like 'a proxy that returns data'
     it 'can be overridden to return errors' do
@@ -36,7 +36,7 @@ describe CalnetCrosswalk::Proxy do
   end
 
   context 'real proxy', testext: true do
-    let(:proxy) { CalnetCrosswalk::Proxy.new(user_id: '61889', fake: false) }
+    let(:proxy) { CalnetCrosswalk::ByUid.new(user_id: '61889', fake: false) }
     let(:feed) { proxy.get[:feed] }
     it_behaves_like 'a proxy that returns data'
     include_context 'looking up ids'

--- a/spec/models/my_tasks/merged_spec.rb
+++ b/spec/models/my_tasks/merged_spec.rb
@@ -19,9 +19,9 @@ describe 'MyTasks::Merged' do
     @fake_canvas_todo_proxy = Canvas::Todo.new({fake: true})
     @fake_canvas_courses = Canvas::UserCourses.new({fake: true}).courses
     @fake_campus_solutions_checklist_proxy = CampusSolutions::Checklist.new({fake: true})
-    @fake_calnet_crosswalk_proxy = CalnetCrosswalk::Proxy.new({fake: true, user_id: '12345'})
+    @fake_calnet_crosswalk_proxy = CalnetCrosswalk::ByUid.new({fake: true, user_id: '12345'})
     allow(CampusSolutions::Checklist).to receive(:new).and_return(@fake_campus_solutions_checklist_proxy)
-    allow(CalnetCrosswalk::Proxy).to receive(:new).and_return(@fake_calnet_crosswalk_proxy)
+    allow(CalnetCrosswalk::ByUid).to receive(:new).and_return(@fake_calnet_crosswalk_proxy)
   end
 
   context 'pre-recorded fake Google and Canvas proxy feeds using the server\'s timezone' do

--- a/spec/models/user/search_users_spec.rb
+++ b/spec/models/user/search_users_spec.rb
@@ -1,18 +1,16 @@
 describe User::SearchUsers do
 
-  let(:users_found) do
-    [
-      { 'student_id' => '24680', 'ldap_uid' => '13579' },
-    ]
+  let(:fake_uid_proxy) { CalnetCrosswalk::ByUid.new }
+  let(:fake_sid_proxy) { CalnetCrosswalk::BySid.new }
+  before do
+    allow(CalnetCrosswalk::ByUid).to receive(:new).and_return(fake_uid_proxy)
+    allow(CalnetCrosswalk::BySid).to receive(:new).and_return(fake_sid_proxy)
   end
-
-  let(:users_not_found) do
-    []
-  end
-
   it "should return valid record for valid uid" do
-    CampusOracle::Queries.should_receive(:get_basic_people_attributes).with(['13579']).and_return(users_found)
-    CampusOracle::Queries.should_receive(:find_people_by_student_id).with('13579').and_return(users_not_found)
+    allow(fake_uid_proxy).to receive(:lookup_student_id).and_return('24680')
+    allow(fake_uid_proxy).to receive(:lookup_ldap_uid).and_return('13579')
+    allow(fake_sid_proxy).to receive(:lookup_student_id).and_return(nil)
+    allow(fake_sid_proxy).to receive(:lookup_ldap_uid).and_return(nil)
     model = User::SearchUsers.new({:id => '13579'})
     result = model.search_users
     expect(result).to be_an_instance_of Array
@@ -22,8 +20,10 @@ describe User::SearchUsers do
   end
 
   it "should return valid record for valid sid" do
-    CampusOracle::Queries.should_receive(:find_people_by_student_id).with('24680').and_return(users_found)
-    CampusOracle::Queries.should_receive(:get_basic_people_attributes).with(['24680']).and_return(users_not_found)
+    allow(fake_uid_proxy).to receive(:lookup_student_id).and_return(nil)
+    allow(fake_uid_proxy).to receive(:lookup_ldap_uid).and_return(nil)
+    allow(fake_sid_proxy).to receive(:lookup_student_id).and_return('24680')
+    allow(fake_sid_proxy).to receive(:lookup_ldap_uid).and_return('13579')
     model = User::SearchUsers.new({:id => '24680'})
     result = model.search_users
     expect(result).to be_an_instance_of Array
@@ -34,8 +34,10 @@ describe User::SearchUsers do
   end
 
   it "returns no record for invalid id" do
-    CampusOracle::Queries.should_receive(:find_people_by_student_id).with('12345').and_return(users_not_found)
-    CampusOracle::Queries.should_receive(:get_basic_people_attributes).with(['12345']).and_return(users_not_found)
+    allow(fake_uid_proxy).to receive(:lookup_student_id).and_return(nil)
+    allow(fake_uid_proxy).to receive(:lookup_ldap_uid).and_return(nil)
+    allow(fake_sid_proxy).to receive(:lookup_student_id).and_return(nil)
+    allow(fake_sid_proxy).to receive(:lookup_ldap_uid).and_return(nil)
     model = User::SearchUsers.new({:id => '12345'})
     result = model.search_users
     expect(result).to be_an_instance_of Array


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-10824

This is a partial fix. It lets you view-as a new user who's not in Oracle. But there's a minor bug where such users won't record in the view-as admin history (SISRP-11917). 