### PR TITLE
SISRP-14532, Expire cache prior to delegate-view-as session to guarantee up-to-date privileges

### DIFF
--- a/app/controllers/delegate_act_as_controller.rb
+++ b/app/controllers/delegate_act_as_controller.rb
@@ -8,12 +8,14 @@ class DelegateActAsController < ActAsController
 
   def act_as_authorization(uid_param)
     acting_user_id = current_user.real_user_id
+    # Expire cache prior to view-as session to guarantee most up-to-date privileges.
+    CampusSolutions::DelegateStudentsExpiry.expire @uid
     response = CampusSolutions::DelegateStudents.new(user_id: acting_user_id).get
     if response[:feed] && (students = response[:feed][:students])
-      campus_solutions_id = CalnetCrosswalk::ByUid.new(user_id: uid_param).lookup_campus_solutions_id
-      student = students.detect { |s| campus_solutions_id == s[:campusSolutionsId] }
+      student = students.detect { |s| uid_param == s[:uid] }
       authorized = student && [:financial, :viewEnrollments, :viewGrades].any? { |k| student[:privileges][k] }
-      raise NotAuthorizedError.new("User #{acting_user_id} is not authorized to delegate-view-as #{student}") unless authorized
+      raise NotAuthorizedError.new("User #{acting_user_id} is unauthorized to delegate-view-as student: #{student.as_json}") unless authorized
+      logger.warn "User #{acting_user_id} is authorized to delegate-view-as #{uid_param} with privileges: #{student[:privileges]}"
     else
       raise NotAuthorizedError.new "User #{acting_user_id} does not have delegate affiliation"
     end

--- a/src/assets/templates/widgets/toolbox/delegate_students.html
+++ b/src/assets/templates/widgets/toolbox/delegate_students.html
@@ -15,7 +15,7 @@
             <div data-ng-if="!student.profilePhotoApi" class="cc-toolbox-widget-delegate-student-profile-img-not-available"></div>
           </div>
           <div class="cc-widget-padding">
-            <button class="cc-button-link" data-ng-click="delegateStudents.actAs(student.emplid)" data-ng-if="student.delegateAccess">
+            <button class="cc-button-link" data-ng-click="delegateStudents.actAs(student.uid)" data-ng-if="student.delegateAccess">
               <span class="cc-text-big" data-ng-bind="student.fullName"></span>
             </button>
             <div data-ng-if="!student.delegateAccess">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-14532

Add `CampusSolutions::DelegateStudentsExpiry.expire` and toss out unnecessary `CalnetCrosswalk::ByUid` lookup.