### PR TITLE
CLC-6149 - QA WebDriver tests for FinAid UIs, part 1

### DIFF
--- a/spec/support/selenium_helper.rb
+++ b/spec/support/selenium_helper.rb
@@ -25,6 +25,7 @@ if ENV["UI_TEST"]
   require_relative '../ui_selenium/pages/my_finances_pages'
   require_relative '../ui_selenium/pages/my_finances_landing_page'
   require_relative '../ui_selenium/pages/my_finances_details_page'
+  require_relative '../ui_selenium/pages/my_finances_financial_aid_page'
   require_relative '../ui_selenium/pages/my_profile_page'
   require_relative '../ui_selenium/pages/my_toolbox_page'
 

--- a/spec/ui_selenium/my_finances_finaid_budget_spec.rb
+++ b/spec/ui_selenium/my_finances_finaid_budget_spec.rb
@@ -37,7 +37,6 @@ describe 'My Finances Financial Aid Estimated Cost of Attendance card', :testui 
             @api_aid_years.get_json @driver
 
             unless @api_aid_years.feed.nil?
-              testable_users << uid
 
               api_aid_years = @api_aid_years.fin_aid_years
               api_aid_years.each { |year| aid_years << year['id'] }
@@ -213,7 +212,7 @@ describe 'My Finances Financial Aid Estimated Cost of Attendance card', :testui 
                     end
 
                   else
-                    # TODO: when test data available, verify "you have no budget" scenario
+                    # TODO: when test data available, verify 'you have no budget' scenario
                   end
                 end
               end

--- a/spec/ui_selenium/my_finances_finaid_budget_spec.rb
+++ b/spec/ui_selenium/my_finances_finaid_budget_spec.rb
@@ -1,0 +1,242 @@
+describe 'My Finances Financial Aid Estimated Cost of Attendance card', :testui => true do
+
+  if ENV["UI_TEST"] && Settings.ui_selenium.layer == 'local'
+
+    include ClassLogger
+
+    begin
+      @driver = WebDriverUtils.launch_browser
+      test_users = UserUtils.load_test_users
+      testable_users = []
+      test_output = UserUtils.initialize_output_csv(self)
+
+      CSV.open(test_output, 'wb') do |row|
+        row << ['UID', 'Aid Years', 'Standard Items', 'Standard Amounts', 'Additional Items', 'Additional Amounts']
+      end
+
+      @api_aid_years = ApiCSAidYearsPage.new @driver
+      @api_fin_aid_data = ApiCSFinAidDataPage.new @driver
+
+      @splash_page = CalCentralPages::SplashPage.new @driver
+      @finances_page = CalCentralPages::MyFinancesPages::MyFinancesLandingPage.new @driver
+      @fin_aid_page = CalCentralPages::MyFinancesPages::MyFinancesFinancialAidPage.new @driver
+
+      test_users.each do |user|
+        if user['finAidCs']
+          uid = user['uid']
+          logger.info "UID is #{uid}"
+          aid_years = []
+          api_std_items = []
+          api_std_amts = []
+          api_addl_items = []
+          api_addl_amts = []
+
+          begin
+            @splash_page.load_page
+            @splash_page.basic_auth uid
+            @api_aid_years.get_json @driver
+
+            unless @api_aid_years.feed.nil?
+              testable_users << uid
+
+              api_aid_years = @api_aid_years.fin_aid_years
+              api_aid_years.each { |year| aid_years << year['id'] }
+
+              if api_aid_years.any?
+                api_aid_years.each do |year|
+
+                  year_id = @api_aid_years.fin_aid_year_id year
+
+                  @api_fin_aid_data.get_json(@driver, year_id)
+                  @fin_aid_page.load_fin_aid_budget year_id
+
+                  # ANNUAL VIEW
+
+                  annual_data = @api_fin_aid_data.budget_annual_data
+                  std_budget_items = @api_fin_aid_data.budget_items(annual_data, 'Standard Budget Items')
+                  addl_budget_items = @api_fin_aid_data.budget_items(annual_data, 'Additional Budget Items')
+
+                  # Standard Budget Items
+
+                  if std_budget_items.any?
+                    testable_users << uid
+
+                    std_budget_table = @fin_aid_page.standard_budget_table_element
+
+                    ui_std_items = @fin_aid_page.budget_items std_budget_table
+                    ui_std_amts = @fin_aid_page.budget_item_annual_totals std_budget_table
+
+                    api_std_items = @api_fin_aid_data.budget_item_titles(annual_data, 'Standard Budget Items')
+                    api_std_amts = @api_fin_aid_data.budget_item_totals(annual_data, 'Standard Budget Items')
+
+                    it ("shows the standard budget items for UID #{uid}") { expect(ui_std_items).to eql(api_std_items) }
+                    it ("shows the standard budget item amounts for UID #{uid}") { expect(ui_std_amts).to eql(api_std_amts) }
+
+                    # Standard Budget Sub-items
+
+                    std_budget_item_toggles = @fin_aid_page.standard_budget_row_toggle_elements
+                    std_budget_items.each do |item|
+
+                      @fin_aid_page.expand_budget_item(std_budget_item_toggles, std_budget_items.index(item))
+
+                      ui_std_subitems = @fin_aid_page.budget_subitems
+                      ui_std_subitem_amts = @fin_aid_page.budget_subitem_annual_amounts
+
+                      api_std_subitems = @api_fin_aid_data.budget_sub_item_titles item
+                      api_std_subitem_amts = @api_fin_aid_data.budget_sub_item_totals item
+
+                      it ("shows the standard budget sub-items for UID #{uid}") { expect(ui_std_subitems).to eql(api_std_subitems) }
+                      it ("shows the standard budget sub-item amounts for UID #{uid}") { expect(ui_std_subitem_amts).to eql(api_std_subitem_amts) }
+
+                    end
+                  end
+
+                  # Additional Budget Items
+
+                  if addl_budget_items.any?
+
+                    addl_budget_table = @fin_aid_page.additional_budget_table_element
+
+                    ui_addl_items = @fin_aid_page.budget_items addl_budget_table
+                    ui_addl_amts = @fin_aid_page.budget_item_annual_totals addl_budget_table
+
+                    api_addl_items = @api_fin_aid_data.budget_item_titles(annual_data, 'Additional Budget Items')
+                    api_addl_amts = @api_fin_aid_data.budget_item_totals(annual_data, 'Additional Budget Items')
+
+                    it ("shows the additional budget items for UID #{uid}") { expect(ui_addl_items).to eql(api_addl_items) }
+                    it ("shows the additional budget item amounts for UID #{uid}") { expect(ui_addl_amts).to eql(api_addl_amts) }
+
+                    # Additional Budget Sub-items
+
+                    addl_budget_item_toggles = @fin_aid_page.additional_budget_row_toggle_elements
+                    addl_budget_items.each do |item|
+
+                      @fin_aid_page.expand_budget_item(addl_budget_item_toggles, addl_budget_items.index(item))
+
+                      ui_addl_subitems = @fin_aid_page.budget_subitems
+                      ui_addl_subitem_amts = @fin_aid_page.budget_subitem_annual_amounts
+
+                      api_addl_subitems = @api_fin_aid_data.budget_sub_item_titles item
+                      api_addl_subitem_amts = @api_fin_aid_data.budget_sub_item_totals item
+
+                      it ("shows the additional budget sub-items for UID #{uid}") { expect(ui_addl_subitems).to eql(api_addl_subitems) }
+                      it ("shows the additional budget sub-item amounts for UID #{uid}") { expect(ui_addl_subitem_amts).to eql(api_addl_subitem_amts) }
+
+                    end
+                  end
+
+                  # TERM VIEW
+
+                  term_data = @api_fin_aid_data.budget_term_data
+                  std_budget_term_items = @api_fin_aid_data.budget_items(term_data, 'Standard Budget Items')
+                  addl_budget_term_items = @api_fin_aid_data.budget_items(term_data, 'Additional Budget Items')
+
+                  @fin_aid_page.toggle_budget_view
+
+                  # Standard Budget Items
+
+                  if std_budget_term_items.any?
+
+                    std_budget_table = @fin_aid_page.standard_budget_table_element
+
+                    ui_std_term_items = @fin_aid_page.budget_items std_budget_table
+                    ui_std_term_amts = @fin_aid_page.budget_item_term_amounts std_budget_table
+                    ui_std_term_ttls = @fin_aid_page.budget_item_term_totals std_budget_table
+
+                    api_std_term_items = @api_fin_aid_data.budget_item_titles(term_data, 'Standard Budget Items')
+                    api_std_term_amts = @api_fin_aid_data.budget_item_amounts(term_data, 'Standard Budget Items')
+                    api_std_term_ttls = @api_fin_aid_data.budget_item_totals(term_data, 'Standard Budget Items')
+
+                    it ("shows the standard budget items by term for UID #{uid}") { expect(ui_std_term_items).to eql(api_std_term_items) }
+                    it ("shows the standard budget item amounts by term for UID #{uid}") { expect(ui_std_term_amts).to eql(api_std_term_amts) }
+                    it ("shows the standard budget item totals by term for UID #{uid}") { expect(ui_std_term_ttls).to eql(api_std_term_ttls) }
+
+                    # Standard Budget Sub-items
+
+                    std_budget_item_toggles = @fin_aid_page.standard_budget_row_toggle_elements
+                    std_budget_term_items.each do |item|
+
+                      @fin_aid_page.expand_budget_item(std_budget_item_toggles, std_budget_term_items.index(item))
+
+                      ui_std_term_subitems = @fin_aid_page.budget_subitems
+                      ui_std_term_subitem_amts = @fin_aid_page.budget_subitem_term_amounts
+                      ui_std_term_subitem_ttls = @fin_aid_page.budget_subitem_term_totals
+
+                      api_std_term_subitems = @api_fin_aid_data.budget_sub_item_titles item
+                      api_std_term_subitem_amts = @api_fin_aid_data.budget_sub_item_amounts item
+                      api_std_term_subitem_ttls = @api_fin_aid_data.budget_sub_item_totals item
+
+                      it ("shows the standard budget sub-items by term for UID #{uid}") { expect(ui_std_term_subitems).to eql(api_std_term_subitems) }
+                      it ("shows the standard budget sub-item amounts by term for UID #{uid}") { expect(ui_std_term_subitem_amts).to eql(api_std_term_subitem_amts) }
+                      it ("shows the standard budget sub-item totals by term for UID #{uid}") { expect(ui_std_term_subitem_ttls).to eql(api_std_term_subitem_ttls) }
+
+                    end
+                  end
+
+                  # Additional Budget Items
+
+                  if addl_budget_term_items.any?
+
+                    addl_budget_table = @fin_aid_page.additional_budget_table_element
+
+                    ui_addl_term_items = @fin_aid_page.budget_items addl_budget_table
+                    ui_addl_term_amts = @fin_aid_page.budget_item_term_amounts addl_budget_table
+                    ui_addl_term_ttls = @fin_aid_page.budget_item_term_totals addl_budget_table
+
+                    api_addl_term_items = @api_fin_aid_data.budget_item_titles(term_data, 'Additional Budget Items')
+                    api_addl_term_amts = @api_fin_aid_data.budget_item_amounts(term_data, 'Additional Budget Items')
+                    api_addl_term_ttls = @api_fin_aid_data.budget_item_totals(term_data, 'Additional Budget Items')
+
+                    it ("shows the additional budget items by term for UID #{uid}") { expect(ui_addl_term_items).to eql(api_addl_term_items) }
+                    it ("shows the additional budget item amounts by term for UID #{uid}") { expect(ui_addl_term_amts).to eql(api_addl_term_amts) }
+                    it ("shows the additional budget item totals by term for UID #{uid}") { expect(ui_addl_term_ttls).to eql(api_addl_term_ttls) }
+
+                    # Additional Budget Sub-items
+
+                    addl_budget_item_toggles = @fin_aid_page.additional_budget_row_toggle_elements
+                    addl_budget_term_items.each do |item|
+
+                      @fin_aid_page.expand_budget_item(addl_budget_item_toggles, addl_budget_term_items.index(item))
+
+                      ui_addl_term_subitems = @fin_aid_page.budget_subitems
+                      ui_addl_term_subitem_amts = @fin_aid_page.budget_subitem_term_amounts
+                      ui_addl_term_subitem_ttls = @fin_aid_page.budget_subitem_term_totals
+
+                      api_addl_term_subitems = @api_fin_aid_data.budget_sub_item_titles item
+                      api_addl_term_subitem_amts = @api_fin_aid_data.budget_sub_item_amounts item
+                      api_addl_term_subitem_ttls = @api_fin_aid_data.budget_sub_item_totals item
+
+                      it ("shows the additional budget sub-items by term for UID #{uid}") { expect(ui_addl_term_subitems).to eql(api_addl_term_subitems) }
+                      it ("shows the additional budget sub-item amounts by term for UID #{uid}") { expect(ui_addl_term_subitem_amts).to eql(api_addl_term_subitem_amts) }
+                      it ("shows the additional budget sub-item totals by term for UID #{uid}") { expect(ui_addl_term_subitem_ttls).to eql(api_addl_term_subitem_ttls) }
+
+                    end
+
+                  else
+                    # TODO: when test data available, verify "you have no budget" scenario
+                  end
+                end
+              end
+            end
+
+          rescue => e
+            logger.error e.message + "\n" + e.backtrace.join("\n")
+
+            # Force a test failure in the event of an error controlling the UI
+            it ("caused an unexpected error in the test for UID #{uid}") { fail }
+
+          ensure
+            CSV.open(test_output, 'a+') do |user_info_csv|
+              user_info_csv << [uid, aid_years * ', ', api_std_items * "\r", api_std_amts * "\r", api_addl_items * "\r", api_addl_amts * "\r"]
+            end
+          end
+        end
+      end
+    rescue => e
+      logger.error e.message + "\n" + e.backtrace.join("\n ")
+    ensure
+      WebDriverUtils.quit_browser(@driver)
+      it ('has FinAid budget data for at least one of the test users') { expect(testable_users.any?).to be true }
+    end
+  end
+end

