### PR TITLE
SISRP-17167 - Retrofit Canvas::CurrentTeacher#user_currently_teaching?

### DIFF
--- a/app/models/berkeley/terms.rb
+++ b/app/models/berkeley/terms.rb
@@ -97,5 +97,16 @@ module Berkeley
       @campus = terms
     end
 
+    def self.legacy_group(terms)
+      terms = terms.to_a
+      sisedo_terms, legacy_terms = [], []
+      if terms.count > 0
+        grouped = terms.group_by &:legacy?
+        legacy_terms = grouped[true]
+        sisedo_terms = grouped[false]
+      end
+      return {:legacy => legacy_terms, :sisedo => sisedo_terms}
+    end
+
   end
 end

--- a/app/models/campus_oracle/queries.rb
+++ b/app/models/campus_oracle/queries.rb
@@ -391,7 +391,7 @@ module CampusOracle
         result = connection.select_one(sql)
       }
       Rails.logger.debug "Instructor #{ldap_uid} history for terms #{instructor_terms} count = #{result}"
-      return result["course_count"].to_i > 0
+      result["course_count"].to_i > 0
     end
 
     def self.has_student_history?(ldap_uid, student_terms = nil)
@@ -408,7 +408,7 @@ module CampusOracle
         result = connection.select_one(sql)
       }
       Rails.logger.debug "Student #{ldap_uid} history for terms #{student_terms} count = #{result}"
-      return result["course_count"].to_i > 0
+      result["course_count"].to_i > 0
     end
 
     def self.terms

--- a/app/models/canvas/current_teacher.rb
+++ b/app/models/canvas/current_teacher.rb
@@ -9,7 +9,7 @@ module Canvas
     def user_currently_teaching?
       self.class.fetch_from_cache @uid do
         current_terms = Canvas::Terms.current_terms
-        CampusOracle::Queries.has_instructor_history?(@uid, current_terms)
+        User::AcademicHistory.new(@uid).has_instructor_history?(current_terms)
       end
     end
 

--- a/app/models/user/academic_history.rb
+++ b/app/models/user/academic_history.rb
@@ -1,0 +1,10 @@
+module User
+  class AcademicHistory < UserSpecificModel
+    def has_instructor_history?(current_terms)
+      grouped_terms = Berkeley::Terms.legacy_group(current_terms)
+      has_legacy_instructor_history = Proc.new { CampusOracle::Queries.has_instructor_history?(@uid, grouped_terms[:legacy]) }
+      has_sisedo_instructor_history = Proc.new { EdoOracle::Queries.has_instructor_history?(@uid, grouped_terms[:sisedo]) }
+      return has_legacy_instructor_history.call || has_sisedo_instructor_history.call
+    end
+  end
+end

--- a/spec/models/berkeley/terms_spec.rb
+++ b/spec/models/berkeley/terms_spec.rb
@@ -86,4 +86,17 @@ describe Berkeley::Terms do
     end
   end
 
+  describe '.legacy_group' do
+    let(:terms) { Berkeley::Terms.fetch.campus.values[0..1] }
+    it 'returns terms grouped by data source' do
+      terms[0].instance_eval { @is_legacy = false }
+      terms[1].instance_eval { @is_legacy = true }
+      result = Berkeley::Terms.legacy_group(terms)
+      expect(result[:legacy].count).to eq 1
+      expect(result[:legacy][0]).to eq terms[1]
+      expect(result[:sisedo].count).to eq 1
+      expect(result[:sisedo][0]).to eq terms[0]
+    end
+  end
+
 end

--- a/spec/models/campus_oracle/user_courses/has_instructor_history_spec.rb
+++ b/spec/models/campus_oracle/user_courses/has_instructor_history_spec.rb
@@ -2,7 +2,7 @@ describe CampusOracle::UserCourses::HasInstructorHistory do
 
   it 'should say that our fake teacher has instructor history', :if => CampusOracle::Connection.test_data? do
     client = CampusOracle::UserCourses::HasInstructorHistory.new({user_id: '238382'})
-    client.has_instructor_history?.should be_truthy
+    client.has_instructor_history?.should be true
   end
 
 end

--- a/spec/models/campus_oracle/user_courses/has_student_history_spec.rb
+++ b/spec/models/campus_oracle/user_courses/has_student_history_spec.rb
@@ -2,7 +2,7 @@ describe CampusOracle::UserCourses::HasStudentHistory do
 
   it 'should say that Tammi has student history', :if => CampusOracle::Connection.test_data? do
     client = CampusOracle::UserCourses::HasStudentHistory.new({user_id: '300939'})
-    client.has_student_history?.should be_truthy
+    client.has_student_history?.should be true
   end
 
 end

--- a/spec/models/canvas/current_teacher_spec.rb
+++ b/spec/models/canvas/current_teacher_spec.rb
@@ -1,6 +1,6 @@
 describe Canvas::CurrentTeacher do
 
-  let(:uid)             { rand(99999).to_s }
+  let(:uid) { rand(99999).to_s }
 
   subject { Canvas::CurrentTeacher.new(uid) }
 
@@ -46,30 +46,33 @@ describe Canvas::CurrentTeacher do
 
     before do
       allow(Canvas::Terms).to receive(:current_terms).and_return(current_terms)
