### PR TITLE
SISRP-7689, transform delegate_students feed; delegate_permissions

### DIFF
--- a/app/models/campus_solutions/delegate_students.rb
+++ b/app/models/campus_solutions/delegate_students.rb
@@ -11,8 +11,8 @@ module CampusSolutions
     def build_feed(response)
       feed = response.parsed_response
       return {} if feed.blank?
-      feed = feed['ROOT']['STUDENT_DELEGATED_ACCESS'] if feed['ROOT'] && feed['ROOT']['STUDENT_DELEGATED_ACCESS']
-      feed
+      students = feed['ROOT']['STUDENT_DELEGATED_ACCESS']['STUDENTS'] if feed['ROOT'] && feed['ROOT']['STUDENT_DELEGATED_ACCESS']
+      transform_feed students
     end
 
     def xml_filename
@@ -23,5 +23,28 @@ module CampusSolutions
       "#{@settings.base_url}/UC_CC_DELEGATED_ACCESS.v1/DelegatedAccess/get?SCC_DA_PRXY_OPRID=#{@uid}"
     end
 
+    def transform_feed(students)
+      return {} if students.nil?
+      feed = {}
+      students.each do |student|
+        transformation = {}
+        transformation['campus_solutions_id'] = student['EMPLID']
+        transformation['full_name'] = student['NAME']
+        transformation['privileges'] = { 'financial' => false, 'view_enrollments' => false, 'view_grades' => false, 'phone' => false }
+        if (role_names = student['ROLENAMES'])
+          role_names.each do |role_name|
+            case role_name.downcase
+              when /financial/ then transformation['privileges']['financial'] = true
+              when /enrollments_view/ then transformation['privileges']['view_enrollments'] = true
+              when /grades/ then transformation['privileges']['view_grades'] = true
+              when /person call/ then transformation['privileges']['phone'] = true
+            end
+          end
+        end
+        feed['students'] ||= []
+        feed['students'] << transformation
+      end
+      feed
+    end
   end
 end

--- a/app/policies/authentication_state.rb
+++ b/app/policies/authentication_state.rb
@@ -16,8 +16,14 @@ class AuthenticationState
   end
 
   def delegate_permissions
-    #TODO implement me
-    nil
+    return nil unless authenticated_as_delegate? &&
+      (response = CampusSolutions::DelegateStudents.new(user_id: @original_delegate_user_id).get)
+    if response[:feed] && (students = response[:feed][:students])
+      campus_solutions_id = CalnetCrosswalk::ByUid.new(user_id: @user_id).lookup_campus_solutions_id
+      students.detect { |s| campus_solutions_id == s[:campusSolutionsId] }
+    else
+      nil
+    end
   end
 
   def directly_authenticated?

--- a/spec/controllers/campus_solutions/delegate_access_controller_spec.rb
+++ b/spec/controllers/campus_solutions/delegate_access_controller_spec.rb
@@ -27,9 +27,9 @@ describe CampusSolutions::DelegateAccessController do
       expect(json['statusCode']).to eq 200
       expect(json['feed']['students']).to be_present
       json['feed']['students'].each do |student|
-        expect(student['emplid']).to be_present
-        expect(student['name']).to be_present
-        expect(student['rolenames']).to be_present
+        expect(student['campusSolutionsId']).to be_present
+        expect(student['fullName']).to be_present
+        expect(student['privileges']).to be_present
       end
     end
 

--- a/spec/models/campus_solutions/delegate_students_spec.rb
+++ b/spec/models/campus_solutions/delegate_students_spec.rb
@@ -10,8 +10,21 @@ describe CampusSolutions::DelegateStudents do
   it 'returns expected mock data' do
     students = subject[:feed][:students]
     expect(students).to have(2).items
