### PR TITLE
SISRP-14236, act-as pattern for new advisor use case

### DIFF
--- a/app/controllers/advisor_act_as_controller.rb
+++ b/app/controllers/advisor_act_as_controller.rb
@@ -1,0 +1,20 @@
+class AdvisorActAsController < ActAsController
+  include CampusSolutions::ProfileFeatureFlagged
+
+  skip_before_filter :check_reauthentication, :only => [:stop_advisor_act_as]
+
+  def initialize
+    super(act_as_session_key: 'original_advisor_user_id')
+  end
+
+  def act_as_authorization(uid_param)
+    if is_cs_profile_feature_enabled
+      user_id = current_user.real_user_id
+      user_attributes = HubEdos::UserAttributes.new(user_id: user_id).get
+      authorized = user_attributes && user_attributes[:roles] && user_attributes[:roles][:advisor]
+      raise NotAuthorizedError.new("User #{user_id} is not an Advisor and thus cannot view-as #{uid_param}") unless authorized
+    else
+      raise NotAuthorizedError.new 'We cannot confirm your role as an Advisor because Campus Solutions is unavailable. Please contact us if the problem persists.'
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -139,16 +139,18 @@ class ApplicationController < ActionController::Base
   end
 
   def session_message
-    session_keys = %w(user_id original_user_id original_delegate_user_id canvas_user_id canvas_masquerading_user_id canvas_course_id)
+    session_keys = %w(user_id original_user_id original_advisor_user_id original_delegate_user_id canvas_user_id canvas_masquerading_user_id canvas_course_id)
     session_keys.map { |key| "#{key}: #{session[key]}" if session[key] }.compact.join('; ')
   end
 
   def access_log
     # HTTP_X_FORWARDED_FOR is the client's IP when we're behind Apache; REMOTE_ADDR otherwise
-    remote = request.env["HTTP_X_FORWARDED_FOR"] || request.env["REMOTE_ADDR"]
+    remote = request.env['HTTP_X_FORWARDED_FOR'] || request.env['REMOTE_ADDR']
     line = "ACCESS_LOG #{remote} #{request.request_method} #{request.filtered_path} #{status}"
     if session['original_user_id']
       line += " uid=#{session['original_user_id']}_acting_as_uid=#{session['user_id']}"
+    elsif session['original_advisor_user_id']
+      line += " uid=#{session['original_advisor_user_id']}_advisor_acting_as_uid=#{session['user_id']}"
     elsif session['original_delegate_user_id']
       line += " uid=#{session['original_delegate_user_id']}_delegate_acting_as_uid=#{session['user_id']}"
     else

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -30,8 +30,8 @@ class SessionsController < ApplicationController
     end
 
     if params['renew'] == 'true'
-      # If we're reauthenticating due to view-as, then the CAS-provided UID should match original_user_id in session.
-      original_uid = session['original_delegate_user_id'] || session['original_user_id']
+      # If we're re-authenticating due to view-as, then the CAS-provided UID should match original_user_id in session.
+      original_uid = session['original_user_id'] || session['original_advisor_user_id'] || session['original_delegate_user_id']
       if original_uid
         if original_uid != auth_uid
           logger.warn "ACT-AS: CAS returned UID #{auth_uid} not matching active session: #{session_message}. Logging user out."
@@ -41,9 +41,9 @@ class SessionsController < ApplicationController
           create_reauth_cookie
         end
       elsif session['user_id'] != auth_uid
-        # If we're reauthenticating for any other reason, then the CAS-provided UID should
+        # If we're re-authenticating for any other reason, then the CAS-provided UID should
         # match the session "user_id" from the previous authentication.
-        logger.warn "REAUTHENTICATION: CAS returned UID #{auth_uid} not matching active session: #{session_message}. Starting new session."
+        logger.warn "RE-AUTHENTICATION: CAS returned UID #{auth_uid} not matching active session: #{session_message}. Starting new session."
         reset_session
       else
         create_reauth_cookie
