### PR TITLE
SISRP-17106 - Adds EdoOracle::Queries#has_instructor_history?

### DIFF
--- a/app/models/edo_oracle/connection.rb
+++ b/app/models/edo_oracle/connection.rb
@@ -11,5 +11,11 @@ module EdoOracle
     def self.stringified_columns
       %w(section_id campus-uid)
     end
+
+    def self.terms_query_list(terms = nil)
+      terms.try :compact!
+      return '' unless terms.present?
+      terms.map { |term| "'#{term.campus_solutions_id}'" }.join ','
+    end
   end
 end

--- a/spec/models/edo_oracle/queries_spec.rb
+++ b/spec/models/edo_oracle/queries_spec.rb
@@ -1,7 +1,10 @@
 describe EdoOracle::Queries, :ignore => true do
   # BIOLOGY 1A - Fall 2016
   let(:section_ids) { ['13572', '31352'] }
-  let(:term_id) { '2168' }
+  let(:all_terms) { Berkeley::Terms.fetch.campus }
+  let(:term_slugs) { ['summer-2010', 'fall-2010'] }
+  let(:terms) { term_slugs.collect {|term_slug| all_terms[term_slug] } }
+  let(:fall_term_id) { '2168' }
 
   it_behaves_like 'an Oracle driven data source' do
     subject { EdoOracle::Queries }
@@ -9,6 +12,19 @@ describe EdoOracle::Queries, :ignore => true do
 
   it 'provides settings' do
     expect(EdoOracle::Queries.settings).to be Settings.edodb
+  end
+
+  describe '.terms_query_list' do
+    context 'when no terms present' do
+      it 'returns empty string' do
+        expect(EdoOracle::Queries.terms_query_list).to eq ''
+      end
+    end
+    context 'when terms present' do
+      it 'returns term list for sql' do
+        expect(EdoOracle::Queries.terms_query_list(terms)).to eq "'2105','2108'"
+      end
+    end
   end
 
   describe '.get_instructing_sections', testext: true do
@@ -41,7 +57,7 @@ describe EdoOracle::Queries, :ignore => true do
 
   describe '.get_sections_by_ids', :testext => true do
     it 'returns sections specified by id array' do
-      results = EdoOracle::Queries.get_sections_by_ids(term_id, section_ids)
+      results = EdoOracle::Queries.get_sections_by_ids(fall_term_id, section_ids)
       expect(results.count).to eq 2
       expect(results[0]['section_id']).to eq '13572'
       expect(results[1]['section_id']).to eq '31352'
@@ -57,7 +73,7 @@ describe EdoOracle::Queries, :ignore => true do
 
   describe '.get_associated_secondary_sections', :testext => true do
     it 'returns a set of secondary sections' do
-      results = EdoOracle::Queries.get_associated_secondary_sections(term_id, '31586')
+      results = EdoOracle::Queries.get_associated_secondary_sections(fall_term_id, '31586')
       expect(results).to be_present
       expected_keys = ['course_title', 'course_title_short', 'dept_name', 'catalog_id', 'primary', 'section_num', 'instruction_format', 'primary_associated_section_id', 'catalog_root', 'catalog_prefix', 'catalog_suffix']
       results.each do |result|
@@ -65,7 +81,7 @@ describe EdoOracle::Queries, :ignore => true do
         expect(result['display_name']).to eq 'ESPM 155AC'
         expect(result['instruction_format']).to eq 'DIS'
         expect(result['primary']).to eq 'false'
-        expect(result['term_id']).to eq term_id
+        expect(result['term_id']).to eq fall_term_id
       end
     end
   end
@@ -73,7 +89,7 @@ describe EdoOracle::Queries, :ignore => true do
 
   describe '.get_section_meetings', :testext => true do
     it 'returns meetings for section id specified' do
-      results = EdoOracle::Queries.get_section_meetings(term_id, section_ids[0])
+      results = EdoOracle::Queries.get_section_meetings(fall_term_id, section_ids[0])
       expect(results.count).to eq 1
       expected_keys = ['section_id', 'term_id', 'session_id', 'location', 'meeting_days', 'meeting_start_time', 'meeting_end_time', 'print_in_schedule_of_classes']
       results.each do |result|
@@ -88,7 +104,7 @@ describe EdoOracle::Queries, :ignore => true do
   describe '.get_section_instructors', :testext => true do
     let(:expected_keys) { ['person_name', 'first_name', 'last_name', 'ldap_uid', 'role_code', 'role_description'] }
     it 'returns instructors for section' do
-      results = EdoOracle::Queries.get_section_instructors(term_id, section_ids[0])
+      results = EdoOracle::Queries.get_section_instructors(fall_term_id, section_ids[0])
       results.each do |result|
         expect(result).to have_keys(expected_keys)
       end
@@ -115,6 +131,18 @@ describe EdoOracle::Queries, :ignore => true do
       results.each do |enrollment|
         expect(enrollment).to have_keys(expected_keys)
       end
+    end
+  end
+
+  describe '.has_instructor_history?', :textext => true do
+    subject { EdoOracle::Queries.has_instructor_history?(ldap_uid, terms) }
+    context 'when user is an instructor' do
+      let(:ldap_uid) { '211449' } # Michael Larkin - Lecturer with College Writing dept
+      it {should eq true}
+    end
+    context 'when user is not an instructor' do
+      let(:ldap_uid) { '211159' } # Ray Davis - staff / developer
+      it {should eq false}
     end
   end
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17106

Implement EDO DB equivalent of CampusOracle::Queries#has_instructor_history?
