### PR TITLE
SISRP-14454, flush CampusSolutions::DelegateStudents cache when user claims student

### DIFF
--- a/app/models/campus_solutions/delegate_students_expiry.rb
+++ b/app/models/campus_solutions/delegate_students_expiry.rb
@@ -1,0 +1,7 @@
+module CampusSolutions
+  module DelegateStudentsExpiry
+    def self.expire(uid=nil)
+      CampusSolutions::DelegateStudents.expire uid
+    end
+  end
+end

--- a/app/models/campus_solutions/my_delegate_access.rb
+++ b/app/models/campus_solutions/my_delegate_access.rb
@@ -9,7 +9,13 @@ module CampusSolutions
     end
 
     def update(params = {})
-      CampusSolutions::DelegateAccessCreate.new(user_id: @uid, params: params).get
+      feed = CampusSolutions::DelegateAccessCreate.new(user_id: @uid, params: params).get
+    rescue => e
+      logger.error "#{self.class.name} failed where uid = #{@uid}"
+      raise e
+    else
+      DelegateStudentsExpiry.expire @uid
+      feed
     end
 
   end

--- a/spec/controllers/campus_solutions/delegate_access_controller_spec.rb
+++ b/spec/controllers/campus_solutions/delegate_access_controller_spec.rb
@@ -20,44 +20,54 @@ describe CampusSolutions::DelegateAccessController do
       allow(User::Auth).to receive(:where).and_return [User::Auth.new(uid: user_id, is_superuser: false, active: true)]
     end
 
-    it 'should get students list' do
-      get :get_students
-      expect(response.status).to eq 200
-      json = JSON.parse(response.body)
-      expect(json['statusCode']).to eq 200
-      expect(json['feed']['students']).to be_present
-      json['feed']['students'].each do |student|
-        expect(student['campusSolutionsId']).to be_present
-        expect(student['fullName']).to be_present
-        expect(student['privileges']).to be_present
+    context 'post' do
+      before do
+        expect(CampusSolutions::DelegateStudentsExpiry).to receive(:expire).once.with user_id
+      end
+      it 'should link a claimed student' do
+        post :post, {
+          proxyEmailAddress: 'squire.allworthy@gmail.com',
+          securityKey: 'uy786XD'
+        }
+        expect(response.status).to eq 200
+        json = JSON.parse response.body
+        expect(json['statusCode']).to eq 200
+        expect(json['feed']['status']).to be_present
       end
     end
 
-    it 'should link a claimed student' do
-      post :post, {
-        proxyEmailAddress: 'squire.allworthy@gmail.com',
-        securityKey: 'uy786XD'
-      }
-      expect(response.status).to eq 200
-      json = JSON.parse(response.body)
-      expect(json['statusCode']).to eq 200
-      expect(json['feed']['status']).to be_present
-    end
+    context 'get' do
+      before do
+        expect(CampusSolutions::DelegateStudentsExpiry).to receive(:expire).never
+      end
+      it 'should get students list' do
+        get :get_students
+        expect(response.status).to eq 200
+        json = JSON.parse(response.body)
+        expect(json['statusCode']).to eq 200
+        expect(json['feed']['students']).to be_present
+        json['feed']['students'].each do |student|
+          expect(student['campusSolutionsId']).to be_present
+          expect(student['fullName']).to be_present
+          expect(student['privileges']).to be_present
+        end
+      end
 
-    it 'should get terms and conditions' do
-      get :get_terms_and_conditions
-      expect(response.status).to eq 200
-      json = JSON.parse(response.body)
-      expect(json['statusCode']).to eq 200
-      expect(json['feed']['daAgreeToTerms']['termsAndConditions']).to include 'Excepteur sint occaecat'
-    end
+      it 'should get terms and conditions' do
+        get :get_terms_and_conditions
+        expect(response.status).to eq 200
+        json = JSON.parse(response.body)
+        expect(json['statusCode']).to eq 200
+        expect(json['feed']['daAgreeToTerms']['termsAndConditions']).to include 'Excepteur sint occaecat'
+      end
 
-    it 'should get Campus Solutions URL for managing delegates' do
-      get :get_delegate_management_url
-      expect(response.status).to eq 200
-      json = JSON.parse(response.body)
-      expect(json['statusCode']).to eq 200
-      expect(json['feed']['delegatedAccessUrl']['url']).to eq 'https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SA_LEARNER_SERVICES.SS_CC_DA_SHAREINFO.GBL?Page=SS_CC_DA_HDR&Action=A&ForceSearch=Y&TargetFrameName=None'
+      it 'should get Campus Solutions URL for managing delegates' do
+        get :get_delegate_management_url
+        expect(response.status).to eq 200
+        json = JSON.parse(response.body)
+        expect(json['statusCode']).to eq 200
+        expect(json['feed']['delegatedAccessUrl']['url']).to eq 'https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SA_LEARNER_SERVICES.SS_CC_DA_SHAREINFO.GBL?Page=SS_CC_DA_HDR&Action=A&ForceSearch=Y&TargetFrameName=None'
+      end
     end
   end
 

--- a/spec/models/campus_solutions/my_delegate_access_spec.rb
+++ b/spec/models/campus_solutions/my_delegate_access_spec.rb
@@ -1,0 +1,15 @@
+describe CampusSolutions::MyDelegateAccess do
+
+  context '#update' do
+    let(:user_id) { random_id }
+    let(:feed) { { success: true } }
+    subject { CampusSolutions::MyDelegateAccess.from_session({ 'user_id' => user_id }) }
+    before do
+      expect(CampusSolutions::DelegateAccessCreate).to receive(:new).with(user_id: user_id, params: {}).once.and_return double(get: feed)
+    end
+    it 'should return feed after update' do
+      expect(subject.update).to eq feed
+    end
+  end
+
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-14454

...such that the newly claimed student shows up on 'My Students' card.