### PR TITLE
SISRP-14774 Identify Law students from Campus Solutions

### DIFF
--- a/app/models/berkeley/user_roles.rb
+++ b/app/models/berkeley/user_roles.rb
@@ -98,7 +98,7 @@ module Berkeley
             result[:applicant] = true
           when 'GRADUATE'
             result[:student] = true
-            result[:graduate] = 'G'
+            result[:graduate] = true
           when 'INSTRUCTOR'
             result[:faculty] = true
           when 'ADVISOR'
@@ -107,7 +107,9 @@ module Berkeley
             result[:student] = true
           when 'UNDERGRAD'
             result[:student] = true
-            result[:undergrad] = 'U'
+            result[:undergrad] = true
+          when 'LAW'
+            result[:law] = true
         end
       end
       cs_affiliations.select { |a| a[:status][:code] == 'INA' }.each do |inactive_affiliation|

--- a/app/models/my_badges/student_info.rb
+++ b/app/models/my_badges/student_info.rb
@@ -42,10 +42,15 @@ module MyBadges
       end
     end
 
-    # True if user's first college is the School of Law.
+    # True if user has a Law 'career' according to Campus Solutions, or if the first college is the School of Law.
     def law_student?
-      if (college_feed = MyAcademics::CollegeAndLevel.new(@uid).merge({})) && college_feed[:majors].present?
-        college_feed[:majors].first[:college] == Berkeley::Departments.get('CLLAW')
+      if (college_feed = MyAcademics::CollegeAndLevel.new(@uid).merge({}))
+        if college_feed[:careers].present? && college_feed[:careers].include?('Law')
+          true
+        else
+          college_feed[:majors].present? &&
+            college_feed[:majors].first[:college] == Berkeley::Departments.get('CLLAW')
+        end
       else
         false
       end

--- a/spec/models/berkeley/user_roles_spec.rb
+++ b/spec/models/berkeley/user_roles_spec.rb
@@ -141,6 +141,36 @@ describe Berkeley::UserRoles do
       it_behaves_like 'a parser for roles', [:student, :graduate]
     end
 
+    context 'Law student' do
+      let(:affiliations) do
+        [
+          {
+            :type => {
+              :code => 'LAW',
+              :description => 'Law School Student'
+            },
+            :status => {
+              :code =>'ACT',
+              :description => 'Active'
+            },
+            :fromDate => '2014-05-15'
+          },
+          {
+            :type => {
+              :code => 'STUDENT',
+              :description => ''
+            },
+            :status => {
+              :code =>'ACT',
+              :description => 'Active'
+            },
+            :fromDate => '2014-05-15'
+          }
+        ]
+      end
+      it_behaves_like 'a parser for roles', [:student, :law]
+    end
+
     context 'new and released admit' do
       let(:affiliations) do
         [


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-14774

Replacement for BearFacts-API-dependent logic.

For now, the Academics profile continues to rely on academic status feeds rather than affiliations.