### PR TITLE
CLC-6238 Display CalNet Directory first/last names as determined by user

### DIFF
--- a/app/models/calnet_ldap/user_attributes.rb
+++ b/app/models/calnet_ldap/user_attributes.rb
@@ -20,8 +20,8 @@ module CalnetLdap
         roles = group_roles.merge affiliation_roles
         {
           email_address: result[:mail].try(:first),
-          first_name: result[:givenname].try(:first),
-          last_name: result[:sn].try(:first),
+          first_name: result[:berkeleyEduFirstName].try(:first) || result[:givenname].try(:first),
+          last_name: result[:berkeleyEduLastName].try(:first) || result[:sn].try(:first),
           ldap_uid: result[:uid].try(:first).try(:to_s),
           person_name: result[:displayname].try(:first),
           roles: roles,

--- a/spec/models/calnet_ldap/user_attributes_spec.rb
+++ b/spec/models/calnet_ldap/user_attributes_spec.rb
@@ -38,6 +38,25 @@ describe CalnetLdap::UserAttributes do
       expect(feed[:student_id]).to eq '11667051'
     end
 
+    context 'customized Directory names' do
+      let(:ldap_result) do
+        {
+          givenname: ['Hermann', 'H Ford'],
+          uid: ['61889'],
+          displayname: ['Daniel Chaucer'],
+          sn: ['Hueffer'],
+          berkeleyEduFirstName: ['Ford Madox'],
+          berkeleyEduLastName: ['Ford']
+        }
+      end
+      it 'prioritizes the customized names' do
+        expect(feed[:first_name]).to eq 'Ford Madox'
+        expect(feed[:last_name]).to eq 'Ford'
+        expect(feed[:ldap_uid]).to eq '61889'
+        expect(feed[:person_name]).to eq 'Daniel Chaucer'
+      end
+    end
+
     context 'no affiliation data in LDAP' do
       let(:ldap_result) do
         {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6238

This was always our intention but we weren't checking the right LDAP attributes.

(The equivalent change for bCourses account management will be handled in other tasks.)