--- a/spec/ui_selenium/my_finances_finaid_legacy_spec.rb
+++ b/spec/ui_selenium/my_finances_finaid_legacy_spec.rb
@@ -107,9 +107,9 @@ describe 'My Finances financial aid messages', :testui => true do
                   end
 
                   # Status popover
-                  has_popover = my_finances_page.status_icon_element.visible?
+                  has_popover = my_finances_page.popover_icon_element.visible?
                   if has_popover
-                    my_finances_page.open_status_popover
+                    my_finances_page.open_profile_popover
                     has_popover_alert = my_finances_page.finaid_status_alert_element.visible?
                     if has_alert
                       popover_fin_aid_count = my_finances_page.finaid_status_alert_count

--- a/spec/ui_selenium/my_finances_finaid_legacy_spec.rb
+++ b/spec/ui_selenium/my_finances_finaid_legacy_spec.rb
@@ -107,9 +107,9 @@ describe 'My Finances financial aid messages', :testui => true do
                   end
 
                   # Status popover
-                  has_popover = my_finances_page.profile_icon_element.visible?
+                  has_popover = my_finances_page.status_icon_element.visible?
                   if has_popover
-                    my_finances_page.open_profile_popover
+                    my_finances_page.open_status_popover
                     has_popover_alert = my_finances_page.finaid_status_alert_element.visible?
                     if has_alert
                       popover_fin_aid_count = my_finances_page.finaid_status_alert_count

--- a/spec/ui_selenium/my_finances_finaid_profile_spec.rb
+++ b/spec/ui_selenium/my_finances_finaid_profile_spec.rb
@@ -1,0 +1,194 @@
+describe 'My Finances Financial Aid Profile card', :testui => true do
+
+  if ENV["UI_TEST"] && Settings.ui_selenium.layer == 'local'
+
+    include ClassLogger
+
+    begin
+      @driver = WebDriverUtils.launch_browser
+      test_users = UserUtils.load_test_users
+      testable_users = []
+      test_output = UserUtils.initialize_output_csv(self)
+
+      CSV.open(test_output, 'wb') do |row|
+        row << ['UID', 'Aid Years', 'Career', 'Grad Date', 'Enrollment', 'Residency', 'Family in College', 'Housing', ]
+      end
+
+      @api_aid_years = ApiCSAidYearsPage.new @driver
+      @api_fin_aid_data = ApiCSFinAidDataPage.new @driver
+
+      @splash_page = CalCentralPages::SplashPage.new @driver
+      @finances_page = CalCentralPages::MyFinancesPages::MyFinancesLandingPage.new @driver
+      @fin_aid_page = CalCentralPages::MyFinancesPages::MyFinancesFinancialAidPage.new @driver
+      @title_iv_page = CalCentralPages::MyProfileTitleIVCard.new @driver
+
+      test_users.each do |user|
+        if user['finAidCs']
+          uid = user['uid']
+          logger.info "UID is #{uid}"
+
+          aid_years = []
+          api_academic_career = []
+          api_expected_grad = nil
+          api_enrollments = []
+          api_residency = []
+          api_family_in_college = nil
+          api_housing = []
+
+          begin
+            @splash_page.load_page
+            @splash_page.basic_auth uid
+            @api_aid_years.get_json @driver
+
+            unless @api_aid_years.feed.nil?
+              api_aid_years = @api_aid_years.fin_aid_years
+              api_aid_years.each { |year| aid_years << year['id'] }
+
+              if api_aid_years.any?
+                testable_users << uid
+
+                api_aid_years.each do |year|
+
+                  year_id = @api_aid_years.fin_aid_year_id year
+
+                  @api_fin_aid_data.get_json(@driver, year_id)
+                  @fin_aid_page.load_fin_aid_profile year_id
+
+                  # PROFILE
+
+                  @fin_aid_page.show_profile
+
+                  ui_academic_career = @fin_aid_page.profile_elements_text @fin_aid_page.academic_career_elements
+                  api_academic_career = @api_fin_aid_data.profile_values 'Academic Career'
+                  it ("displays the right academic career(s) for UID #{uid}") { expect(ui_academic_career).to eql(api_academic_career) }
+
+                  ui_level = @fin_aid_page.profile_elements_text @fin_aid_page.level_elements
+                  api_level = @api_fin_aid_data.profile_sub_values 'Level'
+                  it ("displays the right level for each semester for UID #{uid}") { expect(ui_level).to eql(api_level) }
+
+                  @fin_aid_page.expected_graduation_element.exists? ?
+                      ui_expected_grad = @fin_aid_page.expected_graduation :
+                      ui_expected_grad = nil
+                  api_expected_grad = @api_fin_aid_data.profile_value 'Expected Graduation'
+                  it ("displays expected graduation date for UID #{uid}") { expect(ui_expected_grad).to eql(api_expected_grad) }
+
+                  ui_sap_status = @fin_aid_page.sap_status
+                  api_sap_status = @api_fin_aid_data.profile_value 'SAP Status'
+                  it ("displays the SAP status for UID #{uid}") { expect(ui_sap_status).to eql(api_sap_status) }
+
+                  ui_award_status = @fin_aid_page.award_status
+                  api_award_status = @api_fin_aid_data.profile_value 'Award Status'
+                  it ("displays the awards (packaging) status for UID #{uid}") { expect(ui_award_status).to eql(api_award_status) }
+
+                  ui_verification_status = @fin_aid_page.verification_status
+                  api_verification_status = @api_fin_aid_data.profile_value 'Verification Status'
+                  it ("displays the verification status for UID #{uid}") { expect(ui_verification_status).to eql(api_verification_status) }
+
+                  ui_dependency_status = @fin_aid_page.dependency_status
+                  api_dependency_status = @api_fin_aid_data.profile_value 'Dependency Status'
+                  it ("displays the dependency status for UID #{uid}") { expect(ui_dependency_status).to eql(api_dependency_status) }
+
+                  ui_efc = @fin_aid_page.efc
+                  api_efc = @api_fin_aid_data.profile_value 'Expected Family Contribution (EFC)'
+                  it ("displays the expected family contribution for UID #{uid}") { expect(ui_efc).to eql(api_efc) }
+
+                  ui_berkeley_parent_contrib = @fin_aid_page.berkeley_parent_contrib
+                  api_berkeley_parent_contrib = @api_fin_aid_data.profile_value 'Berkeley Parent Contribution'
+                  it ("displays the Berkeley Parent Contribution for UID #{uid}") { expect(ui_berkeley_parent_contrib).to eql(api_berkeley_parent_contrib) }
+
+                  ui_family_in_college = @fin_aid_page.family_members_in_college
+                  api_family_in_college = @api_fin_aid_data.profile_value 'Family Members in College'
+                  it ("displays the number of family members in college for UID #{uid}") { expect(ui_family_in_college).to eql(api_family_in_college) }
+
+                  ui_residency = @fin_aid_page.profile_elements_text @fin_aid_page.residency_elements
+                  api_residency = @api_fin_aid_data.profile_sub_values 'Residency'
+                  it ("displays the right residency associated with each semester for UID #{uid}") { expect(ui_residency).to eql(api_residency) }
+
+                  ui_enrollments = @fin_aid_page.profile_elements_text @fin_aid_page.enrollment_elements
+                  api_enrollments = @api_fin_aid_data.profile_sub_values 'Enrollment'
+                  it ("displays the right semester(s) and enrolled units for UID #{uid}") { expect(ui_enrollments).to eql(api_enrollments) }
+
+                  ui_ship_health = @fin_aid_page.profile_elements_text @fin_aid_page.ship_health_insurance_elements
+                  api_ship_health = @api_fin_aid_data.profile_sub_values 'SHIP Health Insurance'
+                  it ("displays SHIP health insurance for UID #{uid}") { expect(ui_ship_health).to eql(api_ship_health) }
+
+                  ui_housing = @fin_aid_page.profile_elements_text @fin_aid_page.housing_elements
+                  api_housing = @api_fin_aid_data.profile_sub_values 'Housing'
+                  it ("displays the right housing associated with each semester for UID #{uid}") { expect(ui_housing).to eql(api_housing) }
+
+                  has_update_family_link = @fin_aid_page.family_members_update_link?
+                  it ("offers a family members in college 'update' link for UID #{uid}") { expect(has_update_family_link).to be true }
+
+                  has_update_housing_link = @fin_aid_page.housing_update_link?
+                  it ("offers housing 'update' link for UID #{uid}") { expect(has_update_housing_link).to be true }
+
+                  # T and C
+
+                  @fin_aid_page.show_t_and_c
+                  @api_aid_years.title_iv_approval ? api_title_iv = 'Authorized' : api_title_iv = 'Not Authorized'
+
+                  ui_t_and_c = @fin_aid_page.t_and_c
+                  it ("displays the T&C response for UID #{uid}") { expect(ui_t_and_c).to eql('Accepted') }
+
+                  ui_title_iv = @fin_aid_page.title_iv
+                  it ("displays Title IV response for UID #{uid}") { expect(ui_title_iv).to eql(api_title_iv) }
+
+                  @fin_aid_page.click_title_iv_update
+                  @title_iv_page.authorize_cbx_element.when_visible WebDriverUtils.page_load_timeout
+
+                  if @api_aid_years.title_iv_approval
+
+                    @title_iv_page.revoke_title_iv
+                    shows_not_auth_short_msg = @title_iv_page.non_authorized_msg.include? 'I have not authorized the University to apply my Title IV awards'
+                    it ("allows UID #{uid} to change the Title IV response from authorized to not authorized") { expect(shows_not_auth_short_msg).to be true }
+
+                    @title_iv_page.show_more
+                    shows_not_auth_long_msg = @title_iv_page.non_authorized_msg_long.include? 'If you would like to authorize the use of your Title IV awards to pay all outstanding charges, please check the box below.'
+                    it ("shows UID #{uid} instructions for changing the Title IV response from not authorized to authorized") { expect(shows_not_auth_long_msg).to be true }
+
+                    @fin_aid_page.load_fin_aid_profile year_id
+                    @fin_aid_page.show_t_and_c
+                    updated_title_iv = @fin_aid_page.title_iv
+                    it ("updates the Title IV authorization on the FinAid Profile for UID #{uid}") { expect(updated_title_iv).to eql('Not Authorized') }
+
+                  else
+
+                    @title_iv_page.authorize_title_iv
+                    shows_auth_short_msg = @title_iv_page.authorized_msg.include? 'I have authorized the University to apply my Title IV awards'
+                    it ("allows UID #{uid} to change the Title IV response from not authorized to authorized") { expect(shows_auth_short_msg).to be true }
+
+                    @title_iv_page.show_more
+                    shows_auth_long_msg = @title_iv_page.authorized_msg_long.include? 'If you would like to revoke this authorization, please uncheck the box below.'
+                    it ("shows UID #{uid} instructions for changing the Title IV response from authorized to not authorized") { expect(shows_auth_long_msg).to be true }
+
+                    @fin_aid_page.load_fin_aid_profile year_id
+                    @fin_aid_page.show_t_and_c
+                    updated_title_iv = @fin_aid_page.title_iv
+                    it ("updates the Title IV authorization on the FinAid Profile for UID #{uid}") { expect(updated_title_iv).to eql('Authorized') }
+
+                  end
+                end
+              end
+            end
+
+          rescue => e
+            logger.error e.message + "\n" + e.backtrace.join("\n")
+
+            # Force a test failure in the event of an error controlling the UI
+            it ("caused an unexpected error in the test for UID #{uid}") { fail }
+
+          ensure
+            CSV.open(test_output, 'a+') do |user_info_csv|
+              user_info_csv << [uid, aid_years * ', ', api_academic_career * ', ', api_expected_grad, api_enrollments * ', ', api_residency * ', ', api_family_in_college, api_housing * ', ']
+            end
+          end
+        end
+      end
+    rescue => e
+      logger.error e.message + "\n" + e.backtrace.join("\n ")
+    ensure
+      WebDriverUtils.quit_browser(@driver)
+      it ('has FinAid data for at least one of the test users') { expect(testable_users.any?).to be true }
+    end
+  end
+end

