### PR TITLE
SISRP-15810, hide link to Bear Facts > CARS > eBill unless user canSeeCSLinks

### DIFF
--- a/src/assets/templates/cars_summary.html
+++ b/src/assets/templates/cars_summary.html
@@ -77,7 +77,7 @@
               <div class="cc-page-myfinances-amount" data-cc-amount-directive="myfinances.summary.lastStatementBalance"></div>
             </div>
           </div>
-          <div class="small-12 columns cc-page-myfinances-light cc-print-show" data-ng-show="myfinances.show">
+          <div class="small-12 columns cc-page-myfinances-light cc-print-show" data-ng-show="myfinances.show" data-ng-if="api.user.profile.actAsOptions.canSeeCSLinks">
             <a href="https://bearfacts.berkeley.edu/bearfacts/student/CARS/ebill.do?bfaction=accessEBill">View Statements</a>
           </div>
         </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-15810

**Note:** This PR only hides the `CARS > eBill` link. The other examples are "My Campus" links (i.e., pulled from calcentral db) and don't come with metadata related to `canSeeCSLinks`. Delegates will continue to see all My Campus links. Afaik, we have no security risk here. @raydavis agrees.