### PR TITLE
SISRP-13257, 'original_delegate_user_id' is session marker when delegate-view-as student

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -139,7 +139,7 @@ class ApplicationController < ActionController::Base
   end
 
   def session_message
-    session_keys = %w(user_id original_user_id canvas_user_id canvas_masquerading_user_id canvas_course_id)
+    session_keys = %w(user_id original_user_id original_delegate_user_id canvas_user_id canvas_masquerading_user_id canvas_course_id)
     session_keys.map { |key| "#{key}: #{session[key]}" if session[key] }.compact.join('; ')
   end
 
@@ -149,6 +149,8 @@ class ApplicationController < ActionController::Base
     line = "ACCESS_LOG #{remote} #{request.request_method} #{request.filtered_path} #{status}"
     if session['original_user_id']
       line += " uid=#{session['original_user_id']}_acting_as_uid=#{session['user_id']}"
+    elsif session['original_delegate_user_id']
+      line += " uid=#{session['original_delegate_user_id']}_delegate_acting_as_uid=#{session['user_id']}"
     else
       line += " uid=#{session['user_id']}"
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -30,10 +30,10 @@ class SessionsController < ApplicationController
     end
 
     if params['renew'] == 'true'
-      # If we're reauthenticating due to view-as, then the CAS-provided UID should match
-      # the session's "original_user_id".
-      if session['original_user_id']
-        if session['original_user_id'] != auth_uid
+      # If we're reauthenticating due to view-as, then the CAS-provided UID should match original_user_id in session.
+      original_uid = session['original_delegate_user_id'] || session['original_user_id']
+      if original_uid
+        if original_uid != auth_uid
           logger.warn "ACT-AS: CAS returned UID #{auth_uid} not matching active session: #{session_message}. Logging user out."
           logout
           return redirect_to Settings.cas_logout_url
@@ -111,7 +111,7 @@ class SessionsController < ApplicationController
       redirect_to url_for_path('/uid_error')
     else
       # Unless we're re-authenticating after view-as, initialize the session.
-      session['user_id'] = uid unless session['original_user_id']
+      session['user_id'] = uid unless session['original_user_id'] || session['original_delegate_user_id']
       redirect_to smart_success_path, :notice => 'Signed in!'
     end
   end

--- a/app/models/user_specific_model.rb
+++ b/app/models/user_specific_model.rb
@@ -4,16 +4,18 @@ class UserSpecificModel
   attr_reader :authentication_state
 
   def self.from_session(session_state)
-    self.new(session_state['user_id'], {
-        'original_user_id' => session_state['original_user_id'],
-        'lti_authenticated_only' => session_state['lti_authenticated_only']
-    })
+    filtered_session = {
+      'original_user_id' => session_state['original_user_id'],
+      'original_delegate_user_id' => session_state['original_delegate_user_id'],
+      'lti_authenticated_only' => session_state['lti_authenticated_only']
+    }
+    self.new(session_state['user_id'], filtered_session)
   end
 
   def initialize(uid, options={})
     @uid = uid
     @options = options
-    @authentication_state = AuthenticationState.new(@options.merge('user_id' => @uid))
+    @authentication_state = AuthenticationState.new @options.merge('user_id' => @uid)
   end
 
   def instance_key

--- a/app/policies/authentication_state.rb
+++ b/app/policies/authentication_state.rb
@@ -1,18 +1,18 @@
 class AuthenticationState
-  attr_reader :user_id, :original_user_id, :canvas_masquerading_user_id, :lti_authenticated_only
+  attr_reader :user_id, :original_user_id, :original_delegate_user_id, :canvas_masquerading_user_id, :lti_authenticated_only
 
   LTI_AUTHENTICATED_ONLY = 'Authenticated through LTI'
 
   def initialize(session)
     @user_id = session['user_id']
     @original_user_id = session['original_user_id']
+    @original_delegate_user_id = session['original_delegate_user_id']
     @canvas_masquerading_user_id = session['canvas_masquerading_user_id']
     @lti_authenticated_only = session['lti_authenticated_only']
   end
 
   def authenticated_as_delegate?
-    #TODO implement me
-    false
+    @original_delegate_user_id.present?
   end
 
   def delegate_permissions