--- a/spec/ui_selenium/my_finances_finaid_profile_spec.rb
+++ b/spec/ui_selenium/my_finances_finaid_profile_spec.rb
@@ -11,7 +11,7 @@ describe 'My Finances Financial Aid Profile card', :testui => true do
       test_output = UserUtils.initialize_output_csv(self)
 
       CSV.open(test_output, 'wb') do |row|
-        row << ['UID', 'Aid Years', 'Career', 'Grad Date', 'Enrollment', 'Residency', 'Family in College', 'Housing', ]
+        row << ['UID', 'Aid Years', 'Career', 'Grad Date', 'Enrollment', 'Residency', 'Family in College', 'Housing']
       end
 
       @api_aid_years = ApiCSAidYearsPage.new @driver

--- a/spec/ui_selenium/my_finances_finaid_summary_spec.rb
+++ b/spec/ui_selenium/my_finances_finaid_summary_spec.rb
@@ -42,7 +42,6 @@ describe 'My Finances Financial Aid summary card', :testui => true do
             @splash_page.load_page
             @splash_page.basic_auth uid
             @api_aid_years.get_json @driver
-            @finances_page.load_fin_aid_summary
 
             unless @api_aid_years.feed.nil?
 
@@ -80,7 +79,7 @@ describe 'My Finances Financial Aid summary card', :testui => true do
                     it ("allows UID #{uid} to decline the terms and conditions") { expect(has_declined_msg).to be true }
 
                     # Accept T&C
-                    @fin_aid_page.go_back_to_finances @finances_page
+                    @fin_aid_page.go_back_to_finances
                     @finances_page.click_t_and_c_link @fin_aid_page
                     @fin_aid_page.accept_t_and_c
 
@@ -117,13 +116,8 @@ describe 'My Finances Financial Aid summary card', :testui => true do
                     @fin_aid_page.wait_for_fin_aid_semesters
                     package_visible = @fin_aid_page.net_cost_section_element.visible?
 
-                    # Confirm updates
-                    @api_aid_years.get_json @driver
-                    updated_title_iv = @api_aid_years.title_iv_approval
-
                     it "allows UID #{uid} to authorize Title IV after accepting the terms and conditions" do
                       expect(package_visible).to be true
-                      expect(updated_title_iv).to be true
                     end
 
                   end
@@ -189,7 +183,6 @@ describe 'My Finances Financial Aid summary card', :testui => true do
                       else
                         WebDriverUtils.wait_for_element_and_click page.finaid_funding_offered_toggle_element
                         ui_funding_offered_ttl = WebDriverUtils.currency_to_f page.finaid_funding_offered_ttl
-                        logger.info "Funding offered is #{api_funding_offered_ttl}"
                         it ("shows the right Funding Offered total for UID #{uid}") { expect(ui_funding_offered_ttl).to eql(api_funding_offered_ttl) }
                       end
 
@@ -217,7 +210,6 @@ describe 'My Finances Financial Aid summary card', :testui => true do
                             it ("shows no Grants and Scholarships amount for UID #{uid}") { expect(ui_shows_grants).to be false }
                           else
                             ui_grants =WebDriverUtils.currency_to_f page.finaid_funding_grants
-                            logger.info "Grants total is #{api_grants_amt}"
                             it ("shows the right Grants and Scholarships amount for UID #{uid}") { expect(ui_grants).to eql(api_grants_amt) }
                           end
 
@@ -255,7 +247,6 @@ describe 'My Finances Financial Aid summary card', :testui => true do
                           else
                             has_work_study = true
                             ui_work_study = WebDriverUtils.currency_to_f page.finaid_funding_work_study
-                            logger.info "Work Study total is #{api_work_study_amt}"
                             it ("shows the right Work Study for UID #{uid}") { expect(ui_work_study).to eql (api_work_study_amt) }
                           end
 
@@ -269,7 +260,6 @@ describe 'My Finances Financial Aid summary card', :testui => true do
                           else
                             has_loans = true
                             ui_loans = WebDriverUtils.currency_to_f page.finaid_funding_loans
-                            logger.info "Loans total is #{api_loans_amt}"
                             it ("shows the right Loans total for UID #{uid}") { expect(ui_loans).to eql(api_loans_amt) }
                           end
 

