### PR TITLE
CLC-6084 - more Selenium test fixes

### DIFF
--- a/spec/ui_selenium/my_dashboard_canvas_course_sites_spec.rb
+++ b/spec/ui_selenium/my_dashboard_canvas_course_sites_spec.rb
@@ -109,7 +109,7 @@ describe 'My Dashboard', :testui => true, :order => :defined do
             expect(@my_classes_card.other_course_site_descrips).to include(site_descrip)
           end
           it 'show a link to the course site in My Classes' do
-            expect(WebDriverUtils.verify_external_link(@driver, @my_classes_card.other_course_site_link_elements[0], site_descrip)).to be true
+            expect(WebDriverUtils.verify_external_link(@driver, @my_classes_card.other_site_link(site_descrip), site_descrip)).to be true
           end
 
           # Notifications - announcement, discussion
@@ -198,7 +198,7 @@ describe 'My Dashboard', :testui => true, :order => :defined do
             expect(@my_classes_card.other_course_site_descrips).to include(site_descrip)
           end
           it 'show a link to the course site in My Classes' do
-            expect(WebDriverUtils.verify_external_link(@driver, @my_classes_card.other_course_site_link_elements[0], site_descrip)).to be true
+            expect(WebDriverUtils.verify_external_link(@driver, @my_classes_card.other_site_link(site_descrip), site_descrip)).to be true
           end
 
           # Notifications - assignments, announcement, discussion

--- a/spec/ui_selenium/my_dashboard_data_classes_spec.rb
+++ b/spec/ui_selenium/my_dashboard_data_classes_spec.rb
@@ -217,6 +217,12 @@ describe 'My Dashboard My Classes card', :testui => true do
 
             # HEADINGS DISPLAYED WITHIN THE CARD
 
+            my_classes.wait_until(WebDriverUtils.page_event_timeout) do
+              my_classes.enrollments_heading?
+              my_classes.teaching_heading?
+              my_classes.other_sites_heading?
+            end
+
             has_student_heading = my_classes.enrollments_heading_element.visible?
             has_teaching_heading = my_classes.teaching_heading_element.visible?
             has_other_sites_heading = my_classes.other_sites_heading_element.visible?

--- a/spec/ui_selenium/pages/api_my_academics_page.rb
+++ b/spec/ui_selenium/pages/api_my_academics_page.rb
@@ -406,7 +406,7 @@ class ApiMyAcademicsPage
 
   def other_site_descriptions(sites)
     descriptions = []
-    sites.each { |site| descriptions.push(site['shortDescription']) }
+    sites.each { |site| descriptions.push(site['shortDescription'].gsub('  ', ' ')) }
     descriptions
   end
 

--- a/spec/ui_selenium/pages/cal_central_pages.rb
+++ b/spec/ui_selenium/pages/cal_central_pages.rb
@@ -15,6 +15,7 @@ module CalCentralPages
   button(:email_badge, :xpath => '//button[@title="bMail"]')
   div(:email_count, :xpath => '//button[@title="bMail"]/div[@data-ng-bind="badge.count"]')
   h4(:unread_email_heading, :xpath => '//h4[text()="Unread bMail Messages"]')
+  h4(:email_not_connected_heading, :xpath => '//h4[text()="bMail (Not connected)"]')
   link(:email_one_link, :xpath => '//button[@title="bMail"]/following-sibling::div//a[@data-ng-href="http://bmail.berkeley.edu/"]')
   div(:email_one_sender, :xpath => '//button[@title="bMail"]/following-sibling::div//div[@data-ng-bind="item.editor"]')
   span(:email_one_subject, :xpath => '//button[@title="bMail"]/following-sibling::div//span[@data-ng-bind="item.title"]')

--- a/spec/ui_selenium/pages/cal_central_pages.rb
+++ b/spec/ui_selenium/pages/cal_central_pages.rb
@@ -163,7 +163,8 @@ module CalCentralPages
     login = basic_auth_login_button_element
     basic_auth_login_button
     login.when_not_present(timeout=WebDriverUtils.page_load_timeout)
-    basic_auth_login_button_element.when_present(timeout=WebDriverUtils.page_load_timeout)
+    basic_auth_login_button_element.when_present(timeout)
+    basic_auth_uid_input_element.when_not_visible(timeout)
   end
 
   def click_class_link_by_text(link_text)

--- a/spec/ui_selenium/pages/my_dashboard_my_classes_card.rb
+++ b/spec/ui_selenium/pages/my_dashboard_my_classes_card.rb
@@ -102,5 +102,9 @@ module CalCentralPages
       descriptions
     end
 
+    def other_site_link(link_text)
+      other_course_site_link_elements.find { |link| link.text.include? link_text }
+    end
+
   end
 end

--- a/spec/ui_selenium/user_authorizations_spec.rb
+++ b/spec/ui_selenium/user_authorizations_spec.rb
@@ -107,14 +107,14 @@ describe 'User authorization', :testui => true do
         it 'allows conversion of UID to SID' do
           @settings_page.look_up_user('61889')
           @settings_page.wait_until(timeout) { @settings_page.lookup_results_table_element.visible? }
