### PR TITLE
SISRP-15118, AggregatedAttributes feed for Advisor's student summary card

### DIFF
--- a/app/controllers/student_overview_controller.rb
+++ b/app/controllers/student_overview_controller.rb
@@ -1,0 +1,24 @@
+class StudentOverviewController < ApplicationController
+  include ClassLogger
+
+  before_action :api_authenticate
+  before_action :authorize_access_to_student
+
+  rescue_from StandardError, with: :handle_api_exception
+  rescue_from Errors::ClientError, with: :handle_client_error
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  def authorize_access_to_student
+    authorize current_user, :can_view_as_for_all_uids?
+  end
+
+  def student
+    student_uid = params.require 'student_uid'
+    person = User::AggregatedAttributes.new(student_uid).get_feed
+    unless person[:roles][:student] || person[:roles][:exStudent] || person[:roles][:applicant]
+      raise Pundit::NotAuthorizedError.new "#{current_user.user_id} is forbidden to view #{student_uid} because #{student_uid} is neither student, ex-student nor applicant"
+    end
+    render json: person
+  end
+
+end

--- a/app/models/user/aggregated_attributes.rb
+++ b/app/models/user/aggregated_attributes.rb
@@ -1,40 +1,40 @@
 module User
   class AggregatedAttributes < UserSpecificModel
     include CampusSolutions::ProfileFeatureFlagged
+    include Cache::CachedFeed
     include Cache::RelatedCacheKeyTracker
-
-    attr_reader :campus_solutions_id, :student_id, :given_first_name, :first_name, :last_name, :family_name, :default_name
-    attr_reader :roles, :primary_email_address, :official_bmail_address, :education_abroad, :campus_solutions_student, :sis_profile_visible
-    alias_method :education_abroad?, :education_abroad
-    alias_method :campus_solutions_student?, :campus_solutions_student
-    alias_method :sis_profile_visible?, :sis_profile_visible
 
     # Conservative merge of roles from EDO
     WHITELISTED_EDO_ROLES = [:student, :applicant, :advisor]
 
     def initialize(uid, options={})
       super(uid, options)
+    end
+
+    def get_feed_internal
       @ldap_attributes = CalnetLdap::UserAttributes.new(user_id: @uid).get_feed
       @oracle_attributes = CampusOracle::UserAttributes.new(user_id: @uid).get_feed
-      if is_cs_profile_feature_enabled
-        @edo_attributes = HubEdos::UserAttributes.new(user_id: @uid).get
-      end
-      @campus_solutions_student = @edo_attributes.present? && (@edo_attributes[:is_legacy_user] == false)
-      @sis_profile_visible = is_cs_profile_feature_enabled && (@campus_solutions_student || is_profile_visible_for_legacy_users)
+      @edo_attributes = HubEdos::UserAttributes.new(user_id: @uid).get if is_cs_profile_feature_enabled
+      campus_solutions_student = @edo_attributes.present? && (@edo_attributes[:is_legacy_user] == false)
+      @sis_profile_visible = is_cs_profile_feature_enabled && (campus_solutions_student || is_profile_visible_for_legacy_users)
       @roles = get_campus_roles
-      # Names
-      @default_name = get_campus_attribute('person_name', :string)
-      @first_name = get_campus_attribute('first_name', :string) || ''
-      @last_name = get_campus_attribute('last_name', :string) || ''
-      @given_first_name = (@edo_attributes && @edo_attributes[:given_name]) || @first_name || ''
-      @family_name = (@edo_attributes && @edo_attributes[:family_name]) || @last_name || ''
-      # Identifiers
-      @student_id = get_campus_attribute('student_id', :numeric_string)
-      @campus_solutions_id = get_campus_attribute('campus_solutions_id', :string)
-      # Other
-      @primary_email_address = get_campus_attribute('email_address', :string)
-      @official_bmail_address = get_campus_attribute('official_bmail_address', :string)
-      @education_abroad = !!@oracle_attributes[:education_abroad]
+      first_name = get_campus_attribute('first_name', :string) || ''
+      last_name = get_campus_attribute('last_name', :string) || ''
+      {
+        campus_solutions_student: campus_solutions_student,
+        sis_profile_visible: @sis_profile_visible,
+        roles: @roles,
+        default_name: get_campus_attribute('person_name', :string),
+        first_name: first_name,
+        last_name: last_name,
+        given_first_name: (@edo_attributes && @edo_attributes[:given_name]) || first_name || '',
+        family_name: (@edo_attributes && @edo_attributes[:family_name]) || last_name || '',
+        student_id: get_campus_attribute('student_id', :numeric_string),
+        campus_solutions_id: get_campus_attribute('campus_solutions_id', :string),
+        primary_email_address: get_campus_attribute('email_address', :string),
+        official_bmail_address: get_campus_attribute('official_bmail_address', :string),
+        education_abroad: !!@oracle_attributes[:education_abroad]
+      }
     end
 
     private
