### PR TITLE
SISRP-15334, delegates should not see Academics if privilege is only 'financial'

### DIFF
--- a/app/models/user/api.rb
+++ b/app/models/user/api.rb
@@ -30,7 +30,8 @@ module User
 
     def get_delegate_students
       return nil unless is_cs_delegated_access_feature_enabled
-      response = CampusSolutions::DelegateStudents.new(user_id: @uid).get
+      delegate_uid = authentication_state.original_delegate_user_id || @uid
+      response = CampusSolutions::DelegateStudents.new(user_id: delegate_uid).get
       response && response[:feed] && response[:feed][:students]
     end
 

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -1,5 +1,6 @@
 describe User::Api do
   let(:uid) { random_id }
+  let(:original_delegate_user_id) { nil }
   let(:preferred_name) { 'Sid Vicious' }
   let(:edo_attributes) do
     {
@@ -20,7 +21,8 @@ describe User::Api do
   before(:each) do
     allow(HubEdos::UserAttributes).to receive(:new).with(user_id: uid).and_return double(get: edo_attributes)
     allow(CalnetLdap::UserAttributes).to receive(:new).with(user_id: uid).and_return double(get_feed: ldap_attributes)
-    allow(CampusSolutions::DelegateStudents).to receive(:new).with(user_id: uid).and_return double(get: delegate_students)
+    delegate_uid = original_delegate_user_id || uid
+    allow(CampusSolutions::DelegateStudents).to receive(:new).with(user_id: delegate_uid).and_return double(get: delegate_students)
   end
 
   context 'user attributes' do
@@ -74,7 +76,6 @@ describe User::Api do
       User::Api.from_session(session).get_feed
     }
     context 'has no students' do
-      let(:original_delegate_user_id) { nil }
       context 'never nominated as delegate' do
         let(:response) { nil }
         it 'delegate has student with only phone privilege' do
@@ -117,7 +118,6 @@ describe User::Api do
         }
       }
       context 'before view-as session' do
-        let(:original_delegate_user_id) { nil }
         it 'shows toolbox' do
           expect(api[:isDelegateUser]).to be true
           expect(api[:hasToolboxTab]).to be true


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-15334

When delegate-view-as mode the `get_my_students query` should use uid = original_delegate_user_id