### PR TITLE
SISRP-14262, advisors get Toolbox; clean up data-ng-if statements in toolbox.html

### DIFF
--- a/app/models/campus_solutions/delegated_access_feature_flagged.rb
+++ b/app/models/campus_solutions/delegated_access_feature_flagged.rb
@@ -3,5 +3,6 @@ module CampusSolutions
     def is_feature_enabled
       Settings.features.cs_delegated_access
     end
+    alias_method(:is_cs_delegated_access_feature_enabled, :is_feature_enabled)
   end
 end

--- a/app/policies/authentication_state_policy.rb
+++ b/app/policies/authentication_state_policy.rb
@@ -69,7 +69,4 @@ class AuthenticationStatePolicy
     feature_flag.present? && feature_flag && (can_administrate? || can_view_as? || can_add_current_official_sections?)
   end
 
-  def has_toolbox_tab?
-    (can_administrate? || (@user.user_auth.active? && @user.user_auth.is_viewer?)) && !@user.authenticated_as_delegate?
-  end
 end

--- a/spec/models/hub_edos/user_attributes_spec.rb
+++ b/spec/models/hub_edos/user_attributes_spec.rb
@@ -86,7 +86,7 @@ describe HubEdos::UserAttributes do
         ]
       end
       it 'should return graduate attributes' do
-        expect(subject[:roles][:student]).to eq true
+        expect(subject[:roles][:student]).to be true
         expect(subject[:ug_grad_flag]).to eq 'G'
       end
     end
@@ -115,9 +115,9 @@ describe HubEdos::UserAttributes do
         ]
       end
       it 'should return ex-student attributes' do
-        expect(subject[:roles][:exStudent]).to eq true
-        expect(subject[:roles][:student]).to eq nil
-        expect(subject[:ug_grad_flag]).to eq nil
+        expect(subject[:roles][:exStudent]).to be true
+        expect(subject[:roles][:student]).to be_nil
+        expect(subject[:ug_grad_flag]).to be_nil
       end
     end
 
@@ -154,8 +154,8 @@ describe HubEdos::UserAttributes do
         ]
       end
       it 'should return graduate attributes' do
-        expect(subject[:roles][:exStudent]).to eq nil
-        expect(subject[:roles][:student]).to eq true
+        expect(subject[:roles][:exStudent]).to be_nil
+        expect(subject[:roles][:student]).to be true
         expect(subject[:ug_grad_flag]).to eq 'G'
       end
     end
@@ -175,8 +175,8 @@ describe HubEdos::UserAttributes do
         ]
       end
       it 'should return applicant attributes' do
-        expect(subject[:roles][:applicant]).to eq true
-        expect(subject[:roles][:student]).to eq nil
+        expect(subject[:roles][:applicant]).to be true
+        expect(subject[:roles][:student]).to be_nil
       end
     end
 
@@ -195,7 +195,7 @@ describe HubEdos::UserAttributes do
         ]
       end
       it 'should return faculty attributes' do
-        expect(subject[:roles][:faculty]).to eq true
+        expect(subject[:roles][:faculty]).to be true
         expect(subject[:roles][:student]).to be_nil
       end
     end

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -194,9 +194,10 @@ describe User::Api do
     context 'ordinary profiles' do
       let(:profiles) do
         {
-          :student   => { :student => true,  :exStudent => false, :faculty => false, :staff => false },
-          :faculty   => { :student => false, :exStudent => false, :faculty => true,  :staff => false },
-          :staff     => { :student => false, :exStudent => false, :faculty => true,  :staff => true }
+          :student   => { :student => true,  :exStudent => false, :faculty => false, :advisor => false, :staff => false },
+          :faculty   => { :student => false, :exStudent => false, :faculty => true,  :advisor => false, :staff => false },
+          :advisor   => { :student => false, :exStudent => false, :faculty => true,  :advisor => true,  :staff => true },
+          :staff     => { :student => false, :exStudent => false, :faculty => true,  :advisor => false, :staff => true }
         }
       end
       before do
@@ -212,6 +213,10 @@ describe User::Api do
       context 'faculty' do
         let(:user_roles) { profiles[:faculty] }
         it { should be false }
+      end
+      context 'advisor' do
+        let(:user_roles) { profiles[:advisor] }
+        it { should be true }
       end
       context 'staff' do
         let(:user_roles) { profiles[:staff] }

--- a/spec/policies/authentication_state_policy_spec.rb
+++ b/spec/policies/authentication_state_policy_spec.rb
@@ -152,29 +152,6 @@ describe AuthenticationStatePolicy do
     end
   end
 