@@ -43,7 +43,7 @@ module User
       ldap_roles = (@ldap_attributes && @ldap_attributes[:roles]) || {}
       oracle_roles = (@oracle_attributes && @oracle_attributes[:roles]) || {}
       campus_roles = oracle_roles.merge ldap_roles
-      if sis_profile_visible?
+      if @sis_profile_visible
         edo_roles = (@edo_attributes && @edo_attributes[:roles]) || {}
         edo_roles_to_merge = edo_roles.slice *WHITELISTED_EDO_ROLES
         # While we're in the split-brain stage, LDAP and Oracle are more trusted on ex-student status.
@@ -56,7 +56,7 @@ module User
 
     # Split brain three ways until some subset of the brain proves more trustworthy.
     def get_campus_attribute(field, format)
-      if sis_profile_visible? &&
+      if @sis_profile_visible &&
         (@roles[:student] || @roles[:applicant]) &&
         @edo_attributes[:noStudentId].blank? && (edo_attribute = @edo_attributes[field.to_sym])
         begin

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,18 +128,27 @@ Calcentral::Application.routes.draw do
     post '/logout' => 'sessions#destroy', :as => :logout, :via => :post
   end
 
-  # Act-as endpoints
-  post '/advisor_act_as' => 'advisor_act_as#start'
-  post '/stop_advisor_act_as' => 'advisor_act_as#stop'
-  post '/delegate_act_as' => 'delegate_act_as#start'
-  post '/stop_delegate_act_as' => 'delegate_act_as#stop'
+  # View-as endpoints
+  get '/stored_users' => 'stored_users#get', :via => :get, :defaults => { :format => 'json' }
   post '/act_as' => 'act_as#start'
   post '/stop_act_as' => 'act_as#stop'
-  get '/stored_users' => 'stored_users#get', :via => :get, :defaults => { :format => 'json' }
   post '/store_user/saved' => 'stored_users#store_saved_uid', via: :post, defaults: { format: 'json' }
   post '/delete_user/saved' => 'stored_users#delete_saved_uid', via: :post, defaults: { format: 'json' }
   post '/delete_users/recent' => 'stored_users#delete_all_recent', via: :post, defaults: { format: 'json' }
   post '/delete_users/saved' => 'stored_users#delete_all_saved', via: :post, defaults: { format: 'json' }
+
+  # Advisor endpoints
+  get '/api/student/:student_uid' => 'student_overview#student', :defaults => { :format => 'json' }
+  post '/advisor_act_as' => 'advisor_act_as#start'
+  post '/stop_advisor_act_as' => 'advisor_act_as#stop'
+
+  # Delegated Access endpoints
+  get '/api/campus_solutions/delegate_terms_and_conditions' => 'campus_solutions/delegate_access#get_terms_and_conditions', :defaults => { :format => 'json' }
+  get '/api/campus_solutions/delegate_management_url' => 'campus_solutions/delegate_access#get_delegate_management_url', :defaults => { :format => 'json' }
+  get '/api/campus_solutions/delegate_access/students' => 'campus_solutions/delegate_access#get_students', :defaults => { :format => 'json' }
+  post '/delegate_act_as' => 'delegate_act_as#start'
+  post '/stop_delegate_act_as' => 'delegate_act_as#stop'
+  post '/api/campus_solutions/delegate_access' => 'campus_solutions/delegate_access#post', :defaults => { :format => 'json' }
 
   # Campus Solutions general purpose endpoints
   get '/api/campus_solutions/checklist' => 'campus_solutions/checklist#get', :via => :get, :defaults => { :format => 'json' }