--- a/spec/ui_selenium/my_finances_finaid_summary_spec.rb
+++ b/spec/ui_selenium/my_finances_finaid_summary_spec.rb
@@ -1,0 +1,361 @@
+describe 'My Finances Financial Aid summary card', :testui => true do
+
+  if ENV["UI_TEST"] && Settings.ui_selenium.layer == 'local'
+
+    include ClassLogger
+
+    begin
+      @driver = WebDriverUtils.launch_browser
+      test_users = UserUtils.load_test_users
+      testable_users = []
+      test_output = UserUtils.initialize_output_csv(self)
+      links_tested = false
+
+      CSV.open(test_output, 'wb') do |row|
+        row << ['UID', 'FinAid Years', 'T & C Tested?', 'Title IV Tested?', 'COA', 'Grants', 'Fee Waivers', 'Work Study', 'Loans']
+      end
+
+      @api_aid_years = ApiCSAidYearsPage.new @driver
+      @api_fin_aid_data = ApiCSFinAidDataPage.new @driver
+      @api_funding_sources = ApiCSFinAidFundingSourcesPage.new @driver
+
+      @splash_page = CalCentralPages::SplashPage.new @driver
+      @finances_page = CalCentralPages::MyFinancesPages::MyFinancesLandingPage.new @driver
+      @fin_aid_page = CalCentralPages::MyFinancesPages::MyFinancesFinancialAidPage.new @driver
+
+      test_users.each do |user|
+        if user['finAidCs']
+          uid = user['uid'].to_s
+          logger.info "UID is #{uid}"
+
+          aid_years = []
+          api_semesters = []
+          t_and_c_tested = false
+          title_iv_tested = false
+          api_cost_of_attend = nil
+          api_grants_amt = nil
+          api_waivers_amt = nil
+          api_work_study_amt = nil
+          api_loans_amt = nil
+
+          begin
+            @splash_page.load_page
+            @splash_page.basic_auth uid
+            @api_aid_years.get_json @driver
+            @finances_page.load_fin_aid_summary
+
+            unless @api_aid_years.feed.nil?
+
+              api_aid_years = @api_aid_years.fin_aid_years
+              api_aid_years.each { |year| aid_years << year['id'] }
+
+              if api_aid_years.any?
+                testable_users << uid
+
+                api_aid_years.each do |year|
+                  year_name = @api_aid_years.fin_aid_year_name year
+                  year_id = @api_aid_years.fin_aid_year_id year
+                  @api_fin_aid_data.get_json(@driver, year_id)
+                  @api_funding_sources.get_json(@driver, year_id)
+
+                  # TERMS & CONDITIONS (required annually) and TITLE IV (required once)
+
+                  if @api_aid_years.t_and_c_approval(year).nil? || !@api_aid_years.t_and_c_approval(year)
+
+                    t_and_c_tested = true
+
+                    @finances_page.load_fin_aid_summary
+                    @finances_page.select_fin_aid_year(api_aid_years, year_id)
+
+                    has_t_and_c_msg = @finances_page.finaid_summary_message.include? 'You have not reviewed and agreed to the Terms and Conditions of your financial aid'
+                    it ("tells UID #{uid} to accept the terms and conditions") { expect(has_t_and_c_msg).to be true }
+
+                    @finances_page.click_t_and_c_link @fin_aid_page
+                    sees_t_and_c = @fin_aid_page.t_and_c.include? 'I agree to the following'
+                    it ("shows the Terms and Conditions to UID #{uid}") { expect(sees_t_and_c).to be true }
+
+                    # Decline T&C
+                    @fin_aid_page.decline_t_and_c
+                    has_declined_msg = @fin_aid_page.declined_t_and_c_msg_element.visible?
+                    it ("allows UID #{uid} to decline the terms and conditions") { expect(has_declined_msg).to be true }
+
+                    # Accept T&C
+                    @fin_aid_page.go_back_to_finances @finances_page
+                    @finances_page.click_t_and_c_link @fin_aid_page
+                    @fin_aid_page.accept_t_and_c
+
+                    # Authorize Title IV if necessary
+                    if @api_aid_years.title_iv_approval.nil?
+                      @fin_aid_page.authorize_title_iv
+                      title_iv_tested = true
+                    end
+
+                    @fin_aid_page.wait_for_fin_aid_semesters
+                    package_visible = @fin_aid_page.net_cost_section_element.visible?
+
+                    it "allows UID #{uid} to accept the terms and conditions" do
+                      expect(package_visible).to be true
+                    end
+
+                    it "allows UID #{uid} to authorize Title IV after accepting the terms and conditions" do
+                      expect(package_visible).to be true
+                    end
+
+                  elsif @api_aid_years.title_iv_approval.nil?
+
+                    title_iv_tested = true
+
+                    @finances_page.load_fin_aid_summary
+                    @finances_page.select_fin_aid_year(api_aid_years, year_id)
+
+                    has_title_iv_msg = @finances_page.finaid_summary_message.include? 'You have not selected a Title IV Release option'
+                    it ("tells UID #{uid} to respond to Title IV") { expect(has_title_iv_msg).to be true }
+
+                    # Authorize Title IV
+                    @finances_page.click_title_iv_link @fin_aid_page
+                    @fin_aid_page.authorize_title_iv
+                    @fin_aid_page.wait_for_fin_aid_semesters
+                    package_visible = @fin_aid_page.net_cost_section_element.visible?
+
+                    # Confirm updates
+                    @api_aid_years.get_json @driver
+                    updated_title_iv = @api_aid_years.title_iv_approval
+
+                    it "allows UID #{uid} to authorize Title IV after accepting the terms and conditions" do
+                      expect(package_visible).to be true
+                      expect(updated_title_iv).to be true
+                    end
+
+                  end
+
+                  # SUMMARY CARD - check contents on both the landing page and the financial aid page
+
+                  finances_pages = [@finances_page, @fin_aid_page]
+                  finances_pages.each do |page|
+
+                    page.load_fin_aid_summary year_id
+                    page.select_fin_aid_year(api_aid_years, year_id) if page.instance_of?(CalCentralPages::MyFinancesPages::MyFinancesLandingPage)
+
+                    ui_semesters = page.finaid_semesters
+                    api_semesters = @api_aid_years.fin_aid_ui_semesters year
+                    it ("shows the right semesters for the right aid year for UID #{uid}") { expect(ui_semesters).to eql(api_semesters) }
+
+                    # AID PACKAGE
+
+                    unless @api_fin_aid_data.feed.nil?
+
+                      # NET COST
+
+                      # Cost of Attendance
+                      api_cost_of_attend = @api_fin_aid_data.budget_total
+                      if api_cost_of_attend.nil?
+                        has_coa = false
+                        has_ui_coa = page.finaid_cost_of_attend?
+                        it ("shows no Cost of Attendance for UID #{uid}") { expect(has_ui_coa).to be false }
+                      else
+                        page.net_cost_section_element.when_visible WebDriverUtils.page_event_timeout
+                        ui_cost_of_attend = WebDriverUtils.currency_to_f page.finaid_cost_of_attend
+                        it ("shows the right Cost of Attendance total for UID #{uid}") { expect(ui_cost_of_attend).to eql(api_cost_of_attend) }
+                      end
+
+                      # Gift Aid
+                      api_gift_aid = @api_funding_sources.gift_aid_amt
+                      if api_gift_aid.nil?
+                        has_gift_aid = false
+                        has_ui_gift_aid = page.finaid_gift_aid?
+                        it ("shows no Gift Aid for UID #{uid}") { expect(has_ui_gift_aid).to be false }
+                      else
+                        has_gift_aid = true
+                        ui_gift_aid = WebDriverUtils.currency_to_f page.finaid_gift_aid
+                        it ("shows the right Gift Aid total for UID #{uid}") { expect(ui_gift_aid).to eql(api_gift_aid) }
+                      end
+
+                      # Net Cost
+                      api_net_cost = @api_fin_aid_data.net_cost_amt
+                      if api_net_cost.nil?
+                        has_ui_net_cost = page.finaid_net_cost?
+                        it ("shows no Net Cost to UID #{uid}") { expect(has_ui_net_cost).to be false }
+                      else
+                        ui_net_cost = WebDriverUtils.currency_to_f page.finaid_net_cost
+                        it ("shows the right Net Cost for UID #{uid}") { expect(ui_net_cost).to eql(api_net_cost) }
+                      end
+
+                      # FUNDING OFFERED
+
+                      api_funding_offered_ttl = @api_fin_aid_data.funding_offered_amt
+                      if api_funding_offered_ttl.nil?
+                        has_ui_funding_offered_ttl = page.finaid_funding_offered_ttl?
+                        it ("shows no Funding Offered total to UID #{uid}") { expect(has_ui_funding_offered_ttl).to be false }
+                      else
+                        WebDriverUtils.wait_for_element_and_click page.finaid_funding_offered_toggle_element
+                        ui_funding_offered_ttl = WebDriverUtils.currency_to_f page.finaid_funding_offered_ttl
+                        logger.info "Funding offered is #{api_funding_offered_ttl}"
+                        it ("shows the right Funding Offered total for UID #{uid}") { expect(ui_funding_offered_ttl).to eql(api_funding_offered_ttl) }
+                      end
+
+                      api_gift_aid_funding = @api_fin_aid_data.funding_category_amt 'Gift Aid'
+                      api_other_funding = @api_fin_aid_data.funding_category_amt 'Other Funding'
+
+                      unless api_funding_offered_ttl.nil?
+
+                        # Gift Aid
+
+                        ui_gift_aid_offered = WebDriverUtils.currency_to_f page.finaid_funding_gift_aid
+                        if api_gift_aid_funding.nil?
+                          it ("shows zero Gift Aid offered for UID #{uid}") { expect(ui_gift_aid_offered).to be_zero }
+                        else
+                          it ("shows the right Gift Aid offered amount for UID #{uid}") { expect(ui_gift_aid_offered).to eql(api_gift_aid_funding) }
+
+                          # Gift aid breakdown
+                          api_gift_aid_items = @api_fin_aid_data.funding_category_items 'Gift Aid'
+
+                          # Grants
+                          api_grants = @api_fin_aid_data.funding_category_item(api_gift_aid_items, 'Grants and Scholarships')
+                          api_grants_amt = @api_fin_aid_data.funding_category_item_amt api_grants
+                          if api_grants_amt.nil?
+                            ui_shows_grants = page.finaid_funding_grants?
+                            it ("shows no Grants and Scholarships amount for UID #{uid}") { expect(ui_shows_grants).to be false }
+                          else
+                            ui_grants =WebDriverUtils.currency_to_f page.finaid_funding_grants
+                            logger.info "Grants total is #{api_grants_amt}"
+                            it ("shows the right Grants and Scholarships amount for UID #{uid}") { expect(ui_grants).to eql(api_grants_amt) }
+                          end
+
+                          # Fee waivers
+                          api_waivers = @api_fin_aid_data.funding_category_item(api_gift_aid_items, 'Fee Waivers')
+                          api_waivers_amt = @api_fin_aid_data.funding_category_item_amt api_waivers
+                          if api_waivers_amt.nil?
+                            ui_shows_waivers = page.finaid_funding_waivers?
+                            it ("shows no Fee Waivers amount for UID #{uid}") { expect(ui_shows_waivers).to be false }
+                          else
+                            ui_waivers = page.finaid_funding_waivers
+                            it ("shows the right Fee Waivers for UID #{uid}") { expect(ui_waivers).to eql(api_waivers_amt) }
+                          end
+
+                        end
+
+                        # Other Funding
+
+                        ui_other_funding_ttl = WebDriverUtils.currency_to_f page.finaid_funding_other
+                        if api_other_funding.nil?
+                          it ("shows zero Other Funding for UID #{uid}") { expect(ui_other_funding_ttl).to be_zero }
+                        else
+                          it ("shows the right Other Funding total for UID #{uid}") { expect(ui_other_funding_ttl).to eql(api_other_funding) }
+
+                          # Other funding breakdown
+                          api_other_funding_items = @api_fin_aid_data.funding_category_items 'Other Funding'
+
+                          # Work Study
+                          api_work_study = @api_fin_aid_data.funding_category_item(api_other_funding_items, 'Work Study')
+                          api_work_study_amt = @api_fin_aid_data.funding_category_item_amt api_work_study
+                          if api_work_study_amt.nil?
+                            has_work_study = false
+                            ui_shows_work_study = page.finaid_funding_work_study?
+                            it ("shows no Work Study amount for UID #{uid}") { expect(ui_shows_work_study).to be false }
+                          else
+                            has_work_study = true
+                            ui_work_study = WebDriverUtils.currency_to_f page.finaid_funding_work_study
+                            logger.info "Work Study total is #{api_work_study_amt}"
+                            it ("shows the right Work Study for UID #{uid}") { expect(ui_work_study).to eql (api_work_study_amt) }
+                          end
+
+                          # Loans
+                          api_loans = @api_fin_aid_data.funding_category_item(api_other_funding_items, 'Loans')
+                          api_loans_amt = @api_fin_aid_data.funding_category_item_amt api_loans
+                          if api_loans_amt.nil?
+                            has_loans = false
+                            ui_shows_loans = page.finaid_funding_loans?
+                            it ("shows no Loans amount for UID #{uid}") { expect(ui_shows_loans).to be false }
+                          else
+                            has_loans = true
+                            ui_loans = WebDriverUtils.currency_to_f page.finaid_funding_loans
+                            logger.info "Loans total is #{api_loans_amt}"
+                            it ("shows the right Loans total for UID #{uid}") { expect(ui_loans).to eql(api_loans_amt) }
+                          end
+
+                        end
+                      end
+
+                    end
+
+                    # Links - only test external link for one of the test users
+
+                    unless links_tested
+                      has_faso_link = WebDriverUtils.verify_external_link(@driver, page.learn_more_link_element, 'Financial Aid and Scholarships | UC Berkeley')
+                      it ("offers a link to FASO for UID #{uid}") { expect(has_faso_link).to be true }
+                      links_tested = true
+                    end
+
+                    has_details_link = page.finaid_details_link?
+                    has_awards_link = page.awards_link?
+                    has_shopping_sheet_link = page.shopping_sheet_link?
+
+                    api_shopping_sheet_url = @api_fin_aid_data.shopping_sheet_url
+
+                    if page.instance_of?(CalCentralPages::MyFinancesPages::MyFinancesLandingPage)
+
+                      it ("offers a 'Details' link to UID #{uid}") { expect(has_details_link).to be true }
+
+                      details_url = page.finaid_details_link_element.attribute('href')
+                      it ("offers a 'Details' link pointing to the right aid year to UID #{uid}") { expect(details_url).to eql("#{WebDriverUtils.base_url}/finances/finaid/#{year_id}") }
+
+                      if api_shopping_sheet_url.nil?
+                        awards_url = page.awards_link_element.attribute('href')
+                        it ("offers an 'Awards' link pointing to the right aid year to UID #{uid}") { expect(awards_url).to eql("#{WebDriverUtils.base_url}/finances/finaid/#{year_id}") }
+                      else
+                        it ("offers a 'Shopping Sheet' to UID #{uid}") { expect(has_shopping_sheet_link).to be true }
+                      end
+
+                    elsif page.instance_of?(CalCentralPages::MyFinancesPages::MyFinancesFinancialAidPage)
+
+                      it ("offers no 'Details' link to UID #{uid}") { expect(has_details_link).to be false }
+                      it ("offers no 'Awards' link to UID #{uid}") { expect(has_awards_link).to be false }
+
+                      if api_shopping_sheet_url.nil?
+                        it ("offers no 'Shopping Sheet' link to UID #{uid}") { expect(has_shopping_sheet_link).to be false }
+                      else
+                        it ("offers a 'Shopping Sheet' link to UID #{uid}") { expect(has_shopping_sheet_link).to be true }
+                      end
+
+                    end
+                  end
+                end
+
+              else
+
+                has_no_finaid_msg = @finances_page.no_finaid_message?
+                it ("shows a 'No Fin Aid' message to UID #{uid}") { expect(has_no_finaid_msg).to be true }
+
+                has_details_link = @finances_page.finaid_details_link?
+                it ("offers no 'Details' link to UID #{uid}") { expect(has_details_link).to be false }
+
+                has_myfinaid_link = WebDriverUtils.verify_external_link(@driver, @finances_page.faso_link_element, 'Financial Aid and Scholarships | UC Berkeley')
+                it ("shows a link to MyFinAid to UID #{uid}") { expect(has_myfinaid_link).to be true }
+
+                has_csu_link = WebDriverUtils.verify_external_link(@driver, @finances_page.csu_link_element, 'Cal Student Central')
+                it ("shows a link to Cal Student Central to UID #{uid}") { expect(has_csu_link).to be true }
+
+              end
+            end
+
+          rescue => e
+            logger.error e.message + "\n" + e.backtrace.join("\n")
+
+            # Force a test failure in the event of an error controlling the UI
+            it ("caused an unexpected error in the test for UID #{uid}") { fail }
+
+          ensure
+            CSV.open(test_output, 'a+') do |user_info_csv|
+              user_info_csv << [uid, aid_years * ', ', t_and_c_tested, title_iv_tested, api_cost_of_attend, api_grants_amt, api_waivers_amt, api_work_study_amt, api_loans_amt]
+            end
+          end
+        end
+      end
+    rescue => e
+      logger.error e.message + "\n" + e.backtrace.join("\n ")
+    ensure
+      WebDriverUtils.quit_browser(@driver)
+      it ('has FinAid data for at least one of the test users') { expect(testable_users.any?).to be true }
+    end
+  end
+end

