### PR TITLE
SISRP-13249 Allow JmsWorker to handle multiple connections and queues

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -290,13 +290,14 @@ cache_warmer:
 
 # Bearfacts JMS event queue
 ist_jms:
-  url: tcp://localhost:61616
-  queue: testqueue
-#  username: USERNAME
-#  password: PASSWORD
-  freshen_recording: false
   fake: true
   enabled: true
+  freshen_recording: false
+  connections:
+    - url: 'tcp://localhost:61616'
+      queues: [ 'testqueue' ]
+      #  username: USERNAME
+      #  password: PASSWORD
 
 # This will enable http basic auth for the app and should NEVER be enabled in production
 developer_auth:

--- a/lib/jms/jms_connection.rb
+++ b/lib/jms/jms_connection.rb
@@ -1,4 +1,4 @@
-require "activemq.rb"
+require 'activemq.rb'
 
 # JMS Connection is relatively heavyweight & can be used across multiple threads.
 # JMS Session and Consumer must be single-threaded.
@@ -6,12 +6,9 @@ require "activemq.rb"
 class JmsConnection
   attr_reader :connection
 
-  def initialize(url = Settings.ist_jms.url,
-      username = Settings.ist_jms.username,
-      password = Settings.ist_jms.password,
-      queue_name = Settings.ist_jms.queue)
-    java_import "javax.jms.Session"
-    java_import "org.apache.activemq.ActiveMQConnectionFactory"
+  def initialize(connection_settings)
+    java_import 'javax.jms.Session'
+    java_import 'org.apache.activemq.ActiveMQConnectionFactory'
 
     # JMS listeners do not generate any exceptions when a server goes away. Without failover,
     # a dangling connection and session will stay open and useless forever (or until
@@ -21,15 +18,21 @@ class JmsConnection
     # another thread, and then close the dangling connection/session from there.
     # The following URL means: wait at least 5 minutes before trying to reconnect; wait at most
     # 4 hours; do not block failed "send" attempts forever.
-    url = "failover:(#{url})?initialReconnectDelay=300000&maxReconnectDelay=14400000&timeout=30000&randomize=false"
+    failover_url = "failover:(#{connection_settings.url})?initialReconnectDelay=300000&maxReconnectDelay=14400000&timeout=30000&randomize=false"
 
-    connection_factory = username ?
-        ActiveMQConnectionFactory.new(username, password, url) :
-        ActiveMQConnectionFactory.new(url)
+    connection_factory = connection_settings.username ?
+        ActiveMQConnectionFactory.new(connection_settings.username, connection_settings.password, failover_url) :
+        ActiveMQConnectionFactory.new(failover_url)
     @connection = connection_factory.createConnection
-    @queue_name = queue_name
-    @session = @connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
-    @consumer = @session.createConsumer(@session.createQueue(@queue_name))
+    @sessions = []
+    @consumers = []
+
+    connection_settings.queues.each do |queue_name|
+      session = @connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
+      consumer = session.createConsumer(session.createQueue(queue_name))
+      @sessions << session
+      @consumers << consumer
+    end
   end
 
   def close
@@ -38,7 +41,7 @@ class JmsConnection
   end
 
   def count
-    defined?(@listener) ? @listener.count : nil
+    @listeners.map(&:count).reduce(:+) if @listeners
   end
 
   def finalize
@@ -46,16 +49,19 @@ class JmsConnection
   end
 
   def start_listening_with(&proc)
-    @listener = JmsTextListener.new(&proc)
-    @consumer.setMessageListener(@listener)
+    @listeners = @consumers.map do |consumer|
+      listener = JmsTextListener.new(&proc)
+      consumer.setMessageListener(listener)
+      listener
+    end
     @connection.start
   end
 
   # For testing with local ActiveMQ deployments.
-  def send_message(message_text)
+  def send_message(message_text, queue_name)
     begin
       session = @connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
-      producer = session.createProducer(session.createQueue(@queue_name))
+      producer = session.createProducer(session.createQueue(queue_name))
       producer.send(session.createTextMessage(message_text))
     ensure
       producer.close() if producer
@@ -63,10 +69,10 @@ class JmsConnection
     end
   end
   # For testing error handling of text message listener.
-  def send_bytes_message()
+  def send_bytes_message(queue_name)
     begin
       session = @connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
-      producer = session.createProducer(session.createQueue(@queue_name))
+      producer = session.createProducer(session.createQueue(queue_name))
       producer.send(session.createBytesMessage())
     ensure
       producer.close() if producer

--- a/lib/services/jms_worker.rb
+++ b/lib/services/jms_worker.rb
@@ -4,11 +4,12 @@ class JmsWorker
 
   JMS_RECORDING = "#{Rails.root}/fixtures/jms_recordings/ist_jms.txt"
 
