### PR TITLE
SISRP-13249 Pacify Torquebox by restoring unused JmsWorker opts

### DIFF
--- a/lib/services/jms_worker.rb
+++ b/lib/services/jms_worker.rb
@@ -9,7 +9,8 @@ class JmsWorker
 
   attr_reader :jms_connections
 
-  def initialize
+  # The unused opts argument is expected by Torquebox.
+  def initialize(opts={})
     @handler = Notifications::JmsMessageHandler.new
     @stopped = false
   end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-13249

One more follow-up to #4734.