### PR TITLE
SISRP-15857 EdoDb: Get instructing sections for UID and terms

### DIFF
--- a/app/models/berkeley/term.rb
+++ b/app/models/berkeley/term.rb
@@ -48,6 +48,10 @@ module Berkeley
       end
     end
 
+    def campus_solutions_id
+      TermCodes.to_edo_id(year, code)
+    end
+
     def to_english
       TermCodes.to_english(year, code)
     end

--- a/app/models/berkeley/term_codes.rb
+++ b/app/models/berkeley/term_codes.rb
@@ -18,12 +18,14 @@ module Berkeley
     end
 
     def to_edo_id(term_yr, term_cd)
+      term_yr = term_yr.to_s
       edo_year = term_yr[0] + term_yr[2..3]
       season_code = legacy_to_edo_code.fetch(term_cd)
       edo_year + season_code
     end
 
     def from_edo_id(edo_term_id)
+      edo_term_id = edo_term_id.to_s
       legacy_term_cd = edo_to_legacy_code.fetch(edo_term_id[3])
       legacy_term_yr = edo_term_id[0] + '0' + edo_term_id[1..2]
       {:term_yr => legacy_term_yr, :term_cd => legacy_term_cd}

--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -2,6 +2,43 @@ module EdoOracle
   class Queries < Connection
     include ActiveRecordHelper
 
+    def self.get_instructing_sections(person_id, terms = nil)
+      result = []
+      terms_list = terms.map { |term| "'#{term.campus_solutions_id}'" }.join ','
+      use_pooled_connection do
+        sql = <<-SQL
+        SELECT
+          crs."title" AS title,
+          TRIM(crs."transcriptTitle") AS transcript_title,
+          TRIM(crs."description") AS description,
+          crs."subjectArea" AS dept_name,
+          crs."catalogNumber-number" AS catalog_root,
+          crs."catalogNumber-prefix" AS catalog_prefix,
+          crs."catalogNumber-suffix" AS catalog_suffix,
+          sec."term-id" AS term_id,
+          sec."id" AS section_id,
+          sec."displayName" AS display_name,
+          sec."primary" AS primary_secondary_cd,
+          sec."component-code" AS instruction_format,
+          sec."sectionNumber" AS section_num
+        FROM SISEDO.ASSIGNEDINSTRUCTORV00_VW instr
+        JOIN SISEDO.CLASSSECTIONV00_VW sec ON (
+          instr."term-id" = sec."term-id" AND
+          instr."session-id" = sec."session-id" AND
+          instr."cs-course-id" = sec."cs-course-id" AND
+          instr."offeringNumber" = sec."offeringNumber" AND
+          instr."number" = sec."sectionNumber")
+        LEFT OUTER JOIN SISEDO.API_COURSEV00_VW crs ON (sec."displayName" = crs."displayName")
+        WHERE (crs."status-code" = 'ACTIVE' OR crs."status-code" IS NULL)
+          AND instr."term-id" IN (#{terms_list})
+          AND instr."campus-uid" = '#{person_id}'
+        ORDER BY term_id DESC, display_name, section_num
+        SQL
+        result = connection.select_all sql
+      end
+      stringify_ints! result
+    end
+
     def self.get_sections_from_section_ids(term_yr, term_cd, section_ids)
       edo_term_id = Berkeley::TermCodes.to_edo_id(term_yr, term_cd)
       result = {}

--- a/spec/models/berkeley/term_codes_spec.rb
+++ b/spec/models/berkeley/term_codes_spec.rb
@@ -16,6 +16,14 @@ describe Berkeley::TermCodes do
       expect(result[:term_yr]).to eq '2002'
       expect(result[:term_cd]).to eq 'D'
     end
+
+    it 'should accept integer input' do
+      expect(Berkeley::TermCodes.to_edo_id(2013, 'B')).to eq '2132'
+      expect(Berkeley::TermCodes.from_edo_id(2028)).to eq({
+        term_yr: '2002',
+        term_cd: 'D'
+      })
+    end
   end
 
   it "should convert code and year into nice English" do

--- a/spec/models/berkeley/term_spec.rb
+++ b/spec/models/berkeley/term_spec.rb
@@ -14,6 +14,7 @@ describe Berkeley::Term do
     its(:year) {should eq 2014}
     its(:code) {should eq 'C'}
     its(:name) {should eq 'Summer'}
+    its(:campus_solutions_id) {should eq '2145'}
     its(:is_summer) {should eq true}
     its(:sis_term_status) {should eq 'CS'}
     its(:classes_start) {should eq Time.zone.parse('2014-05-27 00:00:00').to_datetime}
@@ -37,6 +38,7 @@ describe Berkeley::Term do
     its(:year) {should eq 2014}
     its(:code) {should eq 'D'}
     its(:name) {should eq 'Fall'}
+    its(:campus_solutions_id) {should eq '2148'}
     its(:is_summer) {should eq false}
     its(:sis_term_status) {should eq 'FT'}
     its(:classes_start) {should eq Time.zone.parse('2014-08-28 00:00:00').to_datetime}
@@ -60,6 +62,7 @@ describe Berkeley::Term do
     its(:year) {should eq 2014}
     its(:code) {should eq 'B'}
     its(:name) {should eq 'Spring'}
+    its(:campus_solutions_id) {should eq '2142'}
     its(:is_summer) {should eq false}
     its(:sis_term_status) {should eq 'CT'}
     its(:classes_start) {should eq Time.zone.parse('2014-01-21 00:00:00').to_datetime}


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-15857

No spec yet; a sanity check under testext is coming.

Term-code converter also takes more flexible input.