### PR TITLE
CLC-6095 Allow fake Google Drive proxy to respond to v2 or v3 API calls

### DIFF
--- a/app/models/google_apps/drive_list.rb
+++ b/app/models/google_apps/drive_list.rb
@@ -12,7 +12,8 @@ module GoogleApps
     end
 
     def mock_request
-      super.merge(uri_matching: 'https://www.googleapis.com/drive/v2/files')
+      hostname = 'https://www.googleapis.com'
+      super.merge(uri: %r{.*#{Regexp.quote hostname}.*/drive/v[23]/files.*})
     end
 
   end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6095

For how the fix works, see https://github.com/ets-berkeley-edu/calcentral/blob/master/lib/proxies/mock_http_interaction.rb#L34:
- When defining a mock request, we usually pass in a `uri_matching` key with a partial URI, which Proxies::Mockable then turns into a nice URI-matching regexp.
- However, if a class needs the flexibility of building its own regexp, it can be passed in with just `uri` as the key.

