### PR TITLE
SISRP-15079 - Refactors for filtering of confidential group items

### DIFF
--- a/app/models/campus_solutions/my_financial_aid_filtered_for_advisor.rb
+++ b/app/models/campus_solutions/my_financial_aid_filtered_for_advisor.rb
@@ -35,11 +35,8 @@ module CampusSolutions
       return feed unless feed[:feed] && feed[:feed][:status] && (categories = feed[:feed][:status][:categories])
       categories.each do |category|
         if category[:itemGroups]
-          category[:itemGroups].each_with_index do |group, group_index|
-            category[:itemGroups][group_index].each_with_index do |item, item_index|
-              category[:itemGroups][group_index][item_index] = nil if has_confidential_information? item
-            end
-            category[:itemGroups][group_index].compact!
+          category[:itemGroups].each do |group|
+            group.reject! { |item| has_confidential_information? item }
           end
         end
       end

--- a/app/models/campus_solutions/my_financial_aid_filtered_for_advisor.rb
+++ b/app/models/campus_solutions/my_financial_aid_filtered_for_advisor.rb
@@ -28,19 +28,19 @@ module CampusSolutions
       logger.debug "Advisor #{advisor_uid} viewing user #{@uid} financial aid feed where aid_year = #{aid_year}"
       {
         filteredForAdvisor: true
-      }.merge(remove_family_information feed)
+      }.merge(remove_confidential_information feed)
     end
 
-    def remove_family_information(feed={})
+    def remove_confidential_information(feed={})
       return feed unless feed[:feed] && feed[:feed][:status] && (categories = feed[:feed][:status][:categories])
       categories.each do |category|
         if category[:itemGroups]
-          filtered_groups = []
-          category[:itemGroups].each do |group|
-            exclude_group = group.any? { |item| has_family_information? item }
-            filtered_groups << group unless exclude_group
+          category[:itemGroups].each_with_index do |group, group_index|
+            category[:itemGroups][group_index].each_with_index do |item, item_index|
+              category[:itemGroups][group_index][item_index] = nil if has_confidential_information? item
+            end
+            category[:itemGroups][group_index].compact!
           end
-          category[:itemGroups] = filtered_groups
         end
       end
       feed
@@ -50,8 +50,8 @@ module CampusSolutions
       "#{@uid}-#{aid_year}"
     end
 
-    def has_family_information?(item)
-      [item[:title].to_s, item[:value].to_s].any? { |s| s =~ /family|efc|parent/i }
+    def has_confidential_information?(item)
+      !!(item[:title].to_s =~ /expected\sfamily\scontribution|berkeley\sparent\scontribution/i)
     end
   end
 end

--- a/app/models/campus_solutions/my_financial_aid_filtered_for_delegate.rb
+++ b/app/models/campus_solutions/my_financial_aid_filtered_for_delegate.rb
@@ -7,7 +7,7 @@ module CampusSolutions
       logger.debug "Delegate user #{delegate_uid} viewing user #{@uid} financial aid feed where aid_year = #{aid_year}"
       {
         filteredForDelegate: true
-      }.merge(remove_family_information feed)
+      }.merge(remove_confidential_information feed)
     end
 
   end

--- a/spec/models/campus_solutions/my_financial_aid_filtered_for_advisor_spec.rb
+++ b/spec/models/campus_solutions/my_financial_aid_filtered_for_advisor_spec.rb
@@ -1,9 +1,9 @@
 describe CampusSolutions::MyFinancialAidFilteredForAdvisor do
 
   subject { CampusSolutions::MyFinancialAidFilteredForAdvisor.from_session(state) }
-  let(:state) { { 'fake' => true, 'user_id' => random_id } }
 
   context 'mock proxy' do
+    let(:state) { { 'fake' => true, 'user_id' => random_id } }
     context 'no aid year provided' do
       it 'should return empty' do
         expect(subject.get_feed).to be_empty
@@ -20,12 +20,23 @@ describe CampusSolutions::MyFinancialAidFilteredForAdvisor do
       end
       context 'advisor session' do
         let(:state) { { 'fake' => true, 'user_id' => random_id, 'original_advisor_user_id' => random_id } }
