### PR TITLE
CLC-6174 -  QA test fixes for v72 (profile tests)

### DIFF
--- a/spec/ui_selenium/my_profile_basic_info_spec.rb
+++ b/spec/ui_selenium/my_profile_basic_info_spec.rb
@@ -17,7 +17,8 @@ describe 'My Profile Basic Info', :testui => true, :order => :defined do
     before(:all) do
       @student = @test_users.first
       @student_info = @student['basicInfo']
-      @splash_page.log_into_dashboard(@driver, @cal_net_page, @student['username'], @student['password'])
+      @splash_page.load_page
+      @splash_page.basic_auth @student_info['uid']
       @my_dashboard.click_profile_link @driver
     end
 
@@ -63,10 +64,39 @@ describe 'My Profile Basic Info', :testui => true, :order => :defined do
         @basic_info_card.wait_until(WebDriverUtils.page_load_timeout) { @basic_info_card.preferred_name == max_char_name[0..29] }
       end
 
-      it 'permits the use of special characters for an edited name' do
+      it 'permits but trims leading or trailing spaces in an edited name' do
+        whitespace_name = @student_info['preferredName']['leadingWhitespace']
+        @basic_info_card.edit_pref_name whitespace_name
+        @basic_info_card.wait_until(WebDriverUtils.page_load_timeout) { @basic_info_card.preferred_name == whitespace_name.strip }
+      end
+
+    end
+
+    describe 'preferred name validation' do
+
+      it 'does not permit the use of special characters for an edited name' do
         special_char_name = @student_info['preferredName']['specChar']
-        @basic_info_card.edit_pref_name special_char_name
-        @basic_info_card.wait_until(WebDriverUtils.page_load_timeout) { @basic_info_card.preferred_name == special_char_name }
+        @basic_info_card.click_edit_pref_name_button
+        @basic_info_card.enter_preferred_name special_char_name
+        @basic_info_card.preferred_name_error_element.when_visible WebDriverUtils.page_event_timeout
+      end
+
+      it 'does not permit the use of consecutive spaces in an edited name' do
+        spaces_name = @student_info['preferredName']['consecutiveSpaces']
+        @basic_info_card.enter_preferred_name spaces_name
+        @basic_info_card.preferred_name_error_element.when_visible WebDriverUtils.page_event_timeout
+      end
+
+      it 'does not permit the use of consecutive hyphens in an edited name' do
+        hyphens_name = @student_info['preferredName']['consecutiveHyphens']
+        @basic_info_card.enter_preferred_name hyphens_name
+        @basic_info_card.preferred_name_error_element.when_visible WebDriverUtils.page_event_timeout
+      end
+
+      it 'does not permit the use of leading or trailing hyphens in an edited name' do
+        leading_hyphen_name = @student_info['preferredName']['leadingHyphens']
+        @basic_info_card.enter_preferred_name leading_hyphen_name
+        @basic_info_card.preferred_name_error_element.when_visible WebDriverUtils.page_event_timeout
       end
 
     end

--- a/spec/ui_selenium/pages/my_profile_basic_info_card.rb
+++ b/spec/ui_selenium/pages/my_profile_basic_info_card.rb
@@ -13,6 +13,7 @@ module CalCentralPages
     text_area(:preferred_name_input, :id => 'cc-page-widget-basic-preferred-first-name')
     button(:preferred_name_save_button, :xpath => '//button[@type="submit"]')
     button(:preferred_name_cancel_button, :xpath => '//button[@data-ng-click="closeEditor()"]')
+    span(:preferred_name_error, :xpath => '//span[contains(.,"Preferred name can only consist of letters, spaces, and hyphens. Please re-enter.")]')
 
     div(:sid, :xpath => '//div[@data-ng-bind="api.user.profile.sid"]')
     div(:uid, :xpath => '//div[@data-ng-bind="api.user.profile.uid"]')

--- a/spec/ui_selenium/pages/my_profile_contact_info_card.rb
+++ b/spec/ui_selenium/pages/my_profile_contact_info_card.rb
@@ -124,8 +124,8 @@ module CalCentralPages
       logger.debug "There are #{phone_count} phones to delete"
       (1..phone_count).each do
         phone_count = phone_elements.length
-        # Don't try to delete the first phone if it will trigger a validation error
-        (phone_primary?(0) && phone_count > 2) ? index = 1 : index = 0
+        # Delete the preferred phone last or it might trigger a CS validation error
+        (phone_primary?(0) && phone_count > 1) ? index = 1 : index = 0
         delete_phone index
       end
     end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6174

Changes:
- Alters validation tests for preferred name
- Ditches tests that will hit "preferred" flag validation errors
- Uses basic auth instead of CAS authentication so that any type of UID can be tested