+      # TODO: Update spec with EDO test cases instead of defaulting to false
+      current_terms.each {|term| term.set_as_legacy }
+      allow(EdoOracle::Queries).to receive(:has_instructor_history?).and_return(false)
     end
 
     context 'when uid is unavailable' do
       subject { Canvas::CurrentTeacher.new(nil) }
-      its(:user_currently_teaching?) { should be_falsey }
+      its(:user_currently_teaching?) { should eq false }
     end
 
     context 'when user is instructing in current canvas terms', if: CampusOracle::Queries.test_data? do
       subject { Canvas::CurrentTeacher.new(summer_2014_instructor_uid) }
-      its(:user_currently_teaching?) { should be_truthy }
+      its(:user_currently_teaching?) { should eq true }
     end
 
     context 'when user is not instructing in current canvas terms', if: CampusOracle::Queries.test_data? do
       subject { Canvas::CurrentTeacher.new(spring_2012_instructor_uid) }
-      its(:user_currently_teaching?) { should be_falsey }
+      its(:user_currently_teaching?) { should eq false }
     end
 
     context 'when response is cached', if: CampusOracle::Queries.test_data? do
       subject { Canvas::CurrentTeacher.new(summer_2014_instructor_uid) }
       it 'does not make calls to dependent objects' do
-        expect(subject.user_currently_teaching?).to be_truthy
+        expect(subject.user_currently_teaching?).to eq true
         expect(Canvas::Terms).to_not receive(:current_terms)
         expect(CampusOracle::Queries).to_not receive(:has_instructor_history?)
-        expect(subject.user_currently_teaching?).to be_truthy
+        expect(subject.user_currently_teaching?).to eq true
       end
     end
   end

--- a/spec/models/edo_oracle/queries_spec.rb
+++ b/spec/models/edo_oracle/queries_spec.rb
@@ -110,7 +110,6 @@ describe EdoOracle::Queries, :ignore => true do
     end
   end
 
-
   describe '.get_section_meetings', :testext => true do
     it 'returns meetings for section id specified' do
       results = EdoOracle::Queries.get_section_meetings(fall_term_id, section_ids[0])
@@ -162,10 +161,18 @@ describe EdoOracle::Queries, :ignore => true do
     subject { EdoOracle::Queries.has_instructor_history?(ldap_uid, terms) }
     context 'when user is an instructor' do
       let(:ldap_uid) { '172701' } # Leah A Carroll - Haas Scholars Program Manager and Advisor
+      context 'when terms array is empty' do
+        let(:terms) { [] }
+        it {should eq true}
+      end
       it {should eq true}
     end
     context 'when user is not an instructor' do
       let(:ldap_uid) { '211159' } # Ray Davis - staff / developer
+      context 'when terms array is empty' do
+        let(:terms) { [] }
+        it {should eq false}
+      end
       it {should eq false}
     end
   end
@@ -174,10 +181,18 @@ describe EdoOracle::Queries, :ignore => true do
     subject { EdoOracle::Queries.has_student_history?(ldap_uid, terms) }
     context 'when user has a student history' do
       let(:ldap_uid) { '184270' }
+      context 'when terms array is empty' do
+        let(:terms) { [] }
+        it {should eq true}
+      end
       it {should eq true}
     end
     context 'when user does not have a student history' do
       let(:ldap_uid) { '211159' } # Ray Davis - staff / developer
+      context 'when terms array is empty' do
+        let(:terms) { [] }
+        it {should eq false}
+      end
       it {should eq false}
     end
   end

--- a/spec/models/user/academic_history_spec.rb
+++ b/spec/models/user/academic_history_spec.rb
@@ -1,0 +1,32 @@
+describe User::AcademicHistory do
+  let(:uid) { '2050' }
+  subject { User::AcademicHistory.new(uid) }
+
+  describe 'has_instructor_history?' do
+    let(:legacy_term) { double(:term, :legacy? => true) }
+    let(:sisedo_term) { double(:term, :legacy? => true) }
+    let(:current_terms) { [sisedo_term, legacy_term] }
+    let(:is_legacy_instructor) { false }
+    let(:is_sisedo_instructor) { false }
+    before do
+      allow(CampusOracle::Queries).to receive(:has_instructor_history?).and_return(is_legacy_instructor)
+      allow(EdoOracle::Queries).to receive(:has_instructor_history?).and_return(is_sisedo_instructor)
+    end
+    subject { User::AcademicHistory.new(uid).has_instructor_history?(current_terms) }
+
+    context 'when user is not an instructor in legacy or sisedo systems' do
+      it {should eq false}
+    end
+
+    context 'when user is an instructor in legacy system' do
+      let(:is_legacy_instructor) { true }
+      it {should eq true}
+    end
+
+    context 'when user is an instructor in sisedo system' do
+      let(:is_sisedo_instructor) { true }
+      it {should eq true}
+    end
+  end
+
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17167

* Introduces Berkeley::Terms.legacy_group to segregate terms into a hash with `:legacy` and `:sisedo` arrays.
* Updated EdoOracle::Queries.has_instructor_history? so that it returns `false` when terms array is empty
* Ensures CampusOracle::Queries.has_instructor_history? returns false when terms array is empty
* Retrofits Canvas::CurrentTeacher to use User::AcademicHistory.has_instructor_history? with support for legacy and SISEDO sources