### PR TITLE
SISRP-16369, remove two unused queries from CampusOracle::Queries

### DIFF
--- a/app/models/campus_oracle/queries.rb
+++ b/app/models/campus_oracle/queries.rb
@@ -166,23 +166,6 @@ module CampusOracle
       end
     end
 
-    # This method is currently used only for support and research, not by deployed code.
-    def self.get_student_term_info(person_id)
-      result = nil
-      use_pooled_connection {
-        sql = <<-SQL
-      select pi.student_id, reg.ldap_uid, reg.fee_resid_cd, reg.educ_level, reg.reg_status_cd, reg.elig_reg_status_cd, reg.admin_cancel_flag,
-        reg.admit_special_pgm_grp, reg.reg_special_pgm_cd, reg.cat_cd, reg.acad_blk_flag, reg.admin_blk_flag, reg.fin_blk_flag,
-        reg.tot_enroll_unit, reg.new_trfr_flag, reg.term_yr, reg.term_cd, reg.role_cd
-      from calcentral_person_info_vw pi, calcentral_student_term_vw reg where
-        reg.ldap_uid = #{person_id.to_i} and reg.ldap_uid = pi.ldap_uid
-      order by reg.term_yr desc, reg.term_cd desc
-        SQL
-        result = connection.select_all(sql)
-      }
-      stringify_ints! result
-    end
-
     def self.get_enrolled_students(ccn, term_yr, term_cd)
       result = []
       use_pooled_connection {
@@ -379,20 +362,6 @@ module CampusOracle
         result = connection.select_one(sql)
       }
       stringify_ints! result
-    end
-
-    def self.is_previous_ugrad?(ldap_uid)
-      result = {}
-      use_pooled_connection {
-        sql = <<-SQL
-        select ts.student_ldap_uid from calcentral_transcript_vw ts
-        where ts.line_type = 'U'
-          and ts.student_ldap_uid = #{ldap_uid.to_i}
-          and rownum < 2
-        SQL
-        result = connection.select_one(sql)
-      }
-      result.present?
     end
 
     def self.database_alive?

--- a/spec/models/campus_oracle/queries_spec.rb
+++ b/spec/models/campus_oracle/queries_spec.rb
@@ -261,13 +261,6 @@ describe CampusOracle::Queries do
     end
   end
 
-  it 'should find a grad student that used to be an undergrad', if: CampusOracle::Queries.test_data? do
-    expect(CampusOracle::Queries.is_previous_ugrad?('212388')).to be true
-    expect(CampusOracle::Queries.is_previous_ugrad?('212389')).to be true   # grad student expired, previous ugrad
-    expect(CampusOracle::Queries.is_previous_ugrad?('212390')).to be false  # grad student, but not previous ugrad
-    expect(CampusOracle::Queries.is_previous_ugrad?('300939')).to be true   # ugrad only
-  end
-
   it 'should find a user with an expired LDAP account', if: CampusOracle::Queries.test_data? do
     expect(CampusOracle::Queries.get_person_attributes('6188989', current_term.year, current_term.code)['person_type']).to eq 'Z'
     expect(CampusOracle::Queries.get_basic_people_attributes(['6188989']).first['person_type']).to eq 'Z'


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-16369

@raydavis should review/merge this one because I think he is author of `get_student_term_info(person_id)` which is documented with 'currently used only for support and research, not by deployed code'.  If its usefulness has expired then this PR can be merged.

`is_previous_ugrad?(ldap_uid)` was only used by the spec.