### PR TITLE
SISRP-13947 Update enrollment card to match API structure

### DIFF
--- a/app/models/campus_solutions/enrollment_term.rb
+++ b/app/models/campus_solutions/enrollment_term.rb
@@ -7,26 +7,31 @@ module CampusSolutions
 
     def initialize(options = {})
       super options
+      @term_id = options[:term_id]
       initialize_mocks if @fake
     end
 
     def build_feed(response)
-      return {} if response.parsed_response.blank?
-      enrollment_term = response['UC_SR_CLASS_ENROLLMENT']
-      if enrollment_term['ENROLLMENT_PERIODS']
-        enrollment_term['ENROLLMENT_PERIODS'].each { |period| format_cs_datetime period }
+      return {} unless response &&
+        (enrollment_term = response['UC_SR_CLASS_ENROLLMENT']) &&
+        enrollment_term['ENROLLMENT_PERIOD'].present?
+
+      # Though its name is in the singular, ENROLLMENT_PERIOD is an array containing multiple periods.
+      enrollment_term['ENROLLMENT_PERIOD'].each do |period|
+        format_cs_datetime(period, '%Y-%m-%dT%H:%M:%S')
       end
       if enrollment_term['SCHEDULE_OF_CLASSES_PERIOD']
-        format_cs_datetime enrollment_term['SCHEDULE_OF_CLASSES_PERIOD']
+        format_cs_datetime(enrollment_term['SCHEDULE_OF_CLASSES_PERIOD'], '%Y-%m-%d')
       end
       {
         enrollment_term: enrollment_term
       }
     end
 
-    def format_cs_datetime(hash)
+    def format_cs_datetime(hash, format)
       if hash['DATETIME']
-        hash['DATETIME'] = format_date DateTime.rfc3339(hash['DATETIME'])
+        hash['DATE'] = format_date strptime_in_time_zone(hash['DATETIME'], format)
+        hash.delete 'DATETIME'
       end
     end
 
@@ -35,8 +40,7 @@ module CampusSolutions
     end
 
     def url
-      # This fake URL allows tests against mock proxies until we get a real URL.
-      "#{@settings.base_url}/NOT_A_REAL_URL.v1/get/enrollment_term?EMPLID=#{@campus_solutions_id}&TERM_ID=#{@term_id}"
+      "#{@settings.base_url}/UC_SR_STDNT_CLASS_ENROLL.v1/Get?EMPLID=#{@campus_solutions_id}&STRM=#{@term_id}"
     end
   end
 end

--- a/fixtures/xml/campus_solutions/enrollment_term.xml
+++ b/fixtures/xml/campus_solutions/enrollment_term.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <UC_SR_CLASS_ENROLLMENT>
-  <STUDENT_ID>0000012</STUDENT_ID>
-  <TERM_ID>2176</TERM_ID>
-  <TERM_DESCR>Spring 2017</TERM_DESCR>
+  <STUDENT_ID>12701798</STUDENT_ID>
+  <TERM>2162</TERM>
+  <TERM_DESCR>2016 Spring</TERM_DESCR>
   <ADVISORS type="array">
     <ADVISOR>
       <ID>123456</ID>
-      <NAME>Dai Smith</NAME>
-      <EMAIL_ADDRESS>DaiSmith@yahoo.com</EMAIL_ADDRESS>
+      <NAME>Chiron Kentauros</NAME>
+      <EMAIL_ADDRESS>chiron@berkeley.edu</EMAIL_ADDRESS>
       <PROGRAM>College of Engineering</PROGRAM>
       <TITLE>Major Advisor</TITLE>
     </ADVISOR>
@@ -23,12 +23,12 @@
     <SCHEDULE_CLASSES>
       <NAME>Schedule of Classes</NAME>
       <IS_CS_LINK type="boolean">true</IS_CS_LINK>
-      <URL>https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/UC_FA_AWD_MGT_FLU.UC_FA_AWD_MGT_FLU.GBL</URL>
+      <URL>https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SA_LEARNER_SERVICES.CLASS_SEARCH.GBL?</URL>
     </SCHEDULE_CLASSES>
     <COURSE_CATALOG>
       <NAME>Course Catalog</NAME>
       <IS_CS_LINK type="boolean">true</IS_CS_LINK>