-  RECEIVED_MESSAGES = "Received Messages"
-  LAST_MESSAGE_RECEIVED_TIME = "Last Message Received Time"
+  RECEIVED_MESSAGES = 'Received Messages'
+  LAST_MESSAGE_RECEIVED_TIME = 'Last Message Received Time'
 
-  def initialize(opts = {})
-    @jms = nil
+  attr_reader :jms_connections
+
+  def initialize
     @handler = Notifications::JmsMessageHandler.new
     @stopped = false
   end
@@ -31,42 +32,63 @@ class JmsWorker
   def run
     if Settings.ist_jms.fake
       Rails.logger.warn "#{self.class.name} Reading fake messages"
-      read_fake { |msg| @handler.handle(msg) }
+      open_fake_connection { |msg| @handler.handle(msg) }
     else
-      read_jms { |msg| @handler.handle(msg) }
+      open_jms_connections(Settings.ist_jms.connections) { |msg| @handler.handle(msg) }
     end
   end
 
-  def read_jms
-    until @jms do
-      begin
-        @jms ||= JmsConnection.new
-      rescue => e
-        Rails.logger.error "#{self.class.name} Unable to start JMS listener: #{e.class} #{e.message}"
-        sleep(30.minutes)
+  def open_jms_connections(connections, &blk)
+    @jms_connections = []
+    loop do
+      failed_connections = []
+      connections.each do |connection_settings|
+        if (jms_connection = open_connection(connection_settings, &blk))
+          @jms_connections << jms_connection
+        else
+          failed_connections << connection_settings
+        end
+      end
+      if failed_connections.any?
+        # Spell out 30.minutes in seconds because sleep and ActiveSupport are not friends in JRuby 1.7.19
+        # https://github.com/jruby/jruby/issues/1856
+        sleep 1800
+        connections = failed_connections
+      else
+        break
       end
     end
-    Rails.logger.warn "#{self.class.name} JMS Connection is initialized"
-    @jms.start_listening_with() do |msg|
+  end
+
+  def open_connection(connection_settings)
+    begin
+      jms_connection ||= JmsConnection.new(connection_settings)
+    rescue => e
+      Rails.logger.error "#{self.class.name} Unable to start JMS listener at #{connection_settings.url}: #{e.class} #{e.message}"
+      return false
+    end
+    Rails.logger.warn "#{self.class.name} JMS Connection is initialized at #{connection_settings.url}"
+    jms_connection.start_listening_with() do |msg|
       if Settings.ist_jms.freshen_recording
         File.open(JMS_RECORDING, 'a') do |f|
           # Use double newline as a serialized object separator.
           # Hat tip to: http://www.skorks.com/2010/04/serializing-and-deserializing-objects-with-ruby/
-          f.puts(YAML.dump(msg))
-          f.puts('')
+          f.puts YAML.dump(msg)
+          f.puts ''
         end
       end
       write_stats
       Rails.logger.debug "#{self.class} message from JMS Provider = #{@jms.connection.getMetaData.getJMSProviderName} #{@jms.connection.getMetaData.getProviderVersion}"
-      yield(msg)
+      yield msg
     end
+    jms_connection
   end
 
-  def read_fake
+  def open_fake_connection
     File.open(JMS_RECORDING, 'r').each("\n\n") do |msg_yaml|
       msg = YAML::load(msg_yaml)
       write_stats
-      yield(msg)
+      yield msg
     end
   end
 
@@ -76,9 +98,9 @@ class JmsWorker
   end
 
   def self.ping
-    received_messages = self.get_value(RECEIVED_MESSAGES)
-    last_received_message_time = self.get_value(LAST_MESSAGE_RECEIVED_TIME)
-    server = ServerRuntime.get_settings["hostname"]
+    received_messages = self.get_value RECEIVED_MESSAGES
+    last_received_message_time = self.get_value LAST_MESSAGE_RECEIVED_TIME
+    server = ServerRuntime.get_settings['hostname']
     if received_messages || last_received_message_time
       {
         server: server,
@@ -88,11 +110,6 @@ class JmsWorker
     else
       "#{self.name} Running on #{server}; Stats are not available"
     end
-  end
-
-  # Debugging helper.
-  def jms
-    @jms
   end
 
 end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-13249

JmsConnection now handles multiple queues, and JmsWorker handles multiple JmsConnection instances (as we might need to listen to the new Hub connection and our old Bearfacts connection simultaneously).

This implementation sticks with a single handler instance, since our Notifications::Handler seems already well set up to dispatch received messages among multiple processors.

NB: Changing connections and queues to arrays breaks YAML compatibility. Please ping me before merge so that YAML edits can be synchronized with deploys. Developer machines should also update their YAML, since the incompatibility will probably secretly persist until the next time one tries to run Torquebox.