### PR TITLE
SISRP-14515 Enrollment card: back end for academic plan

### DIFF
--- a/app/controllers/campus_solutions/academic_plan_controller.rb
+++ b/app/controllers/campus_solutions/academic_plan_controller.rb
@@ -1,0 +1,11 @@
+module CampusSolutions
+  class AcademicPlanController < CampusSolutionsController
+
+    def get
+      model = CampusSolutions::MyAcademicPlan.from_session(session)
+      model.term_id = params['term_id']
+      render json: model.get_feed_as_json
+    end
+
+  end
+end

--- a/app/models/campus_solutions/academic_plan.rb
+++ b/app/models/campus_solutions/academic_plan.rb
@@ -1,0 +1,28 @@
+module CampusSolutions
+  class AcademicPlan < Proxy
+
+    include CampusSolutionsIdRequired
+    include EnrollmentCardFeatureFlagged
+
+    def initialize(options = {})
+      super options
+      @term_id = options[:term_id]
+      initialize_mocks if @fake
+    end
+
+    def build_feed(response)
+      (response && response['UC_SR_ACADEMIC_PLAN']) || {}
+    end
+
+    def xml_filename
+      'academic_plan.xml'
+    end
+
+    def url
+      "#{@settings.base_url}/UC_SR_ACADEMIC_PLAN.v1/get?EMPLID=#{@campus_solutions_id}".tap do |url|
+        url << "&STRM=#{@term_id}" if @term_id
+      end
+    end
+
+  end
+end

--- a/app/models/campus_solutions/my_academic_plan.rb
+++ b/app/models/campus_solutions/my_academic_plan.rb
@@ -1,0 +1,20 @@
+module CampusSolutions
+  class MyAcademicPlan < UserSpecificModel
+
+    include Cache::LiveUpdatesEnabled
+    include Cache::JsonAddedCacher
+    include EnrollmentCardFeatureFlagged
+
+    attr_accessor :term_id
+
+    def get_feed_internal
+      return {} unless is_feature_enabled && HubEdos::UserAttributes.new(user_id: @uid).has_role?(:student)
+      CampusSolutions::AcademicPlan.new(user_id: @uid, term_id: term_id).get
+    end
+
+    def instance_key
+      "#{@uid}-#{term_id || 'all'}"
+    end
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,6 +166,7 @@ Calcentral::Application.routes.draw do
   get '/api/campus_solutions/holds' => 'campus_solutions/holds#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/enrollment_term' => 'campus_solutions/enrollment_term#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/enrollment_terms' => 'campus_solutions/enrollment_terms#get', :via => :get, :defaults => { :format => 'json' }
+  get '/api/campus_solutions/academic_plan' => 'campus_solutions/academic_plan#get', :via => :get, :defaults => { :format => 'json' }
   post '/api/campus_solutions/address' => 'campus_solutions/address#post', :via => :post, :defaults => { :format => 'json' }
   post '/api/campus_solutions/delegate_access' => 'campus_solutions/delegate_access#post', :via => :post, :defaults => { :format => 'json' }
   post '/api/campus_solutions/email' => 'campus_solutions/email#post', :via => :post, :defaults => { :format => 'json' }

--- a/fixtures/xml/campus_solutions/academic_plan.xml
+++ b/fixtures/xml/campus_solutions/academic_plan.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<UC_SR_ACADEMIC_PLAN>
+  <STUDENT_ID>24437121</STUDENT_ID>
+  <UPDATE_ACADEMIC_PLAN>
+    <NAME>Update</NAME>
+    <URL>https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SCI_PLNR_FL.SCI_PLNR_FL.GBL?ucInstitution=UCB01</URL>
+    <IS_CS_LINK type="boolean">true</IS_CS_LINK>
+  </UPDATE_ACADEMIC_PLAN>
+  <ACADEMICPLAN type="array">
+    <TERM>2168</TERM>
+    <TERM_DESCR>2016 Fall</TERM_DESCR>
+    <CLASSES type="array">
+      <CLASS>
+        <ID>124039</ID>
+        <SUBJECT_CATALOG>PSYCH    C115B</SUBJECT_CATALOG>
+        <TITLE/>
+        <UNITS>4</UNITS>
+      </CLASS>
+    </CLASSES>
+  </ACADEMICPLAN>
+</UC_SR_ACADEMIC_PLAN>