-      <URL>https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/UC_FA_AWD_MGT_FLU.UC_FA_AWD_MGT_FLU.GBL</URL>
+      <URL>https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SA_LEARNER_SERVICES.SSS_BROWSE_CATLG.GBL?</URL>
     </COURSE_CATALOG>
     <DECAL>
       <NAME>DeCal (student-run education programs)</NAME>
@@ -52,7 +52,7 @@
     </FRESHMAN_SEMINARS>
     <CHOOSE_CLASSES>
       <NAME>Choose classes</NAME>
-      <URL>https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/UC_FA_AWD_MGT_FLU.UC_FA_AWD_MGT_FLU.GBL</URL>
+      <URL>https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/ESTABLISH_COURSES.CLASS_SEARCH.GBL?</URL>
       <IS_CS_LINK type="boolean">true</IS_CS_LINK>
     </CHOOSE_CLASSES>
     <ENROLLMENT_RULES>
@@ -62,12 +62,12 @@
     </ENROLLMENT_RULES>
     <UPDATE_ENROLLED_CLASSES>
       <NAME>Update enrolled classes</NAME>
-      <URL>https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/UC_FA_AWD_MGT_FLU.UC_FA_AWD_MGT_FLU.GBL</URL>
+      <URL>https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SA_LEARNER_SERVICES.SSR_SSENRL_EDIT.GBL?</URL>
       <IS_CS_LINK type="boolean">true</IS_CS_LINK>
     </UPDATE_ENROLLED_CLASSES>
     <DROP_WAITLISTED_CLASSES>
       <NAME>Drop waitlisted classes</NAME>
-      <URL>https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/UC_FA_AWD_MGT_FLU.UC_FA_AWD_MGT_FLU.GBL</URL>
+      <URL>https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SA_LEARNER_SERVICES.SSR_SSENRL_DROP.GBL?</URL>
       <IS_CS_LINK type="boolean">true</IS_CS_LINK>
     </DROP_WAITLISTED_CLASSES>
     <WITHDRAW_FROM_SEMESTER>
@@ -76,38 +76,46 @@
       <IS_CS_LINK type="boolean">true</IS_CS_LINK>
     </WITHDRAW_FROM_SEMESTER>
   </LINKS>
-  <ENROLLMENT_PERIODS type="array">
+  <ENROLLMENT_PERIOD type="array">
     <PERIOD>
       <ID>phase1</ID>
       <NAME>Phase I</NAME>
-      <DATETIME>2016-04-18T15:40:00-07:00</DATETIME>
+      <DATETIME>2016-04-18T15:40:00</DATETIME>
     </PERIOD>
     <PERIOD>
       <ID>phase2</ID>
       <NAME>Phase II</NAME>
-      <DATETIME>2016-06-05T16:30:00-07:00</DATETIME>
+      <DATETIME>2016-06-05T16:30:00</DATETIME>
     </PERIOD>
     <PERIOD>
       <ID>adjust</ID>
       <NAME>Adjust</NAME>
-      <DATETIME>2016-08-15T18:20:00-07:00</DATETIME>
+      <DATETIME>2016-08-15T18:20:00</DATETIME>
     </PERIOD>
-  </ENROLLMENT_PERIODS>
+  </ENROLLMENT_PERIOD>
   <SCHEDULE_OF_CLASSES_PERIOD>
-    <DATETIME>2016-03-28T12:00:00-07:00</DATETIME>
+    <DATETIME>2016-03-28</DATETIME>
   </SCHEDULE_OF_CLASSES_PERIOD>
   <ENROLLED_CLASSES type="array">
     <CLASS>
-      <ID>21786</ID>
-      <WHEN>Monday Wednesday Friday</WHEN>
-      <UNITS>4.00</UNITS>
+      <ID>12081</ID>
+      <SUBJECT_CATALOG>ARCH11A</SUBJECT_CATALOG>
+      <WHEN>Monday  Wednesday 9:00 AM-9:59 AM</WHEN>
+      <UNITS>4</UNITS>
+    </CLASS>
+    <CLASS>
+      <ID>19090</ID>
+      <SUBJECT_CATALOG>MATHC103</SUBJECT_CATALOG>
+      <WHEN>Tuesday  Thursday 12:30 PM-1:59 PM</WHEN>
+      <UNITS>4</UNITS>
     </CLASS>
   </ENROLLED_CLASSES>
   <WAITLISTED_CLASSES type="array">
     <CLASS>
       <ID>15636</ID>
