### PR TITLE
CLC-6112 Only show status header when there is status messaging

### DIFF
--- a/src/assets/javascripts/angular/controllers/widgets/statusController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/statusController.js
@@ -17,6 +17,9 @@ angular.module('calcentral.controllers').controller('StatusController', function
 
     $scope.studentInfo = data.studentInfo;
 
+    if (_.get(data, 'studentInfo.regStatus.code') !== null) {
+      $scope.hasRegistrationData = true;
+    }
     if (_.get(data, 'studentInfo.regStatus.needsAction') && apiService.user.profile.features.regstatus) {
       $scope.count++;
       $scope.hasAlerts = true;
@@ -44,6 +47,7 @@ angular.module('calcentral.controllers').controller('StatusController', function
     }
     $scope.totalPastDueAmount = data.summary.totalPastDueAmount;
     $scope.minimumAmountDue = data.summary.minimumAmountDue;
+    $scope.hasBillingData = ($scope.minimumAmountDue !== null);
   };
 
   var loadActivity = function(data) {

--- a/src/assets/templates/widgets/gear_popover.html
+++ b/src/assets/templates/widgets/gear_popover.html
@@ -23,14 +23,16 @@
   </button>
   <div class="cc-popover cc-dropdown cc-launcher-dropdown-menu" data-ng-show="api.popover.status('cc-popover-menu')">
     <div>
-      <div class="cc-popover-title">
-        <h4>Status</h4>
+      <div data-ng-if="!statusLoading && (count !== 0 || hasBillingData || hasRegistrationData)">
+        <div class="cc-popover-title">
+          <h4>Status</h4>
+        </div>
+        <div class="cc-popover-noitems" data-ng-if="count === 0">
+          <i class="cc-left fa fa-check-circle cc-icon-green"></i>
+          <strong>No Active Alerts</strong>
+        </div>
+        <div data-ng-include="'widgets/status_popover.html'" data-ng-if="count !== 0"></div>
       </div>
-      <div class="cc-popover-noitems" data-ng-if="count === 0 && !statusLoading && !(studentInfo.regStatus.needsAction && !(studentInfo.regBlock.needsAction || studentInfo.regBlock.errored) && api.user.profile.features.regstatus) && minimumAmountDue <= 0">
-        <i class="cc-left fa fa-check-circle cc-icon-green"></i>
-        <strong>No Active Alerts</strong>
-      </div>
-      <div data-ng-include="'widgets/status_popover.html'" data-ng-if="count !== 0"></div>
       <div data-ng-include="'widgets/profile_popover.html'"></div>
     </div>
   </div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6112

This refactor of the status popover front end replaces the enormous compound Boolean with a couple of scope variables to clarify intent. In brief, status header and messaging should only show if:
- there are active alerts or warnings;
- or the user has non-null registration data;
- or the user has non-null financial data.