### PR TITLE
SISRP-14578, filtered_for_delegate should not have LiveUpdatesEnabled

### DIFF
--- a/app/models/my_academics/filtered_for_delegate.rb
+++ b/app/models/my_academics/filtered_for_delegate.rb
@@ -1,8 +1,7 @@
 module MyAcademics
   class FilteredForDelegate < UserSpecificModel
 
-    include Cache::LiveUpdatesEnabled
-    include Cache::FreshenOnWarm
+    include Cache::CachedFeed
     include Cache::JsonAddedCacher
     include CampusSolutions::DelegatedAccessFeatureFlagged
     include MergedModel

--- a/spec/controllers/my_academics_controller_spec.rb
+++ b/spec/controllers/my_academics_controller_spec.rb
@@ -52,7 +52,6 @@ describe MyAcademicsController do
       it 'should get a filtered feed' do
         get :get_feed
         json_response = JSON.parse response.body
-        expect(json_response['feedName']).to eq 'MyAcademics::FilteredForDelegate'
         expect(json_response).not_to include 'examSchedule'
         expect(json_response['gpaUnits']).not_to include 'cumulativeGpa'
         expect(json_response).not_to include 'otherSiteMemberships'

--- a/spec/models/my_academics/filtered_for_delegate_spec.rb
+++ b/spec/models/my_academics/filtered_for_delegate_spec.rb
@@ -51,8 +51,8 @@ describe MyAcademics::FilteredForDelegate do
     let(:is_feature_enabled) { false }
     let(:view_enrollments) { true }
     let(:view_grades) { true }
-    it 'should include default metadata but nothing else' do
-      expect(feed.keys).to match_array %w(lastModified feedName)
+    it 'should get nothing' do
+      expect(feed.keys).to be_empty
     end
   end
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-14578

The feed of `filtered_for_delegate` depends on delegate privileges which cannot be predicted at cache warming time.