### PR TITLE
NOJIRA Do not repeatedly log configuration setting at WARN-level

### DIFF
--- a/lib/proxies/base_proxy.rb
+++ b/lib/proxies/base_proxy.rb
@@ -14,8 +14,6 @@ class BaseProxy
   def get_response(url, options={})
     if @settings
       if @settings.respond_to?(:http_timeout_seconds) && (http_timeout = @settings.http_timeout_seconds.to_i) > 0
-        # A proxy class can have custom timeout setting.
-        logger.warn "HTTP calls by this proxy instance will timeout after #{http_timeout} seconds"
         options[:timeout] = http_timeout
       end
     end


### PR DESCRIPTION
3 X [every user in CalCentral] X [every time the basic Hub caches expire] = an awful lot of duplicate log messages.