### PR TITLE
SISRP-14454, flush User::Api cache after delegate claims student

### DIFF
--- a/app/controllers/config_controller.rb
+++ b/app/controllers/config_controller.rb
@@ -13,7 +13,8 @@ class ConfigController < ApplicationController
 
   def proxies
     return {} unless current_user.policy.can_administrate?
-    { proxies:
+    {
+      proxies:
       {
         campusSolutions: Settings.campus_solutions_proxy.base_url,
         hubEdos: Settings.hub_edos_proxy.base_url,
@@ -23,5 +24,4 @@ class ConfigController < ApplicationController
       }
     }
   end
-
 end

--- a/app/models/campus_solutions/my_delegate_access.rb
+++ b/app/models/campus_solutions/my_delegate_access.rb
@@ -15,6 +15,7 @@ module CampusSolutions
       raise e
     else
       DelegateStudentsExpiry.expire @uid
+      User::Api.expire @uid
       feed
     end
 

--- a/spec/controllers/campus_solutions/delegate_access_controller_spec.rb
+++ b/spec/controllers/campus_solutions/delegate_access_controller_spec.rb
@@ -23,6 +23,7 @@ describe CampusSolutions::DelegateAccessController do
     context 'post' do
       before do
         expect(CampusSolutions::DelegateStudentsExpiry).to receive(:expire).once.with user_id
+        expect(User::Api).to receive(:expire).once.with user_id
       end
       it 'should link a claimed student' do
         post :post, {
@@ -39,6 +40,7 @@ describe CampusSolutions::DelegateAccessController do
     context 'get' do
       before do
         expect(CampusSolutions::DelegateStudentsExpiry).to receive(:expire).never
+        expect(User::Api).to receive(:expire).never
       end
       it 'should get students list' do
         get :get_students


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-14454

User::Api flush is needed to get `hasToolboxTab: true` and then 'My Students' card.