### PR TITLE
CLC-6142 Add -Xcompile.invokedynamic=false for Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ matrix:
     - { rvm: jruby-1.7.19 }
 
 env:
-  - JRUBY_OPTS="--client -Xcext.enabled=false -J-Xmx900m" DISPLAY=:99.0 LOGGER_LEVEL=WARN
+  - JRUBY_OPTS="--dev" DISPLAY=:99.0 LOGGER_LEVEL=WARN
 
 before_script: "./script/front-end-test.sh"

--- a/script/bamboo-tests.sh
+++ b/script/bamboo-tests.sh
@@ -4,7 +4,7 @@
 # set up environment
 export RAILS_ENV=${RAILS_ENV:="testext"}
 export DISPLAY=":99"
-export JRUBY_OPTS="-Xcext.enabled=true -J-Xmx900m -J-XX:MaxPermSize=500m -J-Djruby.compile.mode=OFF"
+export JRUBY_OPTS="-Xcompile.invokedynamic=false -Xcext.enabled=true -J-Xmx900m -J-XX:MaxPermSize=500m -J-Djruby.compile.mode=OFF"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 

--- a/script/build-torquebox.sh
+++ b/script/build-torquebox.sh
@@ -14,7 +14,7 @@ source .rvmrc
 export RAILS_ENV=production
 export LOGGER_STDOUT=only
 # Temporary workaround for a JRuby 1.7.4 + Java 1.7 + JIT/invokedynamic bug : CLC-2732
-export JRUBY_OPTS="-Xcext.enabled=true -J-Xmx900m -J-XX:MaxPermSize=500m -J-Djruby.compile.mode=OFF"
+export JRUBY_OPTS="-Xcompile.invokedynamic=false -Xcext.enabled=true -J-Xmx900m -J-XX:MaxPermSize=500m -J-Djruby.compile.mode=OFF"
 # export JRUBY_OPTS="-Xcext.enabled=true -J-Xmx900m"
 
 echo | $LOGIT

--- a/script/calcentral-update.sh
+++ b/script/calcentral-update.sh
@@ -9,7 +9,7 @@ source .rvmrc
 
 export RAILS_ENV=production
 export LOGGER_STDOUT=only
-export JRUBY_OPTS="-Xcext.enabled=true -J-client -X-C"
+export JRUBY_OPTS="--dev"
 
 echo "------------------------------------------"
 echo "`date`: Redeploying CalCentral on app nodes..."

--- a/script/configure-all-canvas-apps-from-current-host.sh
+++ b/script/configure-all-canvas-apps-from-current-host.sh
@@ -19,7 +19,7 @@ source .rvmrc
 export RAILS_ENV=production
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcext.enabled=true -J-client -X-C"
+export JRUBY_OPTS="--dev"
 
 echo | $LOGIT
 echo "------------------------------------------" | $LOGIT

--- a/script/export-cached-csv-enrollments-set.sh
+++ b/script/export-cached-csv-enrollments-set.sh
@@ -17,7 +17,7 @@ source .rvmrc
 export RAILS_ENV=production
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled -J-XX:MaxPermSize=512m"
+export JRUBY_OPTS="-Xcompile.invokedynamic=false -Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled -J-XX:MaxPermSize=512m"
 
 echo | $LOGIT
 echo "------------------------------------------" | $LOGIT

--- a/script/load-test-dev.sh
+++ b/script/load-test-dev.sh
@@ -15,7 +15,7 @@ LOGIT="tee -a $LOG"
 source .rvmrc
 
 export RAILS_ENV=production
-export JRUBY_OPTS="-Xcext.enabled=true -J-client -X-C"
+export JRUBY_OPTS="--dev"
 
 echo | $LOGIT
 echo "------------------------------------------" | $LOGIT

--- a/script/migrate.sh
+++ b/script/migrate.sh
@@ -18,7 +18,7 @@ fi
 
 export RAILS_ENV=production
 export LOGGER_STDOUT=only
-export JRUBY_OPTS="-Xcext.enabled=true -J-client -X-C"
+export JRUBY_OPTS="--dev"
 LOG_DIR=${CALCENTRAL_LOG_DIR:=`pwd`"/log"}
 export CALCENTRAL_LOG_DIR=$LOG_DIR
 

--- a/script/reconfigure-canvas-test-servers.sh
+++ b/script/reconfigure-canvas-test-servers.sh
@@ -19,7 +19,7 @@ source .rvmrc
 export RAILS_ENV=production
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcext.enabled=true -J-client -X-C"
+export JRUBY_OPTS="--dev"
 
 cd deploy
 

--- a/script/refresh-all-canvas-enrollments.sh
+++ b/script/refresh-all-canvas-enrollments.sh
@@ -18,7 +18,7 @@ source .rvmrc
 export RAILS_ENV=production
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled -J-XX:MaxPermSize=512m -J-Xmx1024m"
+export JRUBY_OPTS="-Xcompile.invokedynamic=false -Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled -J-XX:MaxPermSize=512m -J-Xmx1024m"
 
 echo | $LOGIT
 echo "------------------------------------------" | $LOGIT

