### PR TITLE
SISRP-13434 CS finaid proxies: add default year, improve error handling

### DIFF
--- a/app/models/campus_solutions/direct_proxy.rb
+++ b/app/models/campus_solutions/direct_proxy.rb
@@ -15,5 +15,9 @@ module CampusSolutions
       })
     end
 
+    def error_response_root_xml_node
+      'UC_CM_FAULT_DOC'
+    end
+
   end
 end

--- a/app/models/campus_solutions/financial_aid_data.rb
+++ b/app/models/campus_solutions/financial_aid_data.rb
@@ -27,7 +27,7 @@ module CampusSolutions
 
     def build_feed(response)
       return {} if response.parsed_response.blank?
-      response.parsed_response['ROOT']
+      response.parsed_response['ROOT'] || response.parsed_response[error_response_root_xml_node] || {}
     end
 
     def url

--- a/app/models/campus_solutions/financial_aid_funding_sources.rb
+++ b/app/models/campus_solutions/financial_aid_funding_sources.rb
@@ -26,7 +26,7 @@ module CampusSolutions
 
     def build_feed(response)
       return {} if response.parsed_response.blank?
-      response.parsed_response['ROOT']
+      response.parsed_response['ROOT'] || response.parsed_response[error_response_root_xml_node] || {}
     end
 
     def url

--- a/app/models/campus_solutions/financial_aid_funding_sources_term.rb
+++ b/app/models/campus_solutions/financial_aid_funding_sources_term.rb
@@ -26,7 +26,7 @@ module CampusSolutions
 
     def build_feed(response)
       return {} if response.parsed_response.blank?
-      response.parsed_response['ROOT']
+      response.parsed_response['ROOT'] || response.parsed_response[error_response_root_xml_node] || {}
     end
 
     def url

--- a/app/models/campus_solutions/my_aid_years.rb
+++ b/app/models/campus_solutions/my_aid_years.rb
@@ -11,5 +11,13 @@ module CampusSolutions
       CampusSolutions::AidYears.new({user_id: @uid}).get
     end
 
+    def default_aid_year
+      feed = self.get_feed
+      years = feed && feed[:feed] && feed[:feed][:finaidSummary] && feed[:feed][:finaidSummary][:finaidYears]
+      if years && (default_year = years.find { |y| y[:default] })
+        default_year[:id]
+      end
+    end
+
   end
 end

--- a/app/models/campus_solutions/my_financial_aid_data.rb
+++ b/app/models/campus_solutions/my_financial_aid_data.rb
@@ -12,6 +12,7 @@ module CampusSolutions
 
     def get_feed_internal
       return {} unless is_feature_enabled
+      self.aid_year ||= CampusSolutions::MyAidYears.new(@uid).default_aid_year
       logger.debug "User #{@uid}; aid year #{aid_year}"
       CampusSolutions::FinancialAidData.new({user_id: @uid, aid_year: aid_year}).get
     end

--- a/app/models/campus_solutions/posting_proxy.rb
+++ b/app/models/campus_solutions/posting_proxy.rb
@@ -72,10 +72,6 @@ module CampusSolutions
       'PostResponse'
     end
 
-    def error_response_root_xml_node
-      'UC_CM_FAULT_DOC'
-    end
-
     def build_feed(response)
       parsed = response.parsed_response
       parsed[response_root_xml_node] || parsed[error_response_root_xml_node]

--- a/spec/models/campus_solutions/financial_aid_data_spec.rb
+++ b/spec/models/campus_solutions/financial_aid_data_spec.rb
@@ -21,6 +21,16 @@ describe CampusSolutions::FinancialAidData do
   context 'real proxy', testext: true do
     let(:proxy) { CampusSolutions::FinancialAidData.new(user_id: user_id, fake: false, aid_year: 2016) }
     it_should_behave_like 'a proxy that gets data'
+
+    context 'an invalid request' do
+      let(:proxy) { CampusSolutions::FinancialAidData.new(user_id: user_id, fake: false, aid_year: 0) }
+      subject { proxy.get }
+
+      context 'requesting an invalid year' do
+        it_should_behave_like 'a simple proxy that returns errors'
+        it_should_behave_like 'a proxy that responds to user error gracefully'
+      end
+    end
   end
 
 end

--- a/spec/models/campus_solutions/financial_aid_funding_sources_spec.rb
+++ b/spec/models/campus_solutions/financial_aid_funding_sources_spec.rb
@@ -21,6 +21,16 @@ describe CampusSolutions::FinancialAidFundingSources do
   context 'real proxy', testext: true do
     let(:proxy) { CampusSolutions::FinancialAidFundingSources.new(user_id: user_id, fake: false, aid_year: 2016) }
     it_should_behave_like 'a proxy that gets data'
+
+    context 'an invalid request' do
+      let(:proxy) { CampusSolutions::FinancialAidFundingSources.new(user_id: user_id, fake: false, aid_year: 0) }
+      subject { proxy.get }
+
+      context 'requesting an invalid year' do
+        it_should_behave_like 'a simple proxy that returns errors'
+        it_should_behave_like 'a proxy that responds to user error gracefully'
+      end
+    end
   end
 
 end

--- a/spec/models/campus_solutions/financial_aid_funding_sources_term_spec.rb
+++ b/spec/models/campus_solutions/financial_aid_funding_sources_term_spec.rb
@@ -21,6 +21,16 @@ describe CampusSolutions::FinancialAidFundingSourcesTerm do
   context 'real proxy', testext: true do
     let(:proxy) { CampusSolutions::FinancialAidFundingSourcesTerm.new(user_id: user_id, fake: false, aid_year: 2016) }
     it_should_behave_like 'a proxy that gets data'
+
+    context 'an invalid request' do
+      let(:proxy) { CampusSolutions::FinancialAidFundingSourcesTerm.new(user_id: user_id, fake: false, aid_year: 0) }
+      subject { proxy.get }
+
+      context 'requesting an invalid year' do
+        it_should_behave_like 'a simple proxy that returns errors'
+        it_should_behave_like 'a proxy that responds to user error gracefully'
+      end
+    end
   end
 
 end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-13434

Correct a false assumption that only PostingProxy will return UC_CM_FAULT_DOC; financial aid proxies are returning it also.

When CampusSolutions::MyFinancialAidData is called by LiveUpdatesWarmer, set it to the user's default aid year. It would be nice to have it warm up other years as well, but that would require architectural changes to the class.