### PR TITLE
SISRP-13892 Make RelatedCacheKeyTracker aware of JSON keys

### DIFF
--- a/app/models/campus_solutions/my_deposit.rb
+++ b/app/models/campus_solutions/my_deposit.rb
@@ -19,10 +19,5 @@ module CampusSolutions
       "#{@uid}-#{adm_appl_nbr}"
     end
 
-    def get_feed(force_cache_write=false)
-      self.class.save_related_cache_key(@uid, self.class.cache_key(instance_key))
-      super force_cache_write
-    end
-
   end
 end

--- a/app/models/campus_solutions/my_enrollment_term.rb
+++ b/app/models/campus_solutions/my_enrollment_term.rb
@@ -3,6 +3,7 @@ module CampusSolutions
 
     include Cache::LiveUpdatesEnabled
     include Cache::JsonAddedCacher
+    include Cache::RelatedCacheKeyTracker
     include EnrollmentCardFeatureFlagged
 
     attr_accessor :term_id

--- a/app/models/campus_solutions/my_financial_aid_data.rb
+++ b/app/models/campus_solutions/my_financial_aid_data.rb
@@ -21,10 +21,5 @@ module CampusSolutions
       "#{@uid}-#{aid_year}"
     end
 
-    def get_feed(force_cache_write=false)
-      self.class.save_related_cache_key(@uid, self.class.cache_key(instance_key))
-      super force_cache_write
-    end
-
   end
 end

--- a/app/models/campus_solutions/my_financial_aid_funding_sources.rb
+++ b/app/models/campus_solutions/my_financial_aid_funding_sources.rb
@@ -21,10 +21,5 @@ module CampusSolutions
       "#{@uid}-#{aid_year}"
     end
 
-    def get_feed(force_cache_write=false)
-      self.class.save_related_cache_key(@uid, self.class.cache_key(instance_key))
-      super force_cache_write
-    end
-
   end
 end

--- a/app/models/campus_solutions/my_financial_aid_funding_sources_term.rb
+++ b/app/models/campus_solutions/my_financial_aid_funding_sources_term.rb
@@ -21,10 +21,5 @@ module CampusSolutions
       "#{@uid}-#{aid_year}"
     end
 
-    def get_feed(force_cache_write=false)
-      self.class.save_related_cache_key(@uid, self.class.cache_key(instance_key))
-      super force_cache_write
-    end
-
   end
 end

--- a/lib/cache/cached_feed.rb
+++ b/lib/cache/cached_feed.rb
@@ -25,5 +25,9 @@ module Cache
       self.class.expire(instance_key)
     end
 
+    def extended_instance_keys
+      [instance_key]
+    end
+
   end
 end

--- a/lib/cache/json_added_cacher.rb
+++ b/lib/cache/json_added_cacher.rb
@@ -16,6 +16,10 @@ module Cache
       end
     end
 
+    def extended_instance_keys
+      super << self.class.json_key(instance_key)
+    end
+
     module ClassMethods
       def json_key(id)
         "json-#{id}"

--- a/lib/cache/related_cache_key_tracker.rb
+++ b/lib/cache/related_cache_key_tracker.rb
@@ -1,13 +1,20 @@
 module Cache
   module RelatedCacheKeyTracker
 
+    def get_feed(force_cache_write=false)
+      extended_instance_keys.each do |key|
+        self.class.save_related_cache_key(@uid, self.class.cache_key(key))
+      end
+      super force_cache_write
+    end
+
     def self.included base
       base.extend ClassMethods
     end
 
     module ClassMethods
       def user_key(uid)
-        "related-cache-keys-#{uid}"
+        cache_key "related-cache-keys-#{uid}"
       end
 
       def expire(uid=nil)

--- a/spec/lib/cache/related_cache_key_tracker_spec.rb
+++ b/spec/lib/cache/related_cache_key_tracker_spec.rb
@@ -1,0 +1,91 @@
+describe Cache::RelatedCacheKeyTracker do
+
+  class RelatedKeyTestClass
+    include ClassLogger
+    include Cache::CachedFeed
+    include Cache::RelatedCacheKeyTracker
+    attr_accessor :extra_param
+
+    def initialize(uid)
+      @uid = uid
+    end
+
+    def instance_key
+      "#{@uid}-#{self.extra_param}"
+    end
+
+    def get_feed_internal
+      {}
+    end
+  end
+
+  let(:oski_past_data) do
+    test_class.new('61889').tap do |instance|
+      instance.extra_param = '1066'
+    end
+  end
+
+  let(:oski_future_data) do
+    test_class.new('61889').tap do |instance|
+      instance.extra_param = '2525'
+    end
+  end
+
+  let(:oski_related_keys) { "#{test_class}/related-cache-keys-61889" }
+
+  context 'no JSON-added caching' do
+    let(:test_class) { RelatedKeyTestClass }
+
+    before do
+      oski_past_data.get_feed
+      oski_future_data.get_feed
+    end
+
+    it 'tracks multiple cache keys for a given class and UID' do
+      related_keys = Rails.cache.read oski_related_keys
+      expect(related_keys).to eq({
+        "#{test_class}/61889-1066" => 1,
+        "#{test_class}/61889-2525" => 1
+      })
+      related_keys.keys.each { |key| expect(Rails.cache.read key).not_to be_nil }
+    end
+
+    it 'expires tracked keys on request' do
+      related_keys = Rails.cache.read oski_related_keys
+      test_class.expire '61889'
+      related_keys.keys.each { |key| expect(Rails.cache.read key).to be_nil }
+      expect(Rails.cache.read oski_related_keys).to be_nil
+    end
+  end
+
+  context 'JSON-added caching' do
+    class RelatedKeyJsonTestClass < RelatedKeyTestClass
+      include Cache::JsonAddedCacher
+    end
+
+    let(:test_class) { RelatedKeyJsonTestClass }
+
+    before do
+      oski_past_data.get_feed_as_json
+      oski_future_data.get_feed_as_json
+    end
+
+    it 'tracks regular and JSONified cache keys for a given class and UID' do
+      related_keys = Rails.cache.read oski_related_keys
+      expect(related_keys).to eq({
+        "#{test_class}/61889-1066" => 1,
+        "#{test_class}/61889-2525" => 1,
+        "#{test_class}/json-61889-1066" => 1,
+        "#{test_class}/json-61889-2525" => 1
+      })
+      related_keys.keys.each { |key| expect(Rails.cache.read key).not_to be_nil }
+    end
+
+    it 'expires regular and JSONified keys on request' do
+      related_keys = Rails.cache.read oski_related_keys
+      test_class.expire '61889'
+      related_keys.keys.each { |key| expect(Rails.cache.read key).to be_nil }
+      expect(Rails.cache.read oski_related_keys).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-13892

Refactor to make Cache::RelatedCacheKeyTracker work with Cache::JsonAddedCacher. Also changes RelatedCacheKeyTracker to group related keys by uid+class instead of just uid, so that expiring one set of related keys doesn't expire all other related keys for the user.