### PR TITLE
CLC-5935 Reload YAML settings in Torquebox message processors

### DIFF
--- a/config/torquebox.rb
+++ b/config/torquebox.rb
@@ -42,5 +42,11 @@ TorqueBox.configure do
     processor BackgroundJobsCheck
   end
 
+  # Reload settings from YAML across clusters.
+  topic '/topics/settings_reload' do
+    durable false
+    processor SettingsReloadWorker
+  end
+
 end
 

--- a/lib/calcentral_config.rb
+++ b/lib/calcentral_config.rb
@@ -16,10 +16,8 @@ module CalcentralConfig
   def reload_settings
     if Kernel.const_defined? :Settings
       new_settings = load_settings
-      Rails.logger.warn 'Preparing to reload application settings via Kernel'
       Kernel.const_set(:Settings, new_settings)
       update_rails_logger_level Settings.logger.level
-      Rails.logger.warn 'YAML settings reloaded. Ask yourself, should I clear the cache?'
     end
   end
 

--- a/lib/services/settings_reload_worker.rb
+++ b/lib/services/settings_reload_worker.rb
@@ -1,0 +1,17 @@
+class SettingsReloadWorker < TorqueBox::Messaging::MessageProcessor
+  include ClassLogger
+
+  def on_message(body)
+    logger.info "Message received on #{ServerRuntime.get_settings['hostname']}"
+    CalcentralConfig.reload_settings
+  end
+
+  def on_error(exception)
+    logger.error "Got an exception handling a message: #{exception.inspect}"
+    raise exception
+  end
+
+  def self.request_reload
+    Messaging.publish '/topics/settings_reload'
+  end
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5935

This doesn't solve the problem of accessing the web subsystem across multiple nodes, but I'm curious to see if it works with message processors across the cluster.