### PR TITLE
SISRP-13262, delegate_quick_links card using (placeholder) attribute: berkeleyEduCSDelegateID

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,7 +4,7 @@ class SessionsController < ApplicationController
   skip_before_filter :check_reauthentication, :only => [:lookup, :destroy]
 
   def lookup
-    auth = request.env["omniauth.auth"]
+    auth = request.env['omniauth.auth']
     auth_uid = auth['uid']
 
     # Save crosswalk some work by caching critical IDs if they were asserted to us via SAML.
@@ -21,6 +21,11 @@ class SessionsController < ApplicationController
         # TODO reduce this log level once CAS reliably sends us the CS ID
         logger.warn "Caching Campus Solutions ID #{cs_id} for UID #{auth_uid} based on SAML assertion"
         crosswalk.cache_campus_solutions_id cs_id
+      end
+      delegate_id = auth.extra['berkeleyEduCSDelegateID']
+      if delegate_id.present?
+        logger.debug "Caching Campus Solutions Delegate ID #{delegate_id} for UID #{auth_uid} based on SAML assertion"
+        crosswalk.cache_delegate_user_id delegate_id
       end
     end
 
@@ -61,7 +66,7 @@ class SessionsController < ApplicationController
   end
 
   def reauth_admin
-    redirect_to url_for_path("/auth/cas?renew=true&url=/ccadmin")
+    redirect_to url_for_path '/auth/cas?renew=true&url=/ccadmin'
   end
 
   def basic_lookup
@@ -107,7 +112,7 @@ class SessionsController < ApplicationController
     else
       # Unless we're re-authenticating after view-as, initialize the session.
       session['user_id'] = uid unless session['original_user_id']
-      redirect_to smart_success_path, :notice => "Signed in!"
+      redirect_to smart_success_path, :notice => 'Signed in!'
     end
   end
 

--- a/app/models/calnet_crosswalk/proxy.rb
+++ b/app/models/calnet_crosswalk/proxy.rb
@@ -91,6 +91,14 @@ module CalnetCrosswalk
       cache_id('LEGACY_SIS_STUDENT_ID', value)
     end
 
+    def lookup_delegate_user_id
+      lookup_id 'DELEGATE_USER_ID'
+    end
+
+    def cache_delegate_user_id(value)
+      cache_id('DELEGATE_USER_ID', value)
+    end
+
     def lookup_id(id_type)
       self.class.smart_fetch_from_cache({id: "#{@uid}/#{id_type}"}) do
         id = nil

--- a/app/models/hub_edos/user_attributes.rb
+++ b/app/models/hub_edos/user_attributes.rb
@@ -43,6 +43,7 @@ module HubEdos
       result[:ldap_uid] = @uid
       result[:student_id] = lookup_student_id_from_crosswalk
       result[:campus_solutions_id] = lookup_campus_solutions_id
+      result[:delegate_user_id] = lookup_delegate_user_id
     end
 
     def extract_passthrough_elements(edo, result)

--- a/app/models/user/api.rb
+++ b/app/models/user/api.rb
@@ -127,6 +127,10 @@ module User
       @edo_attributes.present? && @edo_attributes[:campus_solutions_id].present? && @edo_attributes[:campus_solutions_id].to_s.length >= 10
     end
 
+    def is_delegate_user?
+      @edo_attributes.present? && @edo_attributes[:delegate_user_id].present?
+    end
+
     def is_sis_profile_visible?
       is_cs_profile_feature_enabled && (is_campus_solutions_student? || is_profile_visible_for_legacy_users)
     end
@@ -169,6 +173,7 @@ module User
         :sid => @student_id,
         :campusSolutionsID => get_campus_attribute('campus_solutions_id', :string),
         :isCampusSolutionsStudent => is_campus_solutions_student?,
+        :isDelegateUser => is_delegate_user?,
         :showSisProfileUI => is_sis_profile_visible?
       }
     end

--- a/app/models/user/student.rb
+++ b/app/models/user/student.rb
@@ -12,5 +12,9 @@ module User
     def lookup_student_id_from_crosswalk
       CalnetCrosswalk::ByUid.new(user_id: @uid).lookup_student_id
     end
+
+    def lookup_delegate_user_id
+      CalnetCrosswalk::ByUid.new(user_id: @uid).lookup_delegate_user_id
+    end
   end
 end

