### PR TITLE
SISRP-13710, delegate users do not need to reauth when view-as

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,8 +45,7 @@ class ApplicationController < ActionController::Base
       delete_reauth_cookie
       return
     end
-    return unless Settings.features.reauthentication
-    reauthenticate(redirect_path: '/') if current_user.viewing_as? && !cookies[:reauthenticated]
+    reauthenticate(redirect_path: '/') if session_state_requires_reauthentication?
   end
 
   def delete_reauth_cookie
@@ -122,6 +121,12 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def session_state_requires_reauthentication?
+    Settings.features.reauthentication &&
+      (current_user.original_user_id || current_user.original_advisor_user_id) &&
+      !cookies[:reauthenticated]
+  end
 
   def get_settings
     @server_settings = ServerRuntime.get_settings

--- a/app/controllers/delegate_act_as_controller.rb
+++ b/app/controllers/delegate_act_as_controller.rb
@@ -1,7 +1,5 @@
 class DelegateActAsController < ActAsController
 
-  skip_before_filter :check_reauthentication, :only => [:stop_delegate_act_as]
-
   def initialize
     super(act_as_session_key: 'original_delegate_user_id')
   end

--- a/spec/controllers/config_controller_spec.rb
+++ b/spec/controllers/config_controller_spec.rb
@@ -38,7 +38,7 @@ describe ConfigController do
     end
     context 'user can administrate' do
       before {
-        expect(AuthenticationState).to receive(:new).and_return double(policy: double(can_administrate?: true), viewing_as?: false)
+        expect(AuthenticationState).to receive(:new).and_return double(policy: double(can_administrate?: true), original_user_id: nil, original_advisor_user_id: nil)
       }
       it 'should contain sensitive data' do
         proxies = subject['proxies']


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-13710

`current_user.viewing_as?` is true when delegate enters view-as so we must get more granular. Only require re-auth if it's standard-view-as or advisor-view-as.