### PR TITLE
CLC-6099, test coverage on CampusSolutions::Proxy is_errored

### DIFF
--- a/spec/models/campus_solutions/proxy_spec.rb
+++ b/spec/models/campus_solutions/proxy_spec.rb
@@ -1,0 +1,21 @@
+describe CampusSolutions::Proxy do
+
+  context 'error' do
+    subject { CampusSolutions::Proxy.new(Settings.campus_solutions_proxy, uid: random_id) }
+    before {
+      response = double
+      allow(Proxies::HttpRequest).to receive(:new).and_return double perform: response
+      allow(response).to receive(:code).and_return double
+      allow(response).to receive(:body).and_return double force_encoding: nil
+      allow(response).to receive(:parsed_response).and_return feed
+    }
+    context 'errmsgtext in response' do
+      let(:feed) { { 'ERRMSGTEXT' => 'Wicked problems' } }
+      it 'should flag error condition' do
+        processed_feed = HashConverter.downcase_and_camelize feed
+        expect(subject.is_errored? processed_feed).to be true
+        expect(subject.get).to eq ({ statusCode: 400, errored: true, feed: processed_feed })
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6099

If we get ERRMSGTEXT from CS we send canned JSON (e.g., statusCode: 400) to front-end. 