@@ -159,9 +168,6 @@ Calcentral::Application.routes.draw do
   get '/api/campus_solutions/financial_aid_data' => 'campus_solutions/financial_aid_data#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/financial_aid_funding_sources' => 'campus_solutions/financial_aid_funding_sources#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/financial_aid_funding_sources_term' => 'campus_solutions/financial_aid_funding_sources_term#get', :via => :get, :defaults => { :format => 'json' }
-  get '/api/campus_solutions/delegate_terms_and_conditions' => 'campus_solutions/delegate_access#get_terms_and_conditions', :via => :get, :defaults => { :format => 'json' }
-  get '/api/campus_solutions/delegate_management_url' => 'campus_solutions/delegate_access#get_delegate_management_url', :via => :get, :defaults => { :format => 'json' }
-  get '/api/campus_solutions/delegate_access/students' => 'campus_solutions/delegate_access#get_students', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/holds' => 'campus_solutions/holds#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/enrollment_term' => 'campus_solutions/enrollment_term#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/enrollment_terms' => 'campus_solutions/enrollment_terms#get', :via => :get, :defaults => { :format => 'json' }
@@ -170,7 +176,6 @@ Calcentral::Application.routes.draw do
   get '/api/campus_solutions/ferpa_deeplink' => 'campus_solutions/ferpa_deeplink#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/billing' => 'campus_solutions/billing#get', :via => :get, :defaults => { :format => 'json' }
   post '/api/campus_solutions/address' => 'campus_solutions/address#post', :via => :post, :defaults => { :format => 'json' }
-  post '/api/campus_solutions/delegate_access' => 'campus_solutions/delegate_access#post', :via => :post, :defaults => { :format => 'json' }
   post '/api/campus_solutions/email' => 'campus_solutions/email#post', :via => :post, :defaults => { :format => 'json' }
   post '/api/campus_solutions/person_name' => 'campus_solutions/person_name#post', :via => :post, :defaults => { :format => 'json' }
   post '/api/campus_solutions/phone' => 'campus_solutions/phone#post', :via => :post, :defaults => { :format => 'json' }

--- a/spec/controllers/student_overview_controller_spec.rb
+++ b/spec/controllers/student_overview_controller_spec.rb
@@ -1,0 +1,68 @@
+describe StudentOverviewController do
+
+  let(:session_user_id) { nil }
+  let(:student_uid) { random_id }
+  let(:can_view_as_for_all_uids) { false }
+  let(:user_attributes) { double }
+
+  before do
+    session['user_id'] = session_user_id
+    allow_any_instance_of(AuthenticationStatePolicy).to receive(:can_view_as_for_all_uids?).and_return can_view_as_for_all_uids
+  end
+
+  context 'no user in session' do
+    subject { get :student, student_uid: student_uid }
+    it 'should return empty json' do
+      expect(JSON.parse subject.body).to be_empty
+    end
+  end
+
+  describe '#student' do
+    let(:session_user_id) { random_id }
+    before do
+      allow(User::AggregatedAttributes).to receive(:new).with(student_uid).and_return double get_feed: user_attributes
+    end
+    subject { get :student, student_uid: student_uid }
+
+    context 'cannot view_as for all UIDs' do
+      it 'should raise an error' do
+        expect(subject.status).to eq 403
+      end
+    end
+    context 'requested user must be a student' do
+      let(:can_view_as_for_all_uids) { true }
+      let(:student) { false }
+      let(:ex_student) { false }
+      let(:applicant) { false }
+      let(:user_attributes) { { roles: { student: student, exStudent: ex_student, applicant: applicant } } }
+
+      context 'not a student' do
+        it 'should raise an error' do
+          expect(subject.status).to eq 403
+        end
+      end
+      context 'student' do
+        let(:student) { true }
+        it 'should succeed' do
+          expect(subject.status).to eq 200
+          expect(JSON.parse(subject.body).deep_symbolize_keys).to eq user_attributes
+        end
+      end
+      context 'ex-student' do
+        let(:ex_student) { true }
+        it 'should succeed' do
+          expect(subject.status).to eq 200
+          expect(JSON.parse(subject.body).deep_symbolize_keys).to eq user_attributes
+        end
+      end
+      context 'applicant' do
+        let(:applicant) { true }
+        it 'should succeed' do
+          expect(subject.status).to eq 200
+          expect(JSON.parse(subject.body).deep_symbolize_keys).to eq user_attributes
+        end
+      end
+    end
+  end
+
+end

