### PR TITLE
CLC-6012 OEC: Do not allow automated tasks to run past end of semester

### DIFF
--- a/app/models/oec/api_task_wrapper.rb
+++ b/app/models/oec/api_task_wrapper.rb
@@ -69,7 +69,7 @@ module Oec
     end
 
     def run(task_id)
-      task = @task_class.new @params.merge(api_task_id: task_id, log_to_cache: true)
+      task = @task_class.new @params.merge(api_task_id: task_id, log_to_cache: true, allow_past_term: true)
       task.run
     end
 

--- a/app/models/oec/term_setup_task.rb
+++ b/app/models/oec/term_setup_task.rb
@@ -59,8 +59,8 @@ module Oec
     def set_default_term_dates(courses)
       term = Berkeley::Terms.fetch.campus[Berkeley::TermCodes.to_slug *@term_code.split('-')]
       courses[0] = {
-        'START_DATE' => term.classes_start.strftime(Oec::Worksheet::WORKSHEET_DATE_FORMAT),
-        'END_DATE' => term.instruction_end.advance(days: 2).strftime(Oec::Worksheet::WORKSHEET_DATE_FORMAT)
+        'START_DATE' => @term_start.strftime(Oec::Worksheet::WORKSHEET_DATE_FORMAT),
+        'END_DATE' => @term_end.strftime(Oec::Worksheet::WORKSHEET_DATE_FORMAT)
       }
     end
   end

--- a/lib/tasks/oec.rake
+++ b/lib/tasks/oec.rake
@@ -2,50 +2,25 @@ namespace :oec do
 
   desc 'Set up folder structure for new term'
   task :term_setup => :environment do
-    raise ArgumentError, 'term_code required' unless ENV['term_code']
-    Oec::TermSetupTask.new(
-      term_code: ENV['term_code'],
-      local_write: ENV['local_write'].present?
-    ).run
+    opts = Oec::Task.opts_from_environment
+    Oec::TermSetupTask.new(opts).run
   end
 
   desc 'Import per-department course CSVs, compare with dept spreadsheets and report on non-empty diffs'
   task :sis_import => :environment do
-    term_code = ENV['term_code']
-    raise ArgumentError, 'term_code required' unless term_code
-    date_time = DateTime.now
-    Oec::SisImportTask.new(
-      term_code: term_code,
-      date_time: date_time,
-      local_write: ENV['local_write'].present?,
-      import_all: ENV['import_all'].present?,
-      dept_names: ENV['dept_names'],
-      dept_codes: ENV['dept_codes']
-    ).run
+    opts = Oec::Task.opts_from_environment.merge(date_time: DateTime.now)
+    Oec::SisImportTask.new(opts).run
   end
 
   desc 'Generate SIS data sheets, one per dept_code, to be shared with department admins'
   task :create_confirmation_sheets => :environment do
-    term_code = ENV['term_code']
-    raise ArgumentError, 'term_code required' unless term_code
-    Oec::CreateConfirmationSheetsTask.new(
-      term_code: ENV['term_code'],
-      local_write: ENV['local_write'].present?,
-      dept_names: ENV['dept_names'],
-      dept_codes: ENV['dept_codes']
-    ).run
+    opts = Oec::Task.opts_from_environment
+    Oec::CreateConfirmationSheetsTask.new(opts).run
   end
 
   desc 'Compare department-managed sheets against latest SIS-import sheets'
   task :report_diff => :environment do
-    term_code = ENV['term_code']
-    raise ArgumentError, 'term_code required' unless term_code
-    opts = {
-      term_code: term_code,
-      local_write: ENV['local_write'].present?,
-      dept_names: ENV['dept_names'],
-      dept_codes: ENV['dept_codes']
-    }
+    opts = Oec::Task.opts_from_environment
     success = Oec::ReportDiffTask.new(opts).run
     unless success
       Rails.logger.error "#{Oec::ReportDiffTask.class} failed on #{opts}"
@@ -55,34 +30,20 @@ namespace :oec do
 
   desc 'Merge all sheets in \'departments\' folder to prepare for publishing'
   task :merge_confirmation_sheets => :environment do