-      <TITLE>Intro Tagalog</TITLE>
-      <POSITION>2</POSITION>
+      <SUBJECT_CATALOG>TAGALOG001</SUBJECT_CATALOG>
+      <WHEN>Monday  Wednesday 10:00 AM-10:59 AM</WHEN>
+      <UNITS>4</UNITS>
     </CLASS>
   </WAITLISTED_CLASSES>
 </UC_SR_CLASS_ENROLLMENT>

--- a/fixtures/xml/campus_solutions/enrollment_terms.xml
+++ b/fixtures/xml/campus_solutions/enrollment_terms.xml
@@ -5,19 +5,19 @@
     <CAREER>
       <ACAD_CAREER>GRAD</ACAD_CAREER>
       <TERM>
-        <TERM_ID>2175</TERM_ID>
-        <TERM_DESCR>2017 Summer</TERM_DESCR>
+        <TERM_ID>2165</TERM_ID>
+        <TERM_DESCR>2016 Summer</TERM_DESCR>
       </TERM>
       <TERM>
-        <TERM_ID>2178</TERM_ID>
-        <TERM_DESCR>2017 Fall</TERM_DESCR>
+        <TERM_ID>2168</TERM_ID>
+        <TERM_DESCR>2016 Fall</TERM_DESCR>
       </TERM>
     </CAREER>
     <CAREER>
       <ACAD_CAREER>UGRD</ACAD_CAREER>
       <TERM>
-        <TERM_ID>2172</TERM_ID>
-        <TERM_DESCR>2017 Spring</TERM_DESCR>
+        <TERM_ID>2162</TERM_ID>
+        <TERM_DESCR>2016 Spring</TERM_DESCR>
       </TERM>
     </CAREER>
   </CAREERS>

--- a/public/dummy/json/enrollment_term.json
+++ b/public/dummy/json/enrollment_term.json
@@ -3,8 +3,8 @@
   "feed": {
     "enrollmentTerm": {
       "studentId": "0000012",
-      "termId": "2176",
-      "termDescr": "Spring 2017",
+      "term": "2168",
+      "termDescr": "2016 Fall",
       "advisors": [
         {
           "id": "123456",
@@ -78,13 +78,13 @@
           "url": "https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/UC_FA_AWD_MGT_FLU.UC_FA_AWD_MGT_FLU.GBL"
         }
       },
-      "enrollmentPeriods": [
+      "enrollmentPeriod": [
         {
           "id": "phase1",
           "name": "Phase I",
           "date": {
-            "epoch": 1461019200,
-            "dateTime": "2016-04-18T15:40:00-07:00",
+            "epoch": 1460962800,
+            "dateTime": "2016-04-18T00:00:00-08:00",
             "dateString": "4/18"
           }
         },
@@ -92,8 +92,8 @@
           "id": "phase2",
           "name": "Phase II",
           "date": {
-            "epoch": 1465169400,
-            "dateTime": "2016-06-05T16:30:00-07:00",
+            "epoch": 1465110000,
+            "dateTime": "2016-06-05T00:00:00-08:00",
             "dateString": "6/05"
           }
         },
@@ -101,19 +101,41 @@
           "id": "adjust",
           "name": "Adjust",
           "date": {
-            "epoch": 1471310400,
-            "dateTime": "2016-08-15T18:20:00-07:00",
+            "epoch": 1471244400,
+            "dateTime": "2016-08-15T00:00:00-08:00",
             "dateString": "8/15"
           }
         }
       ],
       "scheduleOfClassesPeriod": {
         "date": {
-          "epoch": 1459191600,
-          "dateTime": "2016-03-28T12:00:00-07:00",
+          "epoch": 1459148400,
+          "dateTime": "2016-03-28T00:00:00-08:00",
           "dateString": "3/28"
         }
-      }
+      },
+      "enrolledClasses": [
+        {
+          "id": "12081",
+          "subjectCatalog": "ARCH11A",
+          "when": "Monday  Wednesday 9:00 AM-9:59 AM",
+          "units": "4"
+        },
+        {
+          "id": "19090",
+          "subjectCatalog": "MATHC103",
+          "when": "Tuesday  Thursday 12:30 PM-1:59 PM",
+          "units": "4"
+        }
+      ],
+      "waitlistedClasses": [
+        {
+          "id": "5636",
+          "subjectCatalog": "TAGALOG001",
+          "when": "Monday  Wednesday 10:00 AM-10:59 AM",
+          "units": "4"
+        }
+      ]
     }
   },
   "feedName": "CampusSolutions::MyEnrollmentTerm",

