### PR TITLE
SISRP-16877 EdoOracle::UserCourses models and tests

### DIFF
--- a/app/models/berkeley/term.rb
+++ b/app/models/berkeley/term.rb
@@ -62,7 +62,11 @@ module Berkeley
     end
 
     def legacy?
-      self <= Berkeley::Terms.fetch.legacy_cutoff
+      @is_legacy || false
+    end
+
+    def set_as_legacy
+      @is_legacy = true
     end
 
     # Most final grades should appear on the transcript by this date.

--- a/app/models/berkeley/term_codes.rb
+++ b/app/models/berkeley/term_codes.rb
@@ -31,6 +31,10 @@ module Berkeley
       {:term_yr => legacy_term_yr, :term_cd => legacy_term_cd}
     end
 
+    def edo_id_to_code(edo_term_id)
+      self.from_edo_id(edo_term_id).values_at(:term_yr, :term_cd).join '-'
+    end
+
     def to_english(term_yr, term_cd)
       term = codes[term_cd.to_sym]
       unless term

--- a/app/models/berkeley/terms.rb
+++ b/app/models/berkeley/terms.rb
@@ -46,8 +46,6 @@ module Berkeley
     attr_reader :grading_in_progress
     # How far back do we look for enrollments, transcripts, & teaching assignments?
     attr_reader :oldest
-    # This term and earlier will pull academic data from legacy CampusOracle. Later terms will pull from EdoOracle.
-    attr_reader :legacy_cutoff
     # Full list of terms in DB.
     attr_reader :campus
 
@@ -63,9 +61,10 @@ module Berkeley
       future_terms = []
       current_date = options[:fake_now] || DateTime.now
       @oldest = options[:oldest]
-      db_terms = CampusOracle::Queries.terms
+      parsing_legacy_terms = false
+
       # Do initial term parsing.
-      db_terms.each do |db_term|
+      CampusOracle::Queries.terms.each do |db_term|
         term = Term.new(db_term)
         terms[term.slug] = term
         @sis_current_term = term if term.sis_term_status == 'CT'
@@ -77,9 +76,11 @@ module Berkeley
           @previous ||= term
           @grading_in_progress ||= term if term.grades_entered >= current_date
         end
-        @legacy_cutoff = term if term.slug == Settings.terms.legacy_cutoff
+        parsing_legacy_terms = true if term.slug == Settings.terms.legacy_cutoff
+        term.set_as_legacy if parsing_legacy_terms
         break if term.slug == @oldest
       end
+
       @current = @running || future_terms.pop
       if (@next = future_terms.pop)
         if (@future = future_terms.pop)

--- a/app/models/campus_oracle/user_courses/base.rb
+++ b/app/models/campus_oracle/user_courses/base.rb
@@ -8,7 +8,8 @@ module CampusOracle
       def initialize(options = {})
         super(Settings.campusdb, options)
         @uid = @settings.fake_user_id if @fake
-        @academic_terms = Berkeley::Terms.fetch.campus.values
+        # Legacy terms are those before and including Settings.terms.legacy_cutoff.
+        @legacy_academic_terms = Berkeley::Terms.fetch.campus.values.select &:legacy?
       end
 
       def self.expires_in
@@ -21,7 +22,7 @@ module CampusOracle
 
       def merge_enrollments(campus_classes)
         previous_item = {}
-        enrollments = CampusOracle::Queries.get_enrolled_sections(@uid, @academic_terms)
+        enrollments = CampusOracle::Queries.get_enrolled_sections(@uid, @legacy_academic_terms)
         enrollments.each do |row|
           if (item = row_to_feed_item(row, previous_item))
             item[:role] = 'Student'
@@ -35,7 +36,7 @@ module CampusOracle
 
       def merge_explicit_instructing(campus_classes)
         previous_item = {}
-        assigneds = CampusOracle::Queries.get_instructing_sections(@uid, @academic_terms)
+        assigneds = CampusOracle::Queries.get_instructing_sections(@uid, @legacy_academic_terms)
         is_instructing = assigneds.present?
         assigneds.each do |row|
           if (item = row_to_feed_item(row, previous_item))

