### PR TITLE
SISRP-15421, formalize set of view-as related session keys

### DIFF
--- a/app/controllers/act_as_controller.rb
+++ b/app/controllers/act_as_controller.rb
@@ -5,7 +5,7 @@ class ActAsController < ApplicationController
   skip_before_filter :check_reauthentication, :only => [:stop_act_as]
 
   def initialize(options = {})
-    @act_as_session_key = options[:act_as_session_key] || 'original_user_id'
+    @act_as_session_key = options[:act_as_session_key] || SessionKey.original_user_id
   end
 
   def start

--- a/app/controllers/advisor_act_as_controller.rb
+++ b/app/controllers/advisor_act_as_controller.rb
@@ -4,7 +4,7 @@ class AdvisorActAsController < ActAsController
   skip_before_filter :check_reauthentication, :only => [:stop_advisor_act_as]
 
   def initialize
-    super(act_as_session_key: 'original_advisor_user_id')
+    super act_as_session_key: SessionKey.original_advisor_user_id
   end
 
   def act_as_authorization(uid_param)

--- a/app/controllers/concerns/session_key.rb
+++ b/app/controllers/concerns/session_key.rb
@@ -1,0 +1,8 @@
+module SessionKey
+
+    VIEW_AS_TYPES = %w(original_user_id original_advisor_user_id original_delegate_user_id)
+    CANVAS_MASQUERADE_TYPES = %w(canvas_masquerading_user_id)
+
+    (VIEW_AS_TYPES + CANVAS_MASQUERADE_TYPES).each { |key| define_singleton_method(key) { key } }
+
+end

--- a/app/controllers/delegate_act_as_controller.rb
+++ b/app/controllers/delegate_act_as_controller.rb
@@ -1,7 +1,7 @@
 class DelegateActAsController < ActAsController
 
   def initialize
-    super(act_as_session_key: 'original_delegate_user_id')
+    super act_as_session_key: SessionKey.original_delegate_user_id
   end
 
   def act_as_authorization(uid_param)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -114,7 +114,7 @@ class SessionsController < ApplicationController
       redirect_to url_for_path('/uid_error')
     else
       # Unless we're re-authenticating after view-as, initialize the session.
-      session['user_id'] = uid unless session['original_user_id'] || session['original_advisor_user_id'] || session['original_delegate_user_id']
+      session['user_id'] = uid unless get_original_viewer_uid
       redirect_to smart_success_path, :notice => 'Signed in!'
     end
   end
@@ -131,10 +131,6 @@ class SessionsController < ApplicationController
     ensure
       ActiveRecord::Base.clear_active_connections!
     end
-  end
-
-  def get_original_viewer_uid
-    session['original_user_id'] || session['original_advisor_user_id'] || session['original_delegate_user_id']
   end
 
 end

--- a/app/models/user_specific_model.rb
+++ b/app/models/user_specific_model.rb
@@ -4,12 +4,8 @@ class UserSpecificModel
   attr_reader :authentication_state
 
   def self.from_session(session_state)
-    filtered_session = {
-      'original_user_id' => session_state['original_user_id'],
-      'original_advisor_user_id' => session_state['original_advisor_user_id'],
-      'original_delegate_user_id' => session_state['original_delegate_user_id'],
-      'lti_authenticated_only' => session_state['lti_authenticated_only']
-    }
+    view_as_related = Hash[SessionKey::VIEW_AS_TYPES.collect { |k| [k, session_state[k]] }]
+    filtered_session = {'lti_authenticated_only' => session_state['lti_authenticated_only'] }.merge view_as_related
     self.new(session_state['user_id'], filtered_session)
   end
 

--- a/app/policies/authentication_state.rb
+++ b/app/policies/authentication_state.rb
@@ -5,9 +5,9 @@ class AuthenticationState
 
   def initialize(session)
     @user_id = session['user_id']
