### PR TITLE
SISRP-13375, delegate should never see student's preferred name

### DIFF
--- a/app/models/hub_edos/user_attributes.rb
+++ b/app/models/hub_edos/user_attributes.rb
@@ -55,17 +55,24 @@ module HubEdos
     end
 
     def find_name(type, edo, result)
+      found_match = false
       if edo[:names].present?
         edo[:names].each do |name|
-          if name[:type].present? && name[:type][:code].present? && name[:type][:code].upcase == type.upcase
-            result[:first_name] = name[:givenName]
-            result[:last_name] = name[:familyName]
-            result[:person_name] = name[:formattedName]
-            return true
+          if name[:type].present? && name[:type][:code].present?
+            if name[:type][:code].upcase == 'PRI'
+              result[:given_name] = name[:givenName]
+              result[:family_name] = name[:familyName]
+            end
+            if name[:type].present? && name[:type][:code].present? && name[:type][:code].upcase == type.upcase
+              result[:first_name] = name[:givenName]
+              result[:last_name] = name[:familyName]
+              result[:person_name] = name[:formattedName]
+              found_match = true
+            end
           end
         end
       end
-      false
+      found_match
     end
 
     def extract_roles(edo, result)

--- a/app/models/user/api.rb
+++ b/app/models/user/api.rb
@@ -20,6 +20,8 @@ module User
       @first_name ||= get_campus_attribute('first_name', :string) || ''
       @last_name ||= get_campus_attribute('last_name', :string) || ''
       @override_name ||= @calcentral_user_data ? @calcentral_user_data.preferred_name : nil
+      @given_first_name = (@edo_attributes && @edo_attributes[:given_name]) || @first_name || ''
+      @family_name = (@edo_attributes && @edo_attributes[:family_name]) || @last_name || ''
       @student_id = get_campus_attribute('student_id', :numeric_string)
     end
 
@@ -153,8 +155,11 @@ module User
         :isSuperuser => current_user_policy.can_administrate?,
         :isViewer => current_user_policy.can_view_as?,
         :firstLoginAt => @first_login_at,
-        :first_name => @first_name,
+        :firstName => @first_name,
+        :lastName => @last_name,
         :fullName => @first_name + ' ' + @last_name,
+        :givenFirstName => @given_first_name,
+        :givenFullName => @given_first_name + ' ' + @family_name,
         :isGoogleReminderDismissed => is_google_reminder_dismissed,
         :isCalendarOptedIn => is_calendar_opted_in,
         :hasCanvasAccount => Canvas::Proxy.has_account?(@uid),
@@ -169,8 +174,7 @@ module User
         :googleEmail => google_mail,
         :canvasEmail => canvas_mail,
         :officialBmailAddress => official_bmail_address,
-        :last_name => @last_name,
-        :preferred_name => self.preferred_name,
+        :preferredName => self.preferred_name,
         :roles => roles,
         :uid => @uid,
         :sid => @student_id,

--- a/fixtures/json/student_contacts.json
+++ b/fixtures/json/student_contacts.json
@@ -24,12 +24,12 @@
                 "code": "PRF",
                 "description": "Preferred"
               },
-              "familyName": "Bear",
-              "givenName": "René",
+              "familyName": "Stardust",
+              "givenName": "Ziggy",
               "middleName": "",
               "prefixName": "",
               "suffixName": "",