--- a/app/models/edo_oracle/course_sections.rb
+++ b/app/models/edo_oracle/course_sections.rb
@@ -1,0 +1,87 @@
+module EdoOracle
+  class CourseSections < BaseProxy
+
+    def initialize(term_id, course_id)
+      super(Settings.edodb)
+      @term_id = term_id
+      @course_id = course_id
+    end
+
+    def get_section_data
+      self.class.fetch_from_cache "#{@course_id}-#{@term_id}" do
+        {
+          instructors: get_section_instructors,
+          schedules: get_section_schedules
+        }
+      end
+    end
+
+    private
+
+    def get_section_schedules
+      schedules = EdoOracle::Queries.get_section_meetings(@term_id, @course_id).map do |meeting|
+        if meeting && meeting['meeting_days'].present?
+          translate_location(meeting).merge(translate_schedule(meeting))
+        end
+      end
+      schedules.compact
+    end
+
+    def get_section_instructors
+      instructors = EdoOracle::Queries.get_section_instructors(@term_id, @course_id).map do |instructor|
+        {
+          name: instructor['person_name'],
+          role: instructor['role_code'],
+          uid: instructor['ldap_uid']
+        }
+      end
+      instructors.uniq
+    end
+
+    def strip_leading_zeros(str=nil)
+      (str.nil?) ? nil : "#{str}".gsub!(/^[0]*/, '')
+    end
+
+    def translate_location(meeting)
+      return {} unless meeting['location']
+      location_chunks = meeting['location'].rpartition /\s+/
+      if location_chunks.first.present?
+        {
+          buildingName: location_chunks.first,
+          roomNumber: strip_leading_zeros(location_chunks.last)
+        }
+      else
+        {
+          buildingName: location_chunks.last,
+          roomNumber: ''
+        }
+      end
+    end
+
+    def translate_schedule(meeting)
+      schedule = ''
+      if meeting['meeting_days'].present?
+        meeting['meeting_days'].chars.each_slice(2).inject(schedule) do |schedule, day_chars|
+          schedule << case day_chars.join
+            when 'SU' then 'Su'
+            when 'MO' then 'M'
+            when 'TU' then 'Tu'
+            when 'WE' then 'W'
+            when 'TH' then 'Th'
+            when 'FR' then 'F'
+            when 'SA' then 'Sa'
+            else ''
+          end
+        end
+      end
+      if meeting['meeting_start_time'].present?
+        schedule << " #{meeting['meeting_start_time']}"
+        schedule << "-#{meeting['meeting_end_time']}" unless meeting['meeting_end_time'].blank?
+      end
+      {
+        schedule: schedule
+      }
+    end
+
+  end
+end

--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -41,7 +41,8 @@ module EdoOracle
           sec."maxEnroll" AS enroll_limit,
           enr."STDNT_ENRL_STATUS_CODE" AS enroll_status,
           enr."WAITLISTPOSITION" AS waitlist_position,
