### PR TITLE
SISRP-15110 - Update CalCentral with the new academic planner API url

### DIFF
--- a/app/models/campus_solutions/academic_plan.rb
+++ b/app/models/campus_solutions/academic_plan.rb
@@ -11,7 +11,7 @@ module CampusSolutions
     end
 
     def build_feed(response)
-      (response && response['UC_SR_ACADEMIC_PLAN']) || {}
+      (response && response['UC_SR_ACADEMIC_PLANNER']) || {}
     end
 
     def xml_filename
@@ -19,7 +19,7 @@ module CampusSolutions
     end
 
     def url
-      "#{@settings.base_url}/UC_SR_ACADEMIC_PLAN.v1/get?EMPLID=#{@campus_solutions_id}".tap do |url|
+      "#{@settings.base_url}/UC_SR_ACADEMIC_PLANNER.v1/get?EMPLID=#{@campus_solutions_id}".tap do |url|
         url << "&STRM=#{@term_id}" if @term_id
       end
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -321,6 +321,8 @@ features:
   background_jobs_check: true
   course_manage_official_sections: false
   manage_site_mailing_lists: false
+  cs_academic_planner: false
+  cs_academic_progress_report: false
   cs_enrollment_card: false
   cs_fin_aid: false
   cs_holds: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -66,6 +66,8 @@ features:
   audio: true
   advising: true
   course_manage_official_sections: true
+  cs_academic_planner: true
+  cs_academic_progress_report: true
   cs_delegated_access: true
   cs_enrollment_card: true
   cs_fin_aid: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -46,6 +46,8 @@ features:
   cal1card: true
   audio: true
   advising: true
+  cs_academic_planner: true
+  cs_academic_progress_report: true
   cs_delegated_access: true
   cs_enrollment_card: true
   cs_fin_aid: true

--- a/config/settings/testext.yml
+++ b/config/settings/testext.yml
@@ -31,6 +31,8 @@ features:
   cal1card: true
   audio: true
   advising: true
+  cs_academic_planner: true
+  cs_academic_progress_report: true
   cs_delegated_access: true
   cs_enrollment_card: true
   cs_fin_aid: true

--- a/fixtures/xml/campus_solutions/academic_plan.xml
+++ b/fixtures/xml/campus_solutions/academic_plan.xml
@@ -1,23 +1,24 @@
 <?xml version="1.0"?>
-<UC_SR_ACADEMIC_PLAN>
+<UC_SR_ACADEMIC_PLANNER>
   <STUDENT_ID>24437121</STUDENT_ID>
-  <UPDATE_ACADEMIC_PLAN>
+  <UPDATE_ACADEMIC_PLANNER>
     <NAME>Update</NAME>
     <URL>https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SCI_PLNR_FL.SCI_PLNR_FL.GBL?ucInstitution=UCB01</URL>
     <IS_CS_LINK type="boolean">true</IS_CS_LINK>
-  </UPDATE_ACADEMIC_PLAN>
-  <ACADEMICPLANS type="array">
-    <ACADEMICPLAN>
+  </UPDATE_ACADEMIC_PLANNER>
+  <ACADEMICPLANNER type="array">
+    <ACADEMIC_PLAN>
       <TERM>2168</TERM>
       <TERM_DESCR>2016 Fall</TERM_DESCR>
       <CLASSES type="array">
         <CLASS>
           <ID>124039</ID>
-          <SUBJECT_CATALOG>PSYCH  C115B</SUBJECT_CATALOG>
+          <SUBJECT_CATALOG>PSYCHC115B</SUBJECT_CATALOG>
           <TITLE></TITLE>
-          <UNITS>4</UNITS>
+          <UNITS type="float">4.0</UNITS>
         </CLASS>
       </CLASSES>
-    </ACADEMICPLAN>
-  </ACADEMICPLANS>
-</UC_SR_ACADEMIC_PLAN>
+      <TOTAL_UNITS type="float">4.0</TOTAL_UNITS>
+    </ACADEMIC_PLAN>
+  </ACADEMICPLANNER>
+</UC_SR_ACADEMIC_PLANNER>

