### PR TITLE
SISRP-14107 - QA test fixes

### DIFF
--- a/spec/ui_selenium/my_academics_data_profile_and_reqts_spec.rb
+++ b/spec/ui_selenium/my_academics_data_profile_and_reqts_spec.rb
@@ -41,6 +41,8 @@ describe 'My Academics profile and university requirements cards', :testui => tr
             if (status_api_page.has_academics_tab? && status_api_page.is_student?) || status_api_page.has_student_history?
               profile_card.profile_card_element.when_visible(timeout=WebDriverUtils.academics_timeout)
 
+              testable_users << uid unless academics_api_page.transition_term?
+
               # NAME AND IDS
               logger.warn "Expecting UID #{uid}, and UID displayed is #{profile_card.uid}"
               api_full_name = status_api_page.full_name
@@ -275,7 +277,6 @@ describe 'My Academics profile and university requirements cards', :testui => tr
                   api_term_transition = "Academic status as of #{academics_api_page.term_name}"
                   if status_api_page.is_student?
                     user_type = 'existing student'
-                    testable_users.push(uid)
                     my_academics_term_transition = profile_card.term_transition_heading
                     it "show the term transition heading to UID #{uid}" do
                       expect(my_academics_term_transition).to eql(api_term_transition)
@@ -314,7 +315,7 @@ describe 'My Academics profile and university requirements cards', :testui => tr
         end
       end
 
-      it 'have academic profile data for at least one of the test UIDs' do
+      it 'shows academic profile for a current term for at least one of the test UIDs' do
         expect(testable_users.any?).to be true
       end
 

--- a/spec/ui_selenium/my_academics_data_status_blocks_spec.rb
+++ b/spec/ui_selenium/my_academics_data_status_blocks_spec.rb
@@ -154,7 +154,7 @@ describe 'My Academics Status and Blocks', :testui => true do
 
               # CALIFORNIA RESIDENCY
 
-              if academics_api_page.transition_term? || academics_api_page.colleges.include?('Haas School of Business')
+              if academics_api_page.transition_term?
 
                 has_residency_status = my_academics_page.res_status_summary?
 
@@ -163,24 +163,30 @@ describe 'My Academics Status and Blocks', :testui => true do
                 end
 
               else
-
-                api_res_status = badges_api_page.residency_summary
-                api_res_needs_action = badges_api_page.residency_needs_action
-                my_acad_res_status = my_academics_page.res_status_summary
-
-                it "shows residency status of '#{my_acad_res_status}' for UID #{uid}" do
-                  expect(my_acad_res_status).to eql(api_res_status)
-                end
-
-                if api_res_needs_action == true
-                  has_red_res_status_icon = my_academics_page.res_status_icon_red?
-                  it "shows a red residency status icon for UID #{uid}" do
-                    expect(has_red_res_status_icon).to be true
+                if badges_api_page.residency.nil?
+                  has_res_status = my_academics_page.res_status_summary?
+                  it "shows no residency status for UID #{uid}" do
+                    expect(has_res_status).to be false
                   end
                 else
-                  has_green_res_status_icon = my_academics_page.res_status_icon_green?
-                  it "shows a green residency status icon for UID #{uid}" do
-                    expect(has_green_res_status_icon).to be true
+                  api_res_status = badges_api_page.residency_summary
+                  api_res_needs_action = badges_api_page.residency_needs_action
+                  my_acad_res_status = my_academics_page.res_status_summary
+
+                      it "shows residency status of '#{my_acad_res_status}' for UID #{uid}" do
+                        expect(my_acad_res_status).to eql(api_res_status)
+                      end
+
+                  if api_res_needs_action == true
+                    has_red_res_status_icon = my_academics_page.res_status_icon_red?
+                    it "shows a red residency status icon for UID #{uid}" do
+                      expect(has_red_res_status_icon).to be true
+                    end
+                  else
+                    has_green_res_status_icon = my_academics_page.res_status_icon_green?
+                    it "shows a green residency status icon for UID #{uid}" do
+                      expect(has_green_res_status_icon).to be true
+                    end
                   end
                 end
               end

--- a/spec/ui_selenium/my_academics_data_status_blocks_spec.rb
+++ b/spec/ui_selenium/my_academics_data_status_blocks_spec.rb
@@ -154,13 +154,14 @@ describe 'My Academics Status and Blocks', :testui => true do
 
               # CALIFORNIA RESIDENCY
 
-              if academics_api_page.transition_term?
+              if academics_api_page.transition_term? || academics_api_page.colleges.include?('Haas School of Business')
 
                 has_residency_status = my_academics_page.res_status_summary?
 
                 it "shows no residency status for UID #{uid} during the transition term" do
                   expect(has_residency_status).to be false
                 end
+
               else
 
                 api_res_status = badges_api_page.residency_summary

--- a/spec/ui_selenium/my_finances_data_acct_summary_spec.rb
+++ b/spec/ui_selenium/my_finances_data_acct_summary_spec.rb
@@ -67,9 +67,7 @@ describe 'My Finances Billing Summary', :testui => true do
                 # Expect 'zero balance' message, but infrequent ODSQA refresh can leave balance and transactions out of sync, causing intermittent test failures
               elsif fin_api_page.account_balance < 0
                 acct_bal = 'Negative'
