### PR TITLE
CLC-6129 Log and override stray 0 cache expiration times

### DIFF
--- a/app/models/notifications/reg_block_code_translator.rb
+++ b/app/models/notifications/reg_block_code_translator.rb
@@ -8,7 +8,7 @@ module Notifications
 
     def translate_bearfacts_proxy(reason_code, office)
       office_code = office.strip
-      Rails.cache.fetch("global/BearfactsRegBlock/reason_code/#{reason_code}_#{office_code}", :expires_in => 0) {
+      Rails.cache.fetch("global/BearfactsRegBlock/reason_code/#{reason_code}_#{office_code}", :expires_in => Settings.cache.maximum_expires_in) {
         {
           message: translate_to_message(reason_code, office_code),
           office: translate_office_code(office_code),

--- a/lib/cache/related_cache_key_tracker.rb
+++ b/lib/cache/related_cache_key_tracker.rb
@@ -31,7 +31,7 @@ module Cache
         logger.debug "Writing related keys for uid #{uid}: #{related_keys.inspect}"
         Rails.cache.write(user_key(uid),
                           related_keys,
-                          :expires_in => Settings.maximum_expires_in,
+                          :expires_in => Settings.cache.maximum_expires_in,
                           :force => true)
       end
     end


### PR DESCRIPTION
Attempt at gathering diagnostics on the trigger of https://jira.ets.berkeley.edu/jira/browse/CLC-6129

Also fixes a bad config reference in RelatedCacheKeyTracker.