--- a/public/dummy/json/academic_plan.json
+++ b/public/dummy/json/academic_plan.json
@@ -1,0 +1,20 @@
+{
+  "statusCode": 200,
+  "feed": {
+    "studentId": "24437121",
+    "updateAcademicPlan": {
+      "name": "Update",
+      "url": "https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SCI_PLNR_FL.SCI_PLNR_FL.GBL?ucInstitution=UCB01",
+      "isCsLink": true
+    }
+  },
+  "lastModified": {
+    "hash": "c7c7dea3b5817449edd08adc289e1a6f38d8599a",
+    "timestamp": {
+      "epoch": 1454961240,
+      "dateTime": "2016-02-08T11:54:00-08:00",
+      "dateString": "2/08"
+    }
+  },
+  "feedName": "CampusSolutions::MyAcademicPlan"
+}

--- a/spec/controllers/campus_solutions/academic_plan_controller_spec.rb
+++ b/spec/controllers/campus_solutions/academic_plan_controller_spec.rb
@@ -1,0 +1,23 @@
+describe CampusSolutions::AcademicPlanController do
+  let(:user_id) { '12345' }
+  before do
+    allow(Settings.features).to receive(:cs_enrollment_card).and_return true
+    allow_any_instance_of(HubEdos::UserAttributes).to receive(:has_role?).with(:student).and_return true
+  end
+
+  context 'academic plan feed' do
+    let(:feed) { :get }
+    it_behaves_like 'an unauthenticated user'
+
+    context 'authenticated user' do
+      let(:feed_key) { 'updateAcademicPlan' }
+      it_behaves_like 'a successful feed'
+      it 'has some plan data' do
+        session['user_id'] = user_id
+        get feed, {term_id: '2162', format: 'json'}
+        json = JSON.parse response.body
+        expect(json['feed']['updateAcademicPlan']['url']).to be
+      end
+    end
+  end
+end

--- a/spec/models/campus_solutions/academic_plan_spec.rb
+++ b/spec/models/campus_solutions/academic_plan_spec.rb
@@ -1,0 +1,22 @@
+describe CampusSolutions::AcademicPlan do
+  let(:user_id) { '12348' }
+  shared_examples 'a proxy that gets data' do
+    subject { proxy.get }
+    it_should_behave_like 'a simple proxy that returns errors'
+    it_behaves_like 'a proxy that properly observes the enrollment card flag'
+    it_behaves_like 'a proxy that got data successfully'
+    it 'returns data with the expected structure' do
+      expect(subject[:feed][:updateAcademicPlan]).to be
+    end
+  end
+
+  context 'mock proxy' do
+    let(:proxy) { CampusSolutions::AcademicPlan.new(fake: true, user_id: user_id, term_id: '2176') }
+    subject { proxy.get }
+    it_should_behave_like 'a proxy that gets data'
+    it 'includes specific mock data' do
+      expect(subject[:feed][:studentId]).to eq '24437121'
+      expect(subject[:feed][:updateAcademicPlan][:url]).to eq 'https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SCI_PLNR_FL.SCI_PLNR_FL.GBL?ucInstitution=UCB01'
+    end
+  end
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-14515

Note that the XML fixture includes an unparseable array attribute for the `ACADEMICPLAN` element, as currently returned by the CS API (bug reported in https://jira.berkeley.edu/browse/SISRP-14585). Still, `feed.updateAcademicPlan.url` is coming through, so we should be able to surface the deeplink in the front end if that is, in fact, a GL5 requirement.