### PR TITLE
SISRP-15421, cache key generator to accomodate isolated view-as caches

### DIFF
--- a/app/controllers/act_as_controller.rb
+++ b/app/controllers/act_as_controller.rb
@@ -25,9 +25,8 @@ class ActAsController < ApplicationController
   def stop
     exiting_uid = session['user_id']
     return redirect_to root_path unless exiting_uid && session[@act_as_session_key]
-    # Cached user data might have been filtered during view-as session so we flush to reset.
+    # TODO: Can we eliminate the need for this cache-expiry via smarter cache-key scheme? E.g., Cache::KeyGenerator
     Cache::UserCacheExpiry.notify exiting_uid
-    CampusSolutions::UserApiExpiry.expire exiting_uid
     logger.warn "Stop: #{session[@act_as_session_key]} act as #{exiting_uid}"
     session['user_id'] = session[@act_as_session_key]
     session[@act_as_session_key] = nil

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -123,10 +123,7 @@ class ApplicationController < ActionController::Base
   private
 
   def get_active_view_as_session_type
-    SessionKey::VIEW_AS_TYPES.each do |key|
-      return key if session.has_key? key
-    end
-    nil
+    SessionKey::VIEW_AS_TYPES.find { |key| session.has_key? key }
   end
 
   def get_original_viewer_uid

--- a/app/controllers/photo_controller.rb
+++ b/app/controllers/photo_controller.rb
@@ -3,10 +3,7 @@ class PhotoController < ApplicationController
   before_filter :api_authenticate_401
 
   def my_photo
