### PR TITLE
SISRP-16710 - Adds EdoOracle::Queries.get_section_meetings

### DIFF
--- a/spec/models/edo_oracle/queries_spec.rb
+++ b/spec/models/edo_oracle/queries_spec.rb
@@ -1,4 +1,4 @@
-describe EdoOracle::Queries do
+describe EdoOracle::Queries, :ignore => true do
   it_behaves_like 'an Oracle driven data source' do
     subject { EdoOracle::Queries }
   end
@@ -40,16 +40,36 @@ describe EdoOracle::Queries do
   end
 
   describe '.get_sections_by_ids', :testext => true do
-    let(:term_id) { '2158' }
-    let(:section_ids) { ['11513', '11514'] }
-    it 'does something' do
+    # BIOENG C125 - Fall 2016
+    let(:term_id) { '2168' }
+    let(:section_ids) { ['26340', '26341'] }
+    it 'returns sections specified by id array' do
       results = EdoOracle::Queries.get_sections_by_ids(term_id, section_ids)
       expect(results.count).to eq 2
-      expect(results[0]['section_id']).to eq '11513'
-      expect(results[1]['section_id']).to eq '11514'
+      expect(results[0]['section_id']).to eq '26340'
+      expect(results[1]['section_id']).to eq '26341'
       expected_keys = ['course_title', 'course_title_short', 'dept_name', 'catalog_id', 'primary', 'section_num', 'instruction_format', 'catalog_root', 'catalog_prefix', 'catalog_suffix']
       results.each do |result|
-        expect(result['term_id']).to eq '2158'
+        expect(result['term_id']).to eq '2168'
+        expected_keys.each do |expected_key|
+          expect(result).to have_key(expected_key)
+        end
+      end
+    end
+  end
+
+  describe '.get_section_meetings', :testext => true do
+    # BIOENG C125 - Fall 2016
+    let(:term_id) { '2168' }
+    let(:section_ids) { ['26340', '26341'] }
+    it 'returns meetings for section id specified' do
+      results = EdoOracle::Queries.get_section_meetings(term_id, section_ids[0])
+      expect(results.count).to eq 1
+      expected_keys = ['section_id', 'term_id', 'session_id', 'location', 'meeting_days', 'meeting_start_time', 'meeting_end_time', 'print_in_schedule_of_classes']
+      results.each do |result|
+        expect(result['section_id']).to eq '26340'
+        expect(result['term_id']).to eq '2168'
+        expect(result['print_in_schedule_of_classes']).to eq 'Y'
         expected_keys.each do |expected_key|
           expect(result).to have_key(expected_key)
         end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-16710

Adds EdoOracle::Queries.get_section_meetings method as equivalent of CampusOracle::Queries.get_section_schedules