-  describe '#has_toolbox_tab?' do
-    context 'superuser as self' do
-      let(:user_id) {superuser_uid}
-      its(:has_toolbox_tab?) { should eq true }
-    end
-    context 'inactive user with permission to view-as' do
-      let(:user_id) {inactive_superuser_uid}
-      its(:has_toolbox_tab?) { should eq false }
-    end
-    context 'user with permission to view-as' do
-      let(:user_id) {viewer_uid}
-      its(:has_toolbox_tab?) { should eq true }
-    end
-    context 'inactive user with permission to view-as' do
-      let(:user_id) {inactive_viewer_uid}
-      its(:has_toolbox_tab?) { should eq false }
-    end
-    context 'average joe' do
-      let(:user_id) {average_joe_uid}
-      its(:has_toolbox_tab?) { should eq false }
-    end
-  end
-
   describe '#can_administrate_canvas?' do
     let(:user_id) {average_joe_uid}
     it 'returns true when user is a canvas root account administrator' do

--- a/src/assets/templates/toolbox.html
+++ b/src/assets/templates/toolbox.html
@@ -3,17 +3,17 @@
     <div class="column">
       <h1 class="cc-heading-page-title">My Toolbox</h1>
     </div>
-    <div class="medium-4 columns" data-ng-if="api.user.profile.isViewer || api.user.profile.isSuperuser">
-      <div data-ng-include="'widgets/toolbox/view_as.html'"></div>
-      <div data-ng-include="'widgets/toolbox/delegate_intro_to_calcentral.html'" data-ng-if="api.user.profile.isDelegateUser && api.user.profile.features.csDelegatedAccess"></div>
+    <div class="medium-4 columns">
+      <div data-ng-include="'widgets/toolbox/view_as.html'" data-ng-if="api.user.profile.isViewer || api.user.profile.roles.advisor"></div>
+      <div data-ng-include="'widgets/toolbox/delegate_intro_to_calcentral.html'" data-ng-if="api.user.profile.isDelegateUser"></div>
     </div>
-    <div class="medium-4 columns" data-ng-if="api.user.profile.isViewer || api.user.profile.isSuperuser">
-      <div data-ng-include="'widgets/toolbox/delegate_students.html'" data-ng-if="api.user.profile.isDelegateUser && api.user.profile.features.csDelegatedAccess"></div>
-      <div data-ng-include="'widgets/toolbox/uid_lookup.html'"></div>
+    <div class="medium-4 columns">
+      <div data-ng-include="'widgets/toolbox/delegate_students.html'" data-ng-if="api.user.profile.isDelegateUser"></div>
+      <div data-ng-include="'widgets/toolbox/uid_lookup.html'"  data-ng-if="api.user.profile.isViewer || api.user.profile.roles.advisor"></div>
     </div>
-    <div class="medium-4 columns cc-column-last" data-ng-if="api.user.profile.isSuperuser">
-      <div data-ng-include="'widgets/toolbox/api_test.html'"></div>
-      <div data-ng-include="'widgets/toolbox/delegate_quick_links.html'" data-ng-if="api.user.profile.isDelegateUser && api.user.profile.features.csDelegatedAccess"></div>
+    <div class="medium-4 columns cc-column-last" data-ng-if="api.user.profile.isSuperuser || api.user.profile.isDelegateUser">
+      <div data-ng-include="'widgets/toolbox/api_test.html'" data-ng-if="api.user.profile.isSuperuser"></div>
+      <div data-ng-include="'widgets/toolbox/delegate_quick_links.html'" data-ng-if="api.user.profile.isDelegateUser"></div>
     </div>
   </div>
 </div>

--- a/src/assets/templates/widgets/profile/delegate.html
+++ b/src/assets/templates/widgets/profile/delegate.html
@@ -11,7 +11,7 @@
     those privileges at any time.
   </p>
   <p>
-    To created a new delegate or change the privileges of an existing one, click the link above.
+    To create a new delegate or change the privileges of an existing one, click the link above.
   </p>
   <h3>Other information:</h3>
   <ul>
@@ -24,7 +24,7 @@
       content: mail, calendar, etc.
     </li>
     <li>
-      <strong>Advisors:</strong> Advisors can view all financial, and academic information shown in CalCentral, but cannot
+      <strong>Advisors:</strong> Advisors can view all financial and academic information shown in CalCentral but cannot
       see Profile or bConnected content.
     </li>
   </ul>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-14262
* move `has_toolbox_tab?` to `User::Api` because logic needs user roles 
* `has_toolbox_tab?` is false if user is in view-as mode 
* delegate users lose status when feature flag is false
* clean up conditionals in `toolbox.html`
