### PR TITLE
SISRP-15505, no 'Link Your Account with Your Student' page when delegate-view-as mode

### DIFF
--- a/src/assets/templates/delegate_welcome.html
+++ b/src/assets/templates/delegate_welcome.html
@@ -1,3 +1,4 @@
-<div class="medium-4 columns cc-delegate-welcome" ng-if="api.user.profile.features.csDelegatedAccess">
+<div class="medium-4 columns cc-delegate-welcome" ng-if="api.user.profile.features.csDelegatedAccess && !api.user.profile.delegateActingAsUid">
   <div data-ng-include src="'widgets/delegate/linking.html'"></div>
 </div>
+<div data-ng-include="'404.html'" data-ng-if="api.user.profile.delegateActingAsUid"></div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-15505

We don't want delegate to inadvertently go to this page while still viewing-as.