### PR TITLE
SISRP-15682, filter /api/edos/ feeds per view-as type

### DIFF
--- a/app/controllers/hub_edo_controller.rb
+++ b/app/controllers/hub_edo_controller.rb
@@ -2,15 +2,28 @@ class HubEdoController < ApplicationController
   before_filter :api_authenticate_401
 
   def student
-    json_passthrough HubEdos::MyStudent
+    options = case
+                when current_user.authenticated_as_delegate?
+                  { include_fields: %w(affiliations identifiers) }
+                when current_user.authenticated_as_advisor?
+                  { include_fields: %w(addresses affiliations emails emergencyContacts identifiers names phones urls) }
+                else
+                  # Rely on the defaults per proxy class
+                  {}
+              end
+    json_passthrough HubEdos::MyStudent, options
   end
 
   def work_experience
+    # Delegates get an empty feed.
+    return {
+      'filteredForDelegate' => true
+    } if current_user.authenticated_as_delegate?
     json_passthrough HubEdos::MyWorkExperience
   end
 
-  def json_passthrough(classname)
-    model = classname.from_session session
+  def json_passthrough(classname, options={})
+    model = classname.from_session session, options
     render json: model.get_feed_as_json
   end
 

--- a/app/models/hub_edos/contacts.rb
+++ b/app/models/hub_edos/contacts.rb
@@ -3,6 +3,8 @@ module HubEdos
 
     def initialize(options = {})
       super(options)
+      @include_fields = options[:include_fields] || %w(identifiers names addresses phones emails urls emergencyContacts confidential)
+      @instance_key = Cache::KeyGenerator.per_view_as_type @uid, options
     end
 
     def url
@@ -14,7 +16,11 @@ module HubEdos
     end
 
     def include_fields
-      %w(identifiers names addresses phones emails urls emergencyContacts confidential)
+      @include_fields
+    end
+
+    def instance_key
+      @instance_key
     end
 
   end

--- a/app/models/hub_edos/demographics.rb
+++ b/app/models/hub_edos/demographics.rb
@@ -3,6 +3,8 @@ module HubEdos
 
     def initialize(options = {})
       super(options)
+      @include_fields = options[:include_fields] || %w(ethnicities languages usaCountry foreignCountries birth gender)
+      @instance_key = Cache::KeyGenerator.per_view_as_type @uid, options
     end
 
     def url
@@ -14,7 +16,11 @@ module HubEdos
     end
 
     def include_fields
-      %w(ethnicities languages usaCountry foreignCountries birth gender)
+      @include_fields
+    end
+
+    def instance_key
+      @instance_key
     end
 
   end

--- a/app/models/hub_edos/my_student.rb
+++ b/app/models/hub_edos/my_student.rb
@@ -16,8 +16,9 @@ module HubEdos
       }
       return merged unless is_cs_profile_feature_enabled
 
+      proxy_options = @options.merge user_id: @uid
       [HubEdos::Contacts, HubEdos::Demographics, HubEdos::Affiliations].each do |proxy|
-        hub_response = proxy.new({user_id: @uid}).get
+        hub_response = proxy.new(proxy_options).get
         if hub_response[:errored]
           merged[:statusCode] = 500
           merged[:errored] = true
@@ -35,6 +36,10 @@ module HubEdos
       end
 
       merged
+    end
+
+    def instance_key
+      Cache::KeyGenerator.per_view_as_type @uid, @options
     end
 
   end

--- a/app/models/user_specific_model.rb
+++ b/app/models/user_specific_model.rb
@@ -3,10 +3,8 @@ class UserSpecificModel
   include ClassLogger
   attr_reader :authentication_state
 
-  def self.from_session(session_state)
-    view_as_related = Hash[SessionKey::VIEW_AS_TYPES.collect { |k| [k, session_state[k]] }]
-    filtered_session = {'lti_authenticated_only' => session_state['lti_authenticated_only'] }.merge view_as_related
-    self.new(session_state['user_id'], filtered_session)
+  def self.from_session(session_state, options={})
+    self.new session_state['user_id'], options.merge(filtered session_state)
   end
 
   def initialize(uid, options={})
@@ -21,6 +19,11 @@ class UserSpecificModel
 
   def directly_authenticated?
     @authentication_state.directly_authenticated?
