### PR TITLE
SISRP-16962, CalCentral must consider isPrimaryForIdentifierType flag in Crosswalk response

### DIFF
--- a/app/models/calnet_crosswalk/proxy.rb
+++ b/app/models/calnet_crosswalk/proxy.rb
@@ -109,7 +109,8 @@ module CalnetCrosswalk
         feed = response[:feed]
         if feed.present?
           feed['Person']['identifiers'].each do |identifier|
-            if identifier['identifierTypeName'] == id_type
+            # Conservative check on isPrimaryForIdentifierType: evaluate to false if and only if element is present and equal to false.
+            if (identifier['identifierTypeName'] == id_type) && !(identifier['isPrimaryForIdentifierType'].to_s =~ /false/i)
               id = identifier['identifierValue']
               break
             end

--- a/fixtures/json/calnet_crosswalk_5030615093.json
+++ b/fixtures/json/calnet_crosswalk_5030615093.json
@@ -4,22 +4,32 @@
       "emailAddress": "heathcliff@berkeley.edu",
       "emailTypeName": "CAMPUS_EMAIL_SERVICE_ADDRESS"
     }],
-    "identifiers": [{
-      "identifierTypeName": "HRMS_EMPLOYEE_ID",
-      "identifierValue": "712611260",
-      "isActive": false,
-      "isPrimaryForIdentifierType": true
-    }, {
-      "identifierTypeName": "CALNET_ID",
-      "identifierValue": "heathcliff",
-      "isActive": true,
-      "isPrimaryForIdentifierType": true
-    }, {
-      "identifierTypeName": "CAMPUS_SOLUTIONS_ID",
-      "identifierValue": "5030615093",
-      "isActive": true,
-      "isPrimaryForIdentifierType": true
-    }],
+    "identifiers": [
+      {
+        "identifierTypeName": "HRMS_EMPLOYEE_ID",
+        "identifierValue": "712611260",
+        "isActive": false,
+        "isPrimaryForIdentifierType": true
+      },
+      {
+        "identifierTypeName": "CALNET_ID",
+        "identifierValue": "heathcliff",
+        "isActive": false,
+        "isPrimaryForIdentifierType": true
+      },
+      {
+        "identifierTypeName": "CAMPUS_SOLUTIONS_ID",
+        "identifierValue": "15938282",
+        "isActive": false,
+        "isPrimaryForIdentifierType": false
+      },
+      {
+        "identifierTypeName": "CAMPUS_SOLUTIONS_ID",
+        "identifierValue": "5030615093",
+        "isActive": false,
+        "isPrimaryForIdentifierType": true
+      }
+    ],
     "uid": "9110492"
   }
 }

--- a/fixtures/json/calnet_crosswalk_61889.json
+++ b/fixtures/json/calnet_crosswalk_61889.json
@@ -16,6 +16,12 @@
       },
       {
         "identifierTypeName": "CAMPUS_SOLUTIONS_ID",
+        "identifierValue": "15938282",
+        "isActive": false,
+        "isPrimaryForIdentifierType": false
+      },
+      {
+        "identifierTypeName": "CAMPUS_SOLUTIONS_ID",
         "identifierValue": "11667051",
         "isActive": false,
         "isPrimaryForIdentifierType": true

--- a/spec/models/calnet_crosswalk/by_cs_id_spec.rb
+++ b/spec/models/calnet_crosswalk/by_cs_id_spec.rb
@@ -8,9 +8,9 @@ describe CalnetCrosswalk::ByCsId do
   end
 
   shared_context 'looking up ids' do
-    context 'looking up cs id' do
+    context 'CS ID lookup with consideration of \'isPrimaryForIdentifierType\' attribute' do
       subject { proxy.lookup_campus_solutions_id }
-      it 'should return the CS ID' do
+      it 'should return the primary CS ID' do
         expect(subject).to eq campus_solutions_id
       end
     end

--- a/spec/models/calnet_crosswalk/by_uid_spec.rb
+++ b/spec/models/calnet_crosswalk/by_uid_spec.rb
@@ -32,6 +32,12 @@ describe CalnetCrosswalk::ByUid do
       response = proxy.get
       expect(response[:errored]).to eq true
     end
+    context 'Crosswalk \'isPrimaryForIdentifierType\' attribute' do
+      subject { proxy.lookup_campus_solutions_id.to_i }
+      it 'should return the primary CS ID' do
+        expect(subject).to eq 11667051
+      end
+    end
     include_context 'looking up ids'
   end
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-16962

Note:
* We do a conservative check on `isPrimaryForIdentifierType`: evaluate to false if and only if element is present and equal to false.
* The `isActive` attribute has been unreliable in production so we give it no import in our spec / fixture.
