### PR TITLE
CLC-6185 Fix wonky ServiceAlerts::Merged cache keys

### DIFF
--- a/app/models/service_alerts/merged.rb
+++ b/app/models/service_alerts/merged.rb
@@ -1,7 +1,7 @@
 module ServiceAlerts
   class Merged
     include Cache::CachedFeed
-    include Cache::JsonAddedCacher
+    include Cache::JsonifiedFeed
 
     def get_feed_internal
       feed = {}
@@ -13,7 +13,7 @@ module ServiceAlerts
     end
 
     def instance_key
-      self.class.cache_key
+      nil
     end
 
   end

--- a/spec/models/service_alerts/merged_spec.rb
+++ b/spec/models/service_alerts/merged_spec.rb
@@ -1,5 +1,5 @@
 describe ServiceAlerts::Merged do
-  let(:feed) { ServiceAlerts::Merged.new.get_feed }
+  let(:feed) { ServiceAlerts::Merged.new.get_feed_internal }
 
   shared_examples 'a feed with a release note' do
     it 'should include a well-formed release note' do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6185

Cache deletion before:
`/api/cache/delete?key=ServiceAlerts::Merged/ServiceAlerts::Merged`
`/api/cache/delete?key=ServiceAlerts::Merged/json-ServiceAlerts::Merged`

Cache deletion after:
`/api/cache/delete/ServiceAlerts::Merged`

[sigh]