### PR TITLE
CLC-6200 Add a CalnetLdap flavor of UserAttributes

### DIFF
--- a/app/models/calnet_ldap/user_attributes.rb
+++ b/app/models/calnet_ldap/user_attributes.rb
@@ -1,0 +1,33 @@
+module CalnetLdap
+  class UserAttributes < BaseProxy
+
+    include Cache::UserCacheExpiry
+
+    def initialize(options = {})
+      super(Settings.ldap, options)
+    end
+
+    def get_feed
+      self.class.fetch_from_cache @uid do
+        get_feed_internal
+      end
+    end
+
+    def get_feed_internal
+      if (result = CalnetLdap::Client.new.search_by_uid @uid)
+        {
+          email_address: result[:mail].try(:first),
+          first_name: result[:givenname].try(:first),
+          last_name: result[:sn].try(:first),
+          ldap_uid: result[:uid].try(:first).try(:to_s),
+          person_name: result[:displayname].try(:first),
+          roles: Berkeley::UserRoles.roles_from_affiliations(result[:berkeleyeduaffiliations].try(:join, ',')),
+          student_id: result[:berkeleyedustuid].try(:first).try(:to_s)
+        }
+      else
+        {}
+      end
+    end
+
+  end
+end

--- a/spec/models/calnet_ldap/user_attributes_spec.rb
+++ b/spec/models/calnet_ldap/user_attributes_spec.rb
@@ -1,0 +1,49 @@
+describe CalnetLdap::UserAttributes do
+
+  let(:feed) { described_class.new(user_id: uid).get_feed_internal }
+
+  context 'mock LDAP connection' do
+    let(:uid) { '61889' }
+    let(:ldap_result) do
+      {
+        dn: ['uid=61889,ou=people,dc=berkeley,dc=edu'],
+        objectclass: ['top', 'eduPerson', 'inetorgperson', 'berkeleyEduPerson', 'organizationalperson', 'person', 'ucEduPerson'],
+        o: ['University of California, Berkeley'],
+        ou: ['people'],
+        mail: ['oski@berkeley.edu'],
+        berkeleyeduaffiliations: ['AFFILIATE-TYPE-ADVCON-STUDENT', 'AFFILIATE-TYPE-ADVCON-ATTENDEE', 'STUDENT-TYPE-NOT REGISTERED'],
+        givenname: ['Oski'],
+        berkeleyeduconfidentialflag: ['false'],
+        berkeleyeduemailrelflag: ['false'],
+        uid: ['61889'],
+        berkeleyedumoddate: ['20160211155206Z'],
+        berkeleyedustuid: ['11667051'],
+        displayname: ['Oski BEAR'],
+        sn: ['BEAR'],
+        cn: ['BEAR, Oski']
+      }
+    end
+    before { allow(CalnetLdap::Client).to receive(:new).and_return double(search_by_uid: ldap_result) }
+    it 'translates LDAP attributes' do
+      expect(feed[:email_address]).to eq 'oski@berkeley.edu'
+      expect(feed[:first_name]).to eq 'Oski'
+      expect(feed[:last_name]).to eq 'BEAR'
+      expect(feed[:ldap_uid]).to eq '61889'
+      expect(feed[:person_name]).to eq 'Oski BEAR'
+      expect(feed[:roles][:student]).to eq true
+      expect(feed[:roles][:registered]).to eq false
+      expect(feed[:roles][:exStudent]).to eq false
+      expect(feed[:student_id]).to eq '11667051'
+    end
+  end
+
+  context 'test user from real LDAP connection', testext: true do
+    let(:uid) { '212373' }
+    it 'translates attributes' do
+      expect(feed[:ldap_uid]).to eq '212373'
+      expect(feed[:first_name]).to eq 'AFF-GUEST'
+      expect(feed[:last_name]).to eq 'TEST'
+      expect(feed[:person_name]).to eq 'AFF-GUEST TEST'
+    end
+  end
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6200

One more cached translator proxy, on the model of CampusOracle::UserAttributes and HubEdos::UserAttributes.