-          @settings_page.lookup_results_table_element[1][0].when_present timeout
+          @settings_page.wait_until(timeout) { !@settings_page.lookup_results_table_element.rows.zero? }
           expect(@settings_page.lookup_results_table_element[1][0].text).to eql('61889')
           expect(@settings_page.lookup_results_table_element[1][1].text).to eql('11667051')
         end
         it 'allows conversion of SID to UID' do
           @settings_page.look_up_user('11667051')
           @settings_page.wait_until(timeout) { @settings_page.lookup_results_table_element.visible? }
-          @settings_page.lookup_results_table_element[1][0].when_present timeout
+          @settings_page.wait_until(timeout) { !@settings_page.lookup_results_table_element.rows.zero? }
           expect(@settings_page.lookup_results_table_element[1][0].text).to eql('61889')
           expect(@settings_page.lookup_results_table_element[1][1].text).to eql('11667051')
         end

--- a/spec/ui_selenium/user_authorizations_spec.rb
+++ b/spec/ui_selenium/user_authorizations_spec.rb
@@ -106,13 +106,15 @@ describe 'User authorization', :testui => true do
         end
         it 'allows conversion of UID to SID' do
           @settings_page.look_up_user('61889')
-          @settings_page.wait_until(timeout) { @settings_page.lookup_results_table? }
+          @settings_page.wait_until(timeout) { @settings_page.lookup_results_table_element.visible? }
+          @settings_page.lookup_results_table_element[1][0].when_present timeout
           expect(@settings_page.lookup_results_table_element[1][0].text).to eql('61889')
           expect(@settings_page.lookup_results_table_element[1][1].text).to eql('11667051')
         end
         it 'allows conversion of SID to UID' do
           @settings_page.look_up_user('11667051')
-          @settings_page.wait_until(timeout) { @settings_page.lookup_results_table? }
+          @settings_page.wait_until(timeout) { @settings_page.lookup_results_table_element.visible? }
+          @settings_page.lookup_results_table_element[1][0].when_present timeout
           expect(@settings_page.lookup_results_table_element[1][0].text).to eql('61889')
           expect(@settings_page.lookup_results_table_element[1][1].text).to eql('11667051')
         end

--- a/spec/ui_selenium/user_google_connection_spec.rb
+++ b/spec/ui_selenium/user_google_connection_spec.rb
@@ -26,11 +26,6 @@ describe 'Google apps', :testui => true do
       end
 
       context 'when connected' do
-        it 'shows no "connect" UI' do
-          my_dashboard = CalCentralPages::MyDashboardPage.new(@driver)
-          my_dashboard.notifications_heading_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
-          expect(my_dashboard.connect_bconnected_button_element.visible?).to be false
-        end
         it 'shows "connected" on Settings' do
           @settings_page.load_page
           @settings_page.disconnect_button_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
@@ -46,8 +41,9 @@ describe 'Google apps', :testui => true do
           @settings_page.disconnect_button
           @settings_page.disconnect_no_button_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
           @settings_page.disconnect_no_button
-          @settings_page.disconnect_no_button_element.when_not_visible(timeout=WebDriverUtils.page_event_timeout)
-          expect(@settings_page.disconnect_button?).to be true
+          @settings_page.wait_until(WebDriverUtils.page_event_timeout, 'Disconnect button has not appeared') do
+            @settings_page.disconnect_button?
+          end
           expect(@settings_page.connect_button?).to be false
           expect(@settings_page.connected_as).to include("#{UserUtils.qa_gmail_username}")
         end
@@ -57,14 +53,11 @@ describe 'Google apps', :testui => true do
           @settings_page.disconnect_button
           @settings_page.disconnect_yes_button_element.when_visible(timeout=WebDriverUtils.page_event_timeout)
           @settings_page.disconnect_yes_button
-          @settings_page.disconnect_yes_button_element.when_not_present(timeout=WebDriverUtils.page_event_timeout)
+          @settings_page.wait_until(WebDriverUtils.page_event_timeout, 'Connect button has not appeared') do
+            @settings_page.connect_button?
+          end
           expect(@settings_page.disconnect_button?).to be false
-          expect(@settings_page.connect_button?).to be true
           expect(@settings_page.connected_as?).to be false
-          my_dashboard = CalCentralPages::MyDashboardPage.new(@driver)
-          my_dashboard.load_page
-          my_dashboard.connect_bconnected_heading_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
-          expect(my_dashboard.connect_bconnected_button?).to be true
         end
       end
 
@@ -75,8 +68,10 @@ describe 'Google apps', :testui => true do
           @splash_page.wait_for_expected_title?
           @splash_page.click_sign_in_button
           @cal_net.login(UserUtils.qa_username, UserUtils.qa_password)
-          my_dashboard.connect_bconnected_heading_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
-          expect(my_dashboard.connect_bconnected_button?).to be true
+          my_dashboard.click_email_badge
+          my_dashboard.wait_until(WebDriverUtils.page_load_timeout, 'Not-connected message has not appeared') do
+            my_dashboard.email_not_connected_heading_element.visible?
+          end
         end
       end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6084

A few of the Selenium tests fail occasionally, mainly because DOM updates happen in a way the tests don't expect.  This is the first of a set of changes to make the tests more robust.