### PR TITLE
SISRP-12545 Allow ex-student status from Oracle views to override student status from Hub

### DIFF
--- a/app/models/user/api.rb
+++ b/app/models/user/api.rb
@@ -52,7 +52,10 @@ module User
       oracle_roles = (@oracle_attributes && @oracle_attributes[:roles]) || {}
       edo_roles = (@edo_attributes && @edo_attributes[:roles]) || {}
       if is_sis_profile_visible? && edo_roles.respond_to?(:slice)
-        oracle_roles.merge edo_roles.slice(*WHITELISTED_EDO_ROLES)
+        edo_roles_to_merge = edo_roles.slice *WHITELISTED_EDO_ROLES
+        # While we're in the split-brain stage, Oracle views remain our most trusted source on ex-student status.
+        edo_roles_to_merge.delete(:student) if oracle_roles[:exStudent]
+        oracle_roles.merge edo_roles_to_merge
       else
         oracle_roles
       end

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -295,6 +295,21 @@ describe User::Api do
       end
       include_examples 'handling bad behavior'
     end
+
+    context 'when ex-student is incorrectly reported active' do
+      let(:uid) { '2040' }
+      let(:badly_behaved_edo_attributes) do
+        {
+          roles: {
+            student: true
+          }
+        }
+      end
+      it 'should give precedence to campus Oracle on ex-student status' do
+        expect(feed[:roles][:exStudent]).to eq true
+        expect(feed[:roles][:student]).to eq false
+      end
+    end
   end
 
   context 'proper cache handling' do


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-12545