### PR TITLE
SISRP-16717 - Adds EdoOracle::Queries.terms

### DIFF
--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -184,7 +184,7 @@ module EdoOracle
     # EDO equivalent of CampusOracle::Queries.get_section_instructors
     # Changes:
     #   - 'ccn' replaced by 'section_id' argument
-    #   - 'term_yr' and 'term_yr' replaced by 'term_id'
+    #   - 'term_yr' and 'term_cd' replaced by 'term_id'
     #   - 'instructor_func' has become represented by 'role_code' and 'role_description'
     #   - Does not provide all user profile fields ('email_address', 'student_id', 'affiliations').
     #     This will require a programmatic join at a higher level.
@@ -220,6 +220,32 @@ module EdoOracle
         results = connection.select_all(sql)
       }
       stringify_ints! results
+    end
+
+    # EDO equivalent of CampusOracle::Queries.terms
+    # Changes:
+    #   - 'term_yr' and 'term_cd' replaced by 'term_id'
+    #   - 'term_status', 'term_status_desc', and 'current_tb_term_flag' are not present.
+    #     No indication of past, current, or future term status
+    #   - Multiple entries for each term due to differing start and end dates that
+    #     may exist for LAW as compared to GRAD, UGRAD, or UCBX
+    def self.terms
+      result = []
+      use_pooled_connection {
+        sql = <<-SQL
+        SELECT
+          term."STRM" as term_code,
+          trim(term."DESCR") AS term_name,
+          term."TERM_BEGIN_DT" AS term_start_date,
+          term."TERM_END_DT" AS term_end_date
+        FROM
+          SISEDO.TERM_TBL_VW term
+        ORDER BY
+          term_start_date desc
+        SQL
+        result = connection.select_all(sql)
+      }
+      result
     end
 
   end

--- a/spec/models/edo_oracle/queries_spec.rb
+++ b/spec/models/edo_oracle/queries_spec.rb
@@ -94,4 +94,18 @@ describe EdoOracle::Queries, :ignore => true do
       end
     end
   end
+
+  describe '.terms', :testext => true do
+    let(:expected_keys) { ['term_code', 'term_name', 'term_start_date', 'term_end_date'] }
+    it 'returns terms' do
+      results = EdoOracle::Queries.terms
+      results.each do |result|
+        expect(result).to have_keys(expected_keys)
+      end
+      result_codes = results.collect { |result| result['term_code'] }
+      # check for Spring 2015 - Summer 2017 terms
+      expect(result_codes).to include('2152', '2155', '2158', '2162', '2165', '2168', '2172', '2175')
+    end
+  end
+
 end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-16717

Creates EdoOracle::Queries method as equivalent of CampusOracle::Queries.terms