-    term_code = ENV['term_code']
-    raise ArgumentError, 'term_code required' unless term_code
-    Oec::MergeConfirmationSheetsTask.new(
-      term_code: ENV['term_code'],
-      local_write: ENV['local_write'].present?,
-      dept_names: ENV['dept_names'],
-      dept_codes: ENV['dept_codes']
-    ).run
+    opts = Oec::Task.opts_from_environment
+    Oec::MergeConfirmationSheetsTask.new(opts).run
   end
 
   desc 'Simply validate confirmation sheet data. This does not include a push to the \'exports\' directory.'
   task :validate_confirmation_sheets => :environment do
-    term_code = ENV['term_code']
-    raise ArgumentError, 'term_code required' unless term_code
-    Oec::ValidationTask.new(
-      term_code: ENV['term_code'],
-      local_write: ENV['local_write'].present?
-    ).run
+    opts = Oec::Task.opts_from_environment
+    Oec::ValidationTask.new(opts).run
   end
 
   desc 'Push the most recently confirmed data to Explorance\'s Blue system'
   task :publish_to_explorance => :environment do
-    term_code = ENV['term_code']
-    raise ArgumentError, 'term_code required' unless term_code
-    Oec::PublishTask.new(
-      term_code: term_code,
-      local_write: ENV['local_write'].present?
-    ).run
+    opts = Oec::Task.opts_from_environment
+    Oec::PublishTask.new(opts).run
   end
 
   # Legacy tasks below this line

--- a/script/run-oec-task.sh
+++ b/script/run-oec-task.sh
@@ -42,7 +42,7 @@ else
   read -d '' usage << EOF
 Usage:
 
-[term_code='2015-D'] [local_write='Y'] [dept_codes='IMMCB PMATH ...'] ...  ${0} [${PSV}]
+[term_code='2015-D'] [allow_past_term='Y'] [local_write='Y'] [dept_codes='IMMCB PMATH ...'] ...  ${0} [${PSV}]
 EOF
   echo "${usage}" | ${LOGIT}
 fi

--- a/spec/models/google_apps/sheets_manager_spec.rb
+++ b/spec/models/google_apps/sheets_manager_spec.rb
@@ -12,7 +12,7 @@ describe GoogleApps::SheetsManager do
       # No CSV files will be created by this test
       @sis_import_sheet = Oec::SisImportSheet.new(dept_code: 'LPSPP')
       course_codes = [Oec::CourseCode.new(dept_name: 'SPANISH', catalog_id: '', dept_code: 'LPSPP', include_in_oec: true)]
-      Oec::SisImportTask.new(:term_code => '2015-C').import_courses(@sis_import_sheet, course_codes)
+      Oec::SisImportTask.new(:term_code => '2014-C').import_courses(@sis_import_sheet, course_codes)
       @spreadsheet = @sheet_manager.upload_to_spreadsheet(@spreadsheet_title, @sis_import_sheet.to_io, @folder.id, @worksheet_title)
     end
 

--- a/spec/models/oec/create_confirmation_sheets_task_spec.rb
+++ b/spec/models/oec/create_confirmation_sheets_task_spec.rb
@@ -1,6 +1,8 @@
 describe Oec::CreateConfirmationSheetsTask do
   let(:term_code) { '2015-B' }
-  let(:task) { Oec::CreateConfirmationSheetsTask.new(term_code: term_code, local_write: local_write) }
+  let(:task) do
+    Oec::CreateConfirmationSheetsTask.new(term_code: term_code, local_write: local_write, allow_past_term: true)
+  end
 
   let(:fake_remote_drive) { double() }
 

--- a/spec/models/oec/merge_confirmation_sheets_task_spec.rb
+++ b/spec/models/oec/merge_confirmation_sheets_task_spec.rb
@@ -1,6 +1,8 @@
 describe Oec::MergeConfirmationSheetsTask do
   let(:term_code) { '2015-B' }
-  let(:task) { Oec::MergeConfirmationSheetsTask.new(term_code: term_code, local_write: local_write) }
+  let(:task) do
+    Oec::MergeConfirmationSheetsTask.new(term_code: term_code, local_write: local_write, allow_past_term: true)
+  end
 
   let(:fake_remote_drive) { double() }
 

--- a/spec/models/oec/publish_task_spec.rb
+++ b/spec/models/oec/publish_task_spec.rb
@@ -1,7 +1,9 @@
 describe Oec::PublishTask do
   let(:term_code) { '2015-B' }
   let(:now) { DateTime.now }