@@ -112,7 +112,7 @@ class SessionsController < ApplicationController
       redirect_to url_for_path('/uid_error')
     else
       # Unless we're re-authenticating after view-as, initialize the session.
-      session['user_id'] = uid unless session['original_user_id'] || session['original_delegate_user_id']
+      session['user_id'] = uid unless session['original_user_id'] || session['original_advisor_user_id'] || session['original_delegate_user_id']
       redirect_to smart_success_path, :notice => 'Signed in!'
     end
   end

--- a/app/controllers/user_api_controller.rb
+++ b/app/controllers/user_api_controller.rb
@@ -28,13 +28,15 @@ class UserApiController < ApplicationController
         User::Visit.record session['user_id'] if directly_authenticated
         true
       end
+      advisor_acting_as_uid = !directly_authenticated && current_user.original_advisor_user_id
       delegate_acting_as_uid = !directly_authenticated && current_user.original_delegate_user_id
       status.merge!({
         :isBasicAuthEnabled => Settings.developer_auth.enabled,
         :isLoggedIn => true,
         :features => features,
-        :actingAsUid => directly_authenticated || delegate_acting_as_uid ? false : current_user.real_user_id,
-        :delegateActingAsUid => directly_authenticated ? false : delegate_acting_as_uid,
+        :actingAsUid => directly_authenticated || advisor_acting_as_uid || delegate_acting_as_uid ? false : current_user.real_user_id,
+        :advisorActingAsUid => advisor_acting_as_uid,
+        :delegateActingAsUid => delegate_acting_as_uid,
         :youtubeSplashId => Settings.youtube_splash_id
       })
       status.merge! User::Api.from_session(session).get_feed

--- a/app/models/user_specific_model.rb
+++ b/app/models/user_specific_model.rb
@@ -6,6 +6,7 @@ class UserSpecificModel
   def self.from_session(session_state)
     filtered_session = {
       'original_user_id' => session_state['original_user_id'],
+      'original_advisor_user_id' => session_state['original_advisor_user_id'],
       'original_delegate_user_id' => session_state['original_delegate_user_id'],
       'lti_authenticated_only' => session_state['lti_authenticated_only']
     }

--- a/app/policies/authentication_state.rb
+++ b/app/policies/authentication_state.rb
@@ -1,11 +1,12 @@
 class AuthenticationState
-  attr_reader :user_id, :original_user_id, :original_delegate_user_id, :canvas_masquerading_user_id, :lti_authenticated_only
+  attr_reader :user_id, :original_user_id, :original_advisor_user_id, :original_delegate_user_id, :canvas_masquerading_user_id, :lti_authenticated_only
 
   LTI_AUTHENTICATED_ONLY = 'Authenticated through LTI'
 
   def initialize(session)
     @user_id = session['user_id']
     @original_user_id = session['original_user_id']
+    @original_advisor_user_id = session['original_advisor_user_id']
     @original_delegate_user_id = session['original_delegate_user_id']
     @canvas_masquerading_user_id = session['canvas_masquerading_user_id']
     @lti_authenticated_only = session['lti_authenticated_only']
@@ -13,6 +14,10 @@ class AuthenticationState
 
   def authenticated_as_delegate?
     @original_delegate_user_id.present?
+  end
+
+  def authenticated_as_advisor?
+    @original_advisor_user_id.present?
   end
 
   def delegate_permissions
@@ -28,6 +33,7 @@ class AuthenticationState
 
   def directly_authenticated?
     user_id && !lti_authenticated_only &&
+      (original_advisor_user_id.blank? || (user_id == original_advisor_user_id)) &&
       (original_delegate_user_id.blank? || (user_id == original_delegate_user_id)) &&
       (original_user_id.blank? || (user_id == original_user_id))
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,10 +129,12 @@ Calcentral::Application.routes.draw do
   end
 
   # Act-as endpoints
