### PR TITLE
SISRP-13947 Add academic careers and student ID to enrollment terms proxy

### DIFF
--- a/app/models/campus_solutions/enrollment_terms.rb
+++ b/app/models/campus_solutions/enrollment_terms.rb
@@ -10,9 +10,17 @@ module CampusSolutions
     end
 
     def build_feed(response)
-      return {} if response.parsed_response.blank?
+      return {} unless (response.parsed_response && response['UC_SR_ENROLLMENT_TERMS'] && response['UC_SR_ENROLLMENT_TERMS']['CAREERS'])
+      terms = []
+      response['UC_SR_ENROLLMENT_TERMS']['CAREERS'].each do |career|
+        Array.wrap(career['TERM']).each do |term|
+          term['ACAD_CAREER'] = career['ACAD_CAREER']
+          terms << term
+        end
+      end
       {
-        enrollment_terms: response['UC_SR_ENROLLMENT_TERMS']
+        enrollment_terms: terms.sort_by { |term| term['TERM_ID'] },
+        student_id: response['UC_SR_ENROLLMENT_TERMS']['STUDENT_ID']
       }
     end
 
@@ -21,8 +29,7 @@ module CampusSolutions
     end
 
     def url
-      # This fake URL allows tests against mock proxies until we get a real URL.
-      "#{@settings.base_url}/NOT_A_REAL_URL.v1/get/enrollment_terms?EMPLID=#{@campus_solutions_id}"
+      "#{@settings.base_url}/UC_SR_CURR_TERMS.v1/GetCurrentItems?EMPLID=#{@campus_solutions_id}"
     end
   end
 end

--- a/fixtures/xml/campus_solutions/enrollment_terms.xml
+++ b/fixtures/xml/campus_solutions/enrollment_terms.xml
@@ -1,10 +1,24 @@
-<UC_SR_ENROLLMENT_TERMS type="array">
-  <TERM>
-    <TERM_ID>2176</TERM_ID>
-    <TERM_DESCR>Spring 2017</TERM_DESCR>
-  </TERM>
-  <TERM>
-    <TERM_ID>2179</TERM_ID>
-    <TERM_DESCR>Summer 2017</TERM_DESCR>
-  </TERM>
+<?xml version="1.0"?>
+<UC_SR_ENROLLMENT_TERMS>
+  <STUDENT_ID>12701798</STUDENT_ID>
+  <CAREERS type="array">
+    <CAREER>
+      <ACAD_CAREER>GRAD</ACAD_CAREER>
+      <TERM>
+        <TERM_ID>2175</TERM_ID>
+        <TERM_DESCR>2017 Summer</TERM_DESCR>
+      </TERM>
+      <TERM>
+        <TERM_ID>2178</TERM_ID>
+        <TERM_DESCR>2017 Fall</TERM_DESCR>
+      </TERM>
+    </CAREER>
+    <CAREER>
+      <ACAD_CAREER>UGRD</ACAD_CAREER>
+      <TERM>
+        <TERM_ID>2172</TERM_ID>
+        <TERM_DESCR>2017 Spring</TERM_DESCR>
+      </TERM>
+    </CAREER>
+  </CAREERS>
 </UC_SR_ENROLLMENT_TERMS>

--- a/public/dummy/json/enrollment_terms.json
+++ b/public/dummy/json/enrollment_terms.json
@@ -3,13 +3,21 @@
   "feed": {
     "enrollmentTerms": [
       {
-        "termId": "2176",
-        "termDescr": "Spring 2017"
+        "acadCareer": "UGRD",
+        "termId": "2172",
+        "termDescr": "2017 Spring"
       },
       {
-        "termId": "2179",
-        "termDescr": "Summer 2017"
+        "acadCareer": "GRAD",
+        "termId": "2175",
+        "termDescr": "2017 Summer"
+      },
+      {
+        "acadCareer": "GRAD",
+        "termId": "2178",
+        "termDescr": "2017 Fall"
       }
-    ]
+    ],
+    "studentId": "12701798"
   }
 }

--- a/spec/controllers/campus_solutions/enrollment_terms_controller_spec.rb
+++ b/spec/controllers/campus_solutions/enrollment_terms_controller_spec.rb
@@ -17,7 +17,7 @@ describe CampusSolutions::EnrollmentTermsController do
         session['user_id'] = user_id
         get feed
         json = JSON.parse(response.body)
-        expect(json['feed']['enrollmentTerms'][0]['termId']).to eq '2176'
+        expect(json['feed']['enrollmentTerms'][0]['termId']).to eq '2172'
       end
     end
   end

--- a/spec/models/campus_solutions/enrollment_terms_spec.rb
+++ b/spec/models/campus_solutions/enrollment_terms_spec.rb
@@ -13,10 +13,25 @@ describe CampusSolutions::EnrollmentTerms do
   context 'mock proxy' do
     let(:proxy) { CampusSolutions::EnrollmentTerms.new(fake: true, user_id: user_id) }
     subject { proxy.get }
+    let(:terms) { subject[:feed][:enrollmentTerms] }
     it_should_behave_like 'a proxy that gets data'
-    it 'returns specific mock data' do
-      expect(subject[:feed][:enrollmentTerms][0]).to eq(termId: '2176', termDescr: 'Spring 2017')
-      expect(subject[:feed][:enrollmentTerms][1]).to eq(termId: '2179', termDescr: 'Summer 2017')
+
+    it 'includes student ID' do
+      expect(subject[:feed][:studentId]).to eq '12701798'
+    end
+
+    it 'returns expected attributes for all terms' do
+      expect(terms).to all(include(:acadCareer, :termId, :termDescr))
+    end
+
+    it 'returns terms in order of ID' do
+      expect(terms.map { |term| term[:termId] }).to eq %w(2172 2175 2178)
+    end
+
+    it 'map terms to correct academic career' do
+      expect(terms[0][:acadCareer]).to eq 'UGRD'
+      expect(terms[1][:acadCareer]).to eq 'GRAD'
+      expect(terms[2][:acadCareer]).to eq 'GRAD'
     end
   end
 end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-13947

Adjusting proxy behavior to reflect data coming from a real endpoint.

Note that this proxy is no longer a straight passthrough; the `ACAD_CAREER` element is being denormalized to individual terms, as I think this will make things easier for the front end.