-  let(:task) { Oec::PublishTask.new term_code: term_code, local_write: local_write, date_time: now }
+  let(:task) do
+    Oec::PublishTask.new(term_code: term_code, local_write: local_write, date_time: now, allow_past_term: true)
+  end
   let(:tmp_publish_directory) { now.strftime "publish_#{Oec::Task.date_format}_%H%M%S" }
 
   include_context 'OEC enrollment data merge'

--- a/spec/models/oec/remote_drive_spec.rb
+++ b/spec/models/oec/remote_drive_spec.rb
@@ -30,8 +30,8 @@ describe Oec::RemoteDrive do
       before {
         worksheet = Oec::SisImportSheet.new(dept_code: dept_code)
         course_codes = [Oec::CourseCode.new(dept_name: 'SPANISH', catalog_id: '', dept_code: dept_code, include_in_oec: true)]
-        # Import of '2015-D' is intentional because we want valid data as input.
-        Oec::SisImportTask.new(:term_code => '2015-D').import_courses(worksheet, course_codes)
+        # Import of '2013-D' is intentional because we want valid data as input.
+        Oec::SisImportTask.new(:term_code => '2013-D', allow_past_term: true).import_courses(worksheet, course_codes)
         @folder = subject.create_folder transient_folder_name
         subject.check_conflicts_and_upload(worksheet, dept_code, Oec::Worksheet, @folder)
       }

--- a/spec/models/oec/report_diff_task_spec.rb
+++ b/spec/models/oec/report_diff_task_spec.rb
@@ -3,7 +3,7 @@ describe Oec::ReportDiffTask do
   let(:now) { DateTime.now }
 
   context 'Report diff on fake data' do
-    let(:term_code) { '2015-D' }
+    let(:term_code) { '2014-B' }
     # Map dept_code to test-data filenames under fixtures/oec
     let(:dept_code_mappings) {
       {
@@ -14,7 +14,15 @@ describe Oec::ReportDiffTask do
       }
     }
     let (:fake_remote_drive) { double }
-    subject { Oec::ReportDiffTask.new(term_code: term_code, dept_codes: dept_code_mappings.keys, date_time: now, local_write: true) }
+    subject do
+      Oec::ReportDiffTask.new({
+        term_code: term_code,
+        dept_codes: dept_code_mappings.keys,
+        date_time: now,
+        local_write: true,
+        allow_past_term: true
+      })
+    end
 
     before {
       allow(Oec::CourseCode).to receive(:by_dept_code).and_return dept_code_mappings
@@ -31,7 +39,7 @@ describe Oec::ReportDiffTask do
       end
       # Behave as if there is no previous diff report on remote drive
       expect(fake_remote_drive).to receive(:find_nested).with([term_code, Oec::Folder.confirmations]).and_return (departments_folder = double)
-      expect(fake_remote_drive).to receive(:find_first_matching_item).with('2015-D diff report', departments_folder).and_return nil
+      expect(fake_remote_drive).to receive(:find_first_matching_item).with('2014-B diff report', departments_folder).and_return nil
       dept_code_mappings.each do |dept_code, dept_name|
         friendly_name = Berkeley::Departments.get(dept_code, concise: true)
         imports_path = [term_code, Oec::Folder.sis_imports, now.strftime('%F %H:%M:%S'), friendly_name]

--- a/spec/models/oec/validation_task_spec.rb
+++ b/spec/models/oec/validation_task_spec.rb
@@ -1,6 +1,6 @@
 describe Oec::ValidationTask do
   let(:term_code) { '2015-B' }
-  let(:task) { Oec::ValidationTask.new(term_code: term_code, local_write: 'Y') }
+  let(:task) { Oec::ValidationTask.new(term_code: term_code, local_write: 'Y', allow_past_term: true) }
 
   include_context 'OEC enrollment data merge'
 


### PR DESCRIPTION
See https://jira.ets.berkeley.edu/jira/browse/CLC-6012 for a description of the new behavior.

In addition to implementing the `allow_past_term` flag, option handling from environment variables is taken out of the Rake tasks and consolidated in `Oec::Task.opts_from_environment`.

Changes to tests include shifting example terms back a year or two, as our Berkeley::Terms logic doesn't recognize terms too far in the future from "now" (still locked to 2013 for testing purposes).