-                it "shows a credit balance message for UID #{uid}" do
-                  expect(my_fin_credit_bal_text).to be true
-                end
+                # Expect 'credit balance' message, but infrequent ODSQA refresh can leave balance and transactions out of sync, causing intermittent test failures
               end
               it "shows the right account balance for UID #{uid}" do
                 expect(my_fin_acct_bal).to eql(fin_api_page.account_balance_str)

--- a/spec/ui_selenium/pages/api_my_academics_page.rb
+++ b/spec/ui_selenium/pages/api_my_academics_page.rb
@@ -253,7 +253,7 @@ class ApiMyAcademicsPage
       date = (Time.strptime(block_cleared_date(item), '%m/%d/%Y')).strftime('%m/%d/%y')
       dates.push(date)
     end
-    dates
+    dates.sort!
   end
 
   # FINAL EXAMS

--- a/spec/ui_selenium/pages/api_my_badges_page.rb
+++ b/spec/ui_selenium/pages/api_my_badges_page.rb
@@ -10,36 +10,52 @@ class ApiMyBadgesPage
     @parsed = JSON.parse(body)
   end
 
+  def student_info
+    @parsed['studentInfo']
+  end
+
+  def residency
+    student_info['californiaResidency']
+  end
+
   def residency_summary
-    @parsed['studentInfo']['californiaResidency']['summary']
+    residency['summary']
   end
 
   def residency_explanation
-    @parsed['studentInfo']['californiaResidency']['explanation']
+    residency['explanation']
   end
 
   def residency_needs_action
-    @parsed['studentInfo']['californiaResidency']['needsAction']
+    residency['needsAction']
+  end
+
+  def reg_status
+    student_info['regStatus']
   end
 
   def reg_status_summary
-    @parsed['studentInfo']['regStatus']['summary']
+    reg_status['summary']
   end
 
   def reg_status_explanation
-    @parsed['studentInfo']['regStatus']['explanation']
+    reg_status['explanation']
   end
 
   def reg_status_needs_action
-    @parsed['studentInfo']['regStatus']['needsAction']
+    reg_status['needsAction']
+  end
+
+  def reg_block
+    student_info['regBlock']
   end
 
   def active_block_needs_action
-    @parsed['studentInfo']['regBlock']['needsAction']
+    reg_block['needsAction']
   end
 
   def active_block_number_str
-    @parsed['studentInfo']['regBlock']['activeBlocks'].to_s
+    reg_block['activeBlocks'].to_s
   end
 
 end

--- a/spec/ui_selenium/pages/my_academics_status_and_blocks_card.rb
+++ b/spec/ui_selenium/pages/my_academics_status_and_blocks_card.rb
@@ -104,7 +104,7 @@ module CalCentralPages
         date = row[2].text
         dates.push(date)
       end
-      dates.drop(1)
+      dates.drop(1).sort!
     end
   end
 end

--- a/spec/ui_selenium/user_authorizations_spec.rb
+++ b/spec/ui_selenium/user_authorizations_spec.rb
@@ -34,17 +34,14 @@ describe 'User authorization', :testui => true, :order => :defined do
         end
         it 'allows the admin to see recently viewed users' do
           @toolbox_page.wait_until(timeout, 'Recent user did not appear') do
-            @toolbox_page.recent_user_view_as_button_elements.any?
-            @toolbox_page.recent_user_view_as_button_elements[0].text == '61889'
+            @toolbox_page.recent_user_view_as_button_elements[0].text == '61889' if @toolbox_page.recent_user_view_as_button_elements.any?
           end
         end
         it 'allows the admin to save recently viewed users' do
           @toolbox_page.recent_users_element.when_present(timeout)
           @toolbox_page.save_first_recent_user
           @toolbox_page.wait_until(timeout, 'Saved user did not appear') do
-            @toolbox_page.saved_user_view_as_button_elements.any?
-            sleep 2
-            @toolbox_page.saved_user_view_as_button_elements[0].text == '61889'
+            @toolbox_page.saved_user_view_as_button_elements[0].text == '61889' if @toolbox_page.saved_user_view_as_button_elements.any?
           end
         end
       end

--- a/spec/ui_selenium/util/user_utils.rb
+++ b/spec/ui_selenium/util/user_utils.rb
@@ -50,7 +50,7 @@ class UserUtils
 
   def self.initialize_output_csv(spec)
     output_dir = Rails.root.join('tmp', 'ui_selenium_ouput')
-    output_file = "#{spec.inspect.sub('RSpec::ExampleGroups::', '')}"
+    output_file = "#{spec.inspect.sub('RSpec::ExampleGroups::', '')}.csv"
     logger.info("Initializing test output CSV named #{output_file}")
     unless File.exists?(output_dir)
       FileUtils.mkdir_p(output_dir)


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-14107

Final set of Selenium test fixes for v73:
* Toolbox View as - wait more patiently for "saved" and "recent" users tables to be updated
* CFV - stop expecting open transactions and account balance to be in sync in test environments
* Status and residency - don't expect residency info for Haas students; test clean-up
* Academic profile - trigger test failure only when term transition occurs (as way of alerting to the coming and going of term transition phases)
* Final exams - test clean-up