### PR TITLE
SISRP-7689, strengthen act_as_authorization and give front-end uid, too

### DIFF
--- a/app/controllers/delegate_act_as_controller.rb
+++ b/app/controllers/delegate_act_as_controller.rb
@@ -7,8 +7,16 @@ class DelegateActAsController < ActAsController
   end
 
   def act_as_authorization(uid_param)
-    delegate_user_id = CalnetCrosswalk::ByUid.new(user_id: uid_param).lookup_delegate_user_id
-    raise NotAuthorizedError.new('The current user is not authorized to act as a delegate.') unless delegate_user_id
+    acting_user_id = current_user.real_user_id
+    response = CampusSolutions::DelegateStudents.new(user_id: acting_user_id).get
+    if response[:feed] && (students = response[:feed][:students])
+      campus_solutions_id = CalnetCrosswalk::ByUid.new(user_id: uid_param).lookup_campus_solutions_id
+      student = students.detect { |s| campus_solutions_id == s[:campusSolutionsId] }
+      authorized = student && [:financial, :viewEnrollments, :viewGrades].any? { |k| student[:privileges][k] }
+      raise NotAuthorizedError.new("User #{acting_user_id} is not authorized to delegate-view-as #{student}") unless authorized
+    else
+      raise NotAuthorizedError.new "User #{acting_user_id} does not have delegate affiliation"
+    end
   end
 
   def after_successful_start(session, params)

--- a/app/models/campus_solutions/delegate_students.rb
+++ b/app/models/campus_solutions/delegate_students.rb
@@ -28,7 +28,9 @@ module CampusSolutions
       feed = {}
       students.each do |student|
         transformation = {}
-        transformation['campus_solutions_id'] = student['EMPLID']
+        empl_id = student['EMPLID']
+        transformation['campus_solutions_id'] = empl_id
+        transformation['uid'] = CalnetCrosswalk::BySid.new(user_id: empl_id).lookup_ldap_uid
         transformation['full_name'] = student['NAME']
         transformation['privileges'] = { 'financial' => false, 'view_enrollments' => false, 'view_grades' => false, 'phone' => false }
         if (role_names = student['ROLENAMES'])

--- a/spec/models/campus_solutions/delegate_students_spec.rb
+++ b/spec/models/campus_solutions/delegate_students_spec.rb
@@ -7,24 +7,26 @@ describe CampusSolutions::DelegateStudents do
   it_should_behave_like 'a proxy that got data successfully'
   it_should_behave_like 'a proxy that properly observes the delegated access feature flag'
 
-  it 'returns expected mock data' do
-    students = subject[:feed][:students]
-    expect(students).to have(2).items
-    tom = students.find {|s| s[:fullName] == 'Tom Tulliver' }
-    expect(tom[:campusSolutionsId]).to eq '16777216'
-    expect(tom[:privileges]).to eq({
-      financial: false,
-      viewEnrollments: false,
-      viewGrades: false,
-      phone: true
-    })
-    maggie = students.find {|s| s[:fullName] == 'Maggie Tulliver' }
-    expect(maggie[:campusSolutionsId]).to eq '1073741824'
-    expect(maggie[:privileges]).to eq({
-      financial: true,
-      viewEnrollments: false,
-      viewGrades: false,
-      phone: true
-    })
+  context 'delegate is linked to two students' do
+    let(:tom_uid) { random_id }
+    let(:maggie_uid) { random_id }
+    before do
+      allow(CalnetCrosswalk::BySid).to receive(:new).with(user_id: '16777216').and_return (tom = double)
+      allow(tom).to receive(:lookup_ldap_uid).and_return tom_uid
+      allow(CalnetCrosswalk::BySid).to receive(:new).with(user_id: '1073741824').and_return (maggie = double)
+      allow(maggie).to receive(:lookup_ldap_uid).and_return maggie_uid
+    end
+    it 'returns expected mock data' do
+      students = subject[:feed][:students]
+      expect(students).to have(2).items
+      tom = students.find {|s| s[:fullName] == 'Tom Tulliver' }
+      expect(tom[:campusSolutionsId]).to eq '16777216'
+      expect(tom[:uid]).to eq tom_uid
+      expect(tom[:privileges]).to eq({ financial: false, viewEnrollments: false, viewGrades: false, phone: true })
+      maggie = students.find {|s| s[:fullName] == 'Maggie Tulliver' }
+      expect(maggie[:campusSolutionsId]).to eq '1073741824'
+      expect(maggie[:uid]).to eq maggie_uid
+      expect(maggie[:privileges]).to eq({ financial: true, viewEnrollments: false, viewGrades: false, phone: true })
+    end
   end
 end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-7689

The user cannot delegate-view-as unless s/he has one of: :financial, :viewEnrollments, :viewGrades. Delegates with only :phone privileges will be denied. Also, front-end needs `ldap_uid` in delegate_students card.