-  post '/delegate_act_as' => 'delegate_act_as#start', :via => :post
-  post '/stop_delegate_act_as' => 'delegate_act_as#stop', :via => :post
-  post '/act_as' => 'act_as#start', :via => :post
-  post '/stop_act_as' => 'act_as#stop', :via => :post
+  post '/advisor_act_as' => 'advisor_act_as#start'
+  post '/stop_advisor_act_as' => 'advisor_act_as#stop'
+  post '/delegate_act_as' => 'delegate_act_as#start'
+  post '/stop_delegate_act_as' => 'delegate_act_as#stop'
+  post '/act_as' => 'act_as#start'
+  post '/stop_act_as' => 'act_as#stop'
   get '/stored_users' => 'stored_users#get', :via => :get, :defaults => { :format => 'json' }
   post '/store_user/saved' => 'stored_users#store_saved_uid', via: :post, defaults: { format: 'json' }
   post '/delete_user/saved' => 'stored_users#delete_saved_uid', via: :post, defaults: { format: 'json' }

--- a/spec/controllers/user_api_controller_spec.rb
+++ b/spec/controllers/user_api_controller_spec.rb
@@ -76,7 +76,7 @@ describe UserApiController do
       get :mystatus
       JSON.parse response.body
     end
-    context 'when normally authenticated' do
+    context 'normally authenticated' do
       it 'should deliver user\'s preferred and given names' do
         expect(subject['delegateActingAsUid']).to be false
         expect(subject['preferredName']).to_not be_nil
@@ -85,7 +85,7 @@ describe UserApiController do
         expect(subject['preferredName']).to_not eq subject['givenFullName']
       end
     end
-    context 'when viewing as' do
+    context 'viewing as' do
       let(:original_delegate_user_id) { random_id }
       before do
         session['original_delegate_user_id'] = original_delegate_user_id
@@ -111,6 +111,30 @@ describe UserApiController do
         expect(subject['isDelegateUser']).to be false
         expect(subject['isViewer']).to be false
         expect(subject['isSuperuser']).to be false
+      end
+    end
+  end
+
+  describe '#advisor_acting_as_uid' do
+    subject do
+      get :mystatus
+      JSON.parse response.body
+    end
+    context 'viewing as' do
+      let(:original_advisor_user_id) { random_id }
+      before do
+        session['original_advisor_user_id'] = original_advisor_user_id
+        allow(User::Auth).to receive(:get) do |uid|
+          case uid
+            when user_id
+              double(is_superuser?: true, is_viewer?: true, active?: true)
+            else
+              double(is_superuser?: false, is_viewer?: false, active?: true)
+          end
+        end
+      end
+      it 'should identify user in delegate-view-as mode' do
+        expect(subject['advisorActingAsUid']).to eq original_advisor_user_id
       end
     end
   end

--- a/spec/models/user_specific_model_spec.rb
+++ b/spec/models/user_specific_model_spec.rb
@@ -34,6 +34,16 @@ describe UserSpecificModel do
         expect(subject.delegate_permissions).to_not be_nil
       end
     end