--- a/public/dummy/json/enrollment_terms.json
+++ b/public/dummy/json/enrollment_terms.json
@@ -4,18 +4,18 @@
     "enrollmentTerms": [
       {
         "acadCareer": "UGRD",
-        "termId": "2172",
-        "termDescr": "2017 Spring"
+        "termId": "2162",
+        "termDescr": "2016 Spring"
       },
       {
         "acadCareer": "GRAD",
-        "termId": "2175",
-        "termDescr": "2017 Summer"
+        "termId": "2165",
+        "termDescr": "2016 Summer"
       },
       {
         "acadCareer": "GRAD",
-        "termId": "2178",
-        "termDescr": "2017 Fall"
+        "termId": "2168",
+        "termDescr": "2016 Fall"
       }
     ],
     "studentId": "12701798"

--- a/spec/controllers/campus_solutions/enrollment_term_controller_spec.rb
+++ b/spec/controllers/campus_solutions/enrollment_term_controller_spec.rb
@@ -15,9 +15,9 @@ describe CampusSolutions::EnrollmentTermController do
       it_behaves_like 'a successful feed'
       it 'has some term data' do
         session['user_id'] = user_id
-        get feed, {term_id: '2176', format: 'json'}
+        get feed, {term_id: '2162', format: 'json'}
         json = JSON.parse response.body
-        expect(json['feed']['enrollmentTerm']['termDescr']).to eq 'Spring 2017'
+        expect(json['feed']['enrollmentTerm']['termDescr']).to eq '2016 Spring'
       end
     end
   end

--- a/spec/controllers/campus_solutions/enrollment_terms_controller_spec.rb
+++ b/spec/controllers/campus_solutions/enrollment_terms_controller_spec.rb
@@ -17,7 +17,7 @@ describe CampusSolutions::EnrollmentTermsController do
         session['user_id'] = user_id
         get feed
         json = JSON.parse(response.body)
-        expect(json['feed']['enrollmentTerms'][0]['termId']).to eq '2172'
+        expect(json['feed']['enrollmentTerms'][0]['termId']).to eq '2162'
       end
     end
   end

--- a/spec/models/campus_solutions/enrollment_term_spec.rb
+++ b/spec/models/campus_solutions/enrollment_term_spec.rb
@@ -6,7 +6,6 @@ describe CampusSolutions::EnrollmentTerm do
     it_behaves_like 'a proxy that properly observes the enrollment card flag'
     it_behaves_like 'a proxy that got data successfully'
     it 'returns data with the expected structure' do
-      pp subject
       expect(subject[:feed][:enrollmentTerm]).to be
     end
   end
@@ -18,18 +17,17 @@ describe CampusSolutions::EnrollmentTerm do
 
     it 'returns specific mock data' do
       enrollment_feed = subject[:feed][:enrollmentTerm]
-      expect(enrollment_feed[:studentId]).to eq '0000012'
+      expect(enrollment_feed[:studentId]).to eq '12701798'
       expect(enrollment_feed[:advisors][1][:name]).to eq 'Marsh Man'
       expect(enrollment_feed[:links][:decal][:url]).to eq 'http://www.decal.org/'
