### PR TITLE
SISRP-13245 Adapt legacy Bearfacts data to GL5 academic profile design

### DIFF
--- a/app/models/my_badges/student_info.rb
+++ b/app/models/my_badges/student_info.rb
@@ -11,7 +11,7 @@ module MyBadges
       campus_attributes = CampusOracle::UserAttributes.new(user_id: @uid).get_feed
       result = {
         californiaResidency: campus_attributes[:california_residency],
-        isLawStudent: law_student,
+        isLawStudent: law_student?,
         regBlock: get_reg_blocks
       }
       if campus_attributes[:reg_status] && campus_attributes[:reg_status][:transitionTerm]
@@ -42,17 +42,13 @@ module MyBadges
       end
     end
 
-    # Set isLawStudent to true iff user's only college is School of Law
-    def law_student
-      college_feed = {}
-      MyAcademics::CollegeAndLevel.new(@uid).merge(college_feed)
-      if !(college_feed.empty? || college_feed[:empty])
-        colleges = college_feed[:collegeAndLevel][:colleges]
-        if !colleges.nil?
-          return colleges[0][:college].eql? "School of Law"
-        end
+    # True if user's first college is the School of Law.
+    def law_student?
+      if (college_feed = MyAcademics::CollegeAndLevel.new(@uid).merge({})) && college_feed[:majors].present?
+        college_feed[:majors].first[:college] == Berkeley::Departments.get('CLLAW')
+      else
+        false
       end
-      return false
     end
 
     def get_reg_blocks

