### PR TITLE
CLC-6168 Flatten caching in HubEdos models

### DIFF
--- a/app/models/hub_edos/affiliations.rb
+++ b/app/models/hub_edos/affiliations.rb
@@ -1,8 +1,6 @@
 module HubEdos
   class Affiliations < Student
 
-    include Cache::UserCacheExpiry
-
     def initialize(options = {})
       super(options)
     end

--- a/app/models/hub_edos/contacts.rb
+++ b/app/models/hub_edos/contacts.rb
@@ -1,8 +1,6 @@
 module HubEdos
   class Contacts < Student
 
-    include Cache::UserCacheExpiry
-
     def initialize(options = {})
       super(options)
     end

--- a/app/models/hub_edos/demographics.rb
+++ b/app/models/hub_edos/demographics.rb
@@ -1,8 +1,6 @@
 module HubEdos
   class Demographics < Student
 
-    include Cache::UserCacheExpiry
-
     def initialize(options = {})
       super(options)
     end

--- a/app/models/hub_edos/student.rb
+++ b/app/models/hub_edos/student.rb
@@ -1,13 +1,6 @@
 module HubEdos
   class Student < Proxy
 
-    include Cache::UserCacheExpiry
-    include ResponseHandler
-
-    def initialize(options = {})
-      super(Settings.hub_edos_proxy, options)
-    end
-
     def url
       "#{@settings.base_url}/#{@campus_solutions_id}/all"
     end

--- a/app/models/hub_edos/user_attributes.rb
+++ b/app/models/hub_edos/user_attributes.rb
@@ -1,22 +1,17 @@
 module HubEdos
-  class UserAttributes < Proxy
+  class UserAttributes
 
-    include Cache::UserCacheExpiry
     include User::Student
 
     def initialize(options = {})
-      super(Settings.hub_edos_proxy, options)
+      @uid = options[:user_id]
     end
 
     def self.test_data?
       Settings.hub_edos_proxy.fake.present?
     end
 
-    def initialize_mocks
-      #no-op; this proxy calls no endpoints itself.
-    end
-
-    def get_internal
+    def get
       edo_feed = MyStudent.new(@uid).get_feed
       result = {}
       if (feed = edo_feed[:feed])

--- a/app/models/hub_edos/work_experience.rb
+++ b/app/models/hub_edos/work_experience.rb
@@ -1,14 +1,6 @@
 module HubEdos
   class WorkExperience < Proxy
 
-    include Cache::UserCacheExpiry
-    include ResponseHandler
-
-    def initialize(options = {})
-      super(Settings.hub_edos_proxy, options)
-      initialize_mocks if @fake
-    end
-
     def url
       "#{@settings.base_url}/#{@campus_solutions_id}/work-experiences"
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,7 +181,6 @@ Calcentral::Application.routes.draw do
   delete '/api/campus_solutions/ethnicity/:ethnicGroupCode/:regRegion' => 'campus_solutions/ethnicity#delete', :via => :delete, :defaults => { :format => 'json' }
 
   # EDOs from integration hub
-  get '/api/edos/person' => 'hub_edo#person', :via => :get, :defaults => { :format => 'json' }
   get '/api/edos/student' => 'hub_edo#student', :via => :get, :defaults => { :format => 'json' }
   get '/api/edos/work_experience' => 'hub_edo#work_experience', :via => :get, :defaults => { :format => 'json' }
 


### PR DESCRIPTION
Part one of https://jira.ets.berkeley.edu/jira/browse/CLC-6168.

- Subclasses of HubEdos::Proxy (including subclasses of HubEdos::Student) lose endpoint-level caching.
- Controller-accessible merged models HubEdos::MyStudent, HubEdos::MyWorkExperience, and User::Api keep their caching.
- Bits of shared code in HubEdos::Proxy subclasses are condensed into the parent class.
- HubEdos::UserAttributes, which is not a proxy, stops pretending to be one.
- A stray Rails route is removed for HubEdos::Person, a model lost in the mists of time.