### PR TITLE
SISRP-13855 Use Cal1card proxy for user and roster photos

### DIFF
--- a/app/controllers/photo_controller.rb
+++ b/app/controllers/photo_controller.rb
@@ -3,8 +3,8 @@ class PhotoController < ApplicationController
   before_filter :api_authenticate_401
 
   def my_photo
-    if (photo_row = User::Photo.fetch session['user_id'], session)
-      data = photo_row['photo']
+    if (photo_feed = User::Photo.fetch session['user_id'], session)
+      data = photo_feed[:photo]
       send_data(
         data,
         type: 'image/jpeg',

--- a/app/models/campus_oracle/queries.rb
+++ b/app/models/campus_oracle/queries.rb
@@ -188,11 +188,8 @@ module CampusOracle
       use_pooled_connection {
         sql = <<-SQL
       select roster.student_ldap_uid ldap_uid, roster.enroll_status, trim(roster.pnp_flag) as pnp_flag,
-        trim(person.first_name) as first_name, trim(person.last_name) as last_name, person.student_email_address, person.student_id, person.affiliations,
-        ph.bytes photo_bytes
+        trim(person.first_name) as first_name, trim(person.last_name) as last_name, person.student_email_address, person.student_id, person.affiliations
       from calcentral_class_roster_vw roster, calcentral_student_info_vw person
-      left join  calcentral_student_photo_vw ph
-        on ph.student_ldap_uid = person.student_ldap_uid
       where roster.term_yr = #{term_yr.to_i}
         and roster.term_cd = #{connection.quote(term_cd)}
         and roster.course_cntl_num = #{ccn.to_i}
@@ -366,19 +363,6 @@ module CampusOracle
         order by bci.instructor_func
         SQL
         result = connection.select_all(sql)
-      }
-      stringify_ints! result
-    end
-
-    def self.get_photo(ldap_uid)
-      result = {}
-      use_pooled_connection {
-        sql = <<-SQL
-        select ph.bytes, ph.photo
-        from calcentral_student_photo_vw ph
-        where ph.student_ldap_uid=#{ldap_uid.to_i}
-        SQL
-        result = connection.select_one(sql)
       }
       stringify_ints! result
     end

--- a/app/models/rosters/campus.rb
+++ b/app/models/rosters/campus.rb
@@ -58,8 +58,7 @@ module Rosters
                 last_name: enr['last_name'],
                 email: enr['student_email_address'],
                 enroll_status: enr['enroll_status'],
-                section_ccns: [section[:ccn]],
-                photo_bytes: enr['photo_bytes']
+                section_ccns: [section[:ccn]]
               }
             end
           end
@@ -79,7 +78,7 @@ module Rosters
         campus_student[:section_ccns].each do |section_ccn|
           campus_student[:sections].push(sections_index[section_ccn])
         end
-        if campus_student[:enroll_status] == 'E' && campus_student[:photo_bytes]
+        if campus_student[:enroll_status] == 'E'
           campus_student[:photo] = "/campus/#{@campus_course_id}/photo/#{id}"
         end
         feed[:students] << campus_student

--- a/app/models/rosters/canvas.rb
+++ b/app/models/rosters/canvas.rb
@@ -45,7 +45,6 @@ module Rosters
               last_name: enr['last_name'],
               email: enr['student_email_address'],
               enroll_status: enr['enroll_status'],
-              photo_bytes: enr['photo_bytes'],
               sections: [{id: section_ccn}],
               section_ccns: [section_ccn]
             }
@@ -59,7 +58,7 @@ module Rosters
       campus_enrollment_map.each do |ldap_uid, campus_student|
         campus_student[:id] = ldap_uid
         campus_student[:login_id] = ldap_uid
-        if campus_student[:enroll_status] == 'E' && campus_student[:photo_bytes]
+        if campus_student[:enroll_status] == 'E'
           campus_student[:photo] = "/canvas/#{@canvas_course_id}/photo/#{ldap_uid}"
         end
 

--- a/app/models/rosters/common.rb
+++ b/app/models/rosters/common.rb
@@ -46,18 +46,14 @@ module Rosters
     end
 
     def photo_data_or_file(student_id)