--- a/public/dummy/json/academics.json
+++ b/public/dummy/json/academics.json
@@ -14,18 +14,20 @@
     }
   ],
   "collegeAndLevel": {
-    "colleges": [
+    "careers": [
+      "Undergraduate"
+    ],
+    "empty": false,
+    "errored": false,
+    "level": "Senior",
+    "majors": [
       {
         "college": "ENGR",
         "major": "Civil Engineering"
       }
     ],
-    "empty": false,
-    "errored": false,
-    "level": "Senior",
     "nonApLevel": "Junior",
     "noStudentId": false,
-    "standing": "Undergraduate",
     "termName": "Fall 2013"
   },
   "gpaUnits": {

--- a/public/dummy/json/academics_transition_future_profile.json
+++ b/public/dummy/json/academics_transition_future_profile.json
@@ -1,17 +1,19 @@
 {
   "collegeAndLevel": {
-    "colleges": [
+    "careers": [
+      "Undergraduate"
+    ],
+    "empty": false,
+    "errored": false,
+    "level": "Senior",
+    "majors": [
       {
         "college": "ENGR",
         "major": "Civil Engineering"
       }
     ],
-    "empty": false,
-    "errored": false,
-    "level": "Senior",
     "nonApLevel": "Junior",
     "noStudentId": false,
-    "standing": "Undergraduate",
     "termName": "Fall 2014"
   },
   "gpaUnits": {

--- a/public/dummy/json/academics_transition_past_profile_not_registered.json
+++ b/public/dummy/json/academics_transition_past_profile_not_registered.json
@@ -1,17 +1,19 @@
 {
   "collegeAndLevel": {
-    "colleges": [
+    "careers": [
+      "Undergraduate"
+    ],
+    "empty": false,
+    "errored": false,
+    "level": "Senior",
+    "majors": [
       {
         "college": "ENGR",
         "major": "Civil Engineering"
       }
     ],
-    "empty": false,
-    "errored": false,
-    "level": "Senior",
     "nonApLevel": "Junior",
     "noStudentId": false,
-    "standing": "Undergraduate",
     "termName": "Fall 2013"
   },
   "gpaUnits": {

--- a/public/dummy/json/academics_transition_past_profile_registered.json
+++ b/public/dummy/json/academics_transition_past_profile_registered.json
@@ -1,17 +1,19 @@
 {
   "collegeAndLevel": {
-    "colleges": [
+    "careers": [
+      "Undergraduate"
+    ],
+    "empty": false,
+    "errored": false,
+    "level": "Senior",
+    "majors": [
       {
         "college": "ENGR",
         "major": "Civil Engineering"
       }
     ],
-    "empty": false,
-    "errored": false,
-    "level": "Senior",
     "nonApLevel": "Junior",
     "noStudentId": false,
-    "standing": "Undergraduate",
     "termName": "Fall 2013"
   },
   "gpaUnits": {

--- a/spec/models/my_academics/college_and_level_spec.rb
+++ b/spec/models/my_academics/college_and_level_spec.rb
@@ -11,16 +11,18 @@ describe 'MyAcademics::CollegeAndLevel' do
       expect(feed).not_to be_empty
     end
 
-    let(:colleges) { feed[:collegeAndLevel][:colleges] }
+    let(:majors) { feed[:collegeAndLevel][:majors] }
 
     it 'should get properly formatted data from fake Bearfacts' do
-      expect(colleges).to have(1).items
-      expect(colleges.first).to include(
+      expect(majors).to have(1).items
+      expect(majors.first).to include(
         college: 'College of Letters & Science',
         major: 'Statistics'
       )
       expect(feed[:collegeAndLevel]).to include(
-        standing: 'Undergraduate',
+        careers: [
+          'Undergraduate'
+        ],
         termName: 'Fall 2015'
       )
     end
@@ -28,12 +30,12 @@ describe 'MyAcademics::CollegeAndLevel' do
     context 'enrollment in multiple colleges' do
       let(:uid) { '300940' }
       it 'should return multiple colleges and majors' do
-        expect(colleges).to have(2).items
-        expect(colleges[0]).to include(
+        expect(majors).to have(2).items
+        expect(majors[0]).to include(
           college: 'College of Natural Resources',
           major: 'Conservation And Resource Studies'
         )
-        expect(colleges[1]).to include(
+        expect(majors[1]).to include(
           college: 'College of Environmental Design',
           major: 'Landscape Architecture'
         )
@@ -43,16 +45,16 @@ describe 'MyAcademics::CollegeAndLevel' do
     context 'a concurrent enrollment triple major' do
       let(:uid) { '212379' }
       it 'should return even more colleges and majors' do
-        expect(colleges).to have(3).items
-        expect(colleges[0]).to include(
+        expect(majors).to have(3).items
+        expect(majors[0]).to include(
           college: 'College of Chemistry',
           major: 'Chemistry'
         )
-        expect(colleges[1]).to include(
+        expect(majors[1]).to include(
           college: 'College of Letters & Science',
           major: 'Applied Mathematics'
         )
-        expect(colleges[2]).to include(
+        expect(majors[2]).to include(
           college: '',
           major: 'Physics'
         )
@@ -62,12 +64,12 @@ describe 'MyAcademics::CollegeAndLevel' do
     context 'a double law major' do
       let(:uid) { '212381' }
       it 'should return the law in all its aspects' do
-        expect(colleges).to have(2).items
-        expect(colleges[0]).to include(
+        expect(majors).to have(2).items
+        expect(majors[0]).to include(
           college: 'School of Law',
           major: 'Jurisprudence And Social Policy'
         )
-        expect(colleges[1]).to include(
+        expect(majors[1]).to include(
           college: '',
           major: 'Law'
         )

--- a/src/assets/javascripts/angular/controllers/pages/academicsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicsController.js
@@ -1,6 +1,7 @@
 /* jshint camelcase: false */
 'use strict';
 
+var _ = require('lodash');
 var angular = require('angular');
 
 /**
@@ -129,9 +130,9 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
     }
 
     $scope.isLSStudent = academicsService.isLSStudent($scope.collegeAndLevel);
-    $scope.isUndergraduate = ($scope.collegeAndLevel && $scope.collegeAndLevel.standing === 'Undergraduate');
+    $scope.isUndergraduate = _.contains(_.get($scope.collegeAndLevel, 'careers'), 'Undergraduate');
     $scope.isProfileCurrent = !$scope.transitionTerm || $scope.transitionTerm.isProfileCurrent;
-    $scope.showProfileMessage = (!$scope.isProfileCurrent || !$scope.collegeAndLevel || !$scope.collegeAndLevel.standing);
+    $scope.showProfileMessage = (!$scope.isProfileCurrent || !$scope.collegeAndLevel || _.isEmpty($scope.collegeAndLevel.careers));
 
     $scope.hasTeachingClasses = academicsService.hasTeachingClasses(data.teachingSemesters);
     if (data.teachingSemesters) {

--- a/src/assets/javascripts/angular/services/academicsService.js
+++ b/src/assets/javascripts/angular/services/academicsService.js
@@ -1,6 +1,7 @@
 /* jshint camelcase: false */
 'use strict';
 
+var _ = require('lodash');
 var angular = require('angular');
 
 angular.module('calcentral.services').service('academicsService', function() {
@@ -153,14 +154,13 @@ angular.module('calcentral.services').service('academicsService', function() {
   };
 
   var isLSStudent = function(collegeAndLevel) {
-    if (!collegeAndLevel || !collegeAndLevel.colleges) {
-      return false;
-    }
-
-    for (var i = 0; i < collegeAndLevel.colleges.length; i++) {
-      if (collegeAndLevel.colleges[i].college === 'College of Letters & Science') {
-        return true;
-      }
+    var majors = _.get(collegeAndLevel, 'majors');
+    var minors = _.get(collegeAndLevel, 'minors');
+    var isLSCollege = function(career) {
+      return career.college === 'College of Letters & Science';
+    };
+    if ((majors && _.find(majors, isLSCollege)) || (minors && _.find(minors, isLSCollege))) {
+      return true;
     }
   };
 

--- a/src/assets/stylesheets/_profile.scss
+++ b/src/assets/stylesheets/_profile.scss
@@ -10,14 +10,11 @@
     padding: 0 10px 10px 0;
   }
   .cc-widget-profile-content {
-    margin-left: 87px;
+    margin-left: 92px;
     padding-bottom: 10px;
   }
   .cc-widget-profile-content-fullname {
     font-size: 16px;
-  }
-  .cc-widget-profile-content-gpa {
-    padding: 18px 0 0;
   }
   .cc-widget-profile-picture-not-available {
     background: $cc-color-shadow-color;

--- a/src/assets/templates/academics_student_profile.html
+++ b/src/assets/templates/academics_student_profile.html
@@ -5,7 +5,9 @@
   <div data-ng-if="showProfileMessage" class="cc-widget-profile-message">
     <div data-ng-if="collegeAndLevel.errored">
       There was a problem reaching campus services.
-      Please try again later, or check <a href="https://sis.berkeley.edu/bearfacts/student/studentMain.do?bfaction=welcome">Bear Facts</a>.
+      <span data-ng-if="!api.user.profile.isCampusSolutionsStudent">
+        Please try again later, or check <a href="https://sis.berkeley.edu/bearfacts/student/studentMain.do?bfaction=welcome">Bear Facts</a>.
+      </span>
     </div>
     <div data-ng-if="!collegeAndLevel.errored">
       <div data-ng-if="api.user.profile.roles.concurrentEnrollmentStudent">
@@ -26,9 +28,11 @@
       <div data-ng-if="api.user.profile.roles.student && !api.user.profile.roles.concurrentEnrollmentStudent">
         <div data-ng-if="!isProfileCurrent">
           <div data-ng-if="transitionTerm.registered" class="cc-widget-profile-message-text">
-            You are registered for the <span data-ng-bind="transitionTerm.termName"></span> term, but complete profile information is not available. Please check
-            <a href="https://sis.berkeley.edu/bearfacts/student/studentMain.do?bfaction=welcome">Bear Facts</a>
-            for the most current information.
+            You are registered for the <span data-ng-bind="transitionTerm.termName"></span> term, but complete profile information is not available.
+            <span data-ng-if="!api.user.profile.isCampusSolutionsStudent">
+              Please check <a href="https://sis.berkeley.edu/bearfacts/student/studentMain.do?bfaction=welcome">Bear Facts</a>
+              for the most current information.
+            </span>
           </div>
           <div data-ng-if="!transitionTerm.registered" class="cc-widget-profile-message-text">
             You are not officially registered for the <span data-ng-bind="transitionTerm.termName"></span> term.
@@ -36,14 +40,18 @@
         </div>
         <div data-ng-if="!transitionTerm">
           <div data-ng-if="api.user.profile.roles.registered" class="cc-widget-profile-message-text">
-            You are registered as a student, but complete profile information is not available. Please check
-            <a href="https://sis.berkeley.edu/bearfacts/student/studentMain.do?bfaction=welcome">Bear Facts</a>
-            for the most current information.
+            You are registered as a student, but complete profile information is not available.
+            <span data-ng-if="!api.user.profile.isCampusSolutionsStudent">
+              Please check <a href="https://sis.berkeley.edu/bearfacts/student/studentMain.do?bfaction=welcome">Bear Facts</a>
+              for the most current information.
+            </span>
           </div>
           <div data-ng-if="!api.user.profile.roles.registered" class="cc-widget-profile-message-text">
-            You are not registered as a student for the <span data-ng-bind="collegeAndLevel.termName"></span> term. Please
-            check <a href="https://sis.berkeley.edu/bearfacts/student/studentMain.do?bfaction=welcome">Bear Facts</a>
-            for information on other terms.
+            You are not registered as a student for the <span data-ng-bind="collegeAndLevel.termName"></span> term.
+            <span data-ng-if="!api.user.profile.isCampusSolutionsStudent">
+              Please check <a href="https://sis.berkeley.edu/bearfacts/student/studentMain.do?bfaction=welcome">Bear Facts</a>
+              for information on other terms.
+            </span>
           </div>
         </div>
         <div class="cc-academics-nocontent-container" data-ng-if="!isAcademicInfoAvailable">
@@ -87,46 +95,48 @@
       <div class="cc-widget-profile-content-fullname">
         <strong data-ng-bind="api.user.profile.fullName"></strong>
       </div>
-
-      <div class="cc-widget-profile-content-gpa" data-ng-if="gpaUnits.cumulativeGpa !== null && gpaUnits.cumulativeGpa > 0 && !studentInfo.isLawStudent">
-        <button class="cc-button-link" data-ng-click="academics.showGPA = true" data-ng-show="!academics.showGPA">Show GPA</button>
-        <div data-ng-show="academics.showGPA">
-          <span data-ng-bind="gpaUnits.cumulativeGpaFloat"></span> GPA
-          (<button class="cc-button-link" data-ng-click="academics.showGPA = false">Hide</button>)
-        </div>
-      </div>
-
-      <div data-ng-repeat="college in collegeAndLevel.colleges">
-        <div class="cc-text-light" data-ng-if="college.college" data-ng-bind="college.college"></div>
-        <div data-ng-bind="college.major"></div>
-      </div>
     </div>
 
-    <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="collegeAndLevel.standing || gpaUnits.totalUnits">
+    <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="collegeAndLevel.majors.length">
       <table>
-        <thead data-ng-if="collegeAndLevel.standing">
+        <tbody>
           <tr>
-            <th width="87px">General</th>
-            <th class="cc-table-subheader" scope="col">Standing</th>
-          </tr>
-        </thead>
-        <tbody data-ng-if="collegeAndLevel.standing">
-          <tr>
-            <td></td>
-            <td><strong data-ng-bind="collegeAndLevel.standing"></strong></td>
+            <th width="92px" data-ng-pluralize count="collegeAndLevel.majors.length" when="{'1': 'Major', 'other': 'Majors'}"></th>
+            <td>
+              <div data-ng-repeat="major in collegeAndLevel.majors">
+                <div class="cc-text-light" data-ng-if="major.college" data-ng-bind="major.college"></div>
+                <div><strong data-ng-bind="major.major"></strong></div>
+              </div>
+            </td>
           </tr>
         </tbody>
-        <thead data-ng-if="gpaUnits.totalUnits !== null">
+      </table>
+    </div>
+
+    <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="collegeAndLevel.minors.length">
+      <table>
+        <tbody>
           <tr>
-            <th width="87px" data-ng-if="!collegeAndLevel.standing">General</th>
-            <th data-ng-if="collegeAndLevel.standing"></th>
-            <th class="cc-table-subheader" scope="col">Units</th>
+            <th width="92px" data-ng-pluralize count="collegeAndLevel.minors.length" when="{'1': 'Minor', 'other': 'Minors'}"></th>
+            <td>
+              <div data-ng-repeat="minor in collegeAndLevel.minors">
+                <div class="cc-text-light" data-ng-if="minor.college" data-ng-bind="minor.college"></div>
+                <div><strong data-ng-bind="minor.minor"></strong></div>
+              </div>
+            </td>
           </tr>
-        </thead>
-        <tbody data-ng-if="gpaUnits.totalUnits !== null">
+        </tbody>
+      </table>
+    </div>
+
+    <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="collegeAndLevel.careers.length">
+      <table>
+        <tbody>
           <tr>
-            <td></td>
-            <td><strong data-ng-bind="gpaUnits.totalUnits"></strong></td>
+            <th width="92px" data-ng-pluralize count="collegeAndLevel.careers.length" when="{'1': 'Academic Career', 'other': 'Academic Careers'}"></th>
+            <td>
+              <div data-ng-repeat="career in collegeAndLevel.careers"><strong data-ng-bind="career"></strong></div>
+            </td>
           </tr>
         </tbody>
       </table>
@@ -134,29 +144,21 @@
 
     <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="collegeAndLevel.level">
       <table>
-        <thead>
-          <tr>
-            <th width="87px">Level</th>
-            <th class="cc-table-subheader" scope="col">
-              <span data-ng-if="isUndergraduate">Including AP</span>
-              <span data-ng-if="!isUndergraduate">Current</span>
-            </th>
-          </tr>
-        </thead>
         <tbody>
           <tr>
+            <th width="92px">Level</th>
+            <th class="cc-table-subheader" scope="col" data-ng-if="collegeAndLevel.nonApLevel">Including AP</th>
+            <td data-ng-if="!collegeAndLevel.nonApLevel"><strong data-ng-bind="collegeAndLevel.level"></strong></td>
+          </tr>
+          <tr data-ng-if="collegeAndLevel.nonApLevel">
             <td></td>
             <td><strong data-ng-bind="collegeAndLevel.level"></strong></td>
           </tr>
-        </tbody>
-        <thead data-ng-if="isUndergraduate">
-          <tr>
+          <tr data-ng-if="collegeAndLevel.nonApLevel">
             <th></th>
             <th class="cc-table-subheader" scope="col">Not Including AP</th>
           </tr>
-        </thead>
-        <tbody data-ng-if="isUndergraduate">
-          <tr>
+          <tr data-ng-if="collegeAndLevel.nonApLevel">
             <td></td>
             <td><strong data-ng-bind="collegeAndLevel.nonApLevel"></strong></td>
           </tr>
@@ -164,34 +166,33 @@
       </table>
     </div>
 
-    <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="api.user.profile.uid || api.user.profile.sid">
+    <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="gpaUnits.totalUnits !== null">
       <table>
-        <thead>
-          <tr>
-            <th width="87px">ID Number</th>
-            <th class="cc-table-subheader" scope="col">UID</th>
-          </tr>
-        </thead>
         <tbody>
           <tr>
-            <td></td>
-            <td><strong data-ng-bind="api.user.profile.uid"></strong></td>
-          </tr>
-        </tbody>
-        <thead data-ng-if="api.user.profile.sid">
-          <tr>
-            <th></th>
-            <th class="cc-table-subheader" scope="col">Student ID</th>
-          </tr>
-        </thead>
-        <tbody data-ng-if="api.user.profile.sid">
-          <tr>
-            <td></td>
-            <td><strong data-ng-bind="api.user.profile.sid"></strong></td>
+            <th width="92px">Earned Units</th>
+            <td><strong data-ng-bind="gpaUnits.totalUnits"></strong></td>
           </tr>
         </tbody>
       </table>
     </div>
+
+    <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="gpaUnits.cumulativeGpa !== null && gpaUnits.cumulativeGpa > 0 && !studentInfo.isLawStudent">
+      <table>
+        <tbody>
+          <tr>
+            <th width="92px">GPA</th>
+            <td>
+              <button class="cc-button-link" data-ng-click="academics.showGPA = true" data-ng-show="!academics.showGPA">Show GPA</button>
+              <div data-ng-show="academics.showGPA">
+                <span data-ng-bind="gpaUnits.cumulativeGpaFloat"></span> GPA
+                (<button class="cc-button-link" data-ng-click="academics.showGPA = false">Hide</button>)
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
+
   </div>
 </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-13245
JIRA with designs: https://jira.berkeley.edu/browse/SISRP-11939

While waiting for the Hub to finalize its academic status endpoint, we can go ahead and adapt our legacy academics feed to the GL5 academic profile design.
- All users, new and old, get the new design from the JIRA, _except_ that continuing students will not lose the "Including AP / Not Including AP" distinction if relevant.
- Our incomplete-profile messaging remains, but users with 10-digit Campus Solutions IDs will not be directed to Bearfacts.
- The back end replaces its concept of "standing" with possibly-plural "careers."
- "Colleges" becomes "majors," in order to make room for the "minors" data that our new source will provide. 