--- a/spec/ui_selenium/pages/api_cs_aid_years_page.rb
+++ b/spec/ui_selenium/pages/api_cs_aid_years_page.rb
@@ -62,7 +62,7 @@ class ApiCSAidYearsPage
   end
 
   def title_iv
-    fin_aid_summary.nil? ? nil : fin_aid_summary['title4']
+    fin_aid_summary['title4']
   end
 
   def title_iv_approval

--- a/spec/ui_selenium/pages/api_cs_aid_years_page.rb
+++ b/spec/ui_selenium/pages/api_cs_aid_years_page.rb
@@ -1,0 +1,76 @@
+class ApiCSAidYearsPage
+
+  include PageObject
+  include ClassLogger
+
+  def get_json(driver)
+    logger.info('Parsing aid years from CS')
+    navigate_to "#{WebDriverUtils.base_url}/api/campus_solutions/aid_years"
+    wait = Selenium::WebDriver::Wait.new(:timeout => WebDriverUtils.page_load_timeout)
+    wait.until { driver.find_element(:xpath => '//pre[contains(.,"CampusSolutions::MyAidYears")]') }
+    body = driver.find_element(:xpath, '//pre').text
+    @parsed = JSON.parse(body)
+  end
+
+  def feed
+    @parsed['feed']
+  end
+
+  def fin_aid_summary
+    feed['finaidSummary']
+  end
+
+  def fin_aid_years
+    fin_aid_summary['finaidYears']
+  end
+
+  def fin_aid_year_id(year)
+    year['id']
+  end
+
+  def fin_aid_year_name(year)
+    year['name']
+  end
+
+  def fin_aid_semesters(year)
+    year['availableSemesters']
+  end
+
+  def fin_aid_ui_semesters(year)
+    case fin_aid_semesters(year).length
+      when 1
+        "#{fin_aid_semesters(year)[0]} only"
+      when 2
+        "#{fin_aid_semesters(year)[0]} and #{fin_aid_semesters(year)[1]}"
+      when 3
+        "#{fin_aid_semesters(year)[0]}, #{fin_aid_semesters(year)[1]} and #{fin_aid_semesters(year)[2]}"
+      else
+        logger.error 'Unexpected financial aid semesters UI'
+    end
+  end
+
+  def t_and_c(year)
+    year['termsAndConditions']
+  end
+
+  def t_and_c_approval(year)
+    t_and_c(year)['approved']
+  end
+
+  def t_and_c_long_msg(year)
+    t_and_c(year)['longMessage']
+  end
+
+  def title_iv
+    fin_aid_summary.nil? ? nil : fin_aid_summary['title4']
+  end
+
+  def title_iv_approval
+    title_iv['approved']
+  end
+
+  def title_iv_long_msg
+    title_iv['longMessage']
+  end
+
+end

--- a/spec/ui_selenium/pages/api_cs_fin_aid_data_page.rb
+++ b/spec/ui_selenium/pages/api_cs_fin_aid_data_page.rb
@@ -1,0 +1,204 @@
+class ApiCSFinAidDataPage
+
+  include PageObject
+  include ClassLogger
+
+  def get_json(driver, year)
+    logger.info "Parsing FinAid data from CS for aid year #{year}"
+    navigate_to "#{WebDriverUtils.base_url}/api/campus_solutions/financial_aid_data?aid_year=#{year}"
+    wait = Selenium::WebDriver::Wait.new(:timeout => WebDriverUtils.page_load_timeout)
+    wait.until { driver.find_element(:xpath => '//pre[contains(.,"CampusSolutions::MyFinancialAidData")]') }
+    body = driver.find_element(:xpath, '//pre').text
+    @parsed = JSON.parse(body)
+  end
+
+  def feed
+    @parsed['feed']
+  end
+
+  # FIN AID SUMMARY
+
+  def fin_aid_summary
+    feed['financialAidSummary']
+  end
+
+  def net_cost
+    fin_aid_summary['netCost'] unless fin_aid_summary.nil?
+  end
+
+  def net_cost_amt
+    net_cost['total']['amount'] unless net_cost.nil?
+  end
+
+  def funding_offered
+    fin_aid_summary['fundingOffered'] unless fin_aid_summary.nil?
+  end
+
+  def funding_offered_ttl
+    funding_offered['total'] unless funding_offered.nil?
+  end
+
+  def funding_offered_amt
+    funding_offered_ttl['amount'] unless funding_offered_ttl.nil?
+  end
+
+  def funding_category(title)
+    funding_offered['categories'].find { |category| category['total']['title'] == title }
+  end
+
+  def funding_category_ttl(title)
+    category = funding_category title
+    category.nil? ? nil : category['total']
+  end
+
+  def funding_category_amt(title)
+    funding_category_ttl(title)['amount'] unless funding_category_ttl(title).nil?
+  end
+
+  def funding_category_items(title)
+    category = funding_category title
+    category['items'] unless category.nil?
+  end
+
+  def funding_category_item(items, item_title)
+    items.find { |item| item['title'] == item_title } unless items.nil?
+  end
+
+  def funding_category_item_amt(item)
+    item['amount'] unless item.nil?
+  end
+
+  def shopping_sheet_url
+    feed['shoppingSheet']['url'] unless feed['shoppingSheet'].nil?
+  end
+
+  # BUDGET (COST OF ATTENDANCE)
+
+  def budget
+    feed['coa']
+  end
+
+  def item_title(item)
+    item['title']
+  end
+
+  def item_total(item)
+    item['total']
+  end
+
+  def item_amounts(item)
+    item['amounts']
+  end
+
+  def sub_items(item)
+    item['subItems']
+  end
+
+  def budget_annual_data
+    budget['fullyear']['data']
+  end
+
+  def budget_term_data
+    budget['semester']['data']
+  end
+
+  def budget_total
+    if budget_annual_data.nil?
+      nil
+    else
+      item = budget_annual_data.first['items'].find { |item| item['totals'] }
+      item['totals'].first
+    end
+  end
+
+  def budget_items(budget_data, items_title)
+    items = []
+    data_set = budget_data.find { |data| item_title(data) == items_title }
+    data_set['items'].each { |item| items << item if item_total(item) } unless data_set.nil?
+    items
+  end
+
+  def budget_item_titles(budget_data, items_title)
+    titles = []
+    budget_items(budget_data, items_title).each { |item| titles << item_title(item) }
+    titles
+  end
+
+  def budget_item_amounts(budget_data, items_title)
+    amounts = []
+    budget_items(budget_data, items_title).each { |item| amounts << item_amounts(item) }
+    amounts
+  end
+
+  def budget_item_totals(budget_data, items_title)
+    totals = []
+    budget_items(budget_data, items_title).each { |item| totals << item_total(item) }
+    totals
+  end
+
+  def budget_sub_item_titles(item)
+    titles = []
+    sub_items(item).each { |sub_item| titles << item_title(sub_item) }
+    titles
+  end
+
+  def budget_sub_item_totals(item)
+    amounts = []
+    sub_items(item).each { |sub_item| amounts << item_total(sub_item) }
+    amounts
+  end
+
+  def budget_sub_item_amounts(item)
+    amounts = []
+    sub_items(item).each do |sub_item|
+      amounts.concat item_amounts(sub_item)
+    end
+    amounts
+  end
+
+  # PROFILE
+
+  def status_categories
+    feed['status']['categories']
+  end
+
+  def profile
+    status_categories.find { |category| category['title'] == 'Financial Aid Profile' }
+  end
+
+  def profile_items
+    items = []
+    profile['itemGroups'].each { |group| items += group }
+    items
+  end
+
+  def profile_item(type)
+    profile_items.find { |item| item['title'] == type }
+  end
+
+  def profile_value(type)
+    profile_item(type)['value'] unless profile_item(type).nil?
+  end
+
+  def profile_values(type)
+    items = profile_items.select { |item| item['title'] == type }
+    values = []
+    items.each { |item| values << item['value'] }
+    values
+  end
+
+  def profile_sub_values(type)
+    values = []
+    profile_item(type)['values'].each do |value|
+      ui_sub_values = []
+      value['subvalue'].each { |sub_value| ui_sub_values << sub_value.gsub(/[^a-zA-Z0-9]/, ' ').gsub(/\s+/, ' ') }
+      values << ui_sub_values.join(' ')
+    end
+    values
+  end
+
+  def terms_and_conditions
+    status_categories.find { |category| category['title'] == 'Terms and Conditions' }
+  end
+
+end

