### PR TITLE
SISRP-15608, handle delegate deletion during view-as session

### DIFF
--- a/app/controllers/act_as_controller.rb
+++ b/app/controllers/act_as_controller.rb
@@ -31,6 +31,7 @@ class ActAsController < ApplicationController
     session['user_id'] = session[@act_as_session_key]
     session[@act_as_session_key] = nil
 
+    after_successful_stop session
     render :nothing => true, :status => 204
   end
 
@@ -46,6 +47,10 @@ class ActAsController < ApplicationController
     uid_to_store = params['uid']
     User::StoredUsers.delete_recent_uid(original_uid, uid_to_store)
     User::StoredUsers.store_recent_uid(original_uid, uid_to_store)
+  end
+
+  def after_successful_stop(session)
+    # Sub-class might want custom cache management.
   end
 
   def valid_params?(act_as_uid)

--- a/app/controllers/delegate_act_as_controller.rb
+++ b/app/controllers/delegate_act_as_controller.rb
@@ -23,4 +23,8 @@ class DelegateActAsController < ActAsController
     # Do nothing
   end
 
+  def after_successful_stop(session)
+    CampusSolutions::DelegateStudentsExpiry.expire session['user_id']
+  end
+
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -124,6 +124,7 @@ class SessionsController < ApplicationController
       if (uid = session['user_id']) && get_original_viewer_uid
         # TODO: Can we eliminate this cache-expiry in favor of smarter cache-key scheme? E.g., Cache::KeyGenerator
         Cache::UserCacheExpiry.notify uid
+        CampusSolutions::DelegateStudentsExpiry.expire uid
       end
       delete_reauth_cookie
       reset_session


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-15608

Post-processing when view-as session ends. Same pattern as `after_successful_start`.