### PR TITLE
SISRP-16120 Have RelatedCacheKeyTracker register keys after creation, not before

### DIFF
--- a/app/controllers/bootstrap_controller.rb
+++ b/app/controllers/bootstrap_controller.rb
@@ -45,12 +45,8 @@ class BootstrapController < ApplicationController
     # a Fluid activity that may have changed some data.
     flag = params['ucUpdateCache']
     case flag
-      when 'finaid'
-        CampusSolutions::FinancialAidExpiry.expire current_user.user_id
       when 'profile'
         CampusSolutions::PersonDataExpiry.expire current_user.user_id
-      when 'enrollment'
-        CampusSolutions::EnrollmentTermExpiry.expire current_user.user_id
       else
         # no-op
     end

--- a/lib/cache/related_cache_key_tracker.rb
+++ b/lib/cache/related_cache_key_tracker.rb
@@ -3,16 +3,18 @@ module Cache
 
     # This hook is used for mixins with BaseProxy subclasses.
     def get
+      result = super
       self.class.save_related_cache_key(@uid, self.class.cache_key(instance_key))
-      super
+      result
     end
 
     # This hook is used for mixins with Cache::CachedFeed.
     def get_feed(force_cache_write=false)
+      feed = super force_cache_write
       extended_instance_keys.each do |key|
         self.class.save_related_cache_key(@uid, self.class.cache_key(key))
       end
-      super force_cache_write
+      feed
     end
 
     def self.included base


### PR DESCRIPTION
I wouldn't call this a long-term fix for https://jira.berkeley.edu/browse/SISRP-16120, but I would like to see if it reduces blockage for QA while we consider next steps.

Also remove the ucUpdateCache query-param check for finaid and enrollment, since that's one bit of redundancy we have power to skip.