+    context 'advisor view-as mode' do
+      let(:session_extras) {
+        {
+          'original_advisor_user_id' => random_id
+        }
+      }
+      it 'should identify user as having delegate_permissions' do
+        expect(subject.directly_authenticated?).to be false
+      end
+    end
     context 'when only authenticated from an external app' do
       let(:session_extras) {
         {

--- a/spec/policies/authentication_state_spec.rb
+++ b/spec/policies/authentication_state_spec.rb
@@ -6,33 +6,40 @@ describe AuthenticationState do
       let(:fake_session) {{
         'user_id' => random_id
       }}
-      it {should be_truthy}
+      it {should be true}
     end
     context 'when viewing as' do
       let(:fake_session) {{
         'user_id' => random_id,
         'original_user_id' => random_id
       }}
-      it {should be_falsey}
+      it {should be false}
     end
     context 'when delegate viewing as' do
       let(:fake_session) {{
         'user_id' => random_id,
         'original_delegate_user_id' => random_id
       }}
-      it {should be_falsey}
+      it {should be false}
+    end
+    context 'when advisor viewing as' do
+      let(:fake_session) {{
+        'user_id' => random_id,
+        'original_advisor_user_id' => random_id
+      }}
+      it {should be false}
     end
     context 'when only authenticated from an external app' do
       let(:fake_session) {{
         'user_id' => random_id,
         'lti_authenticated_only' => true
       }}
-      it {should be_falsey}
+      it {should be false}
     end
     context 'when not logged in' do
       let(:fake_session) {{
       }}
-      it {should be_falsey}
+      it {should be_nil}
     end
   end
 
@@ -69,7 +76,7 @@ describe AuthenticationState do
     context 'when not logged in' do
       let(:fake_session) {{
       }}
-      it {should be_falsey}
+      it {should be_nil}
     end
   end
 
@@ -79,26 +86,26 @@ describe AuthenticationState do
       let(:fake_session) {{
         'user_id' => random_id
       }}
-      it {should be_falsey}
+      it {should be false}
     end
     context 'when viewing as' do
       let(:fake_session) {{
         'user_id' => random_id,
         'original_user_id' => random_id
       }}
-      it {should be_truthy}
+      it {should be true}
     end
     context 'when only authenticated from an external app' do
       let(:fake_session) {{
         'user_id' => random_id,
         'lti_authenticated_only' => true
       }}
-      it {should be_falsey}
+      it {should be false}
     end
     context 'when not logged in' do
       let(:fake_session) {{
       }}
-      it {should be_falsey}
+      it {should be false}
     end
   end
 
@@ -135,6 +142,16 @@ describe AuthenticationState do
            viewGrades: false,
            phone: true
          })
+      end
+    end
+    context 'when in advisor-view-as mode' do
+      let(:user_id) { random_id }
+      let(:fake_session) {{
+        'user_id' => user_id,
+        'original_advisor_user_id' => random_id
+      }}
+      it 'should get student of advisor user' do
+        expect(subject).to be_authenticated_as_advisor
       end
     end
     context 'when only authenticated from an external app' do

--- a/src/assets/javascripts/angular/factories/adminFactory.js
+++ b/src/assets/javascripts/angular/factories/adminFactory.js
@@ -7,16 +7,26 @@ var angular = require('angular');
  */
 angular.module('calcentral.factories').factory('adminFactory', function(apiService, $http) {
   var actAsUrl = '/act_as';
+  var advisorActAsUrl = '/advisor_act_as';
   var delegateActAsUrl = '/delegate_act_as';
   var searchUsersUrl = '/api/search_users/';
   var searchUsersByUidUrl = '/api/search_users/uid/';
   var stopActAsUrl = '/stop_act_as';
+  var stopAdvisorActAsUrl = '/stop_advisor_act_as';
   var stopDelegateActAsUrl = '/stop_delegate_act_as';
   var storedUsersUrl = '/stored_users';
   var storeSavedUserUrl = '/store_user/saved';
   var deleteSavedUserUrl = '/delete_user/saved';
   var deleteAllRecentUsersUrl = '/delete_users/recent';
   var deleteAllSavedUsersUrl = '/delete_users/saved';
+
+  var advisorActAs = function(user) {
+    return $http.post(advisorActAsUrl, user);
+  };
+
+  var stopAdvisorActAs = function() {
+    return $http.post(stopAdvisorActAsUrl);
+  };
 
   var delegateActAs = function(user) {
     return $http.post(delegateActAsUrl, user);
@@ -64,12 +74,14 @@ angular.module('calcentral.factories').factory('adminFactory', function(apiServi
 
   return {
     actAs: actAs,
+    advisorActAs: advisorActAs,
     delegateActAs: delegateActAs,
     deleteAllRecentUsers: deleteAllRecentUsers,
     deleteAllSavedUsers: deleteAllSavedUsers,
     deleteUser: deleteUser,
     getStoredUsers: getStoredUsers,
     stopActAs: stopActAs,
+    stopAdvisorActAs: stopAdvisorActAs,
     stopDelegateActAs: stopDelegateActAs,
     storeUser: storeUser,
     userLookup: userLookup,


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-14236

Following the pattern established by delegate-view-as. I created a distinct advisor-act-as controller and session variable because overloading the delegate-act-as logic would be prone to regressions.