### PR TITLE
SISRP-14768 Per-environment edodb settings on campusdb pattern

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,7 +35,7 @@ postgres:
   pool: 95
 
 edodb:
-  fake: true
+  fake: false
   adapter: h2
   driver: org.h2.Driver
   url: jdbc:h2:mem:h2EdoOracle::EdoDataSource;DB_CLOSE_DELAY=-1;MODE=Oracle
@@ -402,16 +402,6 @@ hub_edos_proxy:
   username: secret
   password: secret
   http_timeout_seconds: 30
-
-edo_oracle:
-  fake: true
-  adapter: jdbc
-  driver: oracle.jdbc.OracleDriver
-  url:
-  username: calcentral_bcs
-  password:
-  pool: 200
-  timeout: 5000
 
 calnet_crosswalk_proxy:
   fake: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -51,6 +51,9 @@ postgres:
 campusdb:
   fake: true
 
+edodb:
+  fake: true
+
 ist_jms:
   fake: true
   enabled: false

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -18,6 +18,15 @@ campusdb:
   pool: 95
   timeout: 5000
 
+edodb:
+  adapter: jdbc
+  driver: oracle.jdbc.OracleDriver
+  url: jdbc:oracle:thin:@<yer_host>:<yer_port>:<yer_sid>
+  username: <yer_username>
+  password: <yer_password>
+  pool: 95
+  timeout: 5000
+
 canvas_proxy:
   export_directory: '/home/app_calcentral/calcentral/tmp/canvas'
   # Set to "true" when Canvas allows it.

--- a/config/settings/testext.yml
+++ b/config/settings/testext.yml
@@ -27,6 +27,15 @@ campusdb:
   pool: 5
   timeout: 5000
 
+edodb:
+  adapter: jdbc
+  driver: oracle.jdbc.OracleDriver
+  url: jdbc:oracle:thin:@<yer_host>:<yer_port>:<yer_sid>
+  username: <yer_username>
+  password: <yer_password>
+  pool: 5
+  timeout: 5000
+
 cache:
   store: "memory"
   log_level: <%= Logger::DEBUG %>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-14768

EDO DB settings should be configured per environment on the `campusdb` convention, and called `edodb` to match the database.yml entry.