### PR TITLE
CLC-6175 Reduce log level on OEC unexpected-data errors

### DIFF
--- a/app/models/oec/merged_sheet_validation.rb
+++ b/app/models/oec/merged_sheet_validation.rb
@@ -123,7 +123,7 @@ module Oec
         [instructors, course_instructors, courses, students, course_students, supervisors, course_supervisors]
       else
         @status = 'Error'
-        log :error, 'Validation failed!'
+        log :warn, 'Validation failed!'
         log_validation_errors
         nil
       end

--- a/app/models/oec/remote_drive.rb
+++ b/app/models/oec/remote_drive.rb
@@ -9,7 +9,7 @@ module Oec
 
     def check_conflicts_and_copy_file(file, dest_folder, opts={})
       if find_items_by_title(file.title, parent_id: folder_id(dest_folder)).any?
-        raise RuntimeError, "File '#{file.title}' already exists in remote drive folder '#{dest_folder.title}'; could not copy"
+        raise Oec::Task::UnexpectedDataError, "File '#{file.title}' already exists in remote drive folder '#{dest_folder.title}'; could not copy"
       elsif (item = copy_item_to_folder(file, folder_id(dest_folder)))
         opts[:on_success].call if opts[:on_success]
         item
@@ -24,7 +24,7 @@ module Oec
           when :return_existing
             return existing_folder
           when :error
-            raise RuntimeError, "Folder '#{folder_name}' with parent '#{folder_title(parent)}' already exists on remote drive"
+            raise Oec::Task::UnexpectedDataError, "Folder '#{folder_name}' with parent '#{folder_title(parent)}' already exists on remote drive"
         end
       elsif (new_folder = create_folder(folder_name, folder_id(parent)))
         opts[:on_creation].call if opts[:on_creation]
@@ -36,7 +36,7 @@ module Oec
 
     def check_conflicts_and_upload(item, title, type, folder, opts={})
       if find_items_by_title(title, parent_id: folder_id(folder)).any?
-        raise RuntimeError, "Item '#{title}' already exists in remote drive folder '#{folder.title}'; could not upload"
+        raise Oec::Task::UnexpectedDataError, "Item '#{title}' already exists in remote drive folder '#{folder.title}'; could not upload"
       end
       upload_operation = (type == Oec::Worksheet) ?
         upload_to_spreadsheet(title, item.to_io, folder_id(folder)) :
@@ -61,7 +61,7 @@ module Oec
         if !(item = find_first_matching_item(title, parent))
           case opts[:on_failure]
           when :error
-            raise RuntimeError, "Could not locate folder '#{title}' with parent '#{folder_title(parent)}' on remote drive"
+            raise Oec::Task::UnexpectedDataError, "Could not locate folder '#{title}' with parent '#{folder_title(parent)}' on remote drive"
           else
             return nil
           end

--- a/app/models/oec/report_diff_task.rb
+++ b/app/models/oec/report_diff_task.rb
@@ -16,7 +16,7 @@ module Oec
 
     def update_remote_drive
       confirmations_folder = @remote_drive.find_nested([@term_code, Oec::Folder.confirmations])
-      raise RuntimeError, "No department confirmations folder found for term #{@term_code}" unless confirmations_folder
+      raise UnexpectedDataError, "No department confirmations folder found for term #{@term_code}" unless confirmations_folder
       title = "#{@term_code} diff report"
       if (remote_file = @remote_drive.find_first_matching_item(title, confirmations_folder))
         # TODO: Be transactional, implement @remote_drive.update_worksheet(). For now, the benefit is not worth the risk of refactor.

--- a/app/models/oec/validator.rb
+++ b/app/models/oec/validator.rb
@@ -51,7 +51,7 @@ module Oec
           message << "\n"
         end
       end
-      log :error, "\n#{message}\n" unless message.blank?
+      log :warn, "\n#{message}\n" unless message.blank?
     end
 
   end

--- a/spec/models/oec/merge_confirmation_sheets_task_spec.rb
+++ b/spec/models/oec/merge_confirmation_sheets_task_spec.rb
@@ -158,7 +158,7 @@ describe Oec::MergeConfirmationSheetsTask do
     end
 
     it 'should record errors' do
-      expect(Rails.logger).to receive(:error).at_least(1).times
+      expect(Rails.logger).to receive(:warn).at_least(1).times
       task.run
       expect(task.errors['Merged course confirmations']['2015-B-91111-100008'].keys).to eq ["Conflicting values found under DEPT_FORM: 'GWS', 'MCELLBI'"]
     end
@@ -178,7 +178,7 @@ describe Oec::MergeConfirmationSheetsTask do
     end
 
     it 'should record errors' do
-      expect(Rails.logger).to receive(:error).at_least(1).times
+      expect(Rails.logger).to receive(:warn).at_least(1).times
       task.run
       expect(task.errors['Merged course confirmations']['2015-B-91111-100008'].keys).to eq ['No SIS import row found matching confirmation row']
     end
@@ -202,7 +202,7 @@ describe Oec::MergeConfirmationSheetsTask do
     end
 
     it 'should record errors' do
-      expect(Rails.logger).to receive(:error).at_least(1).times
+      expect(Rails.logger).to receive(:warn).at_least(1).times
       task.run
       pp task.errors
       expect(task.errors['Merged supervisor confirmations']['999999'].keys).to match_array([
@@ -226,7 +226,7 @@ describe Oec::MergeConfirmationSheetsTask do
     end
 
     it 'should record errors' do
-      expect(Rails.logger).to receive(:error).at_least(1).times
+      expect(Rails.logger).to receive(:warn).at_least(1).times
       task.run
       expect(task.errors['Merged supervisor confirmations']['999999'].keys).to include 'No supervisors row found matching confirmation row'
     end

--- a/spec/models/oec/validation_task_spec.rb
+++ b/spec/models/oec/validation_task_spec.rb
@@ -15,8 +15,8 @@ describe Oec::ValidationTask do
   shared_examples 'validation error logging' do
     it 'should log error' do
       merged_course_confirmations_csv.concat invalid_row
-      allow(Rails.logger).to receive(:error)
-      expect(Rails.logger).to receive(:error).with /Validation failed!/
+      allow(Rails.logger).to receive(:warn)
+      expect(Rails.logger).to receive(:warn).with /Validation failed!/
       task.run
       expect(task.errors[sheet_name][key].keys.first).to eq expected_message
     end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6175

For a large class of OEC errors involving user-modifiable data on Google Drive, surface the problem to users, but log at WARN instead of ERROR and don't include a stack trace.

For more serious problems, Google connection errors, etc., retain current behavior.