### PR TITLE
SISRP-14283, filter out EFC when advisor-view-as

### DIFF
--- a/app/controllers/campus_solutions/financial_aid_data_controller.rb
+++ b/app/controllers/campus_solutions/financial_aid_data_controller.rb
@@ -2,7 +2,11 @@ module CampusSolutions
   class FinancialAidDataController < CampusSolutionsController
 
     def get
-      model = CampusSolutions::MyFinancialAidData.from_session(session)
+      if current_user.authenticated_as_advisor?
+        model = CampusSolutions::MyFinancialAidFilteredForAdvisor.from_session(session)
+      else
+        model = CampusSolutions::MyFinancialAidData.from_session(session)
+      end
       model.aid_year = params['aid_year']
       render json: model.get_feed_as_json
     end

--- a/app/models/campus_solutions/my_financial_aid_filtered_for_advisor.rb
+++ b/app/models/campus_solutions/my_financial_aid_filtered_for_advisor.rb
@@ -1,0 +1,55 @@
+module CampusSolutions
+  class MyFinancialAidFilteredForAdvisor < UserSpecificModel
+
+    include ClassLogger
+    include Cache::CachedFeed
+    include Cache::JsonAddedCacher
+    include Cache::RelatedCacheKeyTracker
+    include CampusSolutions::FinaidFeatureFlagged
+
+    attr_accessor :aid_year
+
+    def get_feed_as_json(force_cache_write=false)
+      feed = get_feed force_cache_write
+      feed.to_json
+    end
+
+    def get_feed_internal
+      return {} unless is_feature_enabled
+      self.aid_year ||= CampusSolutions::MyAidYears.new(@uid).default_aid_year
+      filter_for_advisor CampusSolutions::FinancialAidData.new({user_id: @uid, aid_year: aid_year}).get
+    end
+
+    def filter_for_advisor(feed)
+      advisor_uid = authentication_state.original_advisor_user_id
+      raise RuntimeError, "Only advisors have access to this filtered #{instance_key} FinAid feed" unless advisor_uid
+      logger.debug "Advisor #{advisor_uid} viewing user #{@uid} financial aid feed where aid_year = #{aid_year}"
+      {
+        filteredForAdvisor: true
+      }.merge(remove_family_information feed)
+    end
+
+    def remove_family_information(feed={})
+      return feed unless feed[:feed] && feed[:feed][:status] && (categories = feed[:feed][:status][:categories])
+      categories.each do |category|
+        if category[:itemGroups]
+          filtered_groups = []
+          category[:itemGroups].each do |group|
+            exclude_group = group.any? { |item| has_family_information? item }
+            filtered_groups << group unless exclude_group
+          end
+          category[:itemGroups] = filtered_groups
+        end
+      end
+      feed
+    end
+
+    def instance_key
+      "#{@uid}-#{aid_year}"
+    end
+
+    def has_family_information?(item)
+      [item[:title].to_s, item[:value].to_s].any? { |s| s =~ /family|efc|parent/i }
+    end
+  end
+end

--- a/spec/controllers/campus_solutions/financial_aid_data_controller_spec.rb
+++ b/spec/controllers/campus_solutions/financial_aid_data_controller_spec.rb
@@ -12,8 +12,25 @@ describe CampusSolutions::FinancialAidDataController do
       it 'has some field mapping info' do
         session['user_id'] = user_id
         get feed, {:aid_year => '2016', :format => 'json'}
-        json = JSON.parse(response.body)
+        json = JSON.parse response.body
         expect(json['feed']['coa']['title']).to eq 'Estimated Cost of Attendance'
+      end
+    end
+
+    context 'authenticated user' do
+      let(:filtered_feed) { { key: 'value' } }
+      before {
+        session['user_id'] = user_id
+        session['original_advisor_user_id'] = random_id
+        model = double(get_feed_as_json: filtered_feed)
+        expect(model).to receive(:aid_year=).with '2016'
+        expect(CampusSolutions::MyFinancialAidFilteredForAdvisor).to receive(:from_session).once.and_return model
+        expect(CampusSolutions::MyFinancialAidData).to_not receive :from_session
+      }
+      it 'invokes the filtered feed when advisor-view-as mode' do
+        get feed, {:aid_year => '2016', :format => 'json'}
+        json = JSON.parse response.body
+        expect(json['key']).to eq 'value'
       end
     end
   end

--- a/spec/models/campus_solutions/my_financial_aid_filtered_for_advisor_spec.rb
+++ b/spec/models/campus_solutions/my_financial_aid_filtered_for_advisor_spec.rb
@@ -1,0 +1,27 @@
+describe CampusSolutions::MyFinancialAidFilteredForAdvisor do
+
+  context 'mock proxy' do
+    context 'no advisor session' do
+      it 'should deny access' do
+        state = { 'fake' => true, 'user_id' => random_id }
+        expect{
+          CampusSolutions::MyFinancialAidFilteredForAdvisor.from_session(state).get_feed
+        }.to raise_exception /Only advisors have access/
+      end
+    end
+    context 'advisor session' do
+      let(:original_advisor_user_id) { random_id }
+      subject {
+        state = { 'fake' => true, 'user_id' => random_id, 'original_advisor_user_id' => original_advisor_user_id }
+        CampusSolutions::MyFinancialAidFilteredForAdvisor.from_session(state)
+      }
+      it 'should filter out \'Expected Family Contribution\' and similar' do
+        feed = subject.get_feed
+        expect(feed[:filteredForAdvisor]).to be true
+        json = feed.to_json
+        expect(json).to include 'SHIP Health Insurance', 'Student Standing', 'Estimated Cost of Attendance'
+        expect(json).to_not include 'EFC', 'Family', 'Parent'
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-14283

FinancialAidDataController invokes filtered feed, which excludes 'Expected Family Contribution' and similar, when advisor-view-as mode.