### PR TITLE
SISRP-16371, edo_oracle in YAMLs of Git:/config

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,10 +1,3 @@
-logger:
-  level: <%= ENV['LOGGER_LEVEL'] || WARN %>
-  stdout: <%= ENV['LOGGER_STDOUT'] %>
-  slow_query_threshold_in_ms: 700
-  slow_request_threshold_in_ms: 30000
-  proxy_threshold_in_ms: 8000
-
 application:
   # Set to true if testing production env without Apache/Nginx
   serve_static_assets: false
@@ -21,7 +14,15 @@ application:
   # Lifespan of session cookie
   session_expiration: <%= 4.hours %>
 
+logger:
+  level: <%= ENV['LOGGER_LEVEL'] || WARN %>
+  stdout: <%= ENV['LOGGER_STDOUT'] %>
+  slow_query_threshold_in_ms: 700
+  slow_request_threshold_in_ms: 30000
+  proxy_threshold_in_ms: 8000
+
 cas_server: 'https://auth.berkeley.edu/cas'
+
 cas_logout_url: 'https://auth.berkeley.edu/cas/logout'
 
 # Database settings
@@ -42,6 +43,7 @@ campusdb:
   pool: 95
   fake: false
   fake_user_id: "300939"
+
 terms:
   # Limit how far back our academic history goes.
   oldest: spring-2010
@@ -49,6 +51,7 @@ terms:
   # Can also be used to force selection of a "current term" different
   # from the default.
   fake_now:
+
 test_sqlite:
   pool: 3
 
@@ -95,11 +98,13 @@ canvas_proxy:
   test_cas_url: 'https://auth-test.berkeley.edu/cas'
   # If reports are provided through Google Drive, this is the UID that creates them.
   reporter_uid:
+
 ldap:
   host: 'nds.berkeley.edu'
   port: 636
   application_bind: 'uid=someApp,ou=applications,dc=berkeley,dc=edu'
   application_password: 'someMumboJumbo'
+
 google_proxy:
   client_id: 1
   client_secret: 'bogusClientSecret'
@@ -388,6 +393,16 @@ hub_edos_proxy:
   username: secret
   password: secret
   http_timeout_seconds: 30
+
+edo_oracle:
+  fake: true
+  adapter: jdbc
+  driver: oracle.jdbc.OracleDriver
+  url:
+  username: calcentral_bcs
+  password:
+  pool: 200
+  timeout: 5000
 
 calnet_crosswalk_proxy:
   fake: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,6 +1,11 @@
 application:
   layer: "development"
 
+logger:
+  level: <%= ENV['LOGGER_LEVEL'] || DEBUG %>
+  stdout: <%= ENV['LOGGER_STDOUT'] || true %>
+  slow_query_threshold_in_ms: 2000
+
 bearfacts_proxy:
   fake: true
 
@@ -18,6 +23,7 @@ canvas_proxy:
   fake: true
 
 cas_server: 'https://auth-test.berkeley.edu/cas'
+
 cas_logout_url: 'https://auth-test.berkeley.edu/cas/logout'
 
 financials_proxy:
@@ -28,11 +34,6 @@ textbooks_proxy:
 
 google_proxy:
   fake: true
-
-logger:
-  level: <%= ENV['LOGGER_LEVEL'] || DEBUG %>
-  stdout: <%= ENV['LOGGER_STDOUT'] || true %>
-  slow_query_threshold_in_ms: 2000
 
 myfinaid_proxy:
   fake: true

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,11 +1,14 @@
-logger:
-  level: <%= ENV['LOGGER_LEVEL'] || WARN %>
-secret_token: some 128 char random hex string
 application:
   # Set if running behind Apache/Nginx + https
   protocol: "https://"
   layer: "production"
   fake_proxies_enabled: false
+
+secret_token: some 128 char random hex string
+
+logger:
+  level: <%= ENV['LOGGER_LEVEL'] || WARN %>
+
 campusdb:
   adapter: jdbc
   driver: oracle.jdbc.OracleDriver
@@ -14,6 +17,7 @@ campusdb:
   password: <yer_password>
   pool: 95
   timeout: 5000
+
 canvas_proxy:
   export_directory: '/home/app_calcentral/calcentral/tmp/canvas'
   # Set to "true" when Canvas allows it.

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,31 +1,42 @@
-# The test environment should require minimal configuration, and is the one targeted by travis.
+# The test environment should require minimal configuration, and is the one targeted by Travis.
 # Avoid creating too many dependencies (if any) on a test.local.yml
+application:
+  layer: 'test'
+
 logger:
   level: <%= ENV['LOGGER_LEVEL'] || DEBUG %>
   stdout: <%= ENV['LOGGER_STDOUT'] || 'only' %>
-application:
-  layer: "test"
+
 canvas_proxy:
   fake: true
   app_provider_host: 'https://cc-dev.example.com'
+
 ldap:
   fake: 'true'
   host: 'nds-test.berkeley.edu'
+
 google_proxy:
   fake: true
+
 financials_proxy:
   fake: true
+
 textbooks_proxy:
   fake: true
+
 terms:
   # Keyed to H2 test data
   fake_now: 2013-10-11 04:20:00
+
 cal_link_proxy:
   fake: true
+
 cal1card_proxy:
   fake: true
+
 calmail_proxy:
   fake: true
+
 calnet_crosswalk_proxy:
   fake: true
 

--- a/config/settings/testext.yml
+++ b/config/settings/testext.yml
@@ -1,18 +1,23 @@
 application:
-  layer: "testext"
+  layer: 'testext'
+
 logger:
   level: <%= ENV['LOGGER_LEVEL'] || DEBUG %>
   stdout: <%= ENV['LOGGER_STDOUT'] || 'only' %>
+
 ldap:
   host: 'nds-test.berkeley.edu'
+
 terms:
   fake_now: 2013-10-11 04:20:00
+
 postgres:
   database: <%= ENV['DB_ENV_POSTGRESQL_DB'] || 'calcentral_test' %>
   username: <%= ENV['DB_ENV_POSTGRESQL_USER'] || 'calcentral_test' %>
   password: <%= ENV['DB_ENV_POSTGRESQL_PASS'] || 'secret' %>
   host: <%= ENV['DB_PORT_5432_TCP_ADDR'] || 'localhost' %>
   port: <%= ENV['DB_PORT_5432_TCP_PORT'] || '5432' %>
+
 campusdb:
   adapter: jdbc
   driver: oracle.jdbc.OracleDriver


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-16371

For now, only the _settings.yml_ file gets `edo_oracle` config. Plus:
* I added extra line breaks in YAMLs for readability.
* `application` setting is always at top of YAML