### PR TITLE
SISRP-16877 Handle sparse results from EDO DB

### DIFF
--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -20,7 +20,7 @@ module EdoOracle
       sec."sectionNumber" AS section_num,
       sec."component-code" as instruction_format,
       sec."primaryAssociatedSectionId" as primary_associated_section_id,
-      crs."displayName" AS display_name,
+      sec."displayName" AS display_name,
       crs."catalogNumber-formatted" AS catalog_id,
       crs."catalogNumber-number" AS catalog_root,
       crs."catalogNumber-prefix" AS catalog_prefix,

--- a/app/models/edo_oracle/user_courses/base.rb
+++ b/app/models/edo_oracle/user_courses/base.rb
@@ -102,7 +102,13 @@ module EdoOracle
       #   "slug" : URL-friendly ID without term information; used by Academics
       #   "course_code" : the short course name as displayed in the UX
       def course_ids_from_row(row)
-        slug = %w(dept_name catalog_id).map { |key| normalize_to_slug row[key] }.join '-'
+        dept_name, catalog_id = row.values_at('dept_name', 'catalog_id')
+        unless dept_name && catalog_id
+          name_components = row['display_name'].split
+          catalog_id = name_components.pop
+          dept_name = name_components.join '_'
+        end
+        slug = [dept_name, catalog_id].map { |str| normalize_to_slug str }.join '-'
         term_code = Berkeley::TermCodes.edo_id_to_code row['term_id']
         {
           course_code: row['display_name'],

--- a/spec/models/edo_oracle/user_courses/base_spec.rb
+++ b/spec/models/edo_oracle/user_courses/base_spec.rb
@@ -258,16 +258,30 @@ describe EdoOracle::UserCourses::Base do
   end
 
   describe '#course_ids_from_row' do
-    let(:row) {{
-      'catalog_id' => '0109AL',
-      'dept_name' => 'MEC ENG/I,RES',
-      'display_name' => 'MEC ENG/I,RES 0109AL',
-      'term_id' => '2168'
-    }}
     subject { EdoOracle::UserCourses::Base.new(user_id: random_id).course_ids_from_row row }
-    its([:slug]) { should eq 'mec_eng_i_res-0109al' }
-    its([:id])  {should eq 'mec_eng_i_res-0109al-2016-D' }
-    its([:course_code]) { should eq 'MEC ENG/I,RES 0109AL' }
+    shared_examples 'a well-parsed id set' do
+      its([:slug]) { should eq 'mec_eng_i_res-0109al' }
+      its([:id])  {should eq 'mec_eng_i_res-0109al-2016-D' }
+      its([:course_code]) { should eq 'MEC ENG/I,RES 0109AL' }
+    end
+    context 'dept_name and catalog_id available' do
+      let(:row) {{
+        'catalog_id' => '0109AL',
+        'dept_name' => 'MEC ENG/I,RES',
+        'display_name' => 'MEC ENG/I,RES 0109AL',
+        'term_id' => '2168'
+      }}
+      it_should_behave_like 'a well-parsed id set'
+    end
+    context 'dept_name and catalog_id unavailable' do
+      let(:row) {{
+        'catalog_id' => nil,
+        'dept_name' => nil,
+        'display_name' => 'MEC ENG/I,RES 0109AL',
+        'term_id' => '2168'
+      }}
+      it_should_behave_like 'a well-parsed id set'
+    end
   end
 
   describe '#row_to_feed_item' do


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-16877

The nature of the course-section join in the EDO DB is such that the "course" half of the row might come back null. We must adapt or perish.