-      roster = get_feed
-      return nil if roster.nil?
-      match = roster[:students].index { |stu| stu[:id].to_s == student_id.to_s }
-      if (match)
-        student = roster[:students][match]
-        if student[:enroll_status] == 'E'
-          if (photo_row = CampusOracle::Queries.get_photo(student[:login_id]))
-            return {
-              size: photo_row['bytes'],
-              data: photo_row['photo']
-            }
-          end
+      return nil unless roster = get_feed
+      if (student = roster[:students].find { |stu| stu[:id].to_s == student_id.to_s }) && student[:enroll_status] == 'E'
+        photo_feed = Cal1card::Photo.new(student[:login_id]).get_feed
+        if photo_feed[:photo]
+          {
+            size: photo_feed[:length],
+            data: photo_feed[:photo]
+          }
         end
       end
     end

--- a/app/models/user/photo.rb
+++ b/app/models/user/photo.rb
@@ -6,9 +6,10 @@ module User
       # Delegate user is not allowed to see his/her student's photo due to privacy concern.
       return nil if opts[SessionKey.original_delegate_user_id]
       cache_key = Cache::KeyGenerator.per_view_as_type uid, opts
-      smart_fetch_from_cache({id: cache_key, user_message_on_exception: 'Photo server unreachable'}) do
-        CampusOracle::Queries.get_photo(uid)
+      photo_feed = smart_fetch_from_cache({id: cache_key, user_message_on_exception: 'Photo server unreachable'}) do
+        Cal1card::Photo.new(uid).get_feed
       end
+      photo_feed[:photo] ? photo_feed : nil
     end
 
   end

--- a/spec/controllers/photo_controller_spec.rb
+++ b/spec/controllers/photo_controller_spec.rb
@@ -5,7 +5,7 @@ describe PhotoController do
   context 'when a user is authenticated' do
     before do
       session['user_id'] = random_id
-      allow(CampusOracle::Queries).to receive(:get_photo).and_return(test_photo_object)
+      allow_any_instance_of(Cal1card::Photo).to receive(:get_feed).and_return(test_photo_object)
     end
 
     shared_examples 'a controller with no photo' do
@@ -25,12 +25,12 @@ describe PhotoController do
     end
 
     context 'when user has no photo' do
-      let(:test_photo_object) { nil }
+      let(:test_photo_object) { {} }
       it_should_behave_like 'a controller with no photo'
     end
 
     context 'when user has photo' do
-      let(:test_photo_object) { {'photo' => 'photo_binary_content'} }
+      let(:test_photo_object) { {photo: 'photo_binary_content'} }
       it_should_behave_like 'a controller with a photo'
       context 'delegate view' do
         before do

--- a/spec/models/rosters/canvas_spec.rb
+++ b/spec/models/rosters/canvas_spec.rb
@@ -179,14 +179,12 @@ describe Rosters::Canvas do
           {
             'ldap_uid' => enrolled_student_login_id,
             'enroll_status' => 'E',
-            'student_id' => enrolled_student_student_id,
-            'photo_bytes' => '8203.0'
+            'student_id' => enrolled_student_student_id
           },
           {
             'ldap_uid' => waitlisted_student_login_id,
             'enroll_status' => 'W',
-            'student_id' => waitlisted_student_student_id,
-            'photo_bytes' => '7834.1'
+            'student_id' => waitlisted_student_student_id
           }
         ]
       )
@@ -195,14 +193,12 @@ describe Rosters::Canvas do
           {
             'ldap_uid' => enrolled_student_login_id,
             'enroll_status' => 'W',
-            'student_id' => enrolled_student_student_id,
-            'photo_bytes' => '8203.0'
+            'student_id' => enrolled_student_student_id
           },
           {
             'ldap_uid' => waitlisted_student_login_id,
             'enroll_status' => 'W',
-            'student_id' => waitlisted_student_student_id,
-            'photo_bytes' => '7834.1'
+            'student_id' => waitlisted_student_student_id
           }
         ]
       )
