### PR TITLE
SISRP-15812, more robust auth for oec.admin

### DIFF
--- a/app/models/oec/administrator.rb
+++ b/app/models/oec/administrator.rb
@@ -1,8 +1,13 @@
 module Oec
   module Administrator
+    include ClassLogger
 
     def self.is_admin?(uid)
-      uid.to_s == Settings.oec.administrator_uid
+      administrator_uid = Settings.oec.administrator_uid
+      if (invalid_config = administrator_uid.blank?)
+        logger.error 'OEC admin cannot log in because our YAML has blank \'oec.administrator_uid\' config.'
+      end
+      !invalid_config && uid.to_s == administrator_uid
     end
 
   end

--- a/spec/models/oec/administrator_spec.rb
+++ b/spec/models/oec/administrator_spec.rb
@@ -1,0 +1,40 @@
+describe Oec::Administrator do
+  let(:uid) { nil }
+  before {
+    allow(Settings.oec).to receive(:administrator_uid).and_return oec_admin_uid
+  }
+  subject { Oec::Administrator.is_admin? uid }
+
+  shared_examples 'failed authentication' do
+    it 'should return false' do
+      expect(subject).to be false
+    end
+  end
+  context 'YAML is missing oec.administrator_uid' do
+    let(:oec_admin_uid) { '' }
+
+    it_behaves_like 'failed authentication'
+
+    context 'empty uid' do
+      let(:uid) { '' }
+      it_behaves_like 'failed authentication'
+    end
+  end
+  context 'YAML has a valid OEC administrator_uid' do
+    let(:oec_admin_uid) { random_id }
+    let(:uid) { ' ' }
+
+    it_behaves_like 'failed authentication'
+
+    context 'uid is not matching' do
+      let(:uid) { '12E45' }
+      it_behaves_like 'failed authentication'
+    end
+    context 'uid is matching' do
+      let(:uid) { oec_admin_uid.to_i }
+      it 'should return true' do
+        expect(subject).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-15812

Thank you @redconfetti for reporting this bug. Auth is strengthened and we log error if config is blank.  