### PR TITLE
CLC-6165 Fix bug when cache refreshes on the exact minute it expired

### DIFF
--- a/lib/cache/cacheable.rb
+++ b/lib/cache/cacheable.rb
@@ -91,7 +91,7 @@ module Cache
         next_time = Time.zone.today.in_time_zone.to_datetime.advance(hours: parsed[:hour].to_i,
           minutes: parsed[:minute].to_i)
         now = Time.zone.now.to_i
-        if now > next_time.to_i
+        if now >= next_time.to_i
           next_time = next_time.advance(days: 1)
         end
         next_time.to_i - now

--- a/spec/lib/cache/cacheable_spec.rb
+++ b/spec/lib/cache/cacheable_spec.rb
@@ -1,7 +1,7 @@
 describe Cache::Cacheable do
   class TestCacheable
     extend Cache::Cacheable
-
+    include ClassLogger
     def self.cache_key id
       id
     end
@@ -158,7 +158,7 @@ describe Cache::Cacheable do
   describe '#expires_in' do
     before do
       allow(Time).to receive(:now).and_return(Time.zone.parse(fake_now).to_time)
-      allow(Settings.cache.expiration).to receive(:marshal_dump).and_return({TestCacheable: fake_setting})
+      allow(Settings.cache.expiration).to receive(:marshal_dump).and_return({TestCacheable: fake_setting, default: 1 })
     end
     describe 'next day' do
       let(:fake_setting) {'NEXT_00_01'}
@@ -179,6 +179,12 @@ describe Cache::Cacheable do
         let(:fake_now) {'2014-09-02 09:00'}
         it 'returns tomorrow morning' do
           expect(TestCacheable.expires_in).to eq 23.hours.to_i
+        end
+      end
+      context 'exactly at expiration time' do
+        let(:fake_now) {'2014-09-02 08:00'}
+        it 'returns tomorrow morning' do
+          expect(TestCacheable.expires_in).to eq 24.hours.to_i
         end
       end
     end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6165

This has been plaguing us for many months, but the logging in Monday's release finally pinpointed the cause.