### PR TITLE
SISRP-12478 Handling undergrad/Slate applicants before official acceptance

### DIFF
--- a/app/controllers/act_as_controller.rb
+++ b/app/controllers/act_as_controller.rb
@@ -9,7 +9,8 @@ class ActAsController < ApplicationController
     return redirect_to root_path unless valid_params?(params['uid'])
     logger.warn "ACT-AS: User #{current_user.real_user_id} acting as #{params['uid']} begin"
     session['original_user_id'] = session['user_id'] unless session['original_user_id']
-    session['user_id'] = params['uid']
+    session['user_id'] = User::AuthenticationValidator.new(params['uid']).validated_user_id
+    # TODO Mimic '/uid_error' redirect for nulled session user IDs.
 
     # This makes sure the most recently viewed user is at the top of the list
     User::StoredUsers.delete_recent_uid(session['original_user_id'], params['uid'])

--- a/app/controllers/canvas_lti_controller.rb
+++ b/app/controllers/canvas_lti_controller.rb
@@ -37,9 +37,9 @@ class CanvasLtiController < ApplicationController
       check_for_masquerade canvas_masquerading_user_id
     end
 
-    session['user_id'] = canvas_user_login_id
     session['canvas_user_id'] = canvas_user_id
     session['canvas_course_id'] = canvas_course_id
+    session['user_id'] = User::AuthenticationValidator.new(canvas_user_login_id).validated_user_id
   end
 
   def check_for_masquerade(masquerading_user_id)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -101,6 +101,7 @@ class SessionsController < ApplicationController
     # Force a new CSRF token to be generated on login.
     # http://homakov.blogspot.com.es/2013/06/cookie-forcing-protection-made-easy.html
     session.try(:delete, :_csrf_token)
+    uid = User::AuthenticationValidator.new(uid).validated_user_id
     if (Integer(uid, 10) rescue nil).nil?
       logger.warn "FAILED login with CAS UID: #{uid}"
       redirect_to url_for_path('/uid_error')

--- a/app/models/hub_edos/user_attributes.rb
+++ b/app/models/hub_edos/user_attributes.rb
@@ -73,7 +73,7 @@ module HubEdos
       # TODO We still need to cover staff, guests, concurrent-enrollment students and registration status.
       edo[:affiliations].select { |a| a[:statusCode] == 'ACT' }.each do |active_affiliation|
         case active_affiliation[:type][:code]
-          when 'APPLICANT'
+          when 'ADMT_UX'
             result[:roles][:applicant] = true
           when 'GRADUATE'
             result[:roles][:student] = true

--- a/app/models/user/authentication_validator.rb
+++ b/app/models/user/authentication_validator.rb
@@ -1,0 +1,60 @@
+module User
+  class AuthenticationValidator
+    extend Cache::Cacheable
+    include Cache::UserCacheExpiry
+    include ClassLogger
+
+    attr_reader :auth_uid
+
+    def initialize(auth_uid)
+      @auth_uid = auth_uid
+    end
+
+    def feature_enabled?
+      Settings.features.authentication_validator
+    end
+
+    def validated_user_id
+      if feature_enabled? && cached_held_applicant?
+        nil
+      else
+        @auth_uid
+      end
+    end
+
+    def cached_held_applicant?
+      key = self.class.cache_key @auth_uid
+      entry = Rails.cache.read key
+      if entry
+        logger.debug "Entry is already in cache: #{key}"
+        return (entry == NilClass) ? nil : entry
+      end
+      is_held = held_applicant?
+      logger.warn "Held UID #{@auth_uid} will be treated as blank UID" if is_held
+      expiration = is_held ? self.class.expires_in('User::AuthenticationValidator::short') : self.class.expires_in
+      cached_entry = (is_held.nil?) ? NilClass : is_held
+      logger.debug "Cache_key will be #{key}, expiration #{expiration}"
+      Rails.cache.write(key,
+        cached_entry,
+        :expires_in => expiration,
+        :force => true)
+      is_held
+    end
+
+    def held_applicant?
+      # Check CalDap affiliations first, since that will generally be faster than an API call.
+      # We have a choice between CampusOracle::Queries.get_basic_people_attributes (faster but uncached) and
+      # CampusOracle::UserAttributes (slower but cached and quickly re-used on the happy path).
+      calnet_attributes = CampusOracle::Queries.get_basic_people_attributes([@auth_uid]).first
+      return false if calnet_attributes.present? &&
+        calnet_attributes['affiliations'].present? &&
+        calnet_attributes['affiliations'] != 'STUDENT-TYPE-NOT-REGISTERED'
+      cs_affiliations = HubEdos::Affiliations.new(user_id: @auth_uid).get
+      cs_affiliations[:feed] && cs_affiliations[:feed]['student'] &&
+        cs_affiliations[:feed]['student']['affiliations'].present? &&
+        cs_affiliations[:feed]['student']['affiliations'].length == 1 &&
+        cs_affiliations[:feed]['student']['affiliations'][0]['type']['code'] == 'APPLICANT'
+    end
+
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -215,6 +215,8 @@ cache:
     UpNext::MyUpNext: NEXT_00_00
     User::Api: NEXT_08_00
     User::Photo: <%= 24.hours %>
