### PR TITLE
SISRP-12703 Fix scope of Financial Aid cache expiration

### DIFF
--- a/app/models/campus_solutions/financial_aid_expiry.rb
+++ b/app/models/campus_solutions/financial_aid_expiry.rb
@@ -1,7 +1,16 @@
 module CampusSolutions
   module FinancialAidExpiry
     def self.expire(uid=nil)
-      [AidYears, FinancialAidData, MyAidYears, MyFinancialAidData].each do |klass|
+      [
+        AidYears,
+        FinancialAidData,
+        FinancialAidFundingSources,
+        FinancialAidFundingSourcesTerm,
+        MyAidYears,
+        MyFinancialAidData,
+        MyFinancialAidFundingSources,
+        MyFinancialAidFundingSourcesTerm
+      ].each do |klass|
         klass.expire uid
       end
     end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-12703

The list of cache entries to be expired on return from CS was not kept up to date with the list of cached FinAid-related feeds.

@christianvuerings, @davidlimcheng , once this reaches ETS master, we'll want it and other recent fixes merged into SIS-master for GL4 SIT.