### PR TITLE
SISRP-10777 ~ prework for profile language edits on the backend

### DIFF
--- a/app/models/campus_solutions/language_delete.rb
+++ b/app/models/campus_solutions/language_delete.rb
@@ -12,7 +12,7 @@ module CampusSolutions
     def self.field_mappings
       @field_mappings ||= FieldMapping.to_hash(
         [
-          FieldMapping.required(:jpmCatItemId, :JPM_CAT_ITEM_ID)
+          FieldMapping.required(:languageCode, :JPM_CAT_ITEM_ID)
         ]
       )
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,7 +183,7 @@ Calcentral::Application.routes.draw do
   delete '/api/campus_solutions/address/:type' => 'campus_solutions/address#delete', :via => :delete, :defaults => { :format => 'json' }
   delete '/api/campus_solutions/email/:type' => 'campus_solutions/email#delete', :via => :delete, :defaults => { :format => 'json' }
   delete '/api/campus_solutions/emergency_contact/:contactName' => 'campus_solutions/emergency_contact#delete', :via => :post, :defaults => { :format => 'json' }
-  delete '/api/campus_solutions/language/:jpmCatItemId' => 'campus_solutions/language#delete', :via => :delete, :defaults => { :format => 'json' }
+  delete '/api/campus_solutions/language/:languageCode' => 'campus_solutions/language#delete', :via => :delete, :defaults => { :format => 'json' }
   delete '/api/campus_solutions/person_name/:type' => 'campus_solutions/person_name#delete', :via => :delete, :defaults => { :format => 'json' }
   delete '/api/campus_solutions/phone/:type' => 'campus_solutions/phone#delete', :via => :delete, :defaults => { :format => 'json' }
   delete '/api/campus_solutions/ethnicity/:ethnicGroupCode/:regRegion' => 'campus_solutions/ethnicity#delete', :via => :delete, :defaults => { :format => 'json' }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -329,6 +329,7 @@ features:
   cs_logout: false
   cs_profile: true
   cs_profile_emergency_contacts: false
+  cs_profile_languages: false
   cs_profile_work_experience: false
   cs_profile_visible_for_legacy_users: true
   show_notifications_archive_link: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -74,6 +74,7 @@ features:
   cs_holds: true
   cs_logout: true
   cs_profile_emergency_contacts: true
+  cs_profile_languages: true
   cs_profile_work_experience: true
   prevent_acting_as_users_from_posting: false
   show_notifications_archive_link: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -54,6 +54,7 @@ features:
   cs_holds: true
   cs_logout: true
   cs_profile_emergency_contacts: true
+  cs_profile_languages: true
   cs_profile_work_experience: true
   webcast_sign_up_on_calcentral: true
   show_notifications_archive_link: true

--- a/config/settings/testext.yml
+++ b/config/settings/testext.yml
@@ -39,6 +39,7 @@ features:
   cs_holds: true
   cs_logout: true
   cs_profile_emergency_contacts: true
+  cs_profile_languages: true
   cs_profile_work_experience: true
   webcast_sign_up_on_calcentral: true
   show_notifications_archive_link: true

--- a/fixtures/xml/campus_solutions/language_delete.xml
+++ b/fixtures/xml/campus_solutions/language_delete.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <LANGUAGES_DELETE_RESPONSE>
-  <STATUS>Language Successfully deleted for individual 25753380 for Language code EN</STATUS>
+  <STATUS>Language Successfully deleted for individual 25753380 for Language code LEN</STATUS>
 </LANGUAGES_DELETE_RESPONSE>

--- a/spec/controllers/campus_solutions/language_controller_spec.rb
+++ b/spec/controllers/campus_solutions/language_controller_spec.rb
@@ -17,7 +17,7 @@ describe CampusSolutions::LanguageController do
         post :post,
              {
                bogus_field: 'abc',
-               languageCode: 'EN',
+               languageCode: 'LEN',
                isNative: 'N',
                isTranslateToNative: 'N',
                isTeachLanguage: 'N',
@@ -36,7 +36,7 @@ describe CampusSolutions::LanguageController do
 
   context 'deleting language' do
     it 'should not let an unauthenticated user delete' do
-      delete :delete, {format: 'json', jpmCatItemId: '100'}
+      delete :delete, {format: 'json', languageCode: '100'}
       expect(response.status).to eq 401
     end
 
@@ -49,7 +49,7 @@ describe CampusSolutions::LanguageController do
         delete :delete,
                {
                  bogus_field: 'abc',
-                 jpmCatItemId: 'EN'
+                 languageCode: 'LEN'
                }
         expect(response.status).to eq 200
         json = JSON.parse(response.body)
@@ -61,4 +61,3 @@ describe CampusSolutions::LanguageController do
   end
 
 end
-

--- a/spec/models/campus_solutions/language_delete_spec.rb
+++ b/spec/models/campus_solutions/language_delete_spec.rb
@@ -9,20 +9,22 @@ describe CampusSolutions::LanguageDelete do
     context 'converting params to Campus Solutions field names' do
       let(:params) { {
         bogus: 'foo',
-        jpmCatItemId: 'EN'
+        languageCode: 'LEN'
       } }
       subject {
         proxy.construct_cs_post(params)
       }
+      it 'should convert languageCode param to JPM_CAT_ITEM_ID' do
+        expect(subject[:query][:JPM_CAT_ITEM_ID]).to eq 'LEN'
+      end
       it 'should convert the CalCentral params to Campus Solutions params without exploding on bogus fields' do
-        expect(subject[:query][:JPM_CAT_ITEM_ID]).to eq 'EN'
         expect(subject[:query].keys.length).to eq 2
       end
     end
 
     context 'performing a delete' do
       let(:params) { {
-        jpmCatItemId: 'EN'
+        languageCode: 'LEN'
       } }
       subject {
         proxy.get
@@ -35,7 +37,7 @@ describe CampusSolutions::LanguageDelete do
 
   context 'with a real external service', testext: true do
     let(:create_params) { {
-      languageCode: 'EN',
+      languageCode: 'LEN',
       isNative: 'N',
       isTranslateToNative: 'N',
       isTeachLanguage: 'N',
@@ -52,7 +54,7 @@ describe CampusSolutions::LanguageDelete do
 
     context 'a successful delete' do
       let(:params) { {
-        jpmCatItemId: 'EN'
+        languageCode: 'LEN'
       } }
       context 'performing a real delete' do
         it_behaves_like 'a proxy that got data successfully'

--- a/src/assets/javascripts/angular/services/profileMenuService.js
+++ b/src/assets/javascripts/angular/services/profileMenuService.js
@@ -84,6 +84,7 @@ angular.module('calcentral.services').factory('profileMenuService', function(api
         {
           id: 'languages',
           name: 'Languages',
+          featureFlag: 'csProfileLanguages',
           roles: {
             student: true
           }


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-10777

@johncrossman, @paulkerschen: PR covers some minor/cosmetic changes for the languages edit story on the ruby side, plus a feature flag

+ change xhr param name froom `jpmCatItemId` to `languageCode` (prefer the latter in the angular controller that refers to it)
+ change expected languageCode values from `EN` to `LEN`
+ add feature flag `cs_profile_languages`

Let me know if anything should be modified here.  