@@ -239,22 +235,20 @@ describe Rosters::Canvas do
           {
             'ldap_uid' => enrolled_student_login_id,
             'enroll_status' => 'E',
-            'student_id' => enrolled_student_student_id,
-            'photo_bytes' => '8203.0'
+            'student_id' => enrolled_student_student_id
           },
           {
             'ldap_uid' => waitlisted_student_login_id,
             'enroll_status' => 'W',
-            'student_id' => waitlisted_student_student_id,
-            'photo_bytes' => '7834.1'
+            'student_id' => waitlisted_student_student_id
           }
         ]
       )
       photo_data = rand(99999999)
-      allow(CampusOracle::Queries).to receive(:get_photo).with(enrolled_student_login_id).and_return(
+      allow_any_instance_of(Cal1card::Photo).to receive(:get_feed).and_return(
         {
-          'bytes' => 42,
-          'photo' => photo_data
+          length: 42,
+          photo: photo_data
         }
       )
       enrolled_photo = subject.photo_data_or_file(enrolled_student_login_id)

--- a/spec/models/rosters/common_spec.rb
+++ b/spec/models/rosters/common_spec.rb
@@ -25,7 +25,6 @@ describe Rosters::Common do
             {:ccn => section_id_one, :name => 'COMPSCI 9G SLF 001'}
           ],
           :photo => '/canvas/1/photo/9016',
-          :photo_bytes => '8203.0',
           :profile_url => 'http://example.com/courses/733/users/9016',
         },
         {
@@ -41,7 +40,6 @@ describe Rosters::Common do
             {:ccn => section_id_two, :name => 'COMPSCI 9G SLF 002'}
           ],
           :photo => '/canvas/1/photo/9017',
-          :photo_bytes => '9203.1',
           :profile_url => 'http://example.com/courses/733/users/9017',
         },
         {
@@ -56,7 +54,6 @@ describe Rosters::Common do
             {:ccn => section_id_three, :name => 'COMPSCI 9G SLF 003'}
           ],
           :photo => '/canvas/1/photo/9018',
-          :photo_bytes => '7802.0',
           :profile_url => 'http://example.com/courses/733/users/9018',
         },
       ]

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -79,6 +79,10 @@ describe User::Api do
       }
       User::Api.from_session(session).get_feed
     }
+    before do
+      allow(Cal1card::Photo).to receive(:new).and_call_original
+      allow(Cal1card::Photo).to receive(:new).with(uid).and_return double(get_feed: {})
+    end
     context 'has no students' do
       context 'never nominated as delegate' do
         let(:response) { nil }

--- a/src/assets/javascripts/angular/directives/loadErrorDirective.js
+++ b/src/assets/javascripts/angular/directives/loadErrorDirective.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var angular = require('angular');
+
+angular.module('calcentral.directives').directive('ccLoadErrorDirective', function() {
+  return {
+    link: function(scope, elm, attrs) {
+      elm.bind('error', function() {
+        scope.$apply(function() {
+          scope[attrs.ccLoadErrorDirective].loadError = true;
+        });
+      });
+    }
+  };
+});

--- a/src/assets/templates/widgets/roster_photo.html
+++ b/src/assets/templates/widgets/roster_photo.html
@@ -1,4 +1,4 @@
-<img data-ng-if="student.photo" data-ng-src="{{student.photo}}" width="72" height="96" data-ng-attr-alt="Photo of {{student.first_name}} {{student.last_name}}"/>
-<div data-ng-if="!student.photo" class="cc-image-responsive cc-page-roster-image-unavailable" title="Photo unavailable">
+<img data-cc-load-error-directive="student" data-ng-if="student.photo && !student.loadError" data-ng-src="{{student.photo}}" width="72" height="96" data-ng-attr-alt="Photo of {{student.first_name}} {{student.last_name}}"/>
+<div data-ng-if="!student.photo || student.loadError" class="cc-image-responsive cc-page-roster-image-unavailable" title="Photo unavailable">
   <span class="cc-visuallyhidden">No Official Photo is Available</span>
 </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-13855

Moving away from database photo queries loses us the ability to check (via photo_bytes join) whether a photo exists for a given student before trying to fetch it. An Angular directive now swaps in the "photo unavailable" image in the event of a load error.