--- a/public/dummy/json/academic_plan.json
+++ b/public/dummy/json/academic_plan.json
@@ -2,28 +2,29 @@
   "statusCode": 200,
   "feed": {
     "studentId": "24437121",
-    "updateAcademicPlan": {
+    "updateAcademicPlanner": {
       "name": "Update",
       "url": "https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SCI_PLNR_FL.SCI_PLNR_FL.GBL?ucInstitution=UCB01",
       "isCsLink": true
     },
-    "academicplans": [{
+    "academicplanner": [{
       "term": "2168",
       "termDescr": "2016 Fall",
       "classes": [{
         "id": "124039",
-        "subjectCatalog": "PSYCH    C115B",
+        "subjectCatalog": "PSYCHC115B",
         "title": null,
-        "units": "4"
-      }]
+        "units": 4.0
+      }],
+      "totalUnits": 4.0
     }]
   },
   "lastModified": {
-    "hash": "414963b8a8dfcf6efea56468de904b8b2ab0851b",
+    "hash": "613b4ea9661361558ba9b523e48b13fa90f92791",
     "timestamp": {
-      "epoch": 1454978449,
-      "dateTime": "2016-02-08T16:40:49-08:00",
-      "dateString": "2/08"
+      "epoch": 1455848984,
+      "dateTime": "2016-02-18T18:29:44-08:00",
+      "dateString": "2/18"
     }
   },
   "feedName": "CampusSolutions::MyAcademicPlan"

--- a/spec/controllers/campus_solutions/academic_plan_controller_spec.rb
+++ b/spec/controllers/campus_solutions/academic_plan_controller_spec.rb
@@ -10,13 +10,13 @@ describe CampusSolutions::AcademicPlanController do
     it_behaves_like 'an unauthenticated user'
 
     context 'authenticated user' do
-      let(:feed_key) { 'updateAcademicPlan' }
+      let(:feed_key) { 'updateAcademicPlanner' }
       it_behaves_like 'a successful feed'
       it 'has some plan data' do
         session['user_id'] = user_id
         get feed, {term_id: '2162', format: 'json'}
         json = JSON.parse response.body
-        expect(json['feed']['updateAcademicPlan']['url']).to be
+        expect(json['feed']['updateAcademicPlanner']['url']).to be
       end
     end
   end

--- a/spec/models/campus_solutions/academic_plan_spec.rb
+++ b/spec/models/campus_solutions/academic_plan_spec.rb
@@ -6,7 +6,7 @@ describe CampusSolutions::AcademicPlan do
     it_behaves_like 'a proxy that properly observes the enrollment card flag'
     it_behaves_like 'a proxy that got data successfully'
     it 'returns data with the expected structure' do
-      expect(subject[:feed][:updateAcademicPlan]).to be
+      expect(subject[:feed][:updateAcademicPlanner]).to be
     end
   end
 
@@ -16,7 +16,7 @@ describe CampusSolutions::AcademicPlan do
     it_should_behave_like 'a proxy that gets data'
     it 'includes specific mock data' do
       expect(subject[:feed][:studentId]).to eq '24437121'
-      expect(subject[:feed][:updateAcademicPlan][:url]).to eq 'https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SCI_PLNR_FL.SCI_PLNR_FL.GBL?ucInstitution=UCB01'
+      expect(subject[:feed][:updateAcademicPlanner][:url]).to eq 'https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SCI_PLNR_FL.SCI_PLNR_FL.GBL?ucInstitution=UCB01'
     end
   end
 end

--- a/src/assets/javascripts/angular/controllers/widgets/enrollment/enrollmentCardController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/enrollment/enrollmentCardController.js
@@ -162,9 +162,9 @@ angular.module('calcentral.controllers').controller('EnrollmentCardController', 
   var parseAcademicPlan = function(data) {
     var feedData = _.get(data, 'data.feed');
 
-    if (_.get(feedData, 'updateAcademicPlan')) {
-      $scope.enrollment.academicPlan.updateLink = feedData.updateAcademicPlan;
-      _.each(feedData.academicplans, function(academicPlan) {
+    if (_.get(feedData, 'updateAcademicPlanner')) {
+      $scope.enrollment.academicPlan.updateLink = feedData.updateAcademicPlanner;
+      _.each(feedData.academicplanner, function(academicPlan) {
         setTermData({
           academicPlan: academicPlan
         }, academicPlan.term);
@@ -178,6 +178,10 @@ angular.module('calcentral.controllers').controller('EnrollmentCardController', 
    * Load the academic plan URL and information
    */
   var loadAcademicPlan = function() {
+    if (!apiService.user.profile.features.csAcademicPlanner) {
+      $scope.enrollment.academicPlan.isLoading = false;
+      return true;
+    }
     return enrollmentFactory.getAcademicPlan().then(parseAcademicPlan);
   };
 

--- a/src/assets/javascripts/angular/factories/adminFactory.js
+++ b/src/assets/javascripts/angular/factories/adminFactory.js
@@ -29,7 +29,7 @@ angular.module('calcentral.factories').factory('adminFactory', function(apiServi
   };
 
   var actAs = function(user) {
-    var isAdvisorOnly = apiService.user.profile.roles.advisor && !apiService.api.user.profile.isSuperuser && !apiService.api.user.profile.isViewer;
+    var isAdvisorOnly = apiService.user.profile.roles.advisor && !apiService.user.profile.isSuperuser && !apiService.user.profile.isViewer;
     var url = isAdvisorOnly ? advisorActAsUrl : actAsUrl;
     return $http.post(url, user);
   };

--- a/src/assets/templates/widgets/advisor/resources.html
+++ b/src/assets/templates/widgets/advisor/resources.html
@@ -25,7 +25,7 @@
             data-link="ucAdvisingResources.ucAdvisingLinks.ucAdviseeStudentCenter"
           ></div>
         </li>
-        <li>
+        <li data-ng-if="api.user.profile.features.csAcademicProgressReport">
           <div
             data-cc-campus-solutions-link-item-directive
             data-link="ucAdvisingResources.ucAdvisingLinks.ucAcademicRequirements"

--- a/src/assets/templates/widgets/enrollment/plan.html
+++ b/src/assets/templates/widgets/enrollment/plan.html
@@ -7,7 +7,7 @@
 
 <div class="cc-enrollment-card-section-content" data-ng-if="section.show">
   <div data-cc-spinner-directive="enrollment.academicPlan.isLoading">
-    <div data-ng-if="!enrollment.academicPlan.updateLink && !enrollmentTerm.academicPlan.academicplans.length">
+    <div data-ng-if="!enrollment.academicPlan.updateLink && !enrollmentTerm.academicPlan.classes.length">
       Multi-year academic planner is unavailable at this time.
     </div>
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-15110

SISRP-15173 - Advisor View As: JS error when attempting to view as

https://jira.berkeley.edu/browse/SISRP-15173

SISRP-15179 - Hide Academic Progress report - in advising resources till GL5.4

https://jira.berkeley.edu/browse/SISRP-15179

SISRP-15092 - Hide academic planner link till GL5.4 on enrollment card.

https://jira.berkeley.edu/browse/SISRP-15092