### PR TITLE
SISRP-16031 Stop pretending we can predict CS FERPA URL paths

### DIFF
--- a/fixtures/xml/campus_solutions/ferpa_deeplink_url.xml
+++ b/fixtures/xml/campus_solutions/ferpa_deeplink_url.xml
@@ -3,6 +3,6 @@
   <FERPA_DEEPLINK>
     <NAME>Manage FERPA Restrictions</NAME>
     <IS_CS_LINK type="boolean">true</IS_CS_LINK>
-    <URL>https://bcs-web-dev-03.is.berkeley.edu:8443/PSIGW/RESTListeningConnector/psc/bcsdev/EMPLOYEE/HRMS/c/CC_SERVICES_DATA.FERPA_PERS.GBL</URL>
+    <URL>https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/CC_PORTFOLIO.SS_CC_FERPA_SETUP.GBL?Page=SS_CC_FERPA</URL>
   </FERPA_DEEPLINK>
 </UC_SR_FERPA>

--- a/spec/models/campus_solutions/ferpa_deeplink_spec.rb
+++ b/spec/models/campus_solutions/ferpa_deeplink_spec.rb
@@ -7,7 +7,7 @@ describe CampusSolutions::FerpaDeeplink do
     it 'returns data with the expected structure' do
       expect(subject[:feed][:ucSrFerpa][:ferpaDeeplink][:name]).to eq 'Manage FERPA Restrictions'
       expect(subject[:feed][:ucSrFerpa][:ferpaDeeplink][:isCsLink]).to be true
-      expect(subject[:feed][:ucSrFerpa][:ferpaDeeplink][:url]).to include "/EMPLOYEE/HRMS/c/CC_SERVICES_DATA.FERPA_PERS.GBL"
+      expect(subject[:feed][:ucSrFerpa][:ferpaDeeplink][:url]).to include '/EMPLOYEE/HRMS/'
     end
   end
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-16031

The RSpec change is backwards-compatible (just in case the CS API reverts to the old payload format).