--- a/spec/ui_selenium/pages/api_cs_fin_aid_funding_sources_page.rb
+++ b/spec/ui_selenium/pages/api_cs_fin_aid_funding_sources_page.rb
@@ -1,0 +1,27 @@
+class ApiCSFinAidFundingSourcesPage
+
+  include PageObject
+  include ClassLogger
+
+  def get_json(driver, year)
+    logger.info "Parsing FinAid funding sources data from CS for aid year #{year}"
+    navigate_to "#{WebDriverUtils.base_url}/api/campus_solutions/financial_aid_funding_sources?aid_year=#{year}"
+    wait = Selenium::WebDriver::Wait.new(:timeout => WebDriverUtils.page_load_timeout)
+    wait.until { driver.find_element(:xpath => '//pre[contains(.,"CampusSolutions::MyFinancialAidFundingSources")]') }
+    body = driver.find_element(:xpath, '//pre').text
+    @parsed = JSON.parse(body)
+  end
+
+  def feed
+    @parsed['feed']
+  end
+
+  def awards
+    feed['awards']
+  end
+
+  def gift_aid_amt
+    awards['giftaid']['total']['amount']
+  end
+
+end

--- a/spec/ui_selenium/pages/my_finances_financial_aid_page.rb
+++ b/spec/ui_selenium/pages/my_finances_financial_aid_page.rb
@@ -1,0 +1,255 @@
+module CalCentralPages
+
+  module MyFinancesPages
+
+    class MyFinancesFinancialAidPage
+
+      include PageObject
+      include CalCentralPages
+      include MyFinancesPages
+      include ClassLogger
+
+      # T & C / TITLE IV
+
+      h3(:t_and_c_heading, :xpath => '//h3[text()="Terms and Conditions"]')
+      button(:decline_t_and_c, :xpath => '//button[text()="I Do Not Agree"]')
+      button(:accept_t_and_c, :xpath => '//button[text()="I Do Agree"]')
+      h2(:declined_t_and_c_heading, :xpath => '//h2[text()="Declined Terms and Conditions"]')
+      div(:declined_t_and_c_msg, :xpath => '//div[contains(text(),"You have not agreed to the Terms and Conditions. You are not eligible to view your financial aid via CalCentral.")]')
+      link(:back_to_finances, :text => 'Go Back to My Finances')
+      h2(:title_iv_heading, :xpath => '//h2[text()="Title IV Authorization"]')
+      button(:decline_title_iv, :xpath => '//button[text()="I Do Not Authorize"]')
+      button(:authorize_title_iv, :xpath => '//button[text()="Authorize"]')
+
+      def accept_t_and_c
+        logger.debug 'Clicking button to accept T & C'
+        WebDriverUtils.wait_for_element_and_click accept_t_and_c_element
+      end
+
+      def decline_t_and_c
+        logger.debug 'Clicking button to decline T & C'
+        WebDriverUtils.wait_for_element_and_click decline_t_and_c_element
+        declined_t_and_c_heading_element.when_visible WebDriverUtils.page_load_timeout
+      end
+
+      def authorize_title_iv
+        logger.debug 'Clicking button to authorize Title IV'
+        WebDriverUtils.wait_for_element_and_click authorize_title_iv_element
+      end
+
+      # AWARDS CARD
+      div(:coa_ttl, :xpath => '//span[text()="Estimated Cost of Attendance"]/../following-sibling::div')
+      div(:gift_aid_ttl, :xpath => '//span[text()="Gift Aid"]/../following-sibling::div')
+      div(:net_cost_ttl, :xpath => '//span[text()="Net Cost"]/../following-sibling::div')
+
+      elements(:gift_aid, :div, :xpath => '//h3[text()="Gift Aid"]/../../following-sibling::ul/li')
+      elements(:gift_aid_title, :div, :xpath => '//h3[text()="Gift Aid"]/../../following-sibling::ul/li//div[@data-ng-bind="item.title"]')
+      elements(:gift_aid_source, :div, :xpath => '//h3[text()="Gift Aid"]/../../following-sibling::ul/li//div[@data-ng-bind="item.subtitle"]')
+      elements(:gift_aid_status, :div, :xpath => '//h3[text()="Gift Aid"]/../../following-sibling::ul/li//div[@data-ng-bind="item.leftColumn.value"]')
+      elements(:gift_aid_ttl_amount, :div, :xpath => '//h3[text()="Gift Aid"]/../../following-sibling::ul/li//div[@data-cc-amount-directive="item.leftColumn.amount"]')
+      elements(:gift_aid_used_status, :div, :xpath => '//h3[text()="Gift Aid"]/../../following-sibling::ul/li//span[@data-ng-bind="item.rightColumn.value"]')
+      elements(:gift_aid_used_amount, :div, :xpath => '//h3[text()="Gift Aid"]/../../following-sibling::ul/li//div[@data-cc-amount-directive="item.rightColumn.amount"]')
+
+      elements(:subsidized_loan, :div, :xpath => '//h3[text()="Subsidized Loans"]/../../following-sibling::ul/li')
+      elements(:subsidized_title, :div, :xpath => '//h3[text()="Subsidized Loans"]/../../following-sibling::ul/li//div[@data-ng-bind="item.title"]')
+      elements(:subsidized_source, :div, :xpath => '//h3[text()="Subsidized Loans"]/../../following-sibling::ul/li//div[@data-ng-bind="item.subtitle"]')
+      elements(:subsidized_status, :div, :xpath => '//h3[text()="Subsidized Loans"]/../../following-sibling::ul/li//div[@data-ng-bind="item.leftColumn.value"]')
+      elements(:subsidized_ttl_amount, :div, :xpath => '//h3[text()="Subsidized Loans"]/../../following-sibling::ul/li//div[@data-cc-amount-directive="item.leftColumn.amount"]')
+      elements(:subsidized_used_status, :div, :xpath => '//h3[text()="Subsidized Loans"]/../../following-sibling::ul/li//span[@data-ng-bind="item.rightColumn.value"]')
+      elements(:subsidized_used_amount, :div, :xpath => '//h3[text()="Subsidized Loans"]/../../following-sibling::ul/li//div[@data-cc-amount-directive="item.rightColumn.amount"]')
+
+      elements(:unsubsidized_loan, :div, :xpath => '//h3[text()="Unsubsidized Loans"]/../../following-sibling::ul/li')
+      elements(:unsubsidized_title, :div, :xpath => '//h3[text()="Unsubsidized Loans"]/../../following-sibling::ul/li//div[@data-ng-bind="item.title"]')
+      elements(:unsubsidized_source, :div, :xpath => '//h3[text()="Unsubsidized Loans"]/../../following-sibling::ul/li//div[@data-ng-bind="item.subtitle"]')
+      elements(:unsubsidized_status, :div, :xpath => '//h3[text()="Unsubsidized Loans"]/../../following-sibling::ul/li//div[@data-ng-bind="item.leftColumn.value"]')
+      elements(:unsubsidized_ttl_amount, :div, :xpath => '//h3[text()="Unsubsidized Loans"]/../../following-sibling::ul/li//div[@data-cc-amount-directive="item.leftColumn.amount"]')
+      elements(:unsubsidized_used_status, :div, :xpath => '//h3[text()="Unsubsidized Loans"]/../../following-sibling::ul/li//span[@data-ng-bind="item.rightColumn.value"]')
+      elements(:unsubsidized_used_amount, :div, :xpath => '//h3[text()="Unsubsidized Loans"]/../../following-sibling::ul/li//div[@data-cc-amount-directive="item.rightColumn.amount"]')
+
+      button(:show_t_and_c_toggle, :xpath => '//h3[text()="Terms and Conditions"]/following-sibling::button[@class="cc-button-link cc-widget-finaid-profile-button-toggle"]')
+
+      def load_page(aid_year)
+        logger.info "Loading My Finances Financial Aid details page for aid year #{aid_year}"
+        navigate_to "#{WebDriverUtils.base_url}/finances/finaid/#{aid_year}"
+      end
+
+      def load_fin_aid_summary(aid_year)
+        load_page aid_year
+        finaid_content_element.when_visible WebDriverUtils.page_load_timeout
+      end
+
+      def wait_for_fin_aid_semesters
+        finaid_semesters_element.when_visible WebDriverUtils.page_load_timeout
+        # TODO: add flow control
+        sleep 3
+      end
+
+      def go_back_to_finances(my_finances_page)
+        logger.debug 'Clicking Back to Finances button'
+        WebDriverUtils.wait_for_element_and_click back_to_finances_element
+        finaid_content_element.when_visible WebDriverUtils.page_load_timeout
+      end
+
+      # BUDGET / ESTIMATED COST OF ATTENDANCE
+
+      div(:budget_msg, :xpath => '//div[@data-ng-bind="coa.message"]')
+      button(:toggle_budget_view, :xpath => '//h2[text()="Estimated Cost of Attendance"]/../following-sibling::div//button[@data-ng-click="toggleView()"]')
+      table(:standard_budget_table, :xpath => '//h2[text()="Estimated Cost of Attendance"]/../following-sibling::div//th[text()="Standard Budget Items"]/../../..')
+      table(:additional_budget_table, :xpath => '//h2[text()="Estimated Cost of Attendance"]/../following-sibling::div//th[text()="Additional Items"]/../../..')
+      elements(:standard_budget_row_toggle, :element, :xpath => '//th[text()="Standard Budget Items"]/../../../tbody')
+      elements(:additional_budget_row_toggle, :element, :xpath => '//th[text()="Additional Budget Items"]/../../../tbody')
+      elements(:sub_item_title, :cell, :xpath => '//td[@data-ng-bind="subItem.title"]')
+      elements(:sub_item_total, :cell, :xpath => '//td[@data-cc-amount-directive="subItem.total"]')
+      elements(:sub_item_amount, :cell, :xpath => '//td[@data-ng-repeat="amount in subItem.amounts track by $index"]')
+      table(:grand_total_budget_table, :xpath => '//h2[text()="Estimated Cost of Attendance"]/../following-sibling::div//th[text()="Grand Total"]/../../..')
+
+      def load_fin_aid_budget(aid_year)
+        load_page aid_year
+        budget_msg_element.when_visible WebDriverUtils.page_load_timeout
+      end
+
+      def budget_rows(table_element)
+        rows = []
+        table_element.each { |row| rows << row } if table_element.exists?
+        # Remove rows that do not contain budget items
+        if rows.any?
+          rows = rows.drop 1
+          rows.slice!(-2, 2)
+        end
+        rows
+      end
+
+      def budget_items(table_element)
+        items = []
+        budget_rows(table_element).each { |row| items << row[0].text }
+        items
+      end
+
+      def budget_item_annual_totals(table_element)
+        totals = []
+        budget_rows(table_element).each { |row| totals << WebDriverUtils.currency_to_f(row[1].text) }
+        totals
+      end
+
+      def budget_item_term_amounts(table_element)
+        amounts = []
+        budget_rows(table_element).each do |row|
+          row_amounts = []
+          row.each { |cell| row_amounts << WebDriverUtils.currency_to_f(cell.text) if cell.text.include?('$') }
+          row_amounts.pop
+          amounts << row_amounts
+        end
+        amounts
+      end
+
+      def budget_item_term_totals(table_element)
+        totals = []
+        budget_rows(table_element).each do |row|
+          row_amounts = []
+          row.each { |cell| row_amounts << cell.text }
+          totals << WebDriverUtils.currency_to_f(row_amounts.last)
+        end
+        totals
+      end
+
+      def expand_budget_item(toggle_elements, item_index)
+        WebDriverUtils.wait_for_element_and_click toggle_elements[item_index]
+      end
+
+      def budget_subitems
+        titles = []
+        sub_item_title_elements.each { |title| titles << title.text }
+        titles.drop 1
+        titles
+      end
+
+      def budget_subitem_annual_amounts
+        amounts = []
+        sub_item_total_elements.each { |amount| amounts << WebDriverUtils.currency_to_f(amount.text) }
+        amounts.drop 1
+        amounts
+      end
+
+      def budget_subitem_term_amounts
+        amounts = []
+        sub_item_amount_elements.each { |amount| amounts << WebDriverUtils.currency_to_f(amount.text) }
+        amounts
+      end
+
+      def budget_subitem_term_totals
+        totals = []
+        sub_item_total_elements.each { |total| totals << WebDriverUtils.currency_to_f(total.text) }
+        totals
+      end
+
+      def budget_total(table_element)
+        table_element.last_row[1].text
+      end
+
+      def coa_grand_total
+        grand_total_budget_table_element[1][1].text
+      end
+
+      # PROFILE CARD
+
+      div(:profile_msg, :class => 'cc-widget-finaid-profile-message')
+      button(:show_profile_button, :xpath => '//h3[text()="Financial Aid Profile"]/following-sibling::button[contains(.,"Show")]')
+      button(:hide_profile_button, :xpath => '//h3[text()="Financial Aid Profile"]/following-sibling::button[contains(.,"Hide")]')
+      button(:show_t_and_c_button, :xpath => '//h3[text()="Terms and Conditions"]/following-sibling::button[contains(.,"Show")]')
+      button(:hide_t_and_c_button, :xpath => '//h3[text()="Terms and Conditions"]/following-sibling::button[contains(.,"Hide")]')
+      elements(:academic_career, :div, :xpath => '//strong[text()="Academic Career"]/../following-sibling::div')
+      elements(:level, :div, :xpath => '//strong[text()="Level"]/../following-sibling::div/div')
+      div(:expected_graduation, :xpath => '//strong[text()="Expected Graduation"]/../following-sibling::div')
+      div(:sap_status, :xpath => '//strong[text()="SAP Status"]/../following-sibling::div')
+      div(:academic_holds, :xpath => '//strong[text()="Academic Holds"]/../following-sibling::div')
+      div(:award_status, :xpath => '//strong[text()="Award Status"]/../following-sibling::div')
+      div(:verification_status, :xpath => '//strong[text()="Verification Status"]/../following-sibling::div')
+      div(:dependency_status, :xpath => '//strong[text()="Dependency Status"]/../following-sibling::div')
+      div(:efc, :xpath => '//strong[text()="Expected Family Contribution (EFC)"]/../following-sibling::div')
+      div(:berkeley_parent_contrib, :xpath => '//strong[text()="Berkeley Parent Contribution"]/../following-sibling::div')
+      div(:family_members_in_college, :xpath => '//strong[text()="Family Members in College"]/../following-sibling::div')
+      link(:family_members_update_link, :xpath => '//strong[text()="Family Members in College"]/following-sibling::a')
+      elements(:residency, :div, :xpath => '//strong[text()="Residency"]/../following-sibling::div/div')
+      elements(:enrollment, :div, :xpath => '//strong[text()="Enrollment"]/../following-sibling::div/div')
+      elements(:housing, :div, :xpath => '//strong[text()="Housing"]/../following-sibling::div/div')
+      link(:housing_update_link, :xpath => '//strong[text()="Housing"]/following-sibling::a')
+      elements(:ship_health_insurance, :div, :xpath => '//strong[text()="SHIP Health Insurance"]/../following-sibling::div/div')
+
+      div(:title_iv, :xpath => '//strong[text()="Title IV"]/../following-sibling::div')
+      link(:title_iv_update_link, :xpath => '//strong[text()="Title IV"]/following-sibling::a')
+      div(:t_and_c, :xpath => '//strong[text()="Terms & Conditions"]/../following-sibling::div')
+
+      def load_fin_aid_profile(aid_year)
+        load_page aid_year
+        profile_msg_element.when_visible WebDriverUtils.page_load_timeout
+      end
+
+      def show_profile
+        WebDriverUtils.wait_for_element_and_click show_profile_button_element unless hide_profile_button?
+      end
+
+      def hide_profile
+        WebDriverUtils.wait_for_element_and_click hide_profile_button_element unless show_profile_button?
+      end
+
+      def profile_elements_text(elements)
+        texts = []
+        elements.each { |element| texts << element.text.gsub(/[^a-zA-Z0-9]/, ' ').gsub(/\s+/, ' ') }
+        texts
+      end
+
+      def show_t_and_c
+        WebDriverUtils.wait_for_element_and_click show_t_and_c_button_element unless hide_t_and_c_button?
+      end
+
+      def hide_t_and_c
+        WebDriverUtils.wait_for_element_and_click hide_t_and_c_button_element unless show_t_and_c_button?
+      end
+
+      def click_title_iv_update
+        WebDriverUtils.wait_for_element_and_click title_iv_update_link_element
+      end
+
+    end
+  end
+end

