### PR TITLE
SISRP-16880 EdoOracle::Queries: 'true' > 'false'

### DIFF
--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -2,7 +2,7 @@ module EdoOracle
   class Queries < Connection
     include ActiveRecordHelper
 
-    CANONICAL_SECTION_ORDERING = 'dept_name, catalog_root, catalog_prefix nulls first, catalog_suffix nulls first, primary, instruction_format, display_name, section_num'
+    CANONICAL_SECTION_ORDERING = 'dept_name, catalog_root, catalog_prefix nulls first, catalog_suffix nulls first, primary DESC, instruction_format, display_name, section_num'
 
     # Changes from CampusOracle::Queries section columns:
     #   - 'course_cntl_num' now 'section_id'


### PR DESCRIPTION
Follow-up to #5137 (fun with booleans that ain't booleans). We want primary sections ordered first.

https://jira.berkeley.edu/browse/SISRP-16880