+  end
+
+  def self.filtered(session={})
+    view_as_related = Hash[SessionKey::VIEW_AS_TYPES.collect { |k| [k, session[k]] }]
+    {'lti_authenticated_only' => session['lti_authenticated_only'] }.merge view_as_related
   end
 
 end

--- a/spec/controllers/hub_edo_controller_spec.rb
+++ b/spec/controllers/hub_edo_controller_spec.rb
@@ -2,13 +2,27 @@ describe HubEdoController do
   let(:user_id) { '61889' }
   context 'student feed' do
     let(:feed) { :student }
+    let(:feed_key) { 'student' }
+
     it_behaves_like 'an unauthenticated user'
+
     context 'authenticated user' do
-      let(:feed_key) { 'student' }
       it_behaves_like 'a successful feed'
     end
+    context 'view-as session' do
+      context 'delegate user' do
+        let(:view_as_key) { SessionKey.original_delegate_user_id }
+        let(:expected_elements) { %w(identifiers affiliations) }
+        it_behaves_like 'a successful feed during view-as session'
+      end
+      context 'advisor-view-as' do
+        let(:view_as_key) { SessionKey.original_advisor_user_id }
+        let(:expected_elements) { %w(addresses affiliations emails emergencyContacts identifiers names phones urls) }
+        it_behaves_like 'a successful feed during view-as session'
+      end
+    end
   end
-  context 'work exp feed' do
+  context 'work experience feed' do
     let(:feed) { :work_experience }
     it_behaves_like 'an unauthenticated user'
     context 'authenticated user' do
@@ -17,4 +31,3 @@ describe HubEdoController do
     end
   end
 end
-

--- a/spec/models/hub_edos/my_student_spec.rb
+++ b/spec/models/hub_edos/my_student_spec.rb
@@ -1,0 +1,25 @@
+describe HubEdos::MyStudent do
+  let(:options) { {} }
+  subject {
+    proxy = HubEdos::MyStudent.new(random_id, options)
+    proxy.get_feed_internal
+  }
+  context 'mock proxy' do
+    it 'should return unfiltered feed' do
+      expect(subject[:statusCode]).to eq 200
+      # Verify preferred name
+      expect(subject[:feed][:student]['names'][0]['type']['code']).to eq 'PRF'
+    end
+    context 'view-as session' do
+      let(:fields) { %w(affiliations identifiers) }
+      let(:options) { { include_fields: fields } }
+      it 'should return filtered feed' do
+        expect(subject[:statusCode]).to eq 200
+        student = subject[:feed][:student]
+        expect(student).to have(2).items
+        expect(student).to include *fields
+        expect(student['affiliations'][0]['status']['code']).to_not be_nil
+      end
+    end
+  end
+end

--- a/spec/support/campus_solutions_helper_module.rb
+++ b/spec/support/campus_solutions_helper_module.rb
@@ -35,6 +35,22 @@ module CampusSolutionsHelperModule
     end
   end
 
+  shared_examples 'a successful feed during view-as session' do
+    before {
+      allow(Settings.features).to receive(:reauthentication).and_return false
+    }
+    it 'should exclude certain student data from the feed' do
+      session['user_id'] = user_id
+      session[view_as_key] = random_id
+      get feed
+      json = JSON.parse response.body
+      expect(json['statusCode']).to eq 200
+      feed = json['feed'][feed_key]
+      expect(feed).to have(expected_elements.length).items
+      expect(feed).to include *expected_elements
+    end
+  end
+
   shared_examples 'a proxy that responds to user error gracefully' do
     it 'returns the right status code and helpful error message' do
       expect(subject[:statusCode]).to eq 400

--- a/src/assets/javascripts/angular/controllers/widgets/statusController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/statusController.js
@@ -6,7 +6,7 @@ var angular = require('angular');
 /**
  * Status controller
  */
-angular.module('calcentral.controllers').controller('StatusController', function(activityFactory, apiService, badgesFactory, financesFactory, holdsFactory, profileFactory, $http, $scope, $q) {
+angular.module('calcentral.controllers').controller('StatusController', function(activityFactory, apiService, badgesFactory, financesFactory, holdsFactory, $http, $scope, $q) {
   // Keep track on whether the status has been loaded or not
   var hasLoaded = false;
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-15682

We don't want proxy classes to care about session variables so I've made the previously static `include_fields` list configurable via `options` hash. I also added `Cache::KeyGenerator.per_view_as_type` as needed.