-        it 'should filter out \'Expected Family Contribution\' and similar' do
-          feed = subject.get_feed
+        let(:feed) { subject.get_feed }
+        let(:json) { feed.to_json }
+        it 'should indicate feed as filtered for advisor' do
           expect(feed[:filteredForAdvisor]).to be true
-          json = feed.to_json
-          expect(json).to include 'SHIP Health Insurance', 'Student Standing', 'Estimated Cost of Attendance'
-          expect(json).to_not include 'EFC', 'Family', 'Parent'
+        end
+        it 'includes expected items' do
+          expect(json).to include 'SHIP Health Insurance'
+          expect(json).to include 'Student Standing'
+          expect(json).to include 'Estimated Cost of Attendance'
+          expect(json).to include 'Dependency Status'
+          expect(json).to include 'Family Members in College'
+        end
+        it 'should filter out \'Expected Family Contribution\'' do
+          expect(json).to_not include 'Expected Family Contribution'
+        end
+        it 'should filter out \'Berkeley Family Contribution\'' do
+          expect(json).to_not include 'Berkeley Parent Contribution'
         end
       end
     end

--- a/spec/models/campus_solutions/my_financial_aid_filtered_for_advisor_spec.rb
+++ b/spec/models/campus_solutions/my_financial_aid_filtered_for_advisor_spec.rb
@@ -35,7 +35,7 @@ describe CampusSolutions::MyFinancialAidFilteredForAdvisor do
         it 'should filter out \'Expected Family Contribution\'' do
           expect(json).to_not include 'Expected Family Contribution'
         end
-        it 'should filter out \'Berkeley Family Contribution\'' do
+        it 'should filter out \'Berkeley Parent Contribution\'' do
           expect(json).to_not include 'Berkeley Parent Contribution'
         end
       end

--- a/spec/models/campus_solutions/my_financial_aid_filtered_for_delegate_spec.rb
+++ b/spec/models/campus_solutions/my_financial_aid_filtered_for_delegate_spec.rb
@@ -20,12 +20,24 @@ describe CampusSolutions::MyFinancialAidFilteredForDelegate do
       end
       context 'delegate session' do
         let(:state) { { 'fake' => true, 'user_id' => random_id, 'original_delegate_user_id' => random_id } }
-        it 'should filter out \'Expected Family Contribution\' and similar' do
-          feed = subject.get_feed
+        let(:feed) { subject.get_feed }
+        let(:json) { feed.to_json }
+
+        it 'should indicate feed as filtered for delegate' do
           expect(feed[:filteredForDelegate]).to be true
-          json = feed.to_json
-          expect(json).to include 'SHIP Health Insurance', 'Student Standing', 'Estimated Cost of Attendance'
-          expect(json).to_not include 'EFC', 'Family', 'Parent'
+        end
+        it 'includes expected items' do
+          expect(json).to include 'SHIP Health Insurance'
+          expect(json).to include 'Student Standing'
+          expect(json).to include 'Estimated Cost of Attendance'
+          expect(json).to include 'Dependency Status'
+          expect(json).to include 'Family Members in College'
+        end
+        it 'should filter out \'Expected Family Contribution\'' do
+          expect(json).to_not include 'Expected Family Contribution'
+        end
+        it 'should filter out \'Berkeley Family Contribution\'' do
+          expect(json).to_not include 'Berkeley Parent Contribution'
         end
       end
     end

--- a/spec/models/campus_solutions/my_financial_aid_filtered_for_delegate_spec.rb
+++ b/spec/models/campus_solutions/my_financial_aid_filtered_for_delegate_spec.rb
@@ -36,7 +36,7 @@ describe CampusSolutions::MyFinancialAidFilteredForDelegate do
         it 'should filter out \'Expected Family Contribution\'' do
           expect(json).to_not include 'Expected Family Contribution'
         end
-        it 'should filter out \'Berkeley Family Contribution\'' do
+        it 'should filter out \'Berkeley Parent Contribution\'' do
           expect(json).to_not include 'Berkeley Parent Contribution'
         end
       end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-15079

Refactors for filtering of 'Expected Family Contribution' and 'Berkeley Family Contribution' only, allowing 'Dependency Status' and 'Family Members in College'