--- a/spec/ui_selenium/pages/my_finances_financial_aid_page.rb
+++ b/spec/ui_selenium/pages/my_finances_financial_aid_page.rb
@@ -37,6 +37,12 @@ module CalCentralPages
         WebDriverUtils.wait_for_element_and_click authorize_title_iv_element
       end
 
+      def go_back_to_finances
+        logger.debug 'Clicking Back to Finances button'
+        WebDriverUtils.wait_for_element_and_click back_to_finances_element
+        finaid_content_element.when_visible WebDriverUtils.page_load_timeout
+      end
+
       # AWARDS CARD
       div(:coa_ttl, :xpath => '//span[text()="Estimated Cost of Attendance"]/../following-sibling::div')
       div(:gift_aid_ttl, :xpath => '//span[text()="Gift Aid"]/../following-sibling::div')
@@ -73,21 +79,13 @@ module CalCentralPages
         navigate_to "#{WebDriverUtils.base_url}/finances/finaid/#{aid_year}"
       end
 
+      def wait_for_fin_aid_semesters
+        finaid_content_element.when_visible WebDriverUtils.page_load_timeout
+      end
+
       def load_fin_aid_summary(aid_year)
         load_page aid_year
-        finaid_content_element.when_visible WebDriverUtils.page_load_timeout
-      end
-
-      def wait_for_fin_aid_semesters
-        finaid_semesters_element.when_visible WebDriverUtils.page_load_timeout
-        # TODO: add flow control
-        sleep 3
-      end
-
-      def go_back_to_finances(my_finances_page)
-        logger.debug 'Clicking Back to Finances button'
-        WebDriverUtils.wait_for_element_and_click back_to_finances_element
-        finaid_content_element.when_visible WebDriverUtils.page_load_timeout
+        wait_for_fin_aid_semesters
       end
 
       # BUDGET / ESTIMATED COST OF ATTENDANCE

--- a/spec/ui_selenium/pages/my_finances_landing_page.rb
+++ b/spec/ui_selenium/pages/my_finances_landing_page.rb
@@ -34,22 +34,20 @@ module CalCentralPages
       unordered_list(:fin_resources_list, :xpath => '//ul[@class="cc-list-links"]')
       link(:student_billing_svcs_link, :xpath => '//a[contains(text(),"Billing Services")]')
       link(:ebills_link, :xpath => '//a[contains(text(),"e-bills")]')
-      link(:ship_waiver_link, :xpath => '//a[contains(text(),"How does my SHIP Waiver affect my billing?")]')
       link(:payment_options_link, :xpath => '//a[contains(text(),"Payment Options")]')
       link(:reg_fees_link, :xpath => '//a[contains(text(),"Registration Fees")]')
       link(:tax_1098t_form_link, :xpath => '//a[contains(text(),"Tax 1098-T Form")]')
       link(:fafsa_link, :xpath => '//a[contains(text(),"FAFSA")]')
       link(:fin_aid_scholarships_link, :xpath => '//a[contains(text(),"Financial Aid & Scholarships Office")]')
       link(:grad_fin_support_link, :xpath => '//a[contains(text(),"Graduate Financial Support")]')
-      link(:loan_replay_calc_link, :xpath => '//a[contains(text(),"Loan Repayment Calculator")]')
-      link(:my_fin_aid_link, :xpath => '//a[contains(text(),"MyFinAid")]')
+      link(:my_fin_aid_link, :xpath => '//div[@data-ng-controller="FinancesLinksController"]//a[contains(text(),"MyFinAid")]')
       link(:student_budgets_link, :xpath => '//a[contains(text(),"Student Budgets")]')
       link(:work_study_link, :xpath => '//a[contains(text(),"Work-Study")]')
       link(:have_loan_link, :xpath => '//a[contains(text(),"Have a loan?")]')
       link(:withdraw_cancel_link, :xpath => '//a[contains(text(),"Withdrawing or Canceling?")]')
       link(:sched_and_dead_link, :xpath => '//a[contains(text(),"Schedule & Deadlines")]')
       link(:summer_session_link, :xpath => '//a[contains(text(),"Summer Session")]')
-      link(:cal_student_central_link, :xpath => '//a[contains(text(),"Cal Student Central")]')
+      link(:cal_student_central_link, :xpath => '//div[@data-ng-controller="FinancesLinksController"]//a[contains(text(),"Cal Student Central")]')
 
       # FINANCIAL AID MESSAGES CARD
       h2(:fin_messages_heading, :xpath => '//h2[text()="Financial Messages"]')
@@ -69,10 +67,12 @@ module CalCentralPages
         navigate_to "#{WebDriverUtils.base_url}/finances"
       end
 
-      def click_details_link
-        details_link
-        activity_heading_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
+      def load_fin_aid_summary(aid_year = nil)
+        load_page
+        finaid_content_element.when_visible WebDriverUtils.page_load_timeout
       end
+
+      # FINANCIAL AID - LEGACY CARD
 
       def all_fin_aid_message_titles
         titles = []

--- a/spec/ui_selenium/pages/my_finances_pages.rb
+++ b/spec/ui_selenium/pages/my_finances_pages.rb
@@ -28,6 +28,43 @@ module CalCentralPages
     link(:view_statements_link, :xpath => '//a[contains(text(),"View Statements")]')
     link(:make_payment_link, :xpath => '//a[@href="http://studentbilling.berkeley.edu/carsPaymentOptions.htm"]')
 