-      expect(enrollment_feed[:enrollmentPeriods][0][:id]).to eq 'phase1'
-      expect(enrollment_feed[:enrolledClasses][0][:id]).to eq '21786'
+      expect(enrollment_feed[:enrollmentPeriod][0][:id]).to eq 'phase1'
+      expect(enrollment_feed[:enrolledClasses][0][:id]).to eq '12081'
       expect(enrollment_feed[:waitlistedClasses][0][:id]).to eq '15636'
     end
 
     it 'formats dates' do
-      expect(subject[:feed][:enrollmentTerm][:enrollmentPeriods][0][:datetime]).to eq(
+      expect(subject[:feed][:enrollmentTerm][:enrollmentPeriod][0][:date]).to include(
         epoch: 1461019200,
-        datetime: '2016-04-18T15:40:00-07:00',
         datestring: '4/18'
       )
     end

--- a/spec/models/campus_solutions/enrollment_terms_spec.rb
+++ b/spec/models/campus_solutions/enrollment_terms_spec.rb
@@ -25,7 +25,7 @@ describe CampusSolutions::EnrollmentTerms do
     end
 
     it 'returns terms in order of ID' do
-      expect(terms.map { |term| term[:termId] }).to eq %w(2172 2175 2178)
+      expect(terms.map { |term| term[:termId] }).to eq %w(2162 2165 2168)
     end
 
     it 'map terms to correct academic career' do

--- a/src/assets/javascripts/angular/controllers/widgets/enrollment/enrollmentCardController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/enrollment/enrollmentCardController.js
@@ -62,13 +62,13 @@ angular.module('calcentral.controllers').controller('EnrollmentCardController', 
     var termIndex = _.indexOf(
       $scope.enrollment.terms,
       _.find($scope.enrollment.terms, {
-        termId: data.termId
+        termId: data.term
       })
     );
 
-    data.isTermLoading = false;
-
-    $scope.enrollment.terms.splice(termIndex, 1, data);
+    if (termIndex !== -1) {
+      $scope.enrollment.terms.splice(termIndex, 1, data);
+    }
   };
 
   /**
@@ -76,11 +76,11 @@ angular.module('calcentral.controllers').controller('EnrollmentCardController', 
    * This makes it easier to look it up in JavaScript
    */
   var mapEnrollmentPeriodsById = function(data) {
-    if (!data.enrollmentPeriods) {
+    if (!data.enrollmentPeriod) {
       return data;
     }
 
-    data.enrollmentPeriodsById = _.indexBy(data.enrollmentPeriods, 'id');
+    data.enrollmentPeriodsById = _.indexBy(data.enrollmentPeriod, 'id');
 
     return data;
   };
@@ -106,6 +106,9 @@ angular.module('calcentral.controllers').controller('EnrollmentCardController', 
    */
   var parseEnrollmentTerm = function(data) {
     var termData = _.get(data, 'data.feed.enrollmentTerm');
+    if (!termData) {
+      return;
+    }
 
     termData = mapEnrollmentPeriodsById(termData);
     termData = mapLinks(termData);
@@ -131,16 +134,6 @@ angular.module('calcentral.controllers').controller('EnrollmentCardController', 
   };
 
   /**
-   * Set the scope for the enrollment cards and set each one to loading = true
-   */
-  var setEnrollmentTerms = function(enrollmentTerms) {
-    $scope.enrollment.terms = _.map(enrollmentTerms, function(enrollmentTerm) {
-      enrollmentTerm.isTermLoading = true;
-      return enrollmentTerm;
-    });
-  };
-
-  /**
    * Parse all the terms and create an array of promises for each
    */
   var parseEnrollmentTerms = function(data) {
@@ -149,9 +142,7 @@ angular.module('calcentral.controllers').controller('EnrollmentCardController', 
     }
 
     var enrollmentTerms = _.get(data, 'data.feed.enrollmentTerms');
-    setEnrollmentTerms(enrollmentTerms);
-    stopMainSpinner();
-
+    $scope.enrollment.terms = enrollmentTerms;
     return createEnrollmentPromises(enrollmentTerms);
   };
 
@@ -183,6 +174,8 @@ angular.module('calcentral.controllers').controller('EnrollmentCardController', 
     if (_.get(data, 'student')) {
       loadEnrollmentData();
       loadHolds();
+    } else {
+      stopMainSpinner();
     }
   };
 

--- a/src/assets/templates/widgets/enrollment/decide.html
+++ b/src/assets/templates/widgets/enrollment/decide.html
@@ -21,7 +21,7 @@
     ></span>
   </div>
 
-  <div data-ng-if="enrollmentTerm.enrollmentPeriods.length">
+  <div data-ng-if="enrollmentTerm.enrollmentPeriod.length">
     <h4 class="cc-enrollment-card-headersub-title">Enrollment Period</h4>
     <div class="cc-table">
       <table>
@@ -30,7 +30,7 @@
           <th scope="col">Day of the week</th>
           <th scope="col">Date and time</th>
         </thead>
-        <tr data-ng-repeat="period in enrollmentTerm.enrollmentPeriods">
+        <tr data-ng-repeat="period in enrollmentTerm.enrollmentPeriod">
           <th scope="row">
             <span data-ng-bind="period.name" class="cc-text-light"></span>
           </th>

--- a/src/assets/templates/widgets/enrollment_card.html
+++ b/src/assets/templates/widgets/enrollment_card.html
@@ -1,33 +1,30 @@
 <div data-ng-controller="EnrollmentCardController" data-cc-spinner-directive="enrollment.isLoading" class="cc-enrollment-card">
-  <div class="cc-widget cc-widget-enrollment-card" data-ng-repeat="enrollmentTerm in enrollment.terms">
+  <div class="cc-widget cc-widget-enrollment-card" data-ng-repeat="enrollmentTerm in enrollment.terms" data-ng-if="enrollmentTerm.enrollmentPeriod">
     <div class="cc-widget-title">
       <h2>
         Class Enrollment
         <span class="cc-widget-title-sub" data-ng-bind="enrollmentTerm.termDescr"></span>
       </h2>
     </div>
-    <div data-cc-spinner-directive="enrollmentTerm.isTermLoading">
-      <div class="cc-widget-text cc-enrollment-card-head">
-        <div class="cc-flex cc-flex-space-between cc-text-light">
-          <div>
-            <strong>Action</strong>
-          </div>
-          <div>
-            <strong>When</strong>
-          </div>
+    <div class="cc-widget-text cc-enrollment-card-head">
+      <div class="cc-flex cc-flex-space-between cc-text-light">
+        <div>
+          <strong>Action</strong>
+        </div>
+        <div>
+          <strong>When</strong>
         </div>
       </div>
-
-      <ul class="cc-widget-list cc-widget-list-border-top">
-        <li
-          data-ng-repeat="section in enrollment.sections"
-          class="cc-widget-list-hover cc-widget-list-hover-notriangle cc-enrollment-card-section"
-          data-ng-class="{'cc-widget-list-hover-opened':(section.show)}"
-          data-cc-accessible-focus-directive
-          data-ng-click="api.widget.toggleShow($event, null, section, 'Class Enrollment Section - ' + section.title)"
-          data-ng-include="'widgets/enrollment/' + section.id + '.html'"
-        ></li>
-      </ul>
     </div>
+    <ul class="cc-widget-list cc-widget-list-border-top">
+      <li
+        data-ng-repeat="section in enrollment.sections"
+        class="cc-widget-list-hover cc-widget-list-hover-notriangle cc-enrollment-card-section"
+        data-ng-class="{'cc-widget-list-hover-opened':(section.show)}"
+        data-cc-accessible-focus-directive
+        data-ng-click="api.widget.toggleShow($event, null, section, 'Class Enrollment Section - ' + section.title)"
+        data-ng-include="'widgets/enrollment/' + section.id + '.html'"
+      ></li>
+    </ul>
   </div>
 </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-13947

Adjustments to reflect the final shape of the enrollment term APIs, which diverge from originally expected behavior.

In particular, the "get all enrollment terms" endpoint currently returns many terms for each student, some of which will return no enrollment information via the "get specific enrollment term" endpoint. This requires a change in front-end behavior: instead of showing individual spinners for each term, we have to keep the main spinner active until all terms have loaded. Otherwise individual term cards would briefly appear with spinners, then disappear after coming back empty.