@@ -22,12 +22,14 @@ class AuthenticationState
 
   def directly_authenticated?
     user_id && !lti_authenticated_only &&
-      (original_user_id.blank? ||
-        (user_id == original_user_id))
+      (original_delegate_user_id.blank? || (user_id == original_delegate_user_id)) &&
+      (original_user_id.blank? || (user_id == original_user_id))
   end
 
   def original_user_auth
-    @original_user_auth ||= User::Auth.get(original_user_id)
+    @original_user_auth ||= User::Auth.get original_user_id
+    # If the previous line resulted in nil then we look for delegate user
+    @original_user_auth ||= User::Auth.get original_delegate_user_id
   end
 
   def policy
@@ -35,7 +37,7 @@ class AuthenticationState
   end
 
   def real_user_auth
-    if original_user_id && user_id
+    if (original_user_id || original_delegate_user_id) && user_id
       return original_user_auth
     elsif lti_authenticated_only
       # Public permissions only.
@@ -49,6 +51,8 @@ class AuthenticationState
     if user_id.present?
       if original_user_id.present?
         return original_user_id
+      elsif original_delegate_user_id.present?
+        return original_delegate_user_id
       elsif canvas_masquerading_user_id
         return "#{LTI_AUTHENTICATED_ONLY}: masquerading Canvas ID #{canvas_masquerading_user_id}"
       elsif lti_authenticated_only
@@ -63,7 +67,7 @@ class AuthenticationState
 
   # For better exception messages.
   def to_s
-    session_props = %w(user_id original_user_id canvas_masquerading_user_id lti_authenticated_only).map do |prop|
+    session_props = %w(user_id original_user_id original_delegate_user_id canvas_masquerading_user_id lti_authenticated_only).map do |prop|
       if (prop_value = self.send prop.to_sym)
         "#{prop}=#{prop_value}"
       end
@@ -76,7 +80,9 @@ class AuthenticationState
   end
 
   def viewing_as?
-    original_user_id.present? && user_id.present? && (original_user_id != user_id)
+    # Return true if either of the two view_as modes is active
+    original_uid = original_user_id || original_delegate_user_id
+    original_uid.present? && user_id.present? && (original_uid != user_id)
   end
 
 end

--- a/spec/controllers/user_api_controller_spec.rb
+++ b/spec/controllers/user_api_controller_spec.rb
@@ -71,6 +71,21 @@ describe UserApiController do
     end
   end
 
+  describe '#delegate_acting_as_uid' do
+    subject do
+      get :mystatus
+      JSON.parse(response.body)['delegateActingAsStudent']
+    end
+    context 'when normally authenticated' do
+      it { should be false }
+    end
+    context 'when viewing as' do
+      let(:original_delegate_user_id) { random_id }
+      before { session['original_delegate_user_id'] = original_delegate_user_id }
+      it { should be true }
+    end
+  end
+
   describe 'superuser status' do
     before do
       session['original_user_id'] = original_user_id

--- a/spec/policies/authentication_state_spec.rb
+++ b/spec/policies/authentication_state_spec.rb
@@ -15,6 +15,13 @@ describe AuthenticationState do
       }}
       it {should be_falsey}
     end
+    context 'when delegate viewing as' do
+      let(:fake_session) {{
+        'user_id' => random_id,
+        'original_delegate_user_id' => random_id
+      }}
+      it {should be_falsey}
+    end
     context 'when only authenticated from an external app' do
       let(:fake_session) {{
         'user_id' => random_id,
@@ -78,6 +85,13 @@ describe AuthenticationState do
       let(:fake_session) {{
         'user_id' => random_id,
         'original_user_id' => random_id
+      }}
+      it {should be_truthy}
+    end
+    context 'when viewing as' do
+      let(:fake_session) {{
+        'user_id' => random_id,
+        'original_delegate_user_id' => random_id
       }}
       it {should be_truthy}
     end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-13257
https://jira.berkeley.edu/browse/SISRP-13257

We are moving towards a functioning `Delegate > Students` card. I'm going to start with the session markers that take is in and out of delegate-view-as mode. If / when this PR is merged I will follow with `delegate_act_as_controller.rb` and more front-end changes.