### PR TITLE
CLC-6098, informative logging in campus_solution proxy, plus hash check

### DIFF
--- a/app/models/campus_solutions/proxy.rb
+++ b/app/models/campus_solutions/proxy.rb
@@ -56,8 +56,9 @@ module CampusSolutions
         response = get_response(url, request_options)
         logger.debug "Remote server status #{response.code}, Body = #{response.body.force_encoding('UTF-8')}"
         feed = build_feed response
-        feed = convert_feed_keys(feed)
-        if is_errored?(feed)
+        feed = convert_feed_keys feed
+        if is_errored? feed
+          logger.error "Error reported in Campus Solutions response (campus_solutions_id=#{@campus_solutions_id}): #{response.inspect}"
           {
             statusCode: 400,
             errored: true,
@@ -73,7 +74,7 @@ module CampusSolutions
     end
 
     def convert_feed_keys(feed)
-      HashConverter.downcase_and_camelize(feed)
+      HashConverter.downcase_and_camelize feed
     end
 
     def url
@@ -81,7 +82,7 @@ module CampusSolutions
     end
 
     def is_errored?(feed)
-      feed[:errmsgtext].present?
+      feed.is_a?(Hash) && feed[:errmsgtext].present?
     end
 
     def request_options


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6098

In `campus_solutions/proxy` the call to `convert_feed_keys(feed)` can return either an array or a hash. However, our `is_errored?` method has assumed hash so this PR includes a sanity check.

In the case of error, we now log the cs_id and raw response.  