### PR TITLE
SISRP-15118, student summary card needs a standalone, split-brain getUserAttributes feed

### DIFF
--- a/app/models/user/aggregated_attributes.rb
+++ b/app/models/user/aggregated_attributes.rb
@@ -1,0 +1,82 @@
+module User
+  class AggregatedAttributes < UserSpecificModel
+    include CampusSolutions::ProfileFeatureFlagged
+    include Cache::RelatedCacheKeyTracker
+
+    attr_reader :campus_solutions_id, :student_id, :given_first_name, :first_name, :last_name, :family_name, :default_name
+    attr_reader :roles, :primary_email_address, :official_bmail_address, :education_abroad, :campus_solutions_student, :sis_profile_visible
+    alias_method :education_abroad?, :education_abroad
+    alias_method :campus_solutions_student?, :campus_solutions_student
+    alias_method :sis_profile_visible?, :sis_profile_visible
+
+    # Conservative merge of roles from EDO
+    WHITELISTED_EDO_ROLES = [:student, :applicant, :advisor]
+
+    def initialize(uid, options={})
+      super(uid, options)
+      @ldap_attributes = CalnetLdap::UserAttributes.new(user_id: @uid).get_feed
+      @oracle_attributes = CampusOracle::UserAttributes.new(user_id: @uid).get_feed
+      if is_cs_profile_feature_enabled
+        @edo_attributes = HubEdos::UserAttributes.new(user_id: @uid).get
+      end
+      @campus_solutions_student = @edo_attributes.present? && (@edo_attributes[:is_legacy_user] == false)
+      @sis_profile_visible = is_cs_profile_feature_enabled && (@campus_solutions_student || is_profile_visible_for_legacy_users)
+      @roles = get_campus_roles
+      # Names
+      @default_name = get_campus_attribute('person_name', :string)
+      @first_name = get_campus_attribute('first_name', :string) || ''
+      @last_name = get_campus_attribute('last_name', :string) || ''
+      @given_first_name = (@edo_attributes && @edo_attributes[:given_name]) || @first_name || ''
+      @family_name = (@edo_attributes && @edo_attributes[:family_name]) || @last_name || ''
+      # Identifiers
+      @student_id = get_campus_attribute('student_id', :numeric_string)
+      @campus_solutions_id = get_campus_attribute('campus_solutions_id', :string)
+      # Other
+      @primary_email_address = get_campus_attribute('email_address', :string)
+      @official_bmail_address = get_campus_attribute('official_bmail_address', :string)
+      @education_abroad = !!@oracle_attributes[:education_abroad]
+    end
+
+    private
+
+    def get_campus_roles
+      ldap_roles = (@ldap_attributes && @ldap_attributes[:roles]) || {}
+      oracle_roles = (@oracle_attributes && @oracle_attributes[:roles]) || {}
+      campus_roles = oracle_roles.merge ldap_roles
+      if sis_profile_visible?
+        edo_roles = (@edo_attributes && @edo_attributes[:roles]) || {}
+        edo_roles_to_merge = edo_roles.slice *WHITELISTED_EDO_ROLES
+        # While we're in the split-brain stage, LDAP and Oracle are more trusted on ex-student status.
+        edo_roles_to_merge.delete(:student) if campus_roles[:exStudent]
+        campus_roles.merge edo_roles_to_merge
+      else
+        campus_roles
+      end
+    end
+
+    # Split brain three ways until some subset of the brain proves more trustworthy.
+    def get_campus_attribute(field, format)
+      if sis_profile_visible? &&
+        (@roles[:student] || @roles[:applicant]) &&
+        @edo_attributes[:noStudentId].blank? && (edo_attribute = @edo_attributes[field.to_sym])
+        begin
+          validated_edo_attribute = validate_attribute(edo_attribute, format)
+        rescue
+          logger.error "EDO attribute #{field} failed validation for UID #{@uid}: expected a #{format}, got #{edo_attribute}"
+        end
+      end
+      validated_edo_attribute || @ldap_attributes[field.to_sym] || @oracle_attributes[field]
+    end
+
+    def validate_attribute(value, format)
+      case format
+        when :string
+          raise ArgumentError unless value.is_a?(String) && value.present?
+        when :numeric_string
+          raise ArgumentError unless value.is_a?(String) && Integer(value, 10)
+      end
+      value
+    end
+
+  end
+end