-          enr."UNITS_TAKEN" AS unit,
+          enr."UNITS_TAKEN" AS units,
+          enr."GRADE_MARK" AS grade,
           enr."GRADING_BASIS_CODE" AS grading_basis
         FROM SISEDO.ENROLLMENTV00_VW enr
         JOIN SISEDO.CLASSSECTIONV00_VW sec ON (
@@ -157,19 +158,18 @@ module EdoOracle
     #   - 'term_yr' and 'term_yr' replaced by 'term_id'
     #   - 'instructor_func' has become represented by 'role_code' and 'role_description'
     #   - Does not provide all user profile fields ('email_address', 'student_id', 'affiliations').
-    #     This will require a programatic join at a higher level.
+    #     This will require a programmatic join at a higher level.
     #     See CLC-6239 for implementation of batch LDAP profile requests.
     #
-    # TODO: Update dependencies in CampusOracle::CourseSections and CanvasCsv::SiteMembershipsMaintainer
-    #   to merge user profile data into this feed
-    def self.get_section_instructors(section_id, term_id)
+    # TODO: Update CanvasCsv::SiteMembershipsMaintainer to merge user profile data into this feed.
+    def self.get_section_instructors(term_id, section_id)
       results = []
       use_pooled_connection {
         sql = <<-SQL
           SELECT
             TRIM(instr."formattedName") AS person_name,
             TRIM(instr."givenName") AS first_name,
-            TRIM(instr."givenName") AS last_name,
+            TRIM(instr."familyName") AS last_name,
             instr."campus-uid" AS ldap_uid,
             instr."role-code" AS role_code,
             instr."role-descr" AS role_description

--- a/app/models/edo_oracle/user_courses/all.rb
+++ b/app/models/edo_oracle/user_courses/all.rb
@@ -1,0 +1,36 @@
+module EdoOracle
+  module UserCourses
+    class All < Base
+
+      include Cache::UserCacheExpiry
+
+      def get_all_campus_courses
+        # Because this data structure is used by multiple top-level feeds, it's essential
+        # that it be cached efficiently.
+        self.class.fetch_from_cache @uid do
+          campus_classes = {}
+          merge_instructing campus_classes
+          merge_enrollments campus_classes
+
+          # Sort the hash in descending order of semester.
+          campus_classes = Hash[campus_classes.sort.reverse]
+
+          # Merge each section's schedule, location, and instructor list.
+          # TODO Is this information useful for non-current terms?
+          merge_detailed_section_data(campus_classes)
+
+          campus_classes
+        end
+      end
+
+      def get_enrollments_summary
+        self.class.fetch_from_cache "summary-#{@uid}" do
+          campus_classes = {}
+          merge_enrollments campus_classes
+          Hash[campus_classes.sort.reverse]
+        end
+      end
+
+    end
+  end
+end

--- a/app/models/edo_oracle/user_courses/base.rb
+++ b/app/models/edo_oracle/user_courses/base.rb
@@ -1,0 +1,131 @@
+module EdoOracle
+  module UserCourses
+
+    APP_ID = 'Campus'
+
+    class Base < BaseProxy
+
+      def initialize(options = {})
+        super(Settings.campusdb, options)
+        @uid = @settings.fake_user_id if @fake
+        # Non-legacy terms are those after Settings.terms.legacy_cutoff.
+        @non_legacy_academic_terms = Berkeley::Terms.fetch.campus.values.reject &:legacy?
+      end
+
+      def self.access_granted?(uid)
+        !uid.blank?
+      end
+
+      def merge_enrollments(campus_classes)
+        previous_item = {}
+        EdoOracle::Queries.get_enrolled_sections(@uid, @non_legacy_academic_terms).each do |row|
+          if (item = row_to_feed_item(row, previous_item))
+            item[:role] = 'Student'
+            merge_feed_item(item, campus_classes)
+            previous_item = item
+          end
+        end
+      end
+
+      def merge_instructing(campus_classes)
+        previous_item = {}
+        # TODO flag cross-listings
+        # TODO get implicitly instructed sections
+        EdoOracle::Queries.get_instructing_sections(@uid, @non_legacy_academic_terms).each do |row|
+          if (item = row_to_feed_item(row, previous_item))
+            item[:role] = 'Instructor'
+            merge_feed_item(item, campus_classes)
+            previous_item = item
+          end
+        end
+      end
+
+      def merge_feed_item(item, campus_classes)
+        semester_key = item.values_at(:term_yr, :term_cd).join '-'
+        campus_classes[semester_key] ||= []
+        campus_classes[semester_key] << item
+      end
+
+      def row_to_feed_item(row, previous_item)
+        unless (course_item = new_course_item(row, previous_item))
+          previous_item[:sections] << row_to_section_data(row)
+          nil
+        else
+          term_data = Berkeley::TermCodes.from_edo_id(row['term_id']).merge({
+            term_id: row['term_id']
+          })
+          course_name = row['course_title'].present? ? row['course_title'] : row['course_title_short']
+          course_data = {
+            catid: row['catalog_id'],
+            course_catalog: row['catalog_id'],
+            dept: row['dept_name'],
+            emitter: 'Campus',
+            name: course_name,
+            sections: [
+              row_to_section_data(row)
+            ]
+          }
+          course_item.merge(term_data).merge(course_data)
+        end
+      end
+
+      def new_course_item(row, previous_item)
+        if row.values_at('dept_name', 'catalog_id', 'term_id') != previous_item.values_at(:dept, :catid, :term_id)
+          course_ids_from_row row
+        end
+      end
+
+      # Create IDs for a given course item:
+      #   "id" : unique for the UserCourses feed across terms; used by Classes
+      #   "slug" : URL-friendly ID without term information; used by Academics
+      #   "course_code" : the short course name as displayed in the UX
+      def course_ids_from_row(row)
+        slug = %w(dept_name catalog_id).map { |key| normalize_to_slug row[key] }.join '-'
+        term_code = Berkeley::TermCodes.edo_id_to_code row['term_id']
+        {
+          course_code: row['display_name'],
+          id: "#{slug}-#{term_code}",
+          slug: slug
+        }
+      end
+
+      def normalize_to_slug(str)
+        str.downcase.gsub(/[^a-z0-9-]+/, '_')
+      end
+
+      def row_to_section_data(row)
+        section_data = {
+          ccn: row['section_id'].to_s,
+          instruction_format: row['instruction_format'],
+          is_primary_section: row['primary'],
+          section_label: "#{row['instruction_format']} #{row['section_num']}",
+          section_number: row['section_num']
+        }
+        section_data[:units] = row['units'] if row['primary']
+
+        # Grading and waitlist data only apply to enrollment records and will be skipped for instructors.
+        if row.include? 'enroll_status'
+          section_data[:grade] = row['grade'].strip if row['grade'].present?
+          section_data[:grading_basis] = row['grading_basis'] if row['primary']
+          if row['enroll_status'] == 'W'
+            section_data[:waitlistPosition] = row['waitlist_position'].to_i
+            section_data[:enroll_limit] = row['enroll_limit'].to_i
+          end
+        end
+        section_data
+      end
+
+      def merge_detailed_section_data(campus_classes)
+        campus_classes.each_value do |semester|
+          semester.each do |course|
+            course[:sections].uniq!
+            course[:sections].each do |section|
+              section.merge! EdoOracle::CourseSections.new(course[:term_id], section[:ccn]).get_section_data
+            end
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/app/models/edo_oracle/user_courses/selected_sections.rb
+++ b/app/models/edo_oracle/user_courses/selected_sections.rb
@@ -1,0 +1,26 @@
+module EdoOracle
+  module UserCourses
+    class SelectedSections < Base
+
+      def get_selected_sections(term_yr, term_cd, course_ids)
+        # Sort to get canonical cache key.
+        course_ids = course_ids.sort
+        term_id = Berkeley::TermCodes.to_edo_id(term_yr, term_cd)
+        self.class.fetch_from_cache "selected_sections-#{term_id}-#{course_ids.join(',')}" do
+          campus_classes = {}
+          sections = EdoOracle::Queries.get_sections_by_ids(term_id, course_ids)
+          previous_item = {}
+          sections.each do |row|
+            if (item = row_to_feed_item(row, previous_item))
+              merge_feed_item(item, campus_classes)
+              previous_item = item
+            end
+          end
+          merge_detailed_section_data(campus_classes)
+          campus_classes
+        end
+      end
+
+    end
+  end
+end

--- a/spec/models/berkeley/term_spec.rb
+++ b/spec/models/berkeley/term_spec.rb
@@ -71,21 +71,6 @@ describe Berkeley::Term do
     its(:start) {should eq Time.zone.parse('2014-01-14 00:00:00').to_datetime}
     its(:end) {should eq Time.zone.parse('2014-05-16 23:59:59').to_datetime}
     its(:to_english) {should eq 'Spring 2014'}
-    context 'legacy source-of-record checks' do
-      before { allow(Settings.terms).to receive(:legacy_cutoff).and_return legacy_cutoff }
-      context 'term is before legacy cutoff' do
-        let(:legacy_cutoff) { 'summer-2014' }
-        its(:legacy?) { should eq true }
-      end
-      context 'term is equal to legacy cutoff' do
-        let(:legacy_cutoff) { 'spring-2014' }
-        its(:legacy?) { should eq true }
-      end
-      context 'term is after legacy cutoff' do
-        let(:legacy_cutoff) { 'fall-2013' }
-        its(:legacy?) { should eq false }
-      end
-    end
   end
 
 end

--- a/spec/models/berkeley/terms_spec.rb
+++ b/spec/models/berkeley/terms_spec.rb
@@ -69,4 +69,21 @@ describe Berkeley::Terms do
     end
   end
 
+  context 'legacy source-of-record checks' do
+    before { allow(Settings.terms).to receive(:legacy_cutoff).and_return legacy_cutoff }
+    subject { Berkeley::Terms.fetch.campus['spring-2014'] }
+    context 'term is before legacy cutoff' do
+      let(:legacy_cutoff) { 'summer-2014' }
+      its(:legacy?) { should eq true }
+    end
+    context 'term is equal to legacy cutoff' do
+      let(:legacy_cutoff) { 'spring-2014' }
+      its(:legacy?) { should eq true }
+    end
+    context 'term is after legacy cutoff' do
+      let(:legacy_cutoff) { 'fall-2013' }
+      its(:legacy?) { should eq false }
+    end
+  end
+
 end

--- a/spec/models/campus_oracle/user_courses/base_spec.rb
+++ b/spec/models/campus_oracle/user_courses/base_spec.rb
@@ -1,5 +1,18 @@
 describe CampusOracle::UserCourses::Base do
 
+  RSpec::Matchers.define :terms_preceding_and_including_cutoff do |cutoff|
+    match do |terms|
+      term_ids = terms.map &:campus_solutions_id
+      term_ids.include?(cutoff) && term_ids.all? { |term_id| term_id <= cutoff }
+    end
+  end
+
+  it 'should query legacy terms only' do
+    allow(Settings.terms).to receive(:legacy_cutoff).and_return 'summer-2013'
+    expect(CampusOracle::Queries).to receive(:get_enrolled_sections).with(anything, terms_preceding_and_including_cutoff('2135')).and_return []
+    described_class.new(user_id: random_id).merge_enrollments({})
+  end
+
   describe '#merge_enrollments' do
     let(:user_id) {rand(99999).to_s}
     let(:catalog_id) {"#{rand(999)}"}

--- a/spec/models/edo_oracle/course_sections_spec.rb
+++ b/spec/models/edo_oracle/course_sections_spec.rb
@@ -1,0 +1,80 @@
+describe EdoOracle::CourseSections do
+
+  let(:term_id) { '2168' }
+  let(:course_id) { random_id }
+  subject { described_class.new(term_id, course_id).get_section_data }
+
+  before do
+    expect(EdoOracle::Queries).to receive(:get_section_meetings).with(term_id, course_id).and_return meetings
+    expect(EdoOracle::Queries).to receive(:get_section_instructors).with(term_id, course_id).and_return instructors
+  end
+
+  let(:instructors) { [] }
+  let(:meetings) { [] }
+
+  context 'no instructors or meetings found' do
+    its([:instructors]) { should be_empty }
+    its([:schedules]) { should be_empty }
+  end
+
+  context 'meeting data' do
+    let(:meetings) do
+      [
+        {
+          'location' => 'WHEELER 0233',
+          'meeting_days' => 'MOWEFR',
+          'meeting_start_time' => '09:30',
+          'meeting_end_time' => '10:59'
+        },
+        {
+          'location' => nil,
+          'meeting_days' => nil,
+          'meeting_start_time' => nil,
+          'meeting_end_time' => nil
+        }
+      ]
+    end
+    it 'ignores empty rows' do
+      expect(subject[:schedules]).to have(1).item
+    end
+    it 'translates time' do
+      expect(subject[:schedules].first[:schedule]).to eq 'MWF 09:30-10:59'
+    end
+    it 'translates space' do
+      expect(subject[:schedules].first[:buildingName]).to eq 'WHEELER'
+      expect(subject[:schedules].first[:roomNumber]).to eq '233'
+    end
+  end
+
+  context 'instructor data' do
+    let(:instructors) do
+      [
+        {
+          'ldap_uid' => '2040',
+          'person_name' => 'Albertus Magnus',
+          'role_code' => 'PI'
+        },
+        {
+          'ldap_uid' => '242881',
+          'person_name' => 'Thomas Aquinas',
+          'role_code' => 'TNIC'
+        }
+      ]
+    end
+    it 'translates attributes' do
+      expect(subject[:instructors]).to eq [
+        {
+          name: 'Albertus Magnus',
+          role: 'PI',
+          uid: '2040'
+        },
+        {
+          name: 'Thomas Aquinas',
+          role: 'TNIC',
+          uid: '242881'
+        }
+      ]
+    end
+  end
+
+end

--- a/spec/models/edo_oracle/queries_spec.rb
+++ b/spec/models/edo_oracle/queries_spec.rb
@@ -31,7 +31,7 @@ describe EdoOracle::Queries, :ignore => true do
     it 'fetches expected data' do
       results = EdoOracle::Queries.get_enrolled_sections(uid, [term])
       expect(results.count).to eq 5
-      expected_keys = ['section_id', 'term_id', 'course_title', 'course_title_short', 'dept_name', 'primary', 'section_num', 'instruction_format', 'display_name', 'catalog_id', 'catalog_root', 'catalog_prefix', 'catalog_suffix', 'enroll_limit', 'enroll_status', 'waitlist_position', 'unit', 'grading_basis']
+      expected_keys = ['section_id', 'term_id', 'course_title', 'course_title_short', 'dept_name', 'primary', 'section_num', 'instruction_format', 'display_name', 'catalog_id', 'catalog_root', 'catalog_prefix', 'catalog_suffix', 'enroll_limit', 'enroll_status', 'waitlist_position', 'units', 'grade', 'grading_basis']
       results.each do |result|
         expect(result['term_id']).to eq '2102'
         expect(result).to have_keys(expected_keys)
@@ -72,7 +72,7 @@ describe EdoOracle::Queries, :ignore => true do
   describe '.get_section_instructors', :testext => true do
     let(:expected_keys) { ['person_name', 'first_name', 'last_name', 'ldap_uid', 'role_code', 'role_description'] }
     it 'returns instructors for section' do
-      results = EdoOracle::Queries.get_section_instructors(section_ids[0], term_id)
+      results = EdoOracle::Queries.get_section_instructors(term_id, section_ids[0])
       results.each do |result|
         expect(result).to have_keys(expected_keys)
       end

--- a/spec/models/edo_oracle/queries_spec.rb
+++ b/spec/models/edo_oracle/queries_spec.rb
@@ -55,6 +55,22 @@ describe EdoOracle::Queries, :ignore => true do
     end
   end
 
+  describe '.get_associated_secondary_sections', :testext => true do
+    it 'returns a set of secondary sections' do
+      results = EdoOracle::Queries.get_associated_secondary_sections(term_id, '31586')
+      expect(results).to be_present
+      expected_keys = ['course_title', 'course_title_short', 'dept_name', 'catalog_id', 'primary', 'section_num', 'instruction_format', 'catalog_root', 'catalog_prefix', 'catalog_suffix']
+      results.each do |result|
+        expect(result).to have_keys(expected_keys)
+        expect(result['display_name']).to eq 'ESPM 155AC'
+        expect(result['instruction_format']).to eq 'DIS'
+        expect(result['primary']).to eq false
+        expect(result['term_id']).to eq term_id
+      end
+    end
+  end
+
+
   describe '.get_section_meetings', :testext => true do
     it 'returns meetings for section id specified' do
       results = EdoOracle::Queries.get_section_meetings(term_id, section_ids[0])

--- a/spec/models/edo_oracle/user_courses/base_spec.rb
+++ b/spec/models/edo_oracle/user_courses/base_spec.rb
@@ -1,0 +1,211 @@
+describe EdoOracle::UserCourses::Base do
+
+  RSpec::Matchers.define :terms_following_cutoff do |cutoff|
+    match do |terms|
+      term_ids = terms.map &:campus_solutions_id
+      term_ids.present? && term_ids.all? { |term_id| term_id > cutoff }
+    end
+  end
+
+  it 'should query non-legacy terms only' do
+    allow(Settings.terms).to receive(:legacy_cutoff).and_return 'summer-2013'
+    expect(EdoOracle::Queries).to receive(:get_enrolled_sections).with(anything, terms_following_cutoff('2135')).and_return []
+    described_class.new(user_id: random_id).merge_enrollments({})
+  end
+
+  let(:base_course_data) do
+    {
+      'catalog_id' => '74',
+      'catalog_prefix' => nil,
+      'catalog_root' => '74',
+      'catalog_suffix' => nil,
+      'course_title' => 'Introduction to Selected Musics of the World',
+      'course_title_short' => 'INTR MUSICS WORLD',
+      'dept_name' => 'MUSIC',
+      'display_name' => 'MUSIC 74',
+      'term_id' => '2168',
+    }
+  end
+
+  describe 'enrolled sections merge' do
+    let(:enrollment_query_results) do
+      [
+        base_course_data.merge({
+          'enroll_limit' => '40',
+          'enroll_status' => 'E',
+          'grade' => 'B',
+          'grading_basis' => 'GRD',
+          'instruction_format' => 'LEC',
+          'primary' => true,
+          'section_id' => '44203',
+          'section_num' => '001',
+          'units' => '4',
+          'wait_list_seq_num' => nil
+        }),
+        base_course_data.merge({
+          'enroll_limit' => '50',
+          'enroll_status' => 'W',
+          'grade' => nil,
+          'grading_basis' => 'PNP',
+          'instruction_format' => 'LEC',
+          'primary' => true,
+          'section_id' => '44206',
+          'section_num' => '002',
+          'units' => '3',
+          'wait_list_seq_num' => nil
+        }),
+        base_course_data.merge({
+          'enroll_limit' => '40',
+          'enroll_status' => 'E',
+          'grade' => nil,
+          'grading_basis' => nil,
+          'instruction_format' => 'DIS',
+          'primary' => false,
+          'section_id' => '44214',
+          'section_num' => '201',
+          'units' => nil,
+          'wait_list_seq_num' => nil
+        })
+      ]
+    end
+    before { allow(EdoOracle::Queries).to receive(:get_enrolled_sections).and_return enrollment_query_results }
+    let(:feed) { {}.tap { |feed| EdoOracle::UserCourses::Base.new(user_id: random_id).merge_enrollments feed } }
+    subject { feed['2016-D'] }
+    its(:size) { should eq 1 }
+    it 'includes only course info at the course level' do
+      course = subject.first
+      expect(course[:catid]).to eq '74'
+      expect(course[:course_catalog]).to eq '74'
+      expect(course[:course_code]).to eq 'MUSIC 74'
+      expect(course[:dept]).to eq 'MUSIC'
+      expect(course[:emitter]).to eq 'Campus'
+      expect(course[:id]).to eq 'music-74-2016-D'
+      expect(course[:name]).to eq 'Introduction to Selected Musics of the World'
+      expect(course[:role]).to eq 'Student'
+      expect(course[:slug]).to eq 'music-74'
+      expect(course[:term_cd]).to eq 'D'
+      expect(course[:term_id]).to eq '2168'
+      expect(course[:term_yr]).to eq '2016'
+    end
+    it 'includes per-section information' do
+      course = subject.first
+      expect(course[:sections].size).to eq 3
+      [course[:sections], enrollment_query_results].transpose.each do |section, enrollment|
+        expect(section[:ccn]).to eq enrollment['section_id']
+        expect(section[:instruction_format]).to eq enrollment['instruction_format']
+        expect(section[:section_label]).to eq "#{enrollment['instruction_format']} #{enrollment['section_num']}"
+        expect(section[:section_number]).to eq enrollment['section_num']
+        if enrollment['primary']
+          expect(section[:grading_basis]).to eq enrollment['grading_basis']
+          expect(section[:is_primary_section]).to eq true
+          expect(section[:units]).to eq enrollment['units']
+        else
+          expect(section[:is_primary_section]).to eq false
+          expect(section).not_to include(:grading_basis, :units)
+        end
+        if enrollment['enroll_status'] == 'W'
+          expect(section[:enroll_limit]).to eq enrollment['enroll_limit'].to_i
+          expect(section[:waitlistPosition]).to eq enrollment['wait_list_seq_num'].to_i
+        else
+          expect(section).not_to include(:enroll_limit, :waitlistPosition)
+        end
+      end
+    end
+    it 'includes only non-blank grades' do
+      course = subject.first
+      expect(course[:sections][0][:grade]).to eq 'B'
+      expect(course[:sections][1]).not_to include(:grade)
+    end
+  end
+
+  describe 'instructing sections merge' do
+    let(:instructing_query_results) do
+      [
+        base_course_data.merge({
+          'instruction_format' => 'LEC',
+          'primary' => true,
+          'section_id' => '44206',
+          'section_num' => '001'
+        }),
+        base_course_data.merge({
+          'instruction_format' => 'LEC',
+          'primary' => true,
+          'section_id' => '44207',
+          'section_num' => '002'
+        }),
+        base_course_data.merge({
+          'catalog_id' => '99C',
+          'catalog_prefix' => nil,
+          'catalog_root' => '99',
+          'catalog_suffix' => 'C',
+          'course_title' => 'The Stooges in Context',
+          'course_title_short' => 'STGS CNTXT',
+          'dept_name' => 'MUSIC',
+          'display_name' => 'MUSIC 99C',
+          'instruction_format' => 'LEC',
+          'primary' => true,
+          'section_id' => '44807',
+          'section_num' => '001'
+        })
+      ]
+    end
+    before { allow(EdoOracle::Queries).to receive(:get_instructing_sections).and_return instructing_query_results }
+    let(:feed) { {}.tap { |feed| EdoOracle::UserCourses::Base.new(user_id: random_id).merge_instructing feed } }
+    subject { feed['2016-D'] }
+
+    it 'sorts out sections based on course code' do
+      expect(subject).to have(2).items
+      expect(subject.find { |course| course[:course_code] == 'MUSIC 74'}[:sections]).to have(2).items
+      expect(subject.find { |course| course[:course_code] == 'MUSIC 99C'}[:sections]).to have(1).items
+    end
+
+    it 'includes course data without enrollment-specific properties' do
+      subject.each do |course|
+        expect(course.keys).to include(:catid, :course_catalog, :course_code, :dept, :emitter, :id, :name, :role, :sections, :slug, :term_cd, :term_id, :term_yr)
+        expect(course[:role]).to eq 'Instructor'
+        course[:sections].each do |section|
+          expect(section.keys).to include(:ccn, :instruction_format, :is_primary_section, :section_label, :section_number)
+          expect(section.keys).to include(:units) if section[:is_primary_section]
+          expect(section.keys).not_to include(:grading_basis, :enroll_limit, :waitlistPosition)
+        end
+      end
+    end
+  end
+
+  describe '#course_ids_from_row' do
+    let(:row) {{
+      'catalog_id' => '0109AL',
+      'dept_name' => 'MEC ENG/I,RES',
+      'display_name' => 'MEC ENG/I,RES 0109AL',
+      'term_id' => '2168'
+    }}
+    subject { EdoOracle::UserCourses::Base.new(user_id: random_id).course_ids_from_row row }
+    its([:slug]) { should eq 'mec_eng_i_res-0109al' }
+    its([:id])  {should eq 'mec_eng_i_res-0109al-2016-D' }
+    its([:course_code]) { should eq 'MEC ENG/I,RES 0109AL' }
+  end
+
+  describe '#row_to_feed_item' do
+    let(:row) {{
+      'catalog_id' => '0109AL',
+      'dept_name' => 'MEC ENG/I,RES',
+      'term_id' => '2168',
+      'course_title' => course_title,
+      'course_title_short' => 'KOLLAPS'
+    }}
+    subject { EdoOracle::UserCourses::Base.new(user_id: random_id).row_to_feed_item(row, {}) }
+    context 'course has a nice long title' do
+      let(:course_title) { 'Failure Analysis of Load-Bearing Structures' }
+      it 'uses the official title' do
+        expect(subject[:name]).to eq course_title
+      end
+    end
+    context 'course has a null COURSE_TITLE column' do
+      let(:course_title) { nil }
+      it 'falls back to short title' do
+        expect(subject[:name]).to eq 'KOLLAPS'
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-16715
https://jira.berkeley.edu/browse/SISRP-16716
https://jira.berkeley.edu/browse/SISRP-16877
https://jira.berkeley.edu/browse/SISRP-16878

EdoOracle::UserCourses contains translator classes on the pattern of CampusOracle::UserCourses. There is some oddness and redundancy in the constructed feeds because that's what the higher-level classes are expecting.

Cross-listings can now be determined from the cs-course-id column; implicitly taught sections can be determined from the primaryAssociatedSection column. Both are tracked while building the UserCourses feed for instructors.

Specs are present but will need better data to exercise a wider range of cases.

Legacy term cutoff logic is moved into Berkeley::Terms initialization so as to avoid a bunch of unnecessary cache hits.