+    # FINANCIAL AID SUMMARY CARD
+    div(:finaid_content, :xpath => '//div[@data-ng-if="!finaidSummaryInfo.errored"]')
+    div(:finaid_summary_info, :xpath => '//div[@data-onload="netCostInfo.card = \'summary\'"]')
+    div(:finaid_summary_label, :class => 'cc-widget-finaid-summary-label')
+    div(:finaid_summary_message, :class => 'cc-widget-finaid-summary-message-title')
+    div(:no_finaid_message, :xpath => '//div[contains(.,"You do not currently have any Financial Aid information ready to view.")]')
+
+    span(:finaid_single_year, :xpath => '//span[@data-ng-bind="selected.finaidYear.name"]')
+    select_list(:finaid_multi_year_select, :id => 'cc-widget-finaid-summary-select-year')
+    span(:finaid_semesters, :xpath => '//span[@data-ng-bind="selected.finaidYear.availableSemesters | andFilter"]')
+
+    div(:net_cost_section, :class => 'cc-widget-finaid-summary-netcost-summary')
+    div(:finaid_cost_of_attend, :xpath => '//div[@data-ng-if="finaidSummaryData.netCost"]//span[text()="Estimated Cost of Attendance"]/../following-sibling::div')
+    div(:finaid_gift_aid, :xpath => '//div[@data-ng-if="finaidSummaryData.netCost"]//span[text()="Gift Aid"]/../following-sibling::div')
+    div(:finaid_net_cost, :xpath => '//div[@data-ng-if="finaidSummaryData.netCost"]//span[text()="Net Cost"]/../following-sibling::div')
+
+    div(:finaid_funding_offered_ttl, :xpath => '//div[@data-ng-if="finaidSummaryData.fundingOffered"]//span[text()="Funding Offered"]/../following-sibling::div')
+    div(:finaid_funding_offered_toggle, :xpath => '//div[@data-ng-if="finaidSummaryData.fundingOffered"]/div')
+    div(:finaid_funding_gift_aid, :xpath => '//div[@data-ng-if="showFundingOfferedDetails"]//span[text()="Gift Aid"]/../following-sibling::div')
+    div(:finaid_funding_grants, :xpath => '//div[@data-ng-if="showFundingOfferedDetails"]//span[text()="Grants and Scholarships"]/../following-sibling::div')
+    div(:finaid_funding_waivers, :xpath => '//div[@data-ng-if="showFundingOfferedDetails"]//span[text()="Fee Waivers"]/../following-sibling::div')
+    div(:finaid_funding_other, :xpath => '//div[@data-ng-if="showFundingOfferedDetails"]//span[text()="Other Funding"]/../following-sibling::div')
+    div(:finaid_funding_loans, :xpath => '//div[@data-ng-if="showFundingOfferedDetails"]//span[text()="Loans"]/../following-sibling::div')
+    div(:finaid_funding_work_study, :xpath => '//div[@data-ng-if="showFundingOfferedDetails"]//span[text()="Work Study"]/../following-sibling::div')
+
+    link(:finaid_t_and_c_link, :text => 'Complete Terms and Conditions')
+    link(:finaid_title_iv_link, :text => 'Complete Title IV')
+    link(:finaid_details_link, :xpath => '//h2[text()="Financial Aid and Scholarships"]/following-sibling::a')
+    link(:awards_link, :xpath => '//div[@data-ng-controller="FinaidSummaryController"]//a[contains(.,"View Awards")]')
+    link(:shopping_sheet_link, :xpath => '//a[contains(.,"Shopping Sheet")]')
+
+    link(:learn_more_link, :xpath => '//a[contains(.,"Learn more about Financial Aid")]')
+    link(:faso_link, :xpath => '//div[@data-ng-controller="FinaidSummaryController"]//a[contains(.,"Financial Aid & Scholarships")]')
+    link(:csu_link, :xpath => '//div[@data-ng-controller="FinaidSummaryController"]//a[contains(.,"Cal Student Central")]')
+
+    # BILLING AND PAYMENTS
+
     def show_last_statement_bal
       unless last_statement_bal_element_element.visible?
         toggle_last_statement_bal
@@ -42,7 +79,7 @@ module CalCentralPages
       end
     end
 
-    def click_details_link
+    def click_billing_details_link
       details_link
       activity_heading_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
     end
@@ -80,6 +117,34 @@ module CalCentralPages
     def dpp_normal_install
       dpp_normal_install_element_element.when_visible(timeout=WebDriverUtils.page_load_timeout)
       dpp_normal_install_element.delete('$, ')
+    end
+
+    # FINANCIAL AID - CS CARD
+
+
+    def click_fin_aid_details_link
+      logger.debug 'Clicking link to FinAid Details'
+      details_link
+      activity_heading_element.when_visible WebDriverUtils.page_load_timeout
+    end
+
+    def select_fin_aid_year(available_years, desired_year)
+      logger.debug "Viewing FinAid for #{desired_year}"
+      finaid_summary_label_element.when_visible WebDriverUtils.page_load_timeout
+      WebDriverUtils.wait_for_element_and_select(finaid_multi_year_select_element, desired_year) unless available_years.length == 1
+      wait_until(WebDriverUtils.page_event_timeout) { finaid_details_link_element.attribute('href').include? desired_year }
+    end
+
+    def click_t_and_c_link(finaid_page)
+      logger.info 'Clicking T&C link'
+      WebDriverUtils.wait_for_element_and_click finaid_t_and_c_link_element
+      finaid_page.t_and_c_heading_element.when_visible WebDriverUtils.page_load_timeout
+    end
+
+    def click_title_iv_link(finaid_page)
+      logger.info 'Clicking Title IV link'
+      WebDriverUtils.wait_for_element_and_click finaid_title_iv_link_element
+      finaid_page.title_iv_heading_element.when_visible WebDriverUtils.page_load_timeout
     end
 
   end

--- a/spec/ui_selenium/pages/my_finances_pages.rb
+++ b/spec/ui_selenium/pages/my_finances_pages.rb
@@ -121,7 +121,6 @@ module CalCentralPages
 
     # FINANCIAL AID - CS CARD
 
-
     def click_fin_aid_details_link
       logger.debug 'Clicking link to FinAid Details'
       details_link

--- a/spec/ui_selenium/pages/my_profile_title_iv_card.rb
+++ b/spec/ui_selenium/pages/my_profile_title_iv_card.rb
@@ -1,0 +1,40 @@
+module CalCentralPages
+
+  class MyProfileTitleIVCard < MyProfilePage
+
+    include PageObject
+    include ClassLogger
+
+    checkbox(:authorize_cbx, :id => 'cc-page-widget-profile-title4-check')
+    span(:authorized_msg, :xpath => '//span[@data-ng-if="title4.isApproved"]')
+    span(:non_authorized_msg, :xpath => '//span[@data-ng-if="!title4.isApproved"]')
+    button(:show_more, :xpath => '//button[contains(.,"Show more")]')
+    button(:show_less, :xpath => '//button[contains(.,"Show less")]')
+    div(:expanded_content, :xpath => '//div[@data-ng-if="title4.showMessage"]')
+    div(:authorized_msg_long, :xpath => '//div[@data-ng-if="title4.isApproved"]')
+    div(:non_authorized_msg_long, :xpath => '//div[@data-ng-if="title4.isApproved === false"]')
+
+    def authorize_title_iv
+      authorize_cbx_element.when_visible timeout=WebDriverUtils.page_event_timeout
+      check_authorize_cbx
+      wait_until(timeout) { authorized_msg_element.visible? }
+    end
+
+    def revoke_title_iv
+      authorize_cbx_element.when_visible timeout=WebDriverUtils.page_event_timeout
+      uncheck_authorize_cbx
+      wait_until(timeout) { non_authorized_msg_element.visible? }
+    end
+
+    def show_more
+      WebDriverUtils.wait_for_element_and_click show_more_element
+      expanded_content_element.when_visible WebDriverUtils.page_event_timeout
+    end
+
+    def show_less
+      WebDriverUtils.wait_for_element_and_click show_less_element
+      expanded_content_element.when_not_visible WebDriverUtils.page_event_timeout
+    end
+
+  end
+end

--- a/spec/ui_selenium/util/user_utils.rb
+++ b/spec/ui_selenium/util/user_utils.rb
@@ -48,9 +48,9 @@ class UserUtils
     Settings.ui_selenium.admin_uid
   end
 
-  def self.initialize_output_csv(spec)
+  def self.initialize_output_csv(spec, purpose = nil)
     output_dir = Rails.root.join('tmp', 'ui_selenium_ouput')
-    output_file = spec.inspect.sub('RSpec::ExampleGroups::', '') + '.csv'
+    output_file = "#{spec.inspect.sub('RSpec::ExampleGroups::', '')}#{purpose}.csv"
     logger.info("Initializing test output CSV named #{output_file}")
     unless File.exists?(output_dir)
       FileUtils.mkdir_p(output_dir)

--- a/spec/ui_selenium/util/user_utils.rb
+++ b/spec/ui_selenium/util/user_utils.rb
@@ -48,9 +48,9 @@ class UserUtils
     Settings.ui_selenium.admin_uid
   end
 
-  def self.initialize_output_csv(spec, purpose = nil)
+  def self.initialize_output_csv(spec)
     output_dir = Rails.root.join('tmp', 'ui_selenium_ouput')
-    output_file = "#{spec.inspect.sub('RSpec::ExampleGroups::', '')}#{purpose}.csv"
+    output_file = "#{spec.inspect.sub('RSpec::ExampleGroups::', '')}"
     logger.info("Initializing test output CSV named #{output_file}")
     unless File.exists?(output_dir)
       FileUtils.mkdir_p(output_dir)

--- a/spec/ui_selenium/util/web_driver_utils.rb
+++ b/spec/ui_selenium/util/web_driver_utils.rb
@@ -106,6 +106,10 @@ class WebDriverUtils
     date.strftime("%m/%d/%Y")
   end
 
+  def self.currency_to_f(dollar_amount)
+    dollar_amount.delete('$, ').to_f
+  end
+
   def self.wait_for_page_and_click(element)
     element.when_present timeout=page_load_timeout
     element.when_visible timeout=page_event_timeout
@@ -155,6 +159,14 @@ class WebDriverUtils
       end
       driver.switch_to.window driver.window_handles.first
     end
+  end
+
+  def self.save_screenshot(driver, uid, page_title)
+    output_dir = Rails.root.join('tmp', 'ui_selenium_ouput', 'screenshots')
+    unless File.exists?(output_dir)
+      FileUtils.mkdir_p(output_dir)
+    end
+    driver.save_screenshot Rails.root.join(output_dir, "#{uid}-#{page_title}.png")
   end
 
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6149

Includes:
* Rename existing Fin Aid messages spec to "legacy"
* Tests for the Fin Aid Summary UI (finances landing page and Fin Aid page), the Fin Aid Profile UI (including Title IV updates), and the Estimated Cost of Attendance UI
* A small number of sanity tests for the numbers presented to the user, though this will be expanded with part 2

Part 2 will include the Awards UI and the Comms UI