### PR TITLE
added "A", "A+" grades to fix gpa calculator bug

### DIFF
--- a/src/assets/javascripts/angular/controllers/widgets/academicsGpaController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/academicsGpaController.js
@@ -13,6 +13,14 @@ angular.module('calcentral.controllers').controller('AcademicsGpaController', fu
       weight: 4
     },
     {
+      grade: 'A+',
+      weight: 4
+    },
+    {
+      grade: 'A',
+      weight: 4
+    },
+    {
       grade: 'A-',
       weight: 3.7
     },


### PR DESCRIPTION
Hi,

I'm a student at UC Berkeley, and I've noticed a bug in the GPA estimated calculator, especially after students are assigned grades. This often results because when a student is assigned a "A" or "A+", the GPA calculator doesn't recognize that grade (as opposed to an "A/A+"). This bug is consistent with my own estimated GPA right now, and with this linked Reddit post: https://www.reddit.com/r/berkeley/comments/3y3l06/gpa_on_calcentral/.compact

I will be honest --- I did not test to see if it worked. After reading through this file and the associated HTML template (`academics_gpa.html`), I do think this is the source of the problem: the `findWeight` function cannot identify a "A" or "A+", so these assigned grades will be removed from the "estimated GPA calculation".

Could someone look into this?