### PR TITLE
SISRP-14422, When advisor-view-as mode, show Profile but hide Demographics tab

### DIFF
--- a/src/assets/javascripts/angular/services/profileMenuService.js
+++ b/src/assets/javascripts/angular/services/profileMenuService.js
@@ -39,7 +39,8 @@ angular.module('calcentral.services').factory('profileMenuService', function(api
           featureFlag: 'csDelegatedAccess',
           roles: {
             student: true
-          }
+          },
+          hideWhenActAsModes: ['advisorActingAsUid']
         },
         {
           id: 'information-disclosure',
@@ -77,7 +78,8 @@ angular.module('calcentral.services').factory('profileMenuService', function(api
       categories: [
         {
           id: 'bconnected',
-          name: 'bConnected'
+          name: 'bConnected',
+          hideWhenActAsModes: ['advisorActingAsUid']
         }
       ]
     }
@@ -149,6 +151,30 @@ angular.module('calcentral.services').factory('profileMenuService', function(api
     return defer(navigation, filterFeatureFlagsInNavigation);
   };
 
+  var filterActAsInCategory = function(categories) {
+    var userProfile = apiService.user.profile;
+    return _.filter(categories, function(category) {
+      if (!_.get(category, 'hideWhenActAsModes.length')) {
+        return true;
+      } else {
+        return !_.some(category.hideWhenActAsModes, function(hideWhenActAsMode) {
+          return userProfile[hideWhenActAsMode];
+        });
+      }
+    });
+  };
+
+  var filterActAsInNavigation = function(navigation) {
+    return filterCategories(navigation, filterActAsInCategory);
+  };
+
+  /**
+   * Filter based on active view-as mode (admin, advisor, delegate, etc.)
+   */
+  var filterActAs = function(navigation) {
+    return defer(navigation, filterActAsInNavigation);
+  };
+
   var filterEmptyInNavigation = function(navigation) {
     return _.filter(navigation, function(item) {
       return !!_.get(item, 'categories.length');
@@ -174,6 +200,7 @@ angular.module('calcentral.services').factory('profileMenuService', function(api
       .then(initialNavigation)
       .then(filterRoles)
       .then(filterFeatureFlags)
+      .then(filterActAs)
       .then(filterEmpty);
   };
 

--- a/src/assets/templates/profile.html
+++ b/src/assets/templates/profile.html
@@ -1,4 +1,4 @@
-<div class="cc-page-profile" data-ng-if="api.user.profile.showSisProfileUI && !api.user.profile.delegateActingAsUid && !api.user.profile.advisorActingAsUid">
+<div class="cc-page-profile" data-ng-if="api.user.profile.showSisProfileUI && !api.user.profile.delegateActingAsUid">
 
   <div class="medium-9 medium-push-3 columns cc-sidebar-content">
     <h1 class="cc-heading-page-title" data-ng-bind="header"></h1>
@@ -25,4 +25,4 @@
     </div>
   </div>
 </div>
-<div data-ng-include="'404.html'" data-ng-if="!api.user.profile.showSisProfileUI || api.user.profile.delegateActingAsUid || api.user.profile.advisorActingAsUid"></div>
+<div data-ng-include="'404.html'" data-ng-if="!api.user.profile.showSisProfileUI || api.user.profile.delegateActingAsUid"></div>

--- a/src/assets/templates/widgets/profile/demographic.html
+++ b/src/assets/templates/widgets/profile/demographic.html
@@ -5,9 +5,9 @@
 
   <div data-ng-if="!demographicInformation.isErrored">
     <!-- Editable soon -->
-    <div data-ng-include="'widgets/profile/editable_soon.html'"></div>
+    <div data-ng-include="'widgets/profile/editable_soon.html'" data-ng-if="!api.user.profile.advisorActingAsUid"></div>
     <!-- Gender -->
-    <div data-ng-include="'widgets/profile/demographic_gender.html'"></div>
+    <div data-ng-include="'widgets/profile/demographic_gender.html'" data-ng-if="!api.user.profile.advisorActingAsUid"></div>
     <!-- Ethnicity -->
     <div data-ng-include="'widgets/profile/demographic_ethnicity.html'"></div>
     <!-- Veteran Status -->

--- a/src/assets/templates/widgets/profile_popover.html
+++ b/src/assets/templates/widgets/profile_popover.html
@@ -1,5 +1,5 @@
 <ul class="cc-popover-items cc-profile-popover-links">
-  <li class="cc-popover-item" data-ng-if="api.user.profile.showSisProfileUI && !api.user.profile.delegateActingAsUid && !api.user.profile.advisorActingAsUid">
+  <li class="cc-popover-item" data-ng-if="api.user.profile.showSisProfileUI && !api.user.profile.delegateActingAsUid">
     <button class="cc-button-link cc-popover-link"
       data-ng-click="api.popover.clickThrough('Gear - Profile');api.util.redirect('profile')">Profile
     </button>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-14422

Advisor-view-as mode can get to /profile but will not see student's:
* demographics
* bConnected
* "Assign a delegate" call-to-action

I'm going to add *delegateActingAsUid* references to the `profileMenuService.js` logic just in case we decide to show limited profile to Delegates. 