### PR TITLE
CLC-6228, defaults for advisor during view-as (revised of PR #5124)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,12 +51,18 @@ class ApplicationController < ActionController::Base
 
   # Only a small subset of student API feeds are available to a delegate, and so
   # these methods filter controller endpoints by default.
-  def accessible_by_delegate?
+  def allow_if_delegate_view_as?
     false
   end
+  # The majority of API feeds are available to advisors during view-as mode. Remove advisor access by overriding this method.
+  def allow_if_advisor_view_as?
+    true
+  end
   def deny_if_filtered
-    filtered = !accessible_by_delegate? && current_user.authenticated_as_delegate?
-    raise Pundit::NotAuthorizedError.new("By delegate #{current_user.original_delegate_user_id}") if filtered
+    deny_delegate = !allow_if_delegate_view_as? && current_user.authenticated_as_delegate?
+    raise Pundit::NotAuthorizedError.new("By delegate #{current_user.original_delegate_user_id}") if deny_delegate
+    deny_advisor = !allow_if_advisor_view_as? && current_user.authenticated_as_advisor?
+    raise Pundit::NotAuthorizedError.new("By advisor #{current_user.original_advisor_user_id}") if deny_advisor
   end
 
   def delete_reauth_cookie

--- a/app/controllers/bootstrap_controller.rb
+++ b/app/controllers/bootstrap_controller.rb
@@ -1,6 +1,6 @@
 class BootstrapController < ApplicationController
   include ActiveRecordHelper
-  include DelegateAccessible
+  include AllowDelegateViewAs
   before_filter :get_settings, :initialize_calcentral_config
   before_filter :check_lti_only
   before_filter :check_databases_alive, :warmup_live_updates, :check_cache_clear_flag

--- a/app/controllers/campus_solutions/academic_plan_controller.rb
+++ b/app/controllers/campus_solutions/academic_plan_controller.rb
@@ -1,6 +1,6 @@
 module CampusSolutions
   class AcademicPlanController < CampusSolutionsController
-    include DelegateAccessible
+    include AllowDelegateViewAs
 
     before_filter :authorize_for_enrollments
 

--- a/app/controllers/campus_solutions/aid_years_controller.rb
+++ b/app/controllers/campus_solutions/aid_years_controller.rb
@@ -1,6 +1,6 @@
 module CampusSolutions
   class AidYearsController < CampusSolutionsController
-    include DelegateAccessible
+    include AllowDelegateViewAs
 
     before_filter :authorize_for_financial
 

--- a/app/controllers/campus_solutions/enrollment_term_controller.rb
+++ b/app/controllers/campus_solutions/enrollment_term_controller.rb
@@ -1,6 +1,6 @@
 module CampusSolutions
   class EnrollmentTermController < CampusSolutionsController
-    include DelegateAccessible
+    include AllowDelegateViewAs
 
     before_filter :authorize_for_enrollments
 

--- a/app/controllers/campus_solutions/enrollment_terms_controller.rb
+++ b/app/controllers/campus_solutions/enrollment_terms_controller.rb
@@ -1,6 +1,6 @@
 module CampusSolutions
   class EnrollmentTermsController < CampusSolutionsController
-    include DelegateAccessible
+    include AllowDelegateViewAs
 
     before_filter :authorize_for_enrollments
 

--- a/app/controllers/campus_solutions/financial_aid_data_controller.rb
+++ b/app/controllers/campus_solutions/financial_aid_data_controller.rb
@@ -1,6 +1,6 @@
 module CampusSolutions
   class FinancialAidDataController < CampusSolutionsController
-    include DelegateAccessible
+    include AllowDelegateViewAs
 
     before_filter :authorize_for_financial
 

--- a/app/controllers/campus_solutions/financial_aid_funding_sources_controller.rb
+++ b/app/controllers/campus_solutions/financial_aid_funding_sources_controller.rb
@@ -1,6 +1,6 @@
 module CampusSolutions
   class FinancialAidFundingSourcesController < CampusSolutionsController
-    include DelegateAccessible
+    include AllowDelegateViewAs
 
     before_filter :authorize_for_financial
 

--- a/app/controllers/campus_solutions/financial_aid_funding_sources_controller_term.rb
+++ b/app/controllers/campus_solutions/financial_aid_funding_sources_controller_term.rb
@@ -1,6 +1,6 @@
 module CampusSolutions
   class FinancialAidFundingSourcesTermController < CampusSolutionsController
-    include DelegateAccessible
+    include AllowDelegateViewAs
 
     before_filter :authorize_for_financial
 

--- a/app/controllers/campus_solutions/holds_controller.rb
+++ b/app/controllers/campus_solutions/holds_controller.rb
@@ -1,6 +1,6 @@
 module CampusSolutions
   class HoldsController < CampusSolutionsController
-    include DelegateAccessible
+    include AllowDelegateViewAs
 
     def get
       render json: CampusSolutions::MyHolds.from_session(session).get_feed_as_json

--- a/app/controllers/canvas_controller.rb
+++ b/app/controllers/canvas_controller.rb
@@ -1,4 +1,5 @@
 class CanvasController < ApplicationController
+  include DisallowAdvisorViewAs
   include ClassLogger
 
   before_filter :set_cross_origin_access_control_headers, :only => [:external_tools, :user_can_create_site]

--- a/app/controllers/canvas_course_add_user_controller.rb
+++ b/app/controllers/canvas_course_add_user_controller.rb
@@ -1,4 +1,5 @@
 class CanvasCourseAddUserController < ApplicationController
+  include DisallowAdvisorViewAs
   include SpecificToCourseSite
 
   before_filter :api_authenticate

--- a/app/controllers/canvas_course_grade_export_controller.rb
+++ b/app/controllers/canvas_course_grade_export_controller.rb
@@ -1,4 +1,5 @@
 class CanvasCourseGradeExportController < ApplicationController
+  include DisallowAdvisorViewAs
   include SpecificToCourseSite
 
   before_action :api_authenticate_401, :except => [:is_official_course]

--- a/app/controllers/canvas_course_provision_controller.rb
+++ b/app/controllers/canvas_course_provision_controller.rb
@@ -1,4 +1,5 @@
 class CanvasCourseProvisionController < ApplicationController
+  include DisallowAdvisorViewAs
   include ClassLogger
   include SpecificToCourseSite
 

--- a/app/controllers/canvas_lti_controller.rb
+++ b/app/controllers/canvas_lti_controller.rb
@@ -1,4 +1,5 @@
 class CanvasLtiController < ApplicationController
+  include DisallowAdvisorViewAs
   include ClassLogger
   include CanvasLti::ExternalAppConfigurations
 

--- a/app/controllers/canvas_mailing_lists_controller.rb
+++ b/app/controllers/canvas_mailing_lists_controller.rb
@@ -1,4 +1,5 @@
 class CanvasMailingListsController < ApplicationController
+  include DisallowAdvisorViewAs
   include ClassLogger
   include SpecificToCourseSite
 

--- a/app/controllers/canvas_project_provision_controller.rb
+++ b/app/controllers/canvas_project_provision_controller.rb
@@ -1,4 +1,5 @@
 class CanvasProjectProvisionController < ApplicationController
+  include DisallowAdvisorViewAs
   include ClassLogger
 
   before_filter :api_authenticate

--- a/app/controllers/canvas_rosters_controller.rb
+++ b/app/controllers/canvas_rosters_controller.rb
@@ -1,4 +1,5 @@
 class CanvasRostersController < RostersController
+  include DisallowAdvisorViewAs
   include ClassLogger
   include SpecificToCourseSite
 

--- a/app/controllers/canvas_site_creation_controller.rb
+++ b/app/controllers/canvas_site_creation_controller.rb
@@ -1,4 +1,6 @@
 class CanvasSiteCreationController < ApplicationController
+  include DisallowAdvisorViewAs
+
   before_filter :api_authenticate
   rescue_from StandardError, with: :handle_api_exception
 

--- a/app/controllers/canvas_user_provision_controller.rb
+++ b/app/controllers/canvas_user_provision_controller.rb
@@ -1,4 +1,5 @@
 class CanvasUserProvisionController < ApplicationController
+  include DisallowAdvisorViewAs
   include ClassLogger
 
   before_filter :api_authenticate

--- a/app/controllers/canvas_webcast_recordings_controller.rb
+++ b/app/controllers/canvas_webcast_recordings_controller.rb
@@ -1,4 +1,5 @@
 class CanvasWebcastRecordingsController < ApplicationController
+  include DisallowAdvisorViewAs
   include SpecificToCourseSite
 
   before_filter :api_authenticate

--- a/app/controllers/concerns/allow_delegate_view_as.rb
+++ b/app/controllers/concerns/allow_delegate_view_as.rb
@@ -1,6 +1,6 @@
-module DelegateAccessible
+module AllowDelegateViewAs
   # Indicates that controller endpoints are either publicly available or filtered for delegated access.
-  def accessible_by_delegate?
+  def allow_if_delegate_view_as?
     true
   end
 

--- a/app/controllers/concerns/disallow_advisor_view_as.rb
+++ b/app/controllers/concerns/disallow_advisor_view_as.rb
@@ -1,0 +1,7 @@
+module DisallowAdvisorViewAs
+  # Indicates that controller endpoints are unavailable to advisors.
+  def allow_if_advisor_view_as?
+    false
+  end
+
+end

--- a/app/controllers/config_controller.rb
+++ b/app/controllers/config_controller.rb
@@ -1,5 +1,5 @@
 class ConfigController < ApplicationController
-  include DelegateAccessible
+  include AllowDelegateViewAs
   before_filter :get_settings, :initialize_calcentral_config
 
   def get

--- a/app/controllers/delegate_act_as_controller.rb
+++ b/app/controllers/delegate_act_as_controller.rb
@@ -1,5 +1,5 @@
 class DelegateActAsController < ActAsController
-  include DelegateAccessible
+  include AllowDelegateViewAs
 
   def initialize
     super act_as_session_key: SessionKey.original_delegate_user_id

--- a/app/controllers/my_academics_controller.rb
+++ b/app/controllers/my_academics_controller.rb
@@ -1,5 +1,5 @@
 class MyAcademicsController < ApplicationController
-  include DelegateAccessible
+  include AllowDelegateViewAs
   before_filter :api_authenticate
   before_filter :authorize_for_enrollments
 

--- a/app/controllers/my_activities_controller.rb
+++ b/app/controllers/my_activities_controller.rb
@@ -1,5 +1,5 @@
 class MyActivitiesController < ApplicationController
-  include DelegateAccessible
+  include AllowDelegateViewAs
   before_filter :api_authenticate
   before_filter :authorize_for_financial
 

--- a/app/controllers/my_badges_controller.rb
+++ b/app/controllers/my_badges_controller.rb
@@ -1,5 +1,5 @@
 class MyBadgesController < ApplicationController
-  include DelegateAccessible
+  include AllowDelegateViewAs
 
   before_filter :api_authenticate
 

--- a/app/controllers/my_cal1card_controller.rb
+++ b/app/controllers/my_cal1card_controller.rb
@@ -1,5 +1,5 @@
 class MyCal1cardController < ApplicationController
-  include DelegateAccessible
+  include AllowDelegateViewAs
 
   before_filter :api_authenticate
   before_filter :authorize_for_financial

--- a/app/controllers/my_campus_links_controller.rb
+++ b/app/controllers/my_campus_links_controller.rb
@@ -1,6 +1,6 @@
 class MyCampusLinksController < ApplicationController
   extend Cache::Cacheable
-  include DelegateAccessible
+  include AllowDelegateViewAs
 
   before_filter :api_authenticate
 

--- a/app/controllers/my_finaid_controller.rb
+++ b/app/controllers/my_finaid_controller.rb
@@ -1,5 +1,5 @@
 class MyFinaidController < ApplicationController
-  include DelegateAccessible
+  include AllowDelegateViewAs
 
   before_filter :api_authenticate
   before_filter :authorize_for_financial

--- a/app/controllers/my_financials_controller.rb
+++ b/app/controllers/my_financials_controller.rb
@@ -1,5 +1,5 @@
 class MyFinancialsController < ApplicationController
-  include DelegateAccessible
+  include AllowDelegateViewAs
   before_filter :api_authenticate
   before_filter :authorize_for_financial
 

--- a/app/controllers/my_tasks_controller.rb
+++ b/app/controllers/my_tasks_controller.rb
@@ -1,5 +1,5 @@
 class MyTasksController < ApplicationController
-  include DelegateAccessible
+  include AllowDelegateViewAs
   before_filter :api_authenticate
   before_filter :authorize_for_financial
 

--- a/app/controllers/oec_tasks_controller.rb
+++ b/app/controllers/oec_tasks_controller.rb
@@ -1,4 +1,5 @@
 class OecTasksController < ApplicationController
+  include DisallowAdvisorViewAs
   include ClassLogger
 
   before_action :api_authenticate

--- a/app/controllers/service_alerts_controller.rb
+++ b/app/controllers/service_alerts_controller.rb
@@ -1,5 +1,5 @@
 class ServiceAlertsController < ApplicationController
-  include DelegateAccessible
+  include AllowDelegateViewAs
 
   def get_feed
     render json: ServiceAlerts::Merged.new.get_feed_as_json

--- a/app/controllers/user_api_controller.rb
+++ b/app/controllers/user_api_controller.rb
@@ -1,6 +1,6 @@
 class UserApiController < ApplicationController
   extend Cache::Cacheable
-  include DelegateAccessible
+  include AllowDelegateViewAs
 
   def self.expire(id = nil)
     # no-op; this class uses the cache only to reduce the number of writes to User::Visit. We want to just expire

--- a/spec/controllers/canvas_course_add_user_controller_spec.rb
+++ b/spec/controllers/canvas_course_add_user_controller_spec.rb
@@ -64,6 +64,11 @@ describe CanvasCourseAddUserController do
             allow_any_instance_of(Canvas::Admins).to receive(:admin_user?).and_return(false)
             allow_any_instance_of(Canvas::CourseUser).to receive(:course_user).and_return(canvas_course_student_hash)
           end
+          context 'advisor in view-as mode' do
+            let(:make_request) { get :course_user_roles, request_params }
+            before { allow(Settings.features).to receive(:reauthentication).and_return false }
+            it_behaves_like 'an unauthorized endpoint for users in advisor-view-as mode'
+          end
 
           it 'returns canvas root url and course id' do
             get :course_user_roles, request_params

--- a/spec/controllers/canvas_site_creation_controller_spec.rb
+++ b/spec/controllers/canvas_site_creation_controller_spec.rb
@@ -22,6 +22,11 @@ describe CanvasSiteCreationController do
       let(:make_request) { get :authorizations }
     end
 
+    it_behaves_like 'an unauthorized endpoint for users in advisor-view-as mode' do
+      before { allow(Settings.features).to receive(:reauthentication).and_return false }
+      let(:make_request) { get :authorizations }
+    end
+
     it 'should return sections feed' do
       get :authorizations
       expect(response.status).to eq 200

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -9,10 +9,10 @@
 
 # This example is intended to be used with let(:make_request) which defines the controller method call
 # for the method that is being tested. For exapmle, see spec/controllers/my_academics_controller_spec.rb
-shared_examples "a user authenticated api endpoint" do
-  context "when no user session present" do
+shared_examples 'a user authenticated api endpoint' do
+  context 'when no user session present' do
     before { session['user_id'] = nil }
-    it "returns empty json hash" do
+    it 'returns empty json hash' do
       make_request
       assert_response :success
       json_response = JSON.parse(response.body)
@@ -21,10 +21,10 @@ shared_examples "a user authenticated api endpoint" do
   end
 end
 
-shared_examples "an authenticated endpoint" do
-  context "when no user session present" do
+shared_examples 'an authenticated endpoint' do
+  context 'when no user session present' do
     before { session['user_id'] = nil }
-    it "returns empty response" do
+    it 'returns empty response' do
       make_request
       expect(response.status).to eq(401)
       expect(response.body).to eq " "
@@ -44,21 +44,34 @@ shared_examples 'an unauthorized endpoint for delegates' do
   end
 end
 
-shared_examples "an api endpoint" do
-  context "when standarderror exception raised" do
-    it "returns json formatted 500 error" do
+shared_examples 'an unauthorized endpoint for users in advisor-view-as mode' do
+  before do
+    session['user_id'] = random_id unless session['user_id']
+    session[SessionKey.original_advisor_user_id] = random_id
+  end
+  it 'denies all access' do
+    make_request
+    # Controller might rescue_from authorization failure then return 500 status
+    expect(response.status).to be >= 403
+    expect(response.body.blank? || JSON.parse(response.body)['error']).to be_truthy
+  end
+end
+
+shared_examples 'an api endpoint' do
+  context 'when standarderror exception raised' do
+    it 'returns json formatted 500 error' do
       make_request
       expect(response.status).to eq(500)
       json_response = JSON.parse(response.body)
       expect(json_response['error']).to be_an_instance_of String
-      expect(json_response['error']).to eq "Something went wrong"
+      expect(json_response['error']).to eq 'Something went wrong'
     end
   end
 end
 
-shared_examples "an endpoint" do
-  context "when standarderror exception raised" do
-    it "returns 500 error" do
+shared_examples 'an endpoint' do
+  context 'when standarderror exception raised' do
+    it 'returns 500 error' do
       make_request
       expect(response.status).to eq(500)
       expect(response.body).to eq error_text
@@ -66,12 +79,12 @@ shared_examples "an endpoint" do
   end
 end
 
-shared_examples "a cross-domain endpoint" do
-  it "sets cross origin access control headers" do
+shared_examples 'a cross-domain endpoint' do
+  it 'sets cross origin access control headers' do
     make_request
     expect(response.headers).to be_an_instance_of Hash
     expect(response.headers['Access-Control-Allow-Origin']).to eq Settings.canvas_proxy.url_root
-    expect(response.header["Access-Control-Allow-Methods"]).to eq 'GET, OPTIONS, HEAD'
+    expect(response.header['Access-Control-Allow-Methods']).to eq 'GET, OPTIONS, HEAD'
     expect(response.header["Access-Control-Max-Age"]).to eq '86400'
   end
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6228

This is a revised version of closed PR #5124, which includes feedback from @raydavis. My renaming of `DelegateAccessible` to `AllowDelegateViewAs` must be kept in mind if / when we submit a QA PR relating to #5123 