### PR TITLE
CLC-6226 OEC: tighten data integrity checks prior to Blue push

### DIFF
--- a/app/models/oec/merged_sheet_validation.rb
+++ b/app/models/oec/merged_sheet_validation.rb
@@ -118,6 +118,11 @@ module Oec
           validate_and_add(course_students, capitalized_row, %w(LDAP_UID COURSE_ID))
         end
       end
+
+      validate_integrity('LDAP_UID', students, course_students)
+      validate_integrity('LDAP_UID', instructors, course_instructors)
+      validate_integrity('COURSE_ID', courses, course_instructors)
+
       if valid?
         log :info, 'Validation passed.'
         [instructors, course_instructors, courses, students, course_students, supervisors, course_supervisors]
@@ -126,6 +131,20 @@ module Oec
         log :warn, 'Validation failed!'
         log_validation_errors
         nil
+      end
+    end
+
+    def validate_integrity(key, *worksheets)
+      id_sets = worksheets.map do |worksheet|
+        {
+          name: worksheet.class.export_name,
+          ids: worksheet.inject(Set.new) { |set, row| set.add row[key] }
+        }
+      end
+      id_sets.permutation do |set1, set2|
+        (set1[:ids] - set2[:ids]).each do |id|
+          validate(set1[:name], key) { |errors| errors.add "#{key} #{id} found in #{set1[:name]} but not #{set2[:name]}" }
+        end
       end
     end
 

--- a/spec/models/oec/publish_task_spec.rb
+++ b/spec/models/oec/publish_task_spec.rb
@@ -128,19 +128,29 @@ describe Oec::PublishTask do
           "2015-B-#{ccn}_GSI,2015-B-#{ccn}_GSI,LGBT C146A LEC 001 REP SEXUALITY/LIT,,,LGBT,C146A,LEC,001,P,562283,10945601,Clarice,Cccc,cccc@berkeley.edu,23,Y,LGBT,G,,01-26-2015,05-11-2015")
         expect(Oec::Queries).to receive(:enrollments_for_cntl_nums)
           .with(term_code, [ccn])
-          .and_return student_ids.map { |id| {'course_id' => "2015-B-#{ccn}", 'ldap_uid' => id} }
+          .and_return student_ids_for_ccn.map { |id| {'course_id' => "2015-B-#{ccn}", 'ldap_uid' => id} }
         expect(Oec::Queries).to receive(:students_for_cntl_nums)
           .with(term_code, array_including(ccn))
-          .and_return student_data_rows
+          .and_return(student_data_rows + student_data_rows_for_ccn)
       end
-      let(:student_ids) { %w(1000 2000 3000) }
+      let(:student_ids_for_ccn) { %w(1000 2000 3000) }
+      let(:student_data_rows_for_ccn) do
+        student_ids_for_ccn.map do |id|
+          {
+            'ldap_uid' => id,
+            'first_name' => 'Val',
+            'last_name' => 'Valid',
+            'email_address' => 'valid@berkeley.edu',
+            'sis_id' => random_id
+          }
+        end
+      end
 
       shared_examples 'a smart suffix matcher' do
         it 'should match appropriate data to suffixed CCN' do
           task.run
           expect(courses.find { |course| course['COURSE_ID'] == "2015-B-#{ccn}_GSI"}).to be_present
-          student_ids.each do |id|
-            pp course_students
+          student_ids_for_ccn.each do |id|
             expect(course_students.find { |course_student| course_student['COURSE_ID'] == "2015-B-#{ccn}_GSI" && course_student['LDAP_UID'] == id }).to be_present
           end
           expect(course_instructors.find { |course_instructor| course_instructor['COURSE_ID'] == "2015-B-#{ccn}_GSI" && course_instructor['LDAP_UID'] == '562283'}).to be_present
@@ -154,6 +164,37 @@ describe Oec::PublishTask do
       context 'data with suffixed course ID matching no ID without suffix' do
         let(:ccn) { '50000' }
         it_should_behave_like 'a smart suffix matcher'
+      end
+    end
+  end
+
+  describe 'integrity validation' do
+    let(:local_write) { 'Y' }
+    before { allow(Rails.logger).to receive(:warn) }
+    context 'mismatched enrollment data' do
+      before do
+        enrollment_data_rows << {'course_id' => '2016-B-99999', 'ldap_uid' => '99999999'}
+      end
+      it 'should report error' do
+        expect(Rails.logger).to receive(:warn).with /Validation failed!/
+        expect(Rails.logger).to receive(:warn).with /LDAP_UID 99999999 found in course_students but not students/
+        task.run
+      end
+    end
+    context 'mismatched student data' do
+      before do
+        student_data_rows << {
+          'ldap_uid' => 99999999,
+          'first_name' => 'Inter',
+          'last_name' => 'Loper',
+          'email_address' => 'interloper@berkeley.edu',
+          'sis_id' => random_id
+        }
+      end
+      it 'should report error' do
+        expect(Rails.logger).to receive(:warn).with /Validation failed!/
+        expect(Rails.logger).to receive(:warn).with /LDAP_UID 99999999 found in students but not course_students/
+        task.run
       end
     end
   end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6226 revealed a need for more explicit referential integrity checks between worksheets prior to sending them Blue-ward. 

Validate that certain ID sets are identical between worksheets, as specified.