-    unless current_user.authenticated_as_delegate?
-      photo_row = User::Photo.fetch(session['user_id'])
-    end
-    if photo_row
+    if (photo_row = User::Photo.fetch session['user_id'], session)
       data = photo_row['photo']
       send_data(
         data,

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -122,9 +122,8 @@ class SessionsController < ApplicationController
   def logout
     begin
       if (uid = session['user_id']) && get_original_viewer_uid
-        # Cached user data might have been filtered during view-as session so we flush to reset.
+        # TODO: Can we eliminate this cache-expiry in favor of smarter cache-key scheme? E.g., Cache::KeyGenerator
         Cache::UserCacheExpiry.notify uid
-        CampusSolutions::UserApiExpiry.expire uid
       end
       delete_reauth_cookie
       reset_session

--- a/app/models/cal1card/photo.rb
+++ b/app/models/cal1card/photo.rb
@@ -12,6 +12,10 @@ module Cal1card
       initialize_mocks if @fake
     end
 
+    def instance_key
+      Cache::KeyGenerator.per_view_as_type @uid, @options
+    end
+
     def get_feed_internal
       if Settings.features.cal1card
         get_photo

--- a/app/models/campus_solutions/user_api_expiry.rb
+++ b/app/models/campus_solutions/user_api_expiry.rb
@@ -2,7 +2,6 @@ module CampusSolutions
   module UserApiExpiry
     def self.expire(uid=nil)
       User::Api.expire uid
-      UserApiController.expire uid
     end
   end
 end

--- a/app/models/user/api.rb
+++ b/app/models/user/api.rb
@@ -29,6 +29,10 @@ module User
       @delegate_students = get_delegate_students
     end
 
+    def instance_key
+      Cache::KeyGenerator.per_view_as_type @uid, @options
+    end
+
     def get_delegate_students
       return nil unless is_cs_delegated_access_feature_enabled
       delegate_uid = authentication_state.original_delegate_user_id || @uid
@@ -219,7 +223,7 @@ module User
         canViewGrades: can_view_academics && (!delegate_view_as_privileges || delegate_view_as_privileges[:viewGrades]),
         hasFinancialsTab: has_financials_tab?(roles, delegate_view_as_privileges),
         hasToolboxTab: has_toolbox_tab?(current_user_policy, roles),
-        hasPhoto: User::Photo.has_photo?(@uid) && !authentication_state.original_delegate_user_id,
+        hasPhoto: !!User::Photo.fetch(@uid, @options),
         inEducationAbroadProgram: @oracle_attributes[:education_abroad],
         googleEmail: google_mail,
         canvasEmail: canvas_mail,

--- a/app/models/user/photo.rb
+++ b/app/models/user/photo.rb
@@ -2,14 +2,13 @@ module User
   class Photo
     extend Cache::Cacheable
 
-    def self.fetch(uid)
-      smart_fetch_from_cache({id: uid, user_message_on_exception: "Photo server unreachable"}) do
+    def self.fetch(uid, opts={})
+      # Delegate user is not allowed to see his/her student's photo due to privacy concern.
+      return nil if opts[SessionKey.original_delegate_user_id]
+      cache_key = Cache::KeyGenerator.per_view_as_type uid, opts
+      smart_fetch_from_cache({id: cache_key, user_message_on_exception: 'Photo server unreachable'}) do
         CampusOracle::Queries.get_photo(uid)
       end
-    end
-
-    def self.has_photo?(uid)
-      !!User::Photo.fetch(uid)
     end
 
   end

--- a/lib/cache/key_generator.rb
+++ b/lib/cache/key_generator.rb
@@ -1,0 +1,15 @@
+module Cache
+  module KeyGenerator
+
+    def self.per_view_as_type(default_key, opts={})
+      # View-as-UID:12345 cache should not be shared with standard UID:12345 cache thus the distinct keys.
+      (SessionKey::VIEW_AS_TYPES + SessionKey::CANVAS_MASQUERADE_TYPES).each do |view_as_type|
+        if opts[view_as_type]
+          return "#{default_key}/#{view_as_type}:#{opts[view_as_type]}"
+        end
+      end
+      default_key
+    end
+
+  end
+end

--- a/spec/controllers/photo_controller_spec.rb
+++ b/spec/controllers/photo_controller_spec.rb
@@ -34,8 +34,7 @@ describe PhotoController do
       it_should_behave_like 'a controller with a photo'
       context 'delegate view' do
         before do
-          allow_any_instance_of(AuthenticationState).to receive(:authenticated_as_delegate?).and_return true
-          allow_any_instance_of(AuthenticationState).to receive(:delegate_permissions).and_return({ privileges: { view_grades: true } })
+          session[SessionKey.original_delegate_user_id] = random_id
           allow(Settings.features).to receive(:cs_delegated_access).and_return true
         end
         it_should_behave_like 'a controller with no photo'

--- a/spec/lib/cache/key_generator_spec.rb
+++ b/spec/lib/cache/key_generator_spec.rb
@@ -1,0 +1,41 @@
+describe Cache::KeyGenerator do
+
+  it 'should return nil when provided cache_key is nil' do
+    expect(Cache::KeyGenerator.per_view_as_type nil).to be_nil
+  end
+
+  context 'generate key per view-as type' do
+    let(:cache_key) { random_id }
+    subject { Cache::KeyGenerator.per_view_as_type cache_key, session }
+
+    context 'directly authenticated' do
+      let(:session) { { 'foo' => random_id, 'baz' => random_id } }
+      it 'should not change cache key when there is no view-as marker' do
+        expect(subject).to eq cache_key
+      end
+    end
+
+    context 'view-as session' do
+      let(:viewer_uid) { random_id }
+      let(:session) { { 'foo' => random_id, session_key => viewer_uid, 'baz' => random_id } }
+
+      shared_examples 'view-as session with distinct cache key' do
+        it 'should customize cache key to include the name of view-as type' do
+          expect(subject).to include cache_key, session_key, viewer_uid
+        end
+      end
+      context 'masquerading in canvas' do
+        let(:session_key) { SessionKey.canvas_masquerading_user_id }
+        it_behaves_like 'view-as session with distinct cache key'
+      end
+      context 'super_user in view-as mode' do
+        let(:session_key) { SessionKey.original_user_id }
+        it_behaves_like 'view-as session with distinct cache key'
+      end
+      context 'advisor in view-as mode' do
+        let(:session_key) { SessionKey.original_advisor_user_id }
+        it_behaves_like 'view-as session with distinct cache key'
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-15421

Examples of caching gone wrong: 
* https://jira.berkeley.edu/browse/SISRP-15340 
* https://jira.berkeley.edu/browse/SISRP-15276

**Note:** custom cache keys will also happen when `canvas_masquerading_user_id` is present.

This PR is a partial undo of #4935 