--- a/fixtures/json/calnet_crosswalk_12352.json
+++ b/fixtures/json/calnet_crosswalk_12352.json
@@ -1,0 +1,32 @@
+{
+  "Person": {
+    "emails": [],
+    "identifiers": [
+      {
+        "identifierTypeName": "CALNET_ID",
+        "identifierValue": "imaginary_test_user_8",
+        "isActive": true,
+        "isPrimaryForIdentifierType": true
+      },
+      {
+        "identifierTypeName": "LEGACY_SIS_STUDENT_ID",
+        "identifierValue": "24188910",
+        "isActive": false,
+        "isPrimaryForIdentifierType": true
+      },
+      {
+        "identifierTypeName": "CAMPUS_SOLUTIONS_ID",
+        "identifierValue": "13320459",
+        "isActive": false,
+        "isPrimaryForIdentifierType": true
+      },
+      {
+        "identifierTypeName": "DELEGATE_USER_ID",
+        "identifierValue": "20394351",
+        "isActive": true,
+        "isPrimaryForIdentifierType": true
+      }
+    ],
+    "uid": "12352"
+  }
+}

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,67 +1,88 @@
 describe SessionsController do
-  let(:user_id) { random_id }
   let(:cookie_hash) { {} }
   let(:response_body) { nil }
 
-  before(:each) do
-    @request.env['omniauth.auth'] = { 'uid' => user_id }
-    cookie_hash = {}
-    :logout
-  end
-
   describe '#lookup' do
-    it 'logs the user out when CAS uid does not match original user uid' do
-      expect(controller).to receive(:cookies).and_return cookie_hash
-      :create_reauth_cookie
-      different_user_id = "some_other_#{user_id}"
-      session['original_user_id'] = different_user_id
-      session['user_id'] = different_user_id
-
-      get :lookup, renew: 'true'
-
-      @response.status.should eq 302
-      cookie_hash[:reauthenticated].should be_nil
-      session.empty?.should be_truthy
-      cookie_hash.empty?.should be_truthy
+    before(:each) do
+      @request.env['omniauth.auth'] = {
+        'uid' => user_id
+      }
+      cookie_hash = {}
+      :logout
     end
-    it 'will create reauth cookie if original user_id not found in session' do
-      expect(controller).to receive(:cookies).and_return cookie_hash
-      session['user_id'] = user_id
 
-      get :lookup, renew: 'true'
+    context 'session management' do
+      let(:user_id) { random_id }
 
-      cookie_hash[:reauthenticated].should_not be_nil
-      reauth_cookie = cookie_hash[:reauthenticated]
-      reauth_cookie[:value].should be_truthy
-      (reauth_cookie[:expires] > Date.today).should be_truthy
-      session.empty?.should be_falsey
-      session['user_id'].should eql user_id
+      it 'logs the user out when CAS uid does not match original user uid' do
+        expect(controller).to receive(:cookies).and_return cookie_hash
+        :create_reauth_cookie
+        different_user_id = "some_other_#{user_id}"
+        session['original_user_id'] = different_user_id
+        session['user_id'] = different_user_id
+
+        get :lookup, renew: 'true'
+
+        expect(@response.status).to eq 302
+        expect(cookie_hash[:reauthenticated]).to be_nil
+        expect(session).to be_empty
+        expect(cookie_hash).to be_empty
+      end
+      it 'will create reauth cookie if original user_id not found in session' do
+        expect(controller).to receive(:cookies).and_return cookie_hash
+        session['user_id'] = user_id
+
+        get :lookup, renew: 'true'
+
+        cookie_hash[:reauthenticated].should_not be_nil
+        reauth_cookie = cookie_hash[:reauthenticated]
+        expect(reauth_cookie[:value]).to be true
+        expect(reauth_cookie[:expires]).to be > Date.today
+        expect(session).to_not be_empty
+        expect(session['user_id']).to eq user_id
+      end
+      it 'will reset session when CAS uid does not match uid in session' do
+        expect(controller).to receive(:cookies).and_return cookie_hash
+        :create_reauth_cookie
+        session['original_user_id'] = user_id
+        session['user_id'] = user_id
+
+        get :lookup, renew: 'true'
+
+        reauth_cookie = cookie_hash[:reauthenticated]
+        expect(reauth_cookie).to_not be_nil
+        expect(reauth_cookie[:value]).to be true
+        expect(reauth_cookie[:expires]).to be > Date.today
+
+        expect(session).to_not be_empty
+        expect(session['user_id']).to eq user_id
+      end
+      it 'will redirect to CAS logout, despite LTI user session, when CAS user_id is an unexpected value' do
+        expect(controller).to receive(:cookies).and_return cookie_hash
+        session['lti_authenticated_only'] = true
+        session['user_id'] = "some_other_#{user_id}"
+
+        # No 'renew' param
+        get :lookup
+
+        expect(session).to be_empty
+        expect(cookie_hash).to be_empty
+      end
     end
-    it 'will reset session when CAS uid does not match uid in session' do
-      expect(controller).to receive(:cookies).and_return cookie_hash
-      :create_reauth_cookie
-      session['original_user_id'] = user_id
-      session['user_id'] = user_id
 
-      get :lookup, renew: 'true'
+    context 'campus solutions' do
+      let(:user_id) { '12352' }
 
