### PR TITLE
CLC-6075 Point to new Support page for GL3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/ets-berkeley-edu/calcentral.git"
   },
   "bugs": {
-    "url": "https://www.ets.berkeley.edu/discover-services/calcentral/students-getting-started"
+    "url": "https://www.ets.berkeley.edu/calcentral-support"
   },
   "author": {
     "name": "CalCentral Developers",

--- a/src/assets/templates/academics.html
+++ b/src/assets/templates/academics.html
@@ -39,7 +39,7 @@
       This page displays academic status information for UC Berkeley students and faculty, and is not available to staff.
     </p>
     <p>
-      If you believe you are seeing this message in error, please <a href="http://www.ets.berkeley.edu/discover-services/calcentral/students-getting-started">let us know</a>.
+      If you believe you are seeing this message in error, please <a href="http://www.ets.berkeley.edu/calcentral-support">let us know</a>.
     </p>
   </div>
 </div>

--- a/src/assets/templates/footer.html
+++ b/src/assets/templates/footer.html
@@ -23,7 +23,7 @@
       </span>
       <a href="//security.berkeley.edu/policy">Usage Policy</a>
       <a href="http://www.ets.berkeley.edu/discover-services/calcentral">About</a>
-      <a href="http://www.ets.berkeley.edu/discover-services/calcentral/students-getting-started">Support</a>
+      <a href="http://www.ets.berkeley.edu/calcentral-support">Support</a>
     </div>
   </div>
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6075

("http" is used to avoid browser warnings in certain combinations of test environments between Java and Drupal).