### PR TITLE
SISRP-15732 - Fixes references to Pundit::NotAuthorizedError exception class

### DIFF
--- a/app/controllers/advisor_act_as_controller.rb
+++ b/app/controllers/advisor_act_as_controller.rb
@@ -12,9 +12,9 @@ class AdvisorActAsController < ActAsController
       user_id = current_user.real_user_id
       user_attributes = HubEdos::UserAttributes.new(user_id: user_id).get
       authorized = user_attributes && user_attributes[:roles] && user_attributes[:roles][:advisor]
-      raise NotAuthorizedError.new("User #{user_id} is not an Advisor and thus cannot view-as #{uid_param}") unless authorized
+      raise Pundit::NotAuthorizedError.new("User #{user_id} is not an Advisor and thus cannot view-as #{uid_param}") unless authorized
     else
-      raise NotAuthorizedError.new 'We cannot confirm your role as an Advisor because Campus Solutions is unavailable. Please contact us if the problem persists.'
+      raise Pundit::NotAuthorizedError.new 'We cannot confirm your role as an Advisor because Campus Solutions is unavailable. Please contact us if the problem persists.'
     end
   end
 end

--- a/app/controllers/delegate_act_as_controller.rb
+++ b/app/controllers/delegate_act_as_controller.rb
@@ -12,10 +12,10 @@ class DelegateActAsController < ActAsController
     if response[:feed] && (students = response[:feed][:students])
       student = students.detect { |s| uid_param == s[:uid] }
       authorized = student && [:financial, :viewEnrollments, :viewGrades].any? { |k| student[:privileges][k] }
-      raise NotAuthorizedError.new("User #{acting_user_id} is unauthorized to delegate-view-as student: #{student.as_json}") unless authorized
+      raise Pundit::NotAuthorizedError.new("User #{acting_user_id} is unauthorized to delegate-view-as student: #{student.as_json}") unless authorized
       logger.warn "User #{acting_user_id} is authorized to delegate-view-as #{uid_param} with privileges: #{student[:privileges]}"
     else
-      raise NotAuthorizedError.new "User #{acting_user_id} does not have delegate affiliation"
+      raise Pundit::NotAuthorizedError.new "User #{acting_user_id} does not have delegate affiliation"
     end
   end
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-15732

Related to #4807

References to NotAuthorizedError were invalid, and thus won't result in the empty 403 response we're wanting.
```
>> NotAuthorizedError
NameError: uninitialized constant NotAuthorizedError
>> Pundit::NotAuthorizedError
=> Pundit::NotAuthorizedError
```

This wasn't caught because the class constant isn't called when the conditional doesn't apply
```
>> raise MyMadeUpException if 1 == 0
=> nil
>> raise MyMadeUpException if 1 == 1
NameError: uninitialized constant MyMadeUpException
>> AnotherMadeUpconstant.do_something if 1 == 0
=> nil
```
