### PR TITLE
SISRP-16877 Add cutoff in YAML to specify per-term academic data source

### DIFF
--- a/app/models/berkeley/term.rb
+++ b/app/models/berkeley/term.rb
@@ -1,6 +1,7 @@
 module Berkeley
   class Term
     include ActiveAttrModel, ClassLogger
+    include Comparable
     extend Cache::Cacheable
 
     attr_reader :code
@@ -54,6 +55,14 @@ module Berkeley
 
     def to_english
       TermCodes.to_english(year, code)
+    end
+
+    def <=>(other_term)
+      [year, code] <=> [other_term.year, other_term.code]
+    end
+
+    def legacy?
+      self <= Berkeley::Terms.fetch.legacy_cutoff
     end
 
     # Most final grades should appear on the transcript by this date.

--- a/app/models/berkeley/terms.rb
+++ b/app/models/berkeley/terms.rb
@@ -46,6 +46,8 @@ module Berkeley
     attr_reader :grading_in_progress
     # How far back do we look for enrollments, transcripts, & teaching assignments?
     attr_reader :oldest
+    # This term and earlier will pull academic data from legacy CampusOracle. Later terms will pull from EdoOracle.
+    attr_reader :legacy_cutoff
     # Full list of terms in DB.
     attr_reader :campus
 
@@ -75,6 +77,7 @@ module Berkeley
           @previous ||= term
           @grading_in_progress ||= term if term.grades_entered >= current_date
         end
+        @legacy_cutoff = term if term.slug == Settings.terms.legacy_cutoff
         break if term.slug == @oldest
       end
       @current = @running || future_terms.pop

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -56,6 +56,8 @@ campusdb:
 terms:
   # Limit how far back our academic history goes.
   oldest: spring-2010
+  # This term and earlier will pull academic data from legacy CampusOracle. Later terms will pull from EdoOracle.
+  legacy_cutoff: summer-2016
   # Timestamp in UTC, needed when testing against test Campus data.
   # Can also be used to force selection of a "current term" different
   # from the default.

--- a/spec/models/berkeley/term_spec.rb
+++ b/spec/models/berkeley/term_spec.rb
@@ -71,6 +71,21 @@ describe Berkeley::Term do
     its(:start) {should eq Time.zone.parse('2014-01-14 00:00:00').to_datetime}
     its(:end) {should eq Time.zone.parse('2014-05-16 23:59:59').to_datetime}
     its(:to_english) {should eq 'Spring 2014'}
+    context 'legacy source-of-record checks' do
+      before { allow(Settings.terms).to receive(:legacy_cutoff).and_return legacy_cutoff }
+      context 'term is before legacy cutoff' do
+        let(:legacy_cutoff) { 'summer-2014' }
+        its(:legacy?) { should eq true }
+      end
+      context 'term is equal to legacy cutoff' do
+        let(:legacy_cutoff) { 'spring-2014' }
+        its(:legacy?) { should eq true }
+      end
+      context 'term is after legacy cutoff' do
+        let(:legacy_cutoff) { 'fall-2013' }
+        its(:legacy?) { should eq false }
+      end
+    end
   end
 
 end


### PR DESCRIPTION
First bit of support for https://jira.berkeley.edu/browse/SISRP-16877.

A YAML cutoff is handy for two reasons:
- Moving it into the future is equivalent to switching off an EdoOracle feature flag entirely.
- Moving it into the past allows devs and QA to do limited verification of EdoOracle against converted legacy data. 