### PR TITLE
SISRP-16301 - Academic Profile: "Earned Units" label showing when there are no units yet

### DIFF
--- a/src/assets/javascripts/angular/controllers/pages/academicsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicsController.js
@@ -153,8 +153,11 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
         $scope.widgetSemesterName = $scope.selectedTeachingSemester.name;
       }
     }
-    $scope.gpaUnits.cumulativeGpaFloat = $scope.gpaUnits.cumulativeGpa; // cumulativeGpa is passed as a string to maintain two significant digits
-    $scope.gpaUnits.cumulativeGpa = parseFloat($scope.gpaUnits.cumulativeGpa); // converted to Float to be processed regularly
+    // cumulativeGpa is passed as a string to maintain two significant digits
+    $scope.gpaUnits.cumulativeGpaFloat = $scope.gpaUnits.cumulativeGpa;
+    // Convert these to Number types to be processed regularly. `parseFloat` returns NaN if the input value does not contain at least one digit.
+    $scope.gpaUnits.cumulativeGpa = parseFloat($scope.gpaUnits.cumulativeGpa);
+    $scope.gpaUnits.totalUnits = parseFloat($scope.gpaUnits.totalUnits);
   };
 
   var filterWidgets = function() {

--- a/src/assets/templates/academics_student_profile.html
+++ b/src/assets/templates/academics_student_profile.html
@@ -166,7 +166,7 @@
       </table>
     </div>
 
-    <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="gpaUnits.totalUnits !== null">
+    <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="gpaUnits.totalUnits > 0">
       <table>
         <tbody>
           <tr>
@@ -177,7 +177,7 @@
       </table>
     </div>
 
-    <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="gpaUnits.cumulativeGpa !== null && gpaUnits.cumulativeGpa > 0 && !studentInfo.isLawStudent">
+    <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="gpaUnits.cumulativeGpa > 0 && !studentInfo.isLawStudent">
       <table>
         <tbody>
           <tr>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-16301

Main issue here is the strict-equality check, `value !== null`.  If value is `0` or `undefined` or the empty string, this check will still return `true`.  

<del>Better to set the property to a Number explicitly in the controller using `parseFloat` and check in the template that `value > 0`</del>


@christianvuerings `parseFloat()` returns `NaN` when the input does not contain at least one digit.  Also,  the `value > 0` checks should be corrected to `value >= 0`