--- a/spec/models/user/aggregated_attributes_spec.rb
+++ b/spec/models/user/aggregated_attributes_spec.rb
@@ -1,0 +1,139 @@
+describe User::AggregatedAttributes do
+  let(:uid) { random_id }
+  let(:campus_solutions_id) { random_id }
+  let(:student_id) { random_id }
+  let(:preferred_name) { 'Grigori Rasputin' }
+  let(:bmail_from_edo) { 'rasputin@berkeley.edu' }
+  let(:edo_attributes) do
+    {
+      person_name: preferred_name,
+      student_id: student_id,
+      campus_solutions_id: campus_solutions_id,
+      is_legacy_user: false,
+      official_bmail_address: bmail_from_edo,
+      roles: {
+        student: true,
+        exStudent: false,
+        faculty: false,
+        staff: false
+      }
+    }
+  end
+  let(:ldap_attributes) { {} }
+
+  subject { User::AggregatedAttributes.new uid }
+
+  before(:each) do
+    allow(HubEdos::UserAttributes).to receive(:new).with(user_id: uid).and_return double get: edo_attributes
+    allow(CalnetLdap::UserAttributes).to receive(:new).with(user_id: uid).and_return double get_feed: ldap_attributes
+    allow(CampusOracle::UserAttributes).to receive(:new).with(user_id: uid).and_return double(get_feed: {})
+  end
+
+  describe 'all systems available' do
+    context 'Hub feed' do
+      it 'should return edo user attributes' do
+        expect(subject.campus_solutions_student?).to be true
+        expect(subject.sis_profile_visible?).to be true
+        expect(subject.official_bmail_address).to eq bmail_from_edo
+        expect(subject.campus_solutions_id).to eq campus_solutions_id
+        expect(subject.student_id).to eq student_id
+      end
+    end
+  end
+
+  describe 'LDAP is fallback' do
+    let(:bmail_from_ldap) { 'raspy@berkeley.edu' }
+    let(:ldap_attributes) do
+      {
+        official_bmail_address: bmail_from_ldap,
+        roles: {
+          student: is_active_student,
+          exStudent: !is_active_student,
+          faculty: false,
+          staff: true
+        }
+      }
+    end
+    context 'active student' do
+      let(:is_active_student) { true }
+      it 'should prefer EDO' do
+        expect(subject.official_bmail_address).to eq bmail_from_edo
+      end
+    end
+    context 'former student' do
+      let(:is_active_student) { false }
+      it 'should fall back to LDAP' do
+        expect(subject.official_bmail_address).to eq bmail_from_ldap
+      end
+    end
+    context 'applicant' do
+      let(:edo_attributes) do
+        {
+          person_name: preferred_name,
+          student_id: student_id,
+          campus_solutions_id: campus_solutions_id,
+          official_bmail_address: bmail_from_edo,
+          roles: {
+            student: false,
+            exStudent: false,
+            faculty: false,
+            staff: true,
+            applicant: true
+          }
+        }
+      end
+      let(:is_active_student) { false }
+      it 'should prefer EDO' do
+        expect(subject.official_bmail_address).to eq bmail_from_edo
+      end
+    end
+    context 'broken Hub API' do
+      let(:is_active_student) { true }
+      let(:edo_attributes) do
+        {
+          body: 'An unknown server error occurred',
+          statusCode: 503
+        }
+      end
+      it 'relies on LDAP and Oracle' do
+        expect(subject.official_bmail_address).to eq bmail_from_ldap
+      end
+    end
+  end
+
+  describe 'legacy data' do
+    let(:legacy_id) { random_id } # 8-digit ID means legacy
+    let(:edo_attributes) do
+      {
+        person_name: preferred_name,
+        campus_solutions_id: legacy_id,
+        is_legacy_user: true,
+        roles: {
+          student: true,
+          exStudent: false,
+          faculty: false,
+          staff: false
+        }
+      }
+    end
+    context 'with the fallback enabled' do
+      before do
+        allow(Settings.features).to receive(:cs_profile_visible_for_legacy_users).and_return false
+      end
+      it 'should hide SIS profile for legacy students' do
+        expect(subject.campus_solutions_student?).to be false
+        expect(subject.sis_profile_visible?).to be false
+      end
+    end
+    context 'with the fallback disabled' do
+      before do
+        allow(Settings.features).to receive(:cs_profile_visible_for_legacy_users).and_return true
+      end
+      it 'should show SIS profile for legacy students' do
+        expect(subject.campus_solutions_student?).to be false
+        expect(subject.sis_profile_visible?).to be true
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-15118

The student-overview page for Advisors needs an easy way to pull student attributes using our split-brain logic. This PR extracts logic of EDO/LDAP/Legacy precedence from User::Api and makes it available as a standalone for future use in student_overview_controller. 

**Note:** No change to `api_spec.rb`.