### PR TITLE
SISRP-14362 Create proxy for Cal1card photo API

### DIFF
--- a/app/models/cal1card/my_cal1card.rb
+++ b/app/models/cal1card/my_cal1card.rb
@@ -25,10 +25,10 @@ module Cal1card
     end
 
     def get_converted_xml
-      url = "#{@settings.base_url}?uid=#{@uid}"
       logger.info "Internal_get: Fake = #{@fake}; Making request to #{url} on behalf of user #{@uid}; cache expiration #{self.class.expires_in}"
       response = get_response(
         url,
+        query: {uid: @uid},
         basic_auth: {username: @settings.username, password: @settings.password}
       )
       feed = response.parsed_response
@@ -40,10 +40,20 @@ module Cal1card
       })
     end
 
+    def url
+      "#{@settings.base_url}/csc.asp"
+    end
+
+    def mock_request
+      super.merge({
+        uri_matching: url,
+        query: {uid: @uid}
+      })
+    end
+
     def mock_xml
       read_file('fixtures', 'xml', 'cal1card_feed.xml')
     end
-
   end
 end
 

--- a/app/models/cal1card/photo.rb
+++ b/app/models/cal1card/photo.rb
@@ -1,0 +1,62 @@
+module Cal1card
+  class Photo < UserSpecificModel
+    include Cache::CachedFeed
+    include Cache::FeedExceptionsHandled
+    include Proxies::HttpClient
+    include Proxies::Mockable
+
+    def initialize(uid, options={})
+      super(uid, options)
+      @settings = Settings.cal1card_proxy
+      @fake = (options[:fake] != nil) ? options[:fake] : @settings.fake
+      initialize_mocks if @fake
+    end
+
+    def get_feed_internal
+      if Settings.features.cal1card
+        get_photo
+      else
+        {}
+      end
+    end
+
+    def get_photo
+      logger.info "Fake = #{@fake}; Making request to #{url} on behalf of user #{@uid}; cache expiration #{self.class.expires_in}"
+      response = get_response(
+        url,
+        query: {uid: @uid},
+        basic_auth: {username: @settings.username, password: @settings.password},
+        on_error: {rescue_status: 404}
+      )
+      if response.code == 404
+        logger.debug "404 response from Cal1card photo API for user #{@uid}"
+        {}
+      else
+        photo = response.parsed_response
+        {
+          length: photo.length.to_s,
+          photo: photo
+        }
+      end
+    end
+
+    def url
+      "#{@settings.base_url}/csc_img.asp"
+    end
+
+    def mock_request
+      super.merge({
+        uri_matching: url,
+        query: {uid: @uid}
+      })
+    end
+
+    def mock_response
+      {
+        status: 200,
+        headers: {'Content-Type' => 'application/jpeg'},
+        body: File.open(Rails.root.join('public', 'dummy', 'images', 'sample_student_72x96.jpg'), 'rb').read
+      }
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -174,7 +174,7 @@ blog_latest_release_notes_feed_proxy:
 
 cal1card_proxy:
   fake: false
-  base_url: 'https://webstage.housing.berkeley.edu/c1c/dyn/csc.asp'
+  base_url: 'https://webstage.housing.berkeley.edu/c1c/dyn'
   username: 'secret'
   password: 'secret'
 

--- a/spec/models/cal1card/photo_spec.rb
+++ b/spec/models/cal1card/photo_spec.rb
@@ -1,0 +1,46 @@
+describe Cal1card::Photo do
+  let(:proxy) { Cal1card::Photo.new(uid, fake: fake) }
+  subject { proxy.get_feed }
+
+  shared_examples 'a proxy returning valid photo data' do
+    it 'includes bytes and length' do
+      expect(subject[:length]).to be_present
+      expect(subject[:photo]).to be_present
+    end
+    it 'calculates length correctly' do
+      expect(subject[:length]).to eq subject[:photo].length.to_s
+    end
+  end
+
+  context 'fake proxy' do
+    let(:fake) { true }
+    let(:uid) { '61889' }
+    it_behaves_like 'a polite HTTP client'
+    it_behaves_like 'a proxy returning valid photo data'
+    context 'photo not found' do
+      let(:status) { 404 }
+      before { proxy.set_response(status: status) }
+      it 'logs at debug and returns empty feed' do
+        allow(Rails.logger).to receive :debug
+        expect(Rails.logger).to receive(:debug).with /404 response/
+        expect(Rails.logger).not_to receive :error
+        expect(subject).to be_empty
+      end
+    end
+    context 'server errors' do
+      let(:status) { 506 }
+      before { proxy.set_response(status: status) }
+      include_context 'expecting logs from server errors'
+      it 'reports an error' do
+        expect(subject[:body]).to eq('An unknown server error occurred')
+        expect(subject[:statusCode]).to eq 503
+      end
+    end
+  end
+
+  context 'real proxy', testext: true do
+    let(:fake) { false }
+    let(:uid) { '211159' }
+    it_behaves_like 'a proxy returning valid photo data'
+  end
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-14362

It turns out this is no longer a requirement for delegated access, but we're bound to need it at some point.

NB: This shortens the Cal1card base URL and will require corresponding changes in local YAML.