-    @original_user_id = session['original_user_id']
-    @original_advisor_user_id = session['original_advisor_user_id']
-    @original_delegate_user_id = session['original_delegate_user_id']
+    @original_user_id = session[SessionKey.original_user_id]
+    @original_advisor_user_id = session[SessionKey.original_advisor_user_id]
+    @original_delegate_user_id = session[SessionKey.original_delegate_user_id]
     @canvas_masquerading_user_id = session['canvas_masquerading_user_id']
     @lti_authenticated_only = session['lti_authenticated_only']
   end

--- a/spec/controllers/act_as_controller_spec.rb
+++ b/spec/controllers/act_as_controller_spec.rb
@@ -4,13 +4,13 @@ describe ActAsController do
     post :start, uid: target_uid
     expect(response).to be_success
     expect(session['user_id']).to eq target_uid
-    expect(session['original_user_id']).to eq real_user_id
+    expect(session[SessionKey.original_user_id]).to eq real_user_id
   end
   def it_fails
     post :start, uid: target_uid
     expect(response).to_not be_success
     expect(session['user_id']).to_not eq target_uid
-    expect(session['original_user_id']).to be_nil
+    expect(session[SessionKey.original_user_id]).to be_nil
   end
 
   describe '#start' do
@@ -32,7 +32,7 @@ describe ActAsController do
       end
       it 'switches targets' do
         session['user_id'] = '211159'
-        session['original_user_id'] = real_user_id
+        session[SessionKey.original_user_id] = real_user_id
         it_succeeds
       end
     end

--- a/spec/controllers/bootstrap_controller_spec.rb
+++ b/spec/controllers/bootstrap_controller_spec.rb
@@ -23,7 +23,7 @@ describe BootstrapController do
     before do
       expect(Settings.features).to receive(:reauthentication).and_return(true)
       session['user_id'] = user_id
-      session['original_user_id'] = original_user_id
+      session[SessionKey.original_user_id] = original_user_id
     end
     context 'when viewing as' do
       let(:original_user_id) {random_id}

--- a/spec/controllers/campus_solutions/financial_aid_data_controller_spec.rb
+++ b/spec/controllers/campus_solutions/financial_aid_data_controller_spec.rb
@@ -41,14 +41,14 @@ describe CampusSolutions::FinancialAidDataController do
         }
         context 'advisor' do
           let(:filter_type) { CampusSolutions::MyFinancialAidFilteredForAdvisor }
-          let(:original_user_id) { 'original_advisor_user_id' }
+          let(:original_user_id) { SessionKey.original_advisor_user_id }
           it 'should filter the feed' do
             expect(subject['key']).to eq 'value'
           end
         end
         context 'delegate user' do
           let(:filter_type) { CampusSolutions::MyFinancialAidFilteredForDelegate }
-          let(:original_user_id) { 'original_delegate_user_id' }
+          let(:original_user_id) { SessionKey.original_delegate_user_id }
           it 'should filter the feed' do
             expect(subject['key']).to eq 'value'
           end

--- a/spec/controllers/canvas_lti_controller_spec.rb
+++ b/spec/controllers/canvas_lti_controller_spec.rb
@@ -34,7 +34,7 @@ describe CanvasLtiController do
       end
       it 'does not initiate a view-as session' do
         subject.send(:authenticate_by_lti, lti)
-        expect(session).not_to include 'original_user_id'
+        expect(session).not_to include SessionKey.original_user_id
       end
     end
     context 'when the LTI user is not masquerading' do

--- a/spec/controllers/google_auth_controller_spec.rb
+++ b/spec/controllers/google_auth_controller_spec.rb
@@ -34,7 +34,7 @@ describe GoogleAuthController do
     end
     context 'viewing as' do
       before do
-        session['original_user_id'] = random_id
+        session[SessionKey.original_user_id] = random_id
       end
       it { is_expected.not_to have_http_status :success }
     end

