### PR TITLE
SISRP-15830, proxy can have custom HTTP-timeout setting

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -415,15 +415,18 @@ campus_solutions_proxy:
   logout_url: 'https://bcs-web-dev-03.is.berkeley.edu:8443/psp/logout/EMPLOYEE/HRMS/?cmd=logout'
   username: secret
   password: secret
+  http_timeout_seconds: 30
 
 hub_edos_proxy:
   fake: true
   base_url: 'https://sis-integration.berkeley.edu/apis/sis/v1/students'
   username: secret
   password: secret
+  http_timeout_seconds: 30
 
 calnet_crosswalk_proxy:
   fake: true
   base_url: 'https://registry-d1.calnet.1918.berkeley.edu:8453/registry-service/api/v1/identifiers'
   username: secret
   password: secret
+  http_timeout_seconds: 30

--- a/lib/proxies/base_proxy.rb
+++ b/lib/proxies/base_proxy.rb
@@ -11,4 +11,15 @@ class BaseProxy
     @uid = options[:user_id]
   end
 
+  def get_response(url, options={})
+    if @settings
+      if @settings.respond_to?(:http_timeout_seconds) && (http_timeout = @settings.http_timeout_seconds.to_i) > 0
+        # A proxy class can have custom timeout setting.
+        logger.warn "HTTP calls by this proxy instance will timeout after #{http_timeout} seconds"
+        options[:timeout] = http_timeout
+      end
+    end
+    super(url, options)
+  end
+
 end

--- a/spec/lib/proxies/base_proxy_spec.rb
+++ b/spec/lib/proxies/base_proxy_spec.rb
@@ -1,0 +1,53 @@
+describe BaseProxy do
+
+  context 'a proxy class can have its own custom HTTP settings' do
+    context 'actual YAML' do
+      subject {
+        BaseProxy.new(Settings.hub_edos_proxy, { fake: true }).get_response 'http://www.url.com', (options = { })
+        options[:timeout]
+      }
+      context 'http_timeout is an integer' do
+        it { should be_an Integer }
+        it { should be > 0 }
+      end
+    end
+    context 'proper settings' do
+      subject {
+        settings = double(http_timeout_seconds: timeout_setting)
+        BaseProxy.new(settings, { fake: true }).get_response 'http://www.url.com', (options = { })
+        options[:timeout]
+      }
+      context 'http_timeout is nil' do
+        let(:timeout_setting) { nil }
+        it { should be nil }
+      end
+      context 'http_timeout is blank' do
+        let(:timeout_setting) { '  ' }
+        it { should be nil }
+      end
+      context 'http_timeout is an integer' do
+        let(:timeout_setting) { ' 60 ' }
+        it { should eq 60 }
+      end
+      context 'http_timeout is a float' do
+        let(:timeout_setting) { 10 }
+        it { should eq 10 }
+      end
+    end
+    context 'missing or invalid settings' do
+      subject {
+        BaseProxy.new(settings, { fake: true }).get_response 'http://www.url.com', (options = { })
+        options[:timeout]
+      }
+      context 'nil settings' do
+        let(:settings) { nil }
+        it { should be nil }
+      end
+      context 'unexpected settings type' do
+        let(:settings) { '' }
+        it { should be nil }
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-15830

Notes:
* I've put default 30 second timeout on Hub, CS, Crosswalk. That value matches what was in use before: `application.outgoing_http_timeout`
* BaseProxy intercepts the call to `get_response()` and injects optional timeout. This seemed the most elegant way to avoid code duplication in subclasses. Notice that `Proxies::HttpClient` does not have a handle on the Settings object.
* In a moment I'll describe steps to verify in Jira above. 
 