### PR TITLE
CLC-6155, add 'not authorized' to grep'ing response for errors

### DIFF
--- a/script/sis/sis_script_utils.sh
+++ b/script/sis/sis_script_utils.sh
@@ -24,7 +24,7 @@ parse_yaml() {
 
 validate_api_response() {
   local path_to_file=$1
-  error_count=$(grep -i 'error\|unable to find a routing' ${path_to_file} | wc -l)
+  error_count=$(grep -i 'error\|unable to find a routing\|not authorized' ${path_to_file} | wc -l)
   if [ "${error_count}" -ne "0" ]; then
     echo; echo "    [WARN] Errors found in ${path_to_file}:"
     cat "${path_to_file}"; echo

--- a/script/sis/verify_sis_api_endpoints.sh
+++ b/script/sis/verify_sis_api_endpoints.sh
@@ -81,7 +81,6 @@ API_CALLS=(
   "/UC_CM_XLAT_VALUES.v1/GetXlats?FIELDNAME=PHONE_TYPE"
   "/UC_CC_DELEGATED_ACCESS.v1/DelegatedAccess/get?SCC_DA_PRXY_OPRID=${LEGACY_UID}"
   "/UC_CC_DELEGATED_ACCESS_URL.v1/get"
-  "/UC_DA_T_C.v1/get"
 )
 
 for path in ${API_CALLS[@]}; do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6155

When testing the Delegated Access endpoints I identified another error condition to grep for: 'not authorized'.  I removed "/UC_DA_T_C.v1/get" because it's a placeholder and invalid.