### PR TITLE
CLC-6095 Lock Google Drive client to v2 API

### DIFF
--- a/app/models/google_apps/client.rb
+++ b/app/models/google_apps/client.rb
@@ -10,9 +10,9 @@ module GoogleApps
         @client ||= Google::APIClient.new(options={:application_name => "CalCentral", :application_version => "v1", :auto_refresh_token => true, :retries => 3})
       end
 
-      def discover_resource_method(api, resource, method)
+      def discover_resource_method(api, api_version, resource, method)
         begin
-          discover_api(api).send(resource.to_sym).send(method.to_sym)
+          discover_api(api, api_version).send(resource.to_sym).send(method.to_sym)
         rescue => e
           logger.fatal "#{name}: #{e.to_s} - Unable to resolve resource method"
           nil
@@ -65,8 +65,9 @@ module GoogleApps
         client.preferred_version(api).version
       end
 
-      def discover_api(api)
-        client.discovered_api(api, discover_version(api))
+      def discover_api(api, api_version=nil)
+        api_version ||= discover_version(api)
+        client.discovered_api(api, api_version)
       end
     end
 

--- a/app/models/google_apps/drive_list.rb
+++ b/app/models/google_apps/drive_list.rb
@@ -7,13 +7,18 @@ module GoogleApps
     end
 
     def drive_list(optional_params = {}, page_limiter = nil)
-      request :api => 'drive', :resource => 'files', :method => 'list', :params => optional_params,
-              :page_limiter => page_limiter
+      request(
+        api: 'drive',
+        api_version: 'v2',
+        resource: 'files',
+        method: 'list',
+        params: optional_params,
+        page_limiter: page_limiter
+      )
     end
 
     def mock_request
-      hostname = 'https://www.googleapis.com'
-      super.merge(uri: %r{.*#{Regexp.quote hostname}.*/drive/v[23]/files.*})
+      super.merge(uri_matching: 'https://www.googleapis.com/drive/v2/files')
     end
 
   end

--- a/app/models/google_apps/proxy.rb
+++ b/app/models/google_apps/proxy.rb
@@ -31,7 +31,7 @@ module GoogleApps
     end
 
     def request(request_params={})
-      page_params = setup_page_params(request_params)
+      page_params = setup_page_params request_params
 
       result_pages = Enumerator.new do |yielder|
         logger.info "Making request with @fake = #{@fake}, params = #{request_params}"
@@ -139,15 +139,18 @@ module GoogleApps
       end
     end
 
-
     def setup_page_params(request_params)
+      resource_method = GoogleApps::Client.discover_resource_method(
+        request_params[:api],
+        request_params[:api_version],
+        request_params[:resource],
+        request_params[:method]
+      )
       {
         params: request_params[:params],
         body: request_params[:body],
         headers: request_params[:headers],
-        resource_method: GoogleApps::Client.discover_resource_method(request_params[:api],
-                                                                    request_params[:resource],
-                                                                    request_params[:method]),
+        resource_method: resource_method,
         page_limiter: request_params[:page_limiter]
       }
     end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6095

This change fixes the bDrive badge on my local machine and pacifies the GoogleApps::DriveList testext that's been failing on master for the last 24 hours. 

Bamboo run: https://bamboo.ets.berkeley.edu/bamboo/browse/CPB-CPT229-1/test - the failures that do appear are just our usual batch.

#4638 is reverted, since the version-specific URL match turned out to be our coal-mine canary.