--- a/spec/models/user/aggregated_attributes_spec.rb
+++ b/spec/models/user/aggregated_attributes_spec.rb
@@ -21,7 +21,7 @@ describe User::AggregatedAttributes do
   end
   let(:ldap_attributes) { {} }
 
-  subject { User::AggregatedAttributes.new uid }
+  subject { User::AggregatedAttributes.new(uid).get_feed }
 
   before(:each) do
     allow(HubEdos::UserAttributes).to receive(:new).with(user_id: uid).and_return double get: edo_attributes
@@ -32,11 +32,11 @@ describe User::AggregatedAttributes do
   describe 'all systems available' do
     context 'Hub feed' do
       it 'should return edo user attributes' do
-        expect(subject.campus_solutions_student?).to be true
-        expect(subject.sis_profile_visible?).to be true
-        expect(subject.official_bmail_address).to eq bmail_from_edo
-        expect(subject.campus_solutions_id).to eq campus_solutions_id
-        expect(subject.student_id).to eq student_id
+        expect(subject[:campus_solutions_student]).to be true
+        expect(subject[:sis_profile_visible]).to be true
+        expect(subject[:official_bmail_address]).to eq bmail_from_edo
+        expect(subject[:campus_solutions_id]).to eq campus_solutions_id
+        expect(subject[:student_id]).to eq student_id
       end
     end
   end
@@ -57,13 +57,13 @@ describe User::AggregatedAttributes do
     context 'active student' do
       let(:is_active_student) { true }
       it 'should prefer EDO' do
-        expect(subject.official_bmail_address).to eq bmail_from_edo
+        expect(subject[:official_bmail_address]).to eq bmail_from_edo
       end
     end
     context 'former student' do
       let(:is_active_student) { false }
       it 'should fall back to LDAP' do
-        expect(subject.official_bmail_address).to eq bmail_from_ldap
+        expect(subject[:official_bmail_address]).to eq bmail_from_ldap
       end
     end
     context 'applicant' do
@@ -84,7 +84,7 @@ describe User::AggregatedAttributes do
       end
       let(:is_active_student) { false }
       it 'should prefer EDO' do
-        expect(subject.official_bmail_address).to eq bmail_from_edo
+        expect(subject[:official_bmail_address]).to eq bmail_from_edo
       end
     end
     context 'broken Hub API' do
@@ -96,7 +96,7 @@ describe User::AggregatedAttributes do
         }
       end
       it 'relies on LDAP and Oracle' do
-        expect(subject.official_bmail_address).to eq bmail_from_ldap
+        expect(subject[:official_bmail_address]).to eq bmail_from_ldap
       end
     end
   end
@@ -121,8 +121,8 @@ describe User::AggregatedAttributes do
         allow(Settings.features).to receive(:cs_profile_visible_for_legacy_users).and_return false
       end
       it 'should hide SIS profile for legacy students' do
-        expect(subject.campus_solutions_student?).to be false
-        expect(subject.sis_profile_visible?).to be false
+        expect(subject[:campus_solutions_student]).to be false
+        expect(subject[:sis_profile_visible]).to be false
       end
     end
     context 'with the fallback disabled' do
@@ -130,8 +130,8 @@ describe User::AggregatedAttributes do
         allow(Settings.features).to receive(:cs_profile_visible_for_legacy_users).and_return true
       end
       it 'should show SIS profile for legacy students' do
-        expect(subject.campus_solutions_student?).to be false
-        expect(subject.sis_profile_visible?).to be true
+        expect(subject[:campus_solutions_student]).to be false
+        expect(subject[:sis_profile_visible]).to be true
       end
     end
   end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-15118

`StudentOverviewController` returns aggregated-user-attributes as long as user `can_view_as_for_all_uids?` and the target UID is student, exStudent or applicant. Making `User::AggregatedAttributes` a CachedFeed seemed necessary, sensible and not terribly disruptive to `User::Api`. 

**Note:** Changes in `routes.rb` are in the spirit of readability. 