### PR TITLE
SISRP-14284 Enrollment card front-end updates

### DIFF
--- a/script/sis/verify_sis_api_endpoints.sh
+++ b/script/sis/verify_sis_api_endpoints.sh
@@ -134,9 +134,10 @@ if [ "${yml_features_cs_delegated_access}" == "true" ] ; then
 fi
 
 if [ "${yml_features_cs_enrollment_card}" == "true" ] ; then
-  API_CALLS+=("/UC_SR_CURR_TERMS.v1/GetCurrentItems?EMPLID=#{CAMPUS_SOLUTIONS_ID}")
+  API_CALLS+=("/UC_SR_CURR_TERMS.v1/GetCurrentItems?EMPLID=${CAMPUS_SOLUTIONS_ID}")
   API_CALLS+=("/UC_SR_STDNT_CLASS_ENROLL.v1/Get?EMPLID=${CAMPUS_SOLUTIONS_ID}&STRM=2168")
   API_CALLS+=("/UC_SR_ACADEMIC_PLAN.v1/get?EMPLID=${CAMPUS_SOLUTIONS_ID}&STRM=2168")
+  API_CALLS+=("/UC_SR_COLLEGE_SCHDLR_URL.v1/get?EMPLID=${CAMPUS_SOLUTIONS_ID}&STRM=2168&ACAD_CAREER=UGRD&INSTITUTION=UCB01")
 fi
 
 for path in ${API_CALLS[@]}; do

--- a/src/assets/javascripts/angular/controllers/widgets/enrollment/enrollmentCardController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/enrollment/enrollmentCardController.js
@@ -59,15 +59,12 @@ angular.module('calcentral.controllers').controller('EnrollmentCardController', 
    * Set the data for a specific term
    */
   var setTermData = function(data) {
-    var termIndex = _.indexOf(
-      $scope.enrollment.terms,
-      _.find($scope.enrollment.terms, {
-        termId: data.term
-      })
-    );
+    var term = _.find($scope.enrollment.terms, {
+      termId: data.term
+    });
 
-    if (termIndex !== -1) {
-      $scope.enrollment.terms.splice(termIndex, 1, data);
+    if (term) {
+      angular.extend(term, data);
     }
   };
 

--- a/src/assets/templates/widgets/enrollment/schedule.html
+++ b/src/assets/templates/widgets/enrollment/schedule.html
@@ -6,5 +6,8 @@
 ></div>
 
 <div class="cc-enrollment-card-section-content" data-ng-if="section.show">
-  Customized semester scheduling is unavailable at this time.
+  <a data-ng-href="/college_scheduler/{{enrollmentTerm.acadCareer}}/{{enrollmentTerm.term}}" target="_self">
+    Organize and preview your upcoming semester
+  </a>
+  based on your scheduling needs.
 </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-14284

Follows up on #4849 with front-end code, and also an updated SIS verify script.

The changes in the Angular controller are necessary because the plural "enrollment terms" feed includes the required `acadCareer` parameter, but the singular "enrollment term" feed does not. Data from the latter must extend the former rather than replacing it.