+    User::AuthenticationValidator: <%= 8.hours %>
+    User::AuthenticationValidator::short: <%= 15.minutes %>
     UserApiController: <%= 4.hours %>
     Canvas::CourseStudents: <%= 15.minutes %>
     Canvas::CourseTeachers: <%= 5.minutes %>
@@ -325,6 +327,7 @@ features:
   cs_sir: true
   cs_delegated_access: false
   slate_checklist: false
+  authentication_validator: false
   webcast_sign_up_on_calcentral: false
   prevent_acting_as_users_from_posting: true
 

--- a/fixtures/json/affiliations.json
+++ b/fixtures/json/affiliations.json
@@ -23,6 +23,15 @@
               "statusDescription": "Inactive",
               "fromDate": "2015-10-02",
               "toDate": "2015-10-28"
+            },
+            {
+              "type": {
+                "code": "ADMT_UX",
+                "description": "Admitted Students CalCentral Access"
+              },
+              "statusCode": "ACT",
+              "statusDescription": "Active",
+              "fromDate": "2015-10-22"
             }
           ],
           "confidential": false

--- a/lib/cache/cacheable.rb
+++ b/lib/cache/cacheable.rb
@@ -69,9 +69,10 @@ module Cache
       Rails.cache.exist? key
     end
 
-    def expires_in
+    def expires_in(expires_key = nil)
+      expires_key ||= self.name
       expirations = Settings.cache.expiration.marshal_dump
-      expiration_config = expirations[self.name.to_sym] || expirations[:default]
+      expiration_config = expirations[expires_key.to_sym] || expirations[:default]
       begin
         exp = parse_expiration_setting(expiration_config)
         if exp.blank? || exp == 0

--- a/spec/models/hub_edos/affiliations_spec.rb
+++ b/spec/models/hub_edos/affiliations_spec.rb
@@ -9,7 +9,7 @@ describe HubEdos::Affiliations do
 
     it 'returns data with the expected structure' do
       expect(subject[:feed]['student']).to be
-      expect(subject[:feed]['student']['affiliations'].length).to eq 1
+      expect(subject[:feed]['student']['affiliations'].length).to eq 2
     end
   end
 

