### PR TITLE
SISRP-14832, verify_sis_api_endpoints loads config/settings.yml for default feature flag settings

### DIFF
--- a/script/sis/verify_sis_api_endpoints.sh
+++ b/script/sis/verify_sis_api_endpoints.sh
@@ -140,6 +140,7 @@ if [[ ! -f "${yaml_filename}" ]] ; then
   exit 0
 fi
 
+eval $(parse_yaml ${PWD}/config/settings.yml 'yml_')
 eval $(parse_yaml ${yaml_filename} 'yml_')
 
 # --------------------


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-14832

The intended precedence seems to work. I.e., local.yml wins when feature flag is set in both files. 