### PR TITLE
CLC-6072, 'gulp build' expects port 3001 but underlying code would deduce 3000

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -78,8 +78,9 @@ class SessionsController < ApplicationController
 
   def destroy
     logout
+    url = request.protocol + ApplicationController.correct_port(request.host_with_port, request.env['HTTP_REFERER'])
     render :json => {
-      :redirectUrl => "#{Settings.cas_logout_url}?service=#{CGI.escape(request.protocol + request.host_with_port)}"
+      :redirectUrl => "#{Settings.cas_logout_url}?service=#{CGI.escape url}"
     }.to_json
   end
 

--- a/spec/controllers/bootstrap_controller_spec.rb
+++ b/spec/controllers/bootstrap_controller_spec.rb
@@ -29,9 +29,9 @@ describe BootstrapController do
       let(:original_user_id) {random_id}
       context 'when not already reauthenticated' do
         it 'should redirect to reauthenticate' do
-          # controller.stub(:cookies).and_return({:reauthenticated => nil})
           get :index
-          expect(response).to redirect_to('/auth/cas?renew=true&url=/')
+          hostname = request.env['HTTP_HOST']
+          expect(response).to redirect_to "/auth/cas?renew=true&url=http://#{hostname}/"
         end
       end
       context 'when already reauthenticated' do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6072

See latest comment in Jira. The change in `sessions_controller.rb` fixes [same problem when logging out on localhost:3001](https://jira.ets.berkeley.edu/jira/browse/CLC-6072?focusedCommentId=232320&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-232320)