### PR TITLE
SISRP-15082, Acting as a super user with the advisor affiliation gives the wrong experience

### DIFF
--- a/src/assets/javascripts/angular/factories/adminFactory.js
+++ b/src/assets/javascripts/angular/factories/adminFactory.js
@@ -29,7 +29,8 @@ angular.module('calcentral.factories').factory('adminFactory', function(apiServi
   };
 
   var actAs = function(user) {
-    var url = apiService.user.profile.roles.advisor ? advisorActAsUrl : actAsUrl;
+    var isAdvisorOnly = apiService.user.profile.roles.advisor && !apiService.api.user.profile.isSuperuser && !apiService.api.user.profile.isViewer;
+    var url = isAdvisorOnly ? advisorActAsUrl : actAsUrl;
     return $http.post(url, user);
   };
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-15082

You get limited Advisor-view-as session if you are not SuperUser and do not have standard view-as permission.