### PR TITLE
CLC-6153 Handle nil term values in Oracle queries

### DIFF
--- a/app/models/calendar/queries.rb
+++ b/app/models/calendar/queries.rb
@@ -57,7 +57,11 @@ module Calendar
     end
 
     def self.terms
-      [Berkeley::Terms.fetch.current, Berkeley::Terms.fetch.next, Berkeley::Terms.fetch.future]
+      [
+        Berkeley::Terms.fetch.current,
+        Berkeley::Terms.fetch.next,
+        Berkeley::Terms.fetch.future
+      ].compact
     end
 
     private

--- a/app/models/campus_oracle/connection.rb
+++ b/app/models/campus_oracle/connection.rb
@@ -9,14 +9,12 @@ module CampusOracle
     end
 
     def self.terms_query_clause(table, terms)
-      if !terms.blank?
-        clause = 'and ('
-        terms.each_index do |idx|
-          clause.concat(' or ') if idx > 0
-          clause.concat("(#{table}.term_cd=#{connection.quote(terms[idx].code)} and #{table}.term_yr=#{terms[idx].year.to_i})")
+      terms.try :compact!
+      if terms.present?
+        term_clauses = terms.map do |term|
+          "(#{table}.term_cd=#{connection.quote(term.code)} and #{table}.term_yr=#{term.year.to_i})"
         end
-        clause.concat(')')
-        clause
+        "and (#{term_clauses.join ' or '})"
       else
         ''
       end

--- a/spec/models/calendar/queries_spec.rb
+++ b/spec/models/calendar/queries_spec.rb
@@ -70,13 +70,15 @@ describe Calendar::Queries do
         expect(subject[2].slug).to eq 'summer-2014'
       end
     end
-    # Fall 2014 is the last term in the fake test data for CALCENTRAL_TERM_INFO_VW)
-    context 'in Fall 2014' do
-      before(:each) { Settings.terms.stub(:fake_now).and_return(DateTime.parse('2014-10-10')) }
-      it 'should return Fall 2014' do
-        expect(subject[0].slug).to eq 'fall-2014'
+    # Summer 2016 is the last term in the fake test data for CALCENTRAL_TERM_INFO_VW)
+    context 'in Summer 2016' do
+      before(:each) { Settings.terms.stub(:fake_now).and_return(DateTime.parse('2016-7-10')) }
+      it 'should return Summer 2016' do
+        expect(subject[0].slug).to eq 'summer-2016'
+      end
+      it 'should screen out nil values for terms not in database' do
         if Calendar::Queries.test_data?
-          expect(subject.length).to eq 3
+          expect(subject).to have(1).item
         end
       end
     end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6153

Belt and suspenders for a world in which terms can be nil. The calendar model should not include nil values in its terms array; nor should the Oracle connection freak out if someone does send it a terms array with nil values.