--- a/spec/controllers/my_badges_controller_spec.rb
+++ b/spec/controllers/my_badges_controller_spec.rb
@@ -7,14 +7,14 @@ describe MyBadgesController do
     allow(Settings.features).to receive(:reauthentication).and_return(false)
   end
 
-  it "should be an empty badges feed on non-authenticated user" do
+  it 'should be an empty badges feed on non-authenticated user' do
     get :get_feed
     assert_response :success
     json_response = JSON.parse(response.body)
     json_response.should == {}
   end
 
-  it "should be an non-empty badges feed on authenticated user" do
+  it 'should be an non-empty badges feed on authenticated user' do
     GoogleApps::Proxy.stub(:access_granted?).and_return(true)
     GoogleApps::DriveList.stub(:new).and_return(@fake_drive_list)
     GoogleApps::EventsRecentItems.stub(:new).and_return(@fake_events_list)
@@ -22,18 +22,18 @@ describe MyBadgesController do
     get :get_feed
     json_response = JSON.parse(response.body)
 
-    json_response["badges"].present?.should be_truthy
-    json_response["badges"].is_a?(Hash).should be_truthy
-    json_response["badges"].keys.count.should == 3
+    json_response['badges'].present?.should be_truthy
+    json_response['badges'].is_a?(Hash).should be_truthy
+    json_response['badges'].keys.count.should == 3
 
     existing_badges = %w(bcal bdrive bmail)
     existing_badges.each do |badge|
-      json_response["badges"][badge]["count"].should_not be_nil
+      json_response['badges'][badge]['count'].should_not be_nil
     end
 
-    json_response["studentInfo"].present?.should be_truthy
-    json_response["studentInfo"].is_a?(Hash).should be_truthy
-    json_response["studentInfo"].keys.count.should == 4
+    json_response['studentInfo'].present?.should be_truthy
+    json_response['studentInfo'].is_a?(Hash).should be_truthy
+    json_response['studentInfo'].keys.count.should == 4
   end
 
   context 'viewing-as' do
@@ -45,13 +45,13 @@ describe MyBadgesController do
       expect(Settings.bearfacts_proxy).to receive(:fake).at_least(:once).and_return(true)
     end
     it 'should not give a real user a cached censored feed' do
-      session['original_user_id'] = original_user_id
+      session[SessionKey.original_user_id] = original_user_id
       get :get_feed
       feed = JSON.parse(response.body)
       ['bcal', 'bdrive', 'bmail'].each do |service|
         expect(feed['badges'][service]['count']).to eq 0
       end
-      session['original_user_id'] = nil
+      session[SessionKey.original_user_id] = nil
       get :get_feed
       feed = JSON.parse(response.body)
       ['bcal', 'bdrive', 'bmail'].each do |service|
@@ -65,7 +65,7 @@ describe MyBadgesController do
       ['bcal', 'bdrive', 'bmail'].each do |service|
         expect(feed['badges'][service]['count']).to be > 0
       end
-      session['original_user_id'] = original_user_id
+      session[SessionKey.original_user_id] = original_user_id
       get :get_feed
       feed = JSON.parse(response.body)
       expect(feed['studentInfo']['regBlock']).to be_present

--- a/spec/controllers/my_events_controller_spec.rb
+++ b/spec/controllers/my_events_controller_spec.rb
@@ -76,7 +76,7 @@ describe MyEventsController do
 
         context 'viewing as another user' do
           before do
-            session['original_user_id'] = rand(99999).to_s
+            session[SessionKey.original_user_id] = rand(99999).to_s
             allow(GoogleApps::Proxy).to receive(:access_granted?).with(random_id).and_return(true)
           end
           subject do

--- a/spec/controllers/my_tasks_controller_spec.rb
+++ b/spec/controllers/my_tasks_controller_spec.rb
@@ -90,11 +90,11 @@ describe MyTasksController do
     end
     context 'with real-user data cached' do
       it 'should not give a real user a cached censored feed' do