--- a/script/refresh-canvas-enrollments.sh
+++ b/script/refresh-canvas-enrollments.sh
@@ -18,7 +18,7 @@ source .rvmrc
 export RAILS_ENV=production
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled -J-XX:MaxPermSize=512m -J-Xmx1024m"
+export JRUBY_OPTS="-Xcompile.invokedynamic=false -Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled -J-XX:MaxPermSize=512m -J-Xmx1024m"
 
 echo | $LOGIT
 echo "------------------------------------------" | $LOGIT

--- a/script/refresh-canvas-users.sh
+++ b/script/refresh-canvas-users.sh
@@ -17,7 +17,7 @@ source .rvmrc
 export RAILS_ENV=production
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled -J-XX:MaxPermSize=512m -J-Xmx1024m"
+export JRUBY_OPTS="-Xcompile.invokedynamic=false -Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled -J-XX:MaxPermSize=512m -J-Xmx1024m"
 
 echo | $LOGIT
 echo "------------------------------------------" | $LOGIT

--- a/script/report-lti-usage.sh
+++ b/script/report-lti-usage.sh
@@ -17,7 +17,7 @@ source .rvmrc
 export RAILS_ENV=production
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcext.enabled=true -J-client -X-C"
+export JRUBY_OPTS="--dev"
 
 echo | $LOGIT
 echo "------------------------------------------" | $LOGIT

--- a/script/report-turnitin-usage.sh
+++ b/script/report-turnitin-usage.sh
@@ -17,7 +17,7 @@ source .rvmrc
 export RAILS_ENV=production
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcext.enabled=true -J-client -X-C"
+export JRUBY_OPTS="--dev"
 
 echo | $LOGIT
 echo "------------------------------------------" | $LOGIT

--- a/script/run-oec-task.sh
+++ b/script/run-oec-task.sh
@@ -28,7 +28,7 @@ then
   export RAILS_ENV=${RAILS_ENV:-production}
   export LOGGER_STDOUT=only
   export LOGGER_LEVEL=INFO
-  export JRUBY_OPTS="-Xcext.enabled=true -J-client -X-C"
+  export JRUBY_OPTS="--dev"
 
   echo "[$(date +"%F %H:%M:%S")] [INFO] Begin oec:${TASK} on $(hostname -s)" | ${LOGIT}
 

--- a/script/start-torquebox.sh
+++ b/script/start-torquebox.sh
@@ -23,7 +23,7 @@ export RAILS_ENV=production
 echo | $LOGIT
 echo "------------------------------------------" | $LOGIT
 echo "`date`: Starting CalCentral..." | $LOGIT
-OPTS=${CALCENTRAL_JRUBY_OPTS:="-Xcext.enabled=true -J-Djruby.thread.pool.enabled=true -J-Djava.io.tmpdir=$PWD/tmp"}
+OPTS=${CALCENTRAL_JRUBY_OPTS:="-Xcompile.invokedynamic=false -Xcext.enabled=true -J-Djruby.thread.pool.enabled=true -J-Djava.io.tmpdir=$PWD/tmp"}
 export JRUBY_OPTS=$OPTS
 JVM_OPTS=${CALCENTRAL_JVM_OPTS:="\-server \-verbose:gc \-XX:+PrintGCDateStamps \-XX:+PrintGCCause \-XX:+PrintGCDetails \-XX:+UseConcMarkSweepGC \-Xms3000m \-Xmx3000m \-Xmn500m \-XX:PermSize=400m \-XX:MaxPermSize=400m \-XX:ReservedCodeCacheSize=128m \-XX:+UseCodeCacheFlushing"}
 LOG_DIR=${CALCENTRAL_LOG_DIR:=`pwd`"/log"}

--- a/script/sync-canvas-guest-users.sh
+++ b/script/sync-canvas-guest-users.sh
@@ -17,7 +17,7 @@ source .rvmrc
 export RAILS_ENV=production
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcext.enabled=true -J-client -X-C"
+export JRUBY_OPTS="--dev"
 
 echo | $LOGIT
 echo "------------------------------------------" | $LOGIT

--- a/script/sync-canvas-new-users.sh
+++ b/script/sync-canvas-new-users.sh
@@ -17,7 +17,7 @@ source .rvmrc
 export RAILS_ENV=production
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcext.enabled=true -J-client -X-C"
+export JRUBY_OPTS="--dev"
 
 echo | $LOGIT
 echo "------------------------------------------" | $LOGIT

--- a/script/update-mailing-list-memberships.sh
+++ b/script/update-mailing-list-memberships.sh
@@ -18,7 +18,7 @@ source .rvmrc
 export RAILS_ENV=production
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcext.enabled=true -J-client -X-C"
+export JRUBY_OPTS="--dev"
 
 echo | $LOGIT
 echo "------------------------------------------" | $LOGIT


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6025

This is safe to land before the clusters are moved to 1.8.
