### PR TITLE
CLC-6205, pin jscs to 2.0.0 for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lodash": "^3.6.0",
     "gulp-util": "^3.0.6",
     "js-natural-sort": "^0.8.1",
-    "jscs": "^2.0.0",
+    "jscs": "2.0.0",
     "jshint": "2.8.0",
     "minimist": "^1.1.2",
     "moment": "^2.10.6",


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6205

We'll restore jscs: "^2.0.0" with https://jira.ets.berkeley.edu/jira/browse/CLC-6206