-        session['original_user_id'] = original_user_id
+        session[SessionKey.original_user_id] = original_user_id
         get :get_feed
         feed = JSON.parse(response.body)
         expect(feed['tasks'].index {|t| t['emitter'] == 'Google'}).to be_nil
-        session['original_user_id'] = nil
+        session[SessionKey.original_user_id] = nil
         get :get_feed
         feed = JSON.parse(response.body)
         expect(feed['tasks'].index {|t| t['emitter'] == 'Google'}).to_not be_nil
@@ -104,7 +104,7 @@ describe MyTasksController do
         feed = JSON.parse(response.body)
         expect(feed['tasks'].index {|t| t['emitter'] == 'bCourses'}).to_not be_nil
         expect(feed['tasks'].index {|t| t['emitter'] == 'Google'}).to_not be_nil
-        session['original_user_id'] = original_user_id
+        session[SessionKey.original_user_id] = original_user_id
         get :get_feed
         feed = JSON.parse(response.body)
         expect(feed['tasks'].index {|t| t['emitter'] == 'bCourses'}).to_not be_nil
@@ -112,7 +112,7 @@ describe MyTasksController do
       end
     end
     it 'should not add a Google task to the real user account' do
-      session['original_user_id'] = original_user_id
+      session[SessionKey.original_user_id] = original_user_id
       expect_any_instance_of(MyTasks::GoogleTasks).to receive(:insert_task).never
       hash = {
         'emitter' => 'Google',

--- a/spec/controllers/my_up_next_controller_spec.rb
+++ b/spec/controllers/my_up_next_controller_spec.rb
@@ -28,17 +28,17 @@ describe MyUpNextController do
       allow(Settings.features).to receive(:reauthentication).and_return(false)
     end
     it 'should not give a real user a cached censored feed' do
-      session['original_user_id'] = original_user_id
+      session[SessionKey.original_user_id] = original_user_id
       get :get_feed
       expect(JSON.parse(response.body)['items']).to be_empty
-      session['original_user_id'] = nil
+      session[SessionKey.original_user_id] = nil
       get :get_feed
       expect(JSON.parse(response.body)['items']).to be_present
     end
     it 'should not return a cached real-user feed' do
       get :get_feed
       expect(JSON.parse(response.body)['items']).to be_present
-      session['original_user_id'] = original_user_id
+      session[SessionKey.original_user_id] = original_user_id
       get :get_feed
       expect(JSON.parse(response.body)['items']).to be_empty
     end

--- a/spec/controllers/routes_list_controller_spec.rb
+++ b/spec/controllers/routes_list_controller_spec.rb
@@ -33,7 +33,7 @@ describe RoutesListController do
       end
     end
     session['user_id'] = @user_id
-    session['original_user_id'] = viewer_id
+    session[SessionKey.original_user_id] = viewer_id
     get :smoke_test_routes
     expect(response.status).to eq 403
     expect(response.body).to be_blank

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -18,7 +18,7 @@ describe SessionsController do
         expect(controller).to receive(:cookies).and_return cookie_hash
         :create_reauth_cookie
         different_user_id = "some_other_#{user_id}"
-        session['original_user_id'] = different_user_id
+        session[SessionKey.original_user_id] = different_user_id
         session['user_id'] = different_user_id
 
         get :lookup, renew: 'true'
@@ -44,7 +44,7 @@ describe SessionsController do
       it 'will reset session when CAS uid does not match uid in session' do
         expect(controller).to receive(:cookies).and_return cookie_hash
         :create_reauth_cookie
-        session['original_user_id'] = user_id
+        session[SessionKey.original_user_id] = user_id
         session['user_id'] = user_id
 
         get :lookup, renew: 'true'

--- a/spec/controllers/user_api_controller_spec.rb
+++ b/spec/controllers/user_api_controller_spec.rb
@@ -62,7 +62,7 @@ describe UserApiController do
     end
     context 'when viewing as' do
       let(:original_user_id) { random_id }
-      before { session['original_user_id'] = original_user_id }
+      before { session[SessionKey.original_user_id] = original_user_id }
       it { should eq original_user_id }
     end
     context 'when authenticated by LTI' do
@@ -88,7 +88,7 @@ describe UserApiController do
     context 'viewing as' do
       let(:original_delegate_user_id) { random_id }
       before do
-        session['original_delegate_user_id'] = original_delegate_user_id
+        session[SessionKey.original_delegate_user_id] = original_delegate_user_id
         # Give student superpowers with the hope that delegate user has powers turned off.
         allow(User::Auth).to receive(:get) do |uid|
           case uid
@@ -123,7 +123,7 @@ describe UserApiController do
     context 'viewing as' do
       let(:original_advisor_user_id) { random_id }
       before do
-        session['original_advisor_user_id'] = original_advisor_user_id
+        session[SessionKey.original_advisor_user_id] = original_advisor_user_id
         allow(User::Auth).to receive(:get) do |uid|
           case uid
             when user_id
@@ -141,7 +141,7 @@ describe UserApiController do
 
   describe 'superuser status' do
     before do
-      session['original_user_id'] = original_user_id
+      session[SessionKey.original_user_id] = original_user_id
       allow(User::Auth).to receive(:get) do |uid|
         case uid
           when user_id

--- a/spec/models/campus_solutions/my_financial_aid_filtered_for_advisor_spec.rb
+++ b/spec/models/campus_solutions/my_financial_aid_filtered_for_advisor_spec.rb
@@ -19,7 +19,7 @@ describe CampusSolutions::MyFinancialAidFilteredForAdvisor do
         end
       end
       context 'advisor session' do
-        let(:state) { { 'fake' => true, 'user_id' => random_id, 'original_advisor_user_id' => random_id } }
+        let(:state) { { 'fake' => true, 'user_id' => random_id, SessionKey.original_advisor_user_id => random_id } }
         let(:feed) { subject.get_feed }
         let(:json) { feed.to_json }
         it 'should indicate feed as filtered for advisor' do

--- a/spec/models/campus_solutions/my_financial_aid_filtered_for_delegate_spec.rb
+++ b/spec/models/campus_solutions/my_financial_aid_filtered_for_delegate_spec.rb
@@ -19,7 +19,7 @@ describe CampusSolutions::MyFinancialAidFilteredForDelegate do
         end
       end
       context 'delegate session' do
-        let(:state) { { 'fake' => true, 'user_id' => random_id, 'original_delegate_user_id' => random_id } }
+        let(:state) { { 'fake' => true, 'user_id' => random_id, SessionKey.original_delegate_user_id => random_id } }
         let(:feed) { subject.get_feed }
         let(:json) { feed.to_json }
 

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -75,7 +75,7 @@ describe User::Api do
     let(:api) {
       session = {
         'user_id' => uid,
-        'original_delegate_user_id' => original_delegate_user_id
+        SessionKey.original_delegate_user_id => original_delegate_user_id
       }
       User::Api.from_session(session).get_feed
     }

--- a/spec/models/user_specific_model_spec.rb
+++ b/spec/models/user_specific_model_spec.rb
@@ -10,7 +10,7 @@ describe UserSpecificModel do
     context 'standard view-as mode' do
       let(:session_extras) {
         {
-          'original_user_id' => random_id
+          SessionKey.original_user_id => random_id
         }
       }
       it 'should identify user as not directly_authenticated' do
@@ -20,7 +20,7 @@ describe UserSpecificModel do
     context 'delegate view-as mode' do
       let(:session_extras) {
         {
-          'original_delegate_user_id' => random_id
+          SessionKey.original_delegate_user_id => random_id
         }
       }
       it 'should identify delegated-access session' do
@@ -28,7 +28,7 @@ describe UserSpecificModel do
       end
     end
     context 'advisor view-as mode' do
-      let(:session_extras) { { 'original_advisor_user_id' => random_id } }
+      let(:session_extras) { { SessionKey.original_advisor_user_id => random_id } }
       it 'should identify user as having delegate_permissions' do
         expect(subject.directly_authenticated?).to be false
       end

--- a/spec/models/webcast/merged_spec.rb
+++ b/spec/models/webcast/merged_spec.rb
@@ -234,7 +234,7 @@ describe Webcast::Merged do
     context 'course with zero recordings is different than course not scheduled for recordings' do
       let(:media) do
         user_id = rand(99999).to_s
-        view_as_mode = AuthenticationState.new('user_id' => user_id, 'original_user_id' => rand(99999).to_s)
+        view_as_mode = AuthenticationState.new('user_id' => user_id, SessionKey.original_user_id => rand(99999).to_s)
         policy = AuthenticationStatePolicy.new(view_as_mode, nil)
         Webcast::Merged.new(user_id, policy, 2015, 'B', [1, 56742, 56745]).get_feed[:media]
       end

--- a/spec/policies/authentication_state_policy_spec.rb
+++ b/spec/policies/authentication_state_policy_spec.rb
@@ -1,6 +1,6 @@
 describe AuthenticationStatePolicy do
   let(:session_state) do
-    {'user_id' => user_id, 'original_user_id' => original_user_id, 'lti_authenticated_only' => lti_authenticated_only}
+    {'user_id' => user_id, SessionKey.original_user_id => original_user_id, 'lti_authenticated_only' => lti_authenticated_only}
   end
   let(:original_user_id) {nil}
   let(:lti_authenticated_only) {nil}

--- a/spec/policies/authentication_state_spec.rb
+++ b/spec/policies/authentication_state_spec.rb
@@ -11,21 +11,21 @@ describe AuthenticationState do
     context 'when viewing as' do
       let(:fake_session) {{
         'user_id' => random_id,
-        'original_user_id' => random_id
+        SessionKey.original_user_id => random_id
       }}
       it {should be false}
     end
     context 'when delegate viewing as' do
       let(:fake_session) {{
         'user_id' => random_id,
-        'original_delegate_user_id' => random_id
+        SessionKey.original_delegate_user_id => random_id
       }}
       it {should be false}
     end
     context 'when advisor viewing as' do
       let(:fake_session) {{
         'user_id' => random_id,
-        'original_advisor_user_id' => random_id
+        SessionKey.original_advisor_user_id => random_id
       }}
       it {should be false}
     end
@@ -54,9 +54,9 @@ describe AuthenticationState do
     context 'when viewing as' do
       let(:fake_session) {{
         'user_id' => random_id,
-        'original_user_id' => random_id
+        SessionKey.original_user_id => random_id
       }}
-      it {should eq fake_session['original_user_id']}
+      it {should eq fake_session[SessionKey.original_user_id]}
     end
     context 'when only authenticated from an external app' do
       let(:fake_session) {{
@@ -91,7 +91,7 @@ describe AuthenticationState do
     context 'when viewing as' do
       let(:fake_session) {{
         'user_id' => random_id,
-        'original_user_id' => random_id
+        SessionKey.original_user_id => random_id
       }}
       it {should be true}
     end
@@ -123,7 +123,7 @@ describe AuthenticationState do
       let(:user_id) { random_id }
       let(:fake_session) {{
         'user_id' => user_id,
-        'original_advisor_user_id' => random_id
+        SessionKey.original_advisor_user_id => random_id
       }}
       it 'should get student of advisor user' do
         expect(subject).to be_authenticated_as_advisor


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-15421

This is a prelude to cache-key management scheme involving auth-state. There are many files touched but most are specs. No major refactoring, just formalizing session keys.