### PR TITLE
SISRP-17174 Implement basic fake mode for EDO DB

### DIFF
--- a/app/models/edo_oracle/connection.rb
+++ b/app/models/edo_oracle/connection.rb
@@ -1,8 +1,5 @@
 module EdoOracle
   class Connection < OracleBase
-    # WARNING: Default Rails SQL query caching (done for the lifetime of a controller action) apparently does not apply
-    # to anything but the primary DB connection. Any Oracle query caching needs to be handled explicitly.
-    establish_connection :edodb
 
     def self.settings
       Settings.edodb
@@ -17,5 +14,9 @@ module EdoOracle
       return '' unless terms.present?
       terms.map { |term| "'#{term.campus_solutions_id}'" }.join ','
     end
+
+    # WARNING: Default Rails SQL query caching (done for the lifetime of a controller action) apparently does not apply
+    # to anything but the primary DB connection. Any Oracle query caching needs to be handled explicitly.
+    establish_connection :edodb unless fake?
   end
 end

--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -34,6 +34,7 @@ module EdoOracle
     #   - 'cred_cd' and 'pnp_flag' replaced by 'grading_basis'
     def self.get_enrolled_sections(person_id, terms = nil)
       result = []
+      return result if fake?
       terms_list = terms_query_list(terms)
       use_pooled_connection do
         sql = <<-SQL
@@ -67,6 +68,7 @@ module EdoOracle
     #   - 'cs-course-id' added.
     def self.get_instructing_sections(person_id, terms = nil)
       result = []
+      return result if fake?
       terms_list = terms_query_list(terms)
       use_pooled_connection do
         sql = <<-SQL
@@ -99,6 +101,7 @@ module EdoOracle
     #   - 'cs-course-id' added.
     def self.get_associated_secondary_sections(term_id, section_id)
       result = []
+      return result if fake?
       use_pooled_connection do
         sql = <<-SQL
         SELECT
@@ -130,6 +133,7 @@ module EdoOracle
     #   - 'print_cd' replaced with 'print_in_schedule_of_classes' boolean
     def self.get_section_meetings(term_id, section_id)
       results = []
+      return results if fake?
       use_pooled_connection {
         sql = <<-SQL
         SELECT
@@ -166,6 +170,7 @@ module EdoOracle
     # EDO equivalent of CampusOracle::Queries.get_sections_from_ccns
     def self.get_sections_by_ids(term_id, section_ids)
       result = {}
+      return result if fake?
       use_pooled_connection {
         sql = <<-SQL
         SELECT
@@ -194,6 +199,7 @@ module EdoOracle
     # TODO: Update CanvasCsv::SiteMembershipsMaintainer to merge user profile data into this feed.
     def self.get_section_instructors(term_id, section_id)
       results = []
+      return results if fake?
       use_pooled_connection {
         sql = <<-SQL
           SELECT
@@ -232,6 +238,7 @@ module EdoOracle
     #     may exist for LAW as compared to GRAD, UGRAD, or UCBX
     def self.terms
       result = []
+      return result if fake?
       use_pooled_connection {
         sql = <<-SQL
         SELECT
@@ -258,6 +265,7 @@ module EdoOracle
     #   - ''
     def self.get_enrolled_students(section_id, term_id)
       result = []
+      return result if fake?
       use_pooled_connection {
         sql = <<-SQL
         SELECT
@@ -288,6 +296,7 @@ module EdoOracle
     # EDO equivalent of CampusOracle::Queries.has_instructor_history?
     def self.has_instructor_history?(ldap_uid, instructor_terms = nil)
       result = {}
+      return result if fake?
       terms_list = terms_query_list(instructor_terms)
       use_pooled_connection {
         sql = <<-SQL
@@ -308,6 +317,7 @@ module EdoOracle
 
     def self.has_student_history?(ldap_uid, student_terms = nil)
       result = {}
+      return result if fake?
       terms_list = terms_query_list(student_terms)
       use_pooled_connection {
         sql = <<-SQL

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,11 +36,11 @@ postgres:
 
 edodb:
   fake: false
-  adapter: h2
-  driver: org.h2.Driver
-  url: jdbc:h2:mem:h2EdoOracle::EdoDataSource;DB_CLOSE_DELAY=-1;MODE=Oracle
-  username: sa
-  password: sa
+  adapter:
+  driver:
+  url:
+  username:
+  password:
   pool: 95
 
 campusdb:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -11,6 +11,9 @@ canvas_proxy:
   fake: true
   app_provider_host: 'https://cc-dev.example.com'
 
+edodb:
+  fake: true
+
 ldap:
   fake: 'true'
   host: 'nds-test.berkeley.edu'

--- a/config/settings/testext.yml
+++ b/config/settings/testext.yml
@@ -5,6 +5,9 @@ logger:
   level: <%= ENV['LOGGER_LEVEL'] || DEBUG %>
   stdout: <%= ENV['LOGGER_STDOUT'] || 'only' %>
 
+edodb:
+  fake: false
+
 ldap:
   host: 'nds-test.berkeley.edu'
 

--- a/lib/oracle_base.rb
+++ b/lib/oracle_base.rb
@@ -3,6 +3,10 @@ class OracleBase < ActiveRecord::Base
     self.settings.adapter == "h2"
   end
 
+  def self.fake?
+    self.settings.fake
+  end
+
   # Oracle and H2 have no timestamp formatting function in common.
   def self.timestamp_format(timestamp_column)
     return "formatdatetime(#{timestamp_column}, 'yyyy-MM-dd HH:mm:ss')" if test_data?


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17174

WARNING: A no-op "fake: true" development.yml configuration setting (along with misleading default "edodb" values in settings.yml) wrongly slipped into an earlier commit. This default setting will now have an effect, and developers who want real EDO DB access must update their development.local.yml files.