### PR TITLE
CLC-6097 CLC-6119 bCourses email address deletion

### DIFF
--- a/app/models/canvas/communication_channels.rb
+++ b/app/models/canvas/communication_channels.rb
@@ -8,17 +8,17 @@ module Canvas
     end
 
     def list
-      wrapped_get request_path
+      wrapped_get "#{request_path}?as_user_id=#{@canvas_user_id}"
     end
 
     def delete(channel_id)
-      wrapped_delete "#{request_path}/#{channel_id}"
+      wrapped_delete "#{request_path}/#{channel_id}?as_user_id=#{@canvas_user_id}"
     end
 
     private
 
     def request_path
-      "users/#{@canvas_user_id}/communication_channels"
+      "users/self/communication_channels"
     end
 
     def mock_interactions

--- a/app/models/canvas/report/base.rb
+++ b/app/models/canvas/report/base.rb
@@ -75,7 +75,7 @@ module Canvas
           if @download_to_file_name.blank?
             csv = CSV.parse(csv_response[:body], {headers: true})
           else
-            File.open(@download_to_file_name, 'w') {|fp| fp.write(csv_response[:body])}
+            File.open(@download_to_file_name, 'wb') {|fp| fp.write(csv_response[:body])}
             csv = @download_to_file_name
           end
         end

--- a/app/models/canvas_csv/maintain_users.rb
+++ b/app/models/canvas_csv/maintain_users.rb
@@ -71,12 +71,11 @@ module CanvasCsv
     end
 
     def check_all_user_accounts
-      # As the size of the CSV grows, it will become more efficient to use CSV.foreach.
-      # For now, however, we ingest the entire download.
-      users_csv = Canvas::Report::Users.new.get_csv
-      if users_csv.present?
+      users_csv_file = "#{Settings.canvas_proxy.export_directory}/provisioned-users-#{DateTime.now.strftime('%F-%H-%M')}.csv"
+      users_csv_file = Canvas::Report::Users.new(download_to_file: users_csv_file).get_csv
+      if users_csv_file.present?
         accounts_batch = []
-        users_csv.each do |account_row|
+        CSV.foreach(users_csv_file, headers: true) .each do |account_row|
           accounts_batch << account_row
           if accounts_batch.length == 1000
             compare_to_campus(accounts_batch)
@@ -120,6 +119,7 @@ module CanvasCsv
               if dry_run.present?
                 logger.warn "DRY RUN MODE: Would delete communication channel #{channel}"
               else
+                logger.warn "Deleting communication channel #{channel}"
                 proxy.delete channel_id
               end
             end

--- a/spec/models/canvas_csv/base_spec.rb
+++ b/spec/models/canvas_csv/base_spec.rb
@@ -71,7 +71,7 @@ describe CanvasCsv::Base do
       end
     end
     context 'downloading to the file system' do
-      let(:download_filename) { "tmp/canvas/test_report_download_#{DateTime.now.strftime('%Y%m%dT%H%M%S')}.csv" }
+      let(:download_filename) { "tmp/test_report_download_#{DateTime.now.strftime('%Y%m%dT%H%M%S')}.csv" }
       after { delete_files_if_exists([download_filename]) }
       it 'returns the file name' do
         result = subject.get_csv


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6097

- Work around change to Canvas API permissions.
- Add separate Rake task to delete emails for inactive accounts, since it can take 12+ hours.
- Reduce memory/CPU cost of user account maintenance.
- Fix CSV download-to-file-system UTF-8 bug.
- Fix unit test bug CLC-6119.