-      reauth_cookie = cookie_hash[:reauthenticated]
-      reauth_cookie.should_not be_nil
-      reauth_cookie[:value].should be_truthy
-      (reauth_cookie[:expires] > Date.today).should be_truthy
-      session.empty?.should be_falsey
-      session['user_id'].should eql user_id
-    end
-    it 'will redirect to CAS logout, despite LTI user session, when CAS user_id is an unexpected value' do
-      expect(controller).to receive(:cookies).and_return cookie_hash
-      session['lti_authenticated_only'] = true
-      session['user_id'] = "some_other_#{user_id}"
+      it 'will cache the Campus Solutions IDs' do
+        session['user_id'] = user_id
 
-      # No 'renew' param
-      get :lookup
+        get :lookup
 
-      session.empty?.should be_truthy
-      cookie_hash.empty?.should be_truthy
+        crosswalk = CalnetCrosswalk::ByUid.new user_id: user_id
+        expect(crosswalk.lookup_campus_solutions_id).to eq '13320459'
+        expect(crosswalk.lookup_student_id).to eq '24188910'
+        expect(crosswalk.lookup_delegate_user_id).to eq '20394351'
+      end
     end
   end
 
@@ -70,12 +91,6 @@ describe SessionsController do
       # The after hook below will make the appropriate assertions
       get :reauth_admin
     end
-  end
-
-  after(:each) do
-    @response.status.should eq 302
-    @response.body.should_not be_nil
-    @response.body.should include 'redirected'
   end
 
 end

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -43,6 +43,7 @@ describe User::Api do
     expect(user_data[:hasCanvasAccount]).to_not be_nil
     expect(user_data[:isCalendarOptedIn]).to_not be_nil
     expect(user_data[:isCampusSolutionsStudent]).to be true
+    expect(user_data[:isDelegateUser]).to be false
     expect(user_data[:showSisProfileUI]).to be true
     expect(user_data[:hasToolboxTab]).to be false
     expect(user_data[:officialBmailAddress]).to eq 'foo@foo.com'
@@ -58,6 +59,7 @@ describe User::Api do
           get: {
             :person_name => @preferred_name,
             :campus_solutions_id => '12345678', # 8-digit ID means legacy
+            :delegate_user_id => '87654321',
             :roles => {
               :student => true,
               :exStudent => false,
@@ -82,6 +84,7 @@ describe User::Api do
       it 'should show SIS profile for legacy students' do
         expect(user_data[:isCampusSolutionsStudent]).to be false
         expect(user_data[:showSisProfileUI]).to be true
+        expect(user_data[:isDelegateUser]).to be true
       end
     end
   end

--- a/src/assets/templates/toolbox.html
+++ b/src/assets/templates/toolbox.html
@@ -11,6 +11,7 @@
     </div>
     <div class="medium-4 columns cc-column-last" data-ng-if="api.user.profile.isSuperuser">
       <div data-ng-include="'widgets/toolbox/api_test.html'"></div>
+      <div data-ng-include="'widgets/toolbox/delegate_quick_links.html'" data-ng-if="api.user.profile.isDelegateUser"></div>
     </div>
   </div>
 </div>

--- a/src/assets/templates/widgets/toolbox/delegate_quick_links.html
+++ b/src/assets/templates/widgets/toolbox/delegate_quick_links.html
@@ -1,0 +1,33 @@
+<div class="cc-widget cc-toolbox-widget">
+  <div class="cc-widget-title">
+    <h2>Quick Links</h2>
+  </div>
+  <div class="cc-list-link-container">
+    <h3>Reference Websites</h3>
+    <ul class="cc-list-links">
+      <li>
+        <a href="http://calparents.berkeley.edu">CalParents</a>
+        <ul>
+          <li>Important Dates for Parents</li>
+          <li>Visiting Berkeley</li>
+          <li>Jobs and service opportunities for students </li>
+          <li>Housing for students</li>
+          <li>Finances</li>
+          <li>Academics</li>
+        </ul>
+      </li>
+      <li>
+        <a href="http://registrar.berkeley.edu/current_students/registration_enrollment/stucal.html">Academic Calendar</a>
+      </li>
+      <li>
+        <a href="http://news.berkeley.edu">UC Berkeley NewsCenter</a>
+      </li>
+      <li>
+        <a href="http://www.berkeley.edu/news/in_news/">Berkeley in the News</a>
+      </li>
+      <li>
+        <a href="http://www.dailycal.org">The Daily Californian</a>
+      </li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-13262

Use of `berkeleyEduCSDelegateID` is not arbitrary - it was imagined in https://jira.berkeley.edu/browse/SISRP-10867 Having a placeholder implementation is useful; we can refactor the backend as the technical spec evolves.

`delegate_quick_links.html` is a new card on My Toolbox and it demonstrates the front-end logic of `isDelegateUser`.