-    expect(students.find { |s| s[:name] == 'Tom Tulliver' }[:emplid]).to eq '16777216'
-    expect(students.find { |s| s[:name] == 'Tom Tulliver' }[:rolenames]).to eq ['UC DA InPerson Call Access']
-    expect(students.find { |s| s[:name] == 'Maggie Tulliver' }[:rolenames]).to match_array ['UC DA Financial View', 'UC DA InPerson Call Access']
+    tom = students.find {|s| s[:fullName] == 'Tom Tulliver' }
+    expect(tom[:campusSolutionsId]).to eq '16777216'
+    expect(tom[:privileges]).to eq({
+      financial: false,
+      viewEnrollments: false,
+      viewGrades: false,
+      phone: true
+    })
+    maggie = students.find {|s| s[:fullName] == 'Maggie Tulliver' }
+    expect(maggie[:campusSolutionsId]).to eq '1073741824'
+    expect(maggie[:privileges]).to eq({
+      financial: true,
+      viewEnrollments: false,
+      viewGrades: false,
+      phone: true
+    })
   end
 end

--- a/spec/policies/authentication_state_spec.rb
+++ b/spec/policies/authentication_state_spec.rb
@@ -88,13 +88,6 @@ describe AuthenticationState do
       }}
       it {should be_truthy}
     end
-    context 'when viewing as' do
-      let(:fake_session) {{
-        'user_id' => random_id,
-        'original_delegate_user_id' => random_id
-      }}
-      it {should be_truthy}
-    end
     context 'when only authenticated from an external app' do
       let(:fake_session) {{
         'user_id' => random_id,
@@ -109,4 +102,59 @@ describe AuthenticationState do
     end
   end
 
+  describe '#delegate_viewing_as?' do
+    subject {AuthenticationState.new fake_session}
+    context 'when authenticated but not a delegate' do
+      let(:fake_session) {{
+        'user_id' => random_id
+      }}
+      it 'should not find delegate session attribute' do
+        expect(subject.authenticated_as_delegate?).to be false
+        expect(subject.delegate_permissions).to be_nil
+      end
+    end
+    context 'when in delegate-view-as mode' do
+      let(:user_id) { random_id }
+      let(:campus_solutions_id) { '16777216' }
+      let(:fake_session) {{
+        'user_id' => user_id,
+        'original_delegate_user_id' => random_id
+      }}
+      before do
+        crosswalk_proxy = CalnetCrosswalk::ByUid.new
+        allow(crosswalk_proxy).to receive(:lookup_campus_solutions_id).and_return campus_solutions_id
+        allow(CalnetCrosswalk::ByUid).to receive(:new).with(user_id: user_id).and_return crosswalk_proxy
+      end
+      it 'should get student of delegate user' do
+        expect(subject).to be_authenticated_as_delegate
+        permissions = subject.delegate_permissions
+        expect(permissions).to_not be_nil
+        expect(permissions[:fullName]).to eq 'Tom Tulliver'
+        expect(permissions[:campusSolutionsId]).to eq campus_solutions_id
+        expect(permissions[:privileges]).to eq({
+           financial: false,
+           viewEnrollments: false,
+           viewGrades: false,
+           phone: true
+         })
+      end
+    end
+    context 'when only authenticated from an external app' do
+      let(:fake_session) {{
+        'user_id' => random_id,
+        'lti_authenticated_only' => true
+      }}
+      it 'should force delegate session to false' do
+        expect(subject.authenticated_as_delegate?).to be false
+        expect(subject.delegate_permissions).to be_nil
+      end
+    end
+    context 'when not logged in' do
+      let(:fake_session) { {} }
+      it 'should force delegate session to false' do
+        expect(subject.authenticated_as_delegate?).to be false
+        expect(subject.delegate_permissions).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-7689

The response (feed) from DelegateStudents needs a front-end-friendly structure (e.g., `feed[:privileges][:viewEnrollments] = true|false`). This leads to implementation of AuthenticationState#delegate_permissions. The `delegate_students.html` template will need trivial updates once this is merged.