### PR TITLE
SISRP-14529, hide Est. Family Contrib and similar financial data from delegates

### DIFF
--- a/app/controllers/campus_solutions/financial_aid_data_controller.rb
+++ b/app/controllers/campus_solutions/financial_aid_data_controller.rb
@@ -3,9 +3,11 @@ module CampusSolutions
 
     def get
       if current_user.authenticated_as_advisor?
-        model = CampusSolutions::MyFinancialAidFilteredForAdvisor.from_session(session)
+        model = CampusSolutions::MyFinancialAidFilteredForAdvisor.from_session session
+      elsif current_user.authenticated_as_delegate?
+        model = CampusSolutions::MyFinancialAidFilteredForDelegate.from_session session
       else
-        model = CampusSolutions::MyFinancialAidData.from_session(session)
+        model = CampusSolutions::MyFinancialAidData.from_session session
       end
       model.aid_year = params['aid_year']
       render json: model.get_feed_as_json

--- a/app/models/campus_solutions/my_financial_aid_filtered_for_advisor.rb
+++ b/app/models/campus_solutions/my_financial_aid_filtered_for_advisor.rb
@@ -16,13 +16,13 @@ module CampusSolutions
 
     def get_feed_internal
       if is_feature_enabled && (self.aid_year ||= CampusSolutions::MyAidYears.new(@uid).default_aid_year)
-        filter_for_advisor CampusSolutions::FinancialAidData.new(user_id: @uid, aid_year: aid_year).get
+        apply_filter CampusSolutions::FinancialAidData.new(user_id: @uid, aid_year: aid_year).get
       else
         {}
       end
     end
 
-    def filter_for_advisor(feed)
+    def apply_filter(feed)
       advisor_uid = authentication_state.original_advisor_user_id
       raise RuntimeError, "Only advisors have access to this filtered #{instance_key} FinAid feed" unless advisor_uid
       logger.debug "Advisor #{advisor_uid} viewing user #{@uid} financial aid feed where aid_year = #{aid_year}"

--- a/app/models/campus_solutions/my_financial_aid_filtered_for_delegate.rb
+++ b/app/models/campus_solutions/my_financial_aid_filtered_for_delegate.rb
@@ -1,0 +1,14 @@
+module CampusSolutions
+  class MyFinancialAidFilteredForDelegate < MyFinancialAidFilteredForAdvisor
+
+    def apply_filter(feed)
+      delegate_uid = authentication_state.original_delegate_user_id
+      raise RuntimeError, "Only delegate users have access to this filtered #{instance_key} FinAid feed" unless delegate_uid
+      logger.debug "Delegate user #{delegate_uid} viewing user #{@uid} financial aid feed where aid_year = #{aid_year}"
+      {
+        filteredForDelegate: true
+      }.merge(remove_family_information feed)
+    end
+
+  end
+end

--- a/spec/models/campus_solutions/my_financial_aid_filtered_for_delegate_spec.rb
+++ b/spec/models/campus_solutions/my_financial_aid_filtered_for_delegate_spec.rb
@@ -1,0 +1,33 @@
+describe CampusSolutions::MyFinancialAidFilteredForDelegate do
+
+  subject { CampusSolutions::MyFinancialAidFilteredForDelegate.from_session state }
+  let(:state) { { 'fake' => true, 'user_id' => random_id } }
+
+  context 'mock proxy' do
+    context 'no aid year provided' do
+      it 'should return empty' do
+        expect(subject.get_feed).to be_empty
+      end
+    end
+    context 'aid year provided' do
+      before { subject.aid_year = '2016' }
+      context 'no delegate session' do
+        it 'should deny access' do
+          expect{
+            subject.get_feed
+          }.to raise_exception /Only delegate users have access/
+        end
+      end
+      context 'delegate session' do
+        let(:state) { { 'fake' => true, 'user_id' => random_id, 'original_delegate_user_id' => random_id } }
+        it 'should filter out \'Expected Family Contribution\' and similar' do
+          feed = subject.get_feed
+          expect(feed[:filteredForDelegate]).to be true
+          json = feed.to_json
+          expect(json).to include 'SHIP Health Insurance', 'Student Standing', 'Estimated Cost of Attendance'
+          expect(json).to_not include 'EFC', 'Family', 'Parent'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-14529

Piggyback on logic of the advisors filter whilst keeping purposes separate.