### PR TITLE
SISRP-13251, like view-as footer we have delegate-view-as footer

### DIFF
--- a/src/assets/javascripts/angular/controllers/widgets/delegateStudentsController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/delegateStudentsController.js
@@ -13,7 +13,7 @@ angular.module('calcentral.controllers').controller('DelegateStudentsController'
 
   var getStudents = function() {
     return delegateFactory.getStudents().then(function(data) {
-      angular.extend($scope, _.get(data, 'feed'));
+      angular.extend($scope, _.get(data, 'data.feed'));
       $scope.delegateStudents.isLoading = false;
     });
   };

--- a/src/assets/templates/delegate_acting_as.html
+++ b/src/assets/templates/delegate_acting_as.html
@@ -1,0 +1,6 @@
+<div class="cc-acting-as-fixed" data-ng-cloak data-ng-if="api.user.profile.delegateActingAsStudent" data-ng-controller="DelegateActingAsController">
+  <p>
+    You are viewing <span data-ng-bind="api.user.profile.fullName"></span>'s information.
+    <button class="cc-button cc-button-blue cc-right" data-ng-click="delegate.stopActAs()" type="button">Stop</button>
+  </p>
+</div>

--- a/src/assets/templates/no_bconnected.html
+++ b/src/assets/templates/no_bconnected.html
@@ -1,5 +1,5 @@
 <p data-ng-show="mode === 'upnext' || mode === 'tasks'">
-  <span data-ng-if="mode === 'tasks'">To manage your personal tasks</span><span data-ng-if="mode === 'upnext'">To see events from your bCal calendar</span>, <button data-ng-if="!api.user.profile['actingAsUid']" class="cc-button-link" data-ng-click="api.user.enableOAuth('Google')">Connect</button><span data-ng-if="api.user.profile['actingAsUid']">connect</span> CalCentral to your bConnected Google calendar account, then Accept. <button class="cc-button-link" data-ng-show="!showReminder" data-ng-click="showReminder=!showReminder">Show more</button>
+  <span data-ng-if="mode === 'tasks'">To manage your personal tasks</span><span data-ng-if="mode === 'upnext'">To see events from your bCal calendar</span>, <button data-ng-if="!api.user.profile['actingAsUid'] && !api.user.profile['delegateActingAsUid']" class="cc-button-link" data-ng-click="api.user.enableOAuth('Google')">Connect</button><span data-ng-if="api.user.profile['actingAsUid']">connect</span> CalCentral to your bConnected Google calendar account, then Accept. <button class="cc-button-link" data-ng-show="!showReminder" data-ng-click="showReminder=!showReminder">Show more</button>
 </p>
 <div data-ng-show="mode === 'main'">
   <p>Connect CalCentral to your campus bConnected <em>email</em>, <em>calendar</em> and <em>drive</em> account.</p>

--- a/src/index-main.html
+++ b/src/index-main.html
@@ -20,3 +20,4 @@
   </div>
 </div>
 <div data-ng-include="'acting_as.html'"></div>
+<div data-ng-include="'delegate_acting_as.html'"></div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-13251

On the front-end, we continue to match the `act_as` pattern w.r.t delegate_acting_as. We also hide "connect bConnected" from delegates per https://jira.berkeley.edu/browse/SISRP-13258