-              "formattedName": "René  Bear ",
+              "formattedName": "Ziggy  Stardust ",
               "preferred": true,
               "disclose": false,
               "uiControl": {

--- a/spec/controllers/user_api_controller_spec.rb
+++ b/spec/controllers/user_api_controller_spec.rb
@@ -32,7 +32,7 @@ describe UserApiController do
       json_response = JSON.parse(response.body)
       expect(json_response['isLoggedIn']).to be_truthy
       expect(json_response['uid']).to eq user_id
-      expect(json_response['preferred_name']).to be_present
+      expect(json_response['preferredName']).to be_present
       expect(json_response['features']).to be_present
       visit = User::Visit.where(:uid => session['user_id'])[0]
       expect(visit.last_visit_at).to be_present
@@ -74,15 +74,44 @@ describe UserApiController do
   describe '#delegate_acting_as_uid' do
     subject do
       get :mystatus
-      JSON.parse(response.body)['delegateActingAsUid']
+      JSON.parse response.body
     end
     context 'when normally authenticated' do
-      it { should be false }
+      it 'should deliver user\'s preferred and given names' do
+        expect(subject['delegateActingAsUid']).to be false
+        expect(subject['preferredName']).to_not be_nil
+        expect(subject['firstName']).to_not eq subject['givenFirstName']
+        expect(subject['fullName']).to_not eq subject['givenFullName']
+        expect(subject['preferredName']).to_not eq subject['givenFullName']
+      end
     end
     context 'when viewing as' do
       let(:original_delegate_user_id) { random_id }
-      before { session['original_delegate_user_id'] = original_delegate_user_id }
-      it { should eq original_delegate_user_id }
+      before do
+        session['original_delegate_user_id'] = original_delegate_user_id
+        # Give student superpowers with the hope that delegate user has powers turned off.
+        allow(User::Auth).to receive(:get) do |uid|
+          case uid
+            when user_id
+              double(is_superuser?: true, is_viewer?: true, active?: true)
+            else
+              double(is_superuser?: false, is_viewer?: false, active?: true)
+          end
+        end
+      end
+      it 'should identify user in delegate-view-as mode' do
+        expect(subject['delegateActingAsUid']).to eq original_delegate_user_id
+      end
+      it 'should remove preferred name and other sensitive during delegate-view-as mode' do
+        expect(subject['delegateActingAsUid']).to eq original_delegate_user_id
+        expect(subject['firstLoginAt']).to be_nil
+        expect(subject['firstName']).to eq subject['givenFirstName']
+        expect(subject['fullName']).to eq subject['givenFullName']
+        expect(subject['preferredName']).to eq subject['givenFullName']
+        expect(subject['isDelegateUser']).to be false
+        expect(subject['isViewer']).to be false
+        expect(subject['isSuperuser']).to be false
+      end
     end
   end
 

--- a/spec/models/hub_edos/user_attributes_spec.rb
+++ b/spec/models/hub_edos/user_attributes_spec.rb
@@ -16,9 +16,11 @@ describe HubEdos::UserAttributes do
   it 'should provide the converted person data structure' do
     expect(subject[:ldap_uid]).to eq '61889'
     expect(subject[:student_id]).to eq '11667051'
-    expect(subject[:first_name]).to eq 'René'
-    expect(subject[:last_name]).to eq 'Bear'
-    expect(subject[:person_name]).to eq 'René  Bear '
+    expect(subject[:given_name]).to eq 'Oski'
+    expect(subject[:family_name]).to eq 'Bear'
+    expect(subject[:first_name]).to eq 'Ziggy'
+    expect(subject[:last_name]).to eq 'Stardust'
+    expect(subject[:person_name]).to eq 'Ziggy  Stardust '
     expect(subject[:email_address]).to eq 'oski@gmail.com'
     expect(subject[:official_bmail_address]).to eq 'oski@berkeley.edu'
     expect(subject[:names]).to be

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -39,7 +39,7 @@ describe User::Api do
   end
   it 'should return a user data structure' do
     user_data = User::Api.new(@random_id).get_feed
-    expect(user_data[:preferred_name]).to eq @preferred_name
+    expect(user_data[:preferredName]).to eq @preferred_name
     expect(user_data[:hasCanvasAccount]).to_not be_nil
     expect(user_data[:isCalendarOptedIn]).to_not be_nil
     expect(user_data[:isCampusSolutionsStudent]).to be true
@@ -230,10 +230,12 @@ describe User::Api do
 
     let(:expected_values_from_campus_oracle) {
       {
-        first_name: 'Eugene V',
-        last_name: 'Debs',
-        preferred_name: 'Eugene V Debs',
+        preferredName: 'Eugene V Debs',
+        firstName: 'Eugene V',
+        lastName: 'Debs',
         fullName: 'Eugene V Debs',
+        givenFirstName: 'Eugene V',
+        givenFullName: 'Eugene V Debs',
         uid: '1151855',
         sid: '18551926',
         isCampusSolutionsStudent: false,

--- a/src/assets/templates/widgets/gear_popover.html
+++ b/src/assets/templates/widgets/gear_popover.html
@@ -9,7 +9,7 @@
       <span data-ng-if="!api.user.profile.hasPhoto" class="cc-popover-gear-round-profile cc-popover-gear-round-profile-no-photo">
         <i class="fa fa-user"></i>
       </span>
-      <span data-ng-bind="api.user.profile.first_name" class="cc-popover-gear-first-name" data-ng-class="{'cc-popover-gear-has-alerts': hasAlerts && !api.user.profile.delegateActingAsUid}"></span>
+      <span data-ng-bind="api.user.profile.firstName" class="cc-popover-gear-first-name" data-ng-class="{'cc-popover-gear-has-alerts': hasAlerts && !api.user.profile.delegateActingAsUid}"></span>
       <span data-ng-if="!api.user.profile.delegateActingAsUid">
         <span class="cc-visuallyhidden">.</span>
         <span data-ng-if="hasAlerts" class="cc-icon-status-person-layover cc-icon-status-person-layover-red">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-13375

*Note:* From what I can tell, `preferred_name` and `last_name` are not used in templates but I kept them in the feed, with camelCase.  See Jira comments for more info. 