--- a/spec/models/hub_edos/user_attributes_spec.rb
+++ b/spec/models/hub_edos/user_attributes_spec.rb
@@ -162,7 +162,7 @@ describe HubEdos::UserAttributes do
         [
           {
             'type' => {
-              'code' => 'APPLICANT',
+              'code' => 'ADMT_UX',
               'description' => ''
             },
             'statusCode' => 'ACT',

--- a/spec/models/user/authentication_validator_spec.rb
+++ b/spec/models/user/authentication_validator_spec.rb
@@ -1,0 +1,169 @@
+require 'spec_helper'
+
+describe User::AuthenticationValidator do
+  let(:auth_uid) { random_id }
+  let(:feature_flag) { true }
+  before do
+    allow(Settings.features).to receive(:authentication_validator).and_return(feature_flag)
+  end
+
+  describe '#held_applicant?' do
+    let(:nil_calnet_row) do
+      { 'affiliations' => ''}
+    end
+    let(:held_cs_affiliations) do
+      {:statusCode=>200,
+        :feed=>
+          {'student'=>
+            {'affiliations'=>
+              [{'type'=>{'code'=>'APPLICANT', 'description'=>'Applicant'},
+                'statusCode'=>'ACT',
+                'statusDescription'=>'Active',
+                'fromDate'=>'2016-01-06'}]}},
+        :studentNotFound=>nil}
+    end
+    let(:released_cs_affiliations) do
+      {:statusCode=>200,
+        :feed=>
+          {'student'=>
+            {'affiliations'=>
+              [{'type'=>
+                {'code'=>'ADMT_UX',
+                  'description'=>'Admitted Students CalCentral Access'},
+                'statusCode'=>'ACT',
+                'statusDescription'=>'Active',
+                'fromDate'=>'2016-01-11'},
+                {'type'=>{'code'=>'APPLICANT', 'description'=>'Applicant'},
+                  'statusCode'=>'ACT',
+                  'statusDescription'=>'Active',
+                  'fromDate'=>'2016-01-06'}]}},
+        :studentNotFound=>nil}
+    end
+    before do
+      allow(CampusOracle::Queries).to receive(:get_basic_people_attributes).with([auth_uid]).and_return([calnet_row])
+      allow(HubEdos::Affiliations).to receive(:new).with(user_id: auth_uid).and_return(double(get: cs_affiliations))
+    end
+    subject { User::AuthenticationValidator.new(auth_uid).held_applicant? }
+    context 'CalNet affiliations but no CS affiliations' do
+      let(:calnet_row) do
+        { 'affiliations' => 'EMPLOYEE-TYPE-STAFF,STUDENT-STATUS-EXPIRED'}
+      end
+      let(:cs_affiliations) { held_cs_affiliations }
+      it {should be_falsey}
+    end
+    context 'CalNet affiliations and only pending-admit CS affiliation' do
+      let(:calnet_row) do
+        { 'affiliations' => 'EMPLOYEE-TYPE-STAFF,STUDENT-STATUS-EXPIRED'}
+      end
+      let(:cs_affiliations) { nil }
+      it {should be_falsey}
+    end
+    context 'No CalNet affiliations and only pending-admit CS affiliation' do
+      let(:calnet_row) { nil_calnet_row }
+      let(:cs_affiliations) { held_cs_affiliations }
+      it {should be_truthy}
+    end
+    context 'Only not-registered CalNet affiliation and only pending-admit CS affiliation' do
+      let(:calnet_row) do
+        { 'affiliations' => 'STUDENT-TYPE-NOT-REGISTERED'}
+      end
+      let(:cs_affiliations) { held_cs_affiliations }
+      it {should be_truthy}
+    end
+    context 'No CalNet affiliations and released-admit CS affiliation' do
+      let(:calnet_row) { nil_calnet_row }
+      let(:cs_affiliations) { released_cs_affiliations }
+      it {should be_falsey}
+    end
+    context 'No CalNet affiliations and multiple CS affiliations' do
+      let(:calnet_row) { nil_calnet_row }
+      let(:cs_affiliations) do
+        {:statusCode=>200,
+          :feed=>
+            {"student"=>
+              {"affiliations"=>
+                [{"type"=>{"code"=>"STUDENT", "description"=>""},
+                  "statusCode"=>"ACT",
+                  "statusDescription"=>"Active",
+                  "fromDate"=>"2015-12-14"},
+                  {"type"=>{"code"=>"UNDERGRAD", "description"=>"Undergraduate Student"},
+                    "statusCode"=>"ACT",
+                    "statusDescription"=>"Active",
+                    "fromDate"=>"2015-12-14"}]}},
+          :studentNotFound=>nil}
+      end
+      it {should be_falsey}
+    end
+  end
+
+  describe '#validated_user_id' do
+    before do
+      allow_any_instance_of(User::AuthenticationValidator).to receive(:held_applicant?).and_return(is_held)
+    end
+    subject { User::AuthenticationValidator.new(auth_uid) }
+    context 'user is only known as a held applicant' do
+      let(:is_held) { true }
+      it 'does not accept the session user_id' do
+        expect(subject.validated_user_id).to be_nil
+      end
+    end
+    context 'user is an old friend' do
+      let(:is_held) { false }
+      it 'allows the session user_id' do
+        expect(subject.validated_user_id).to eq auth_uid
+      end
+    end
+  end
+
+  context 'feature disabled' do
+    let(:feature_flag) { false }
+    it 'should not waste time checking affiliations' do
+      expect(CampusOracle::Queries).to receive(:get_basic_people_attributes).never
+      expect(HubEdos::Affiliations).to receive(:new).never
+      expect(User::AuthenticationValidator.new(auth_uid).validated_user_id).to eq auth_uid
+    end
+  end
+
+  describe 'caching' do
+    let(:cache_key) { User::AuthenticationValidator.cache_key(auth_uid) }
+    before do
+      allow_any_instance_of(User::AuthenticationValidator).to receive(:held_applicant?).and_return(is_held)
+      allow(Settings.cache.expiration).to receive(:marshal_dump).and_return({
+        'User::AuthenticationValidator'.to_sym => 8.hours,
+        'User::AuthenticationValidator::short'.to_sym => 1.second
+      })
+    end
+    subject { User::AuthenticationValidator.new(auth_uid) }
+    context 'in a stable institutional relationship' do
+      let(:is_held) { false }
+      it 'remembers the good times' do
+        expect(Rails.cache).to receive(:read).once.with(cache_key).and_call_original
+        expect(Rails.cache).to receive(:write).once.with(
+          cache_key,
+          anything,
+          {
+            expires_in: 8.hours,
+            force: true
+          }
+        )
+        subject.validated_user_id
+      end
+    end
+    context 'just met' do
+      let(:is_held) { true }
+      it 'hopes to make a friend' do
+        expect(Rails.cache).to receive(:read).once.with(cache_key).and_call_original
+        expect(Rails.cache).to receive(:write).once.with(
+          cache_key,
+          anything,
+          {
+            expires_in: 1.second,
+            force: true
+          }
+        )
+        subject.validated_user_id
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-12478
Subtasks:
SISRP-13420 Change SIR/Onboarding trigger
SISRP-13318 CC authentication needs to treat unreleased acceptances as null UIDs	

So far I haven't figured out a good way to mimic the "uid_error" behavior when Viewing As a not-yet-released admit. Doing that will just send you back to the landing page.