### PR TITLE
SISRP-16749, enrollment card for advising-student-lookup with canSeeCSLinks: false

### DIFF
--- a/app/controllers/student_overview_controller.rb
+++ b/app/controllers/student_overview_controller.rb
@@ -2,28 +2,50 @@ class StudentOverviewController < ApplicationController
   include CampusSolutions::StudentLookupFeatureFlagged
 
   before_action :api_authenticate
-  before_action :authorize_access_to_student
+  before_action :authorize_student_lookup
 
   rescue_from StandardError, with: :handle_api_exception
   rescue_from Errors::ClientError, with: :handle_client_error
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
-  def authorize_access_to_student
-    raise NotAuthorizedError.new('The student lookup feature is disabled') unless is_feature_enabled
-    authorize(current_user, :can_view_as_for_all_uids?)
-  end
-
-  def student
-    student_uid = params.require 'student_uid'
-    attributes = User::AggregatedAttributes.new(student_uid).get_feed
-    unless attributes[:roles][:student] || attributes[:roles][:exStudent] || attributes[:roles][:applicant]
-      raise Pundit::NotAuthorizedError.new "#{current_user.user_id} is forbidden to view #{student_uid} because #{student_uid} is neither student, ex-student nor applicant"
-    end
+  def academics
+    student_uid = student_uid_param
     render json: {
-      attributes: attributes,
+      attributes: @attributes,
       academics: MyAcademics::Merged.new(student_uid).get_feed,
       examSchedule: MyAcademics::Exams.new(student_uid).merge
     }
+  end
+
+  def enrollment_term
+    model = CampusSolutions::MyEnrollmentTerm.new student_uid_param
+    model.term_id = params['term_id']
+    render json: model.get_feed_as_json
+  end
+
+  def enrollment_terms
+    render json: CampusSolutions::MyEnrollmentTerms.new(student_uid_param).get_feed_as_json
+  end
+
+  def academic_plan
+    model = CampusSolutions::MyAcademicPlan.new student_uid_param
+    model.term_id = params['term_id']
+    render json: model.get_feed_as_json
+  end
+
+  private
+
+  def authorize_student_lookup
+    raise NotAuthorizedError.new('The student lookup feature is disabled') unless is_feature_enabled
+    authorize current_user, :can_view_as_for_all_uids?
+    @attributes = User::AggregatedAttributes.new(student_uid = student_uid_param).get_feed
+    unless @attributes[:roles][:student] || @attributes[:roles][:exStudent] || @attributes[:roles][:applicant]
+      raise Pundit::NotAuthorizedError.new "#{current_user.user_id} is forbidden to view #{student_uid} because #{student_uid} is neither student, ex-student nor applicant"
+    end
+  end
+
+  def student_uid_param
+    params.require 'student_uid'
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,7 +138,10 @@ Calcentral::Application.routes.draw do
   post '/delete_users/saved' => 'stored_users#delete_all_saved', via: :post, defaults: { format: 'json' }
 
   # Advisor endpoints
-  get '/api/student/:student_uid' => 'student_overview#student', :defaults => { :format => 'json' }
+  get '/api/advising/academic_plan/:student_uid' => 'student_overview#academic_plan', :defaults => { :format => 'json' }
+  get '/api/advising/academics/:student_uid' => 'student_overview#academics', :defaults => { :format => 'json' }
+  get '/api/advising/enrollment_term/:student_uid' => 'student_overview#enrollment_term', :defaults => { :format => 'json' }
+  get '/api/advising/enrollment_terms/:student_uid' => 'student_overview#enrollment_terms', :defaults => { :format => 'json' }
   post '/advisor_act_as' => 'advisor_act_as#start'
   post '/stop_advisor_act_as' => 'advisor_act_as#stop'
 

--- a/spec/controllers/student_overview_controller_spec.rb
+++ b/spec/controllers/student_overview_controller_spec.rb
@@ -12,20 +12,20 @@ describe StudentOverviewController do
   end
 
   context 'no user in session' do
-    subject { get :student, student_uid: student_uid }
+    subject { get :academics, student_uid: student_uid }
     it 'should return empty json' do
       expect(JSON.parse subject.body).to be_empty
     end
   end
 
-  describe '#student' do
+  describe '#academics' do
     let(:session_user_id) { random_id }
     before do
       allow(User::AggregatedAttributes).to receive(:new).with(student_uid).and_return double get_feed: user_attributes
       allow(MyAcademics::Merged).to receive(:new).with(student_uid).and_return double get_feed: academics
       allow(MyAcademics::Exams).to receive(:new).with(student_uid).and_return double merge: double
     end
-    subject { get :student, student_uid: student_uid }
+    subject { get :academics, student_uid: student_uid }
 
     context 'cannot view_as for all UIDs' do
       it 'should raise an error' do

--- a/src/assets/javascripts/angular/configuration/routeConfiguration.js
+++ b/src/assets/javascripts/angular/configuration/routeConfiguration.js
@@ -88,7 +88,8 @@ angular.module('calcentral.config').config(function($routeProvider) {
   }).
   when('/advising/student/:uid', {
     templateUrl: 'advisor_student_overview.html',
-    controller: 'AdvisorStudentOverviewController'
+    controller: 'AdvisorStudentOverviewController',
+    isAdvisingStudentLookup: true
   }).
   when('/toolbox', {
     templateUrl: 'toolbox.html',

--- a/src/assets/javascripts/angular/controllers/pages/advisorStudentOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/advisorStudentOverviewController.js
@@ -12,7 +12,7 @@ angular.module('calcentral.controllers').controller('AdvisorStudentOverviewContr
   };
 
   var loadInformation = function() {
-    advisorStudentOverviewFactory.getStudent({
+    advisorStudentOverviewFactory.getAcademics({
       uid: $routeParams.uid
     }).then(function(data) {
       $scope.student = data.data;

--- a/src/assets/javascripts/angular/controllers/widgets/enrollment/enrollmentCardController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/enrollment/enrollmentCardController.js
@@ -7,7 +7,7 @@ var _ = require('lodash');
  * Enrollment Card Controller
  * Main controller for the enrollment card on the My Academics page
  */
-angular.module('calcentral.controllers').controller('EnrollmentCardController', function(apiService, badgesFactory, enrollmentFactory, holdsFactory, $scope, $q) {
+angular.module('calcentral.controllers').controller('EnrollmentCardController', function(apiService, badgesFactory, enrollmentFactory, holdsFactory, $route, $scope, $q) {
   var backToText = 'Class Enrollment';
   var sections = [
     {
@@ -219,7 +219,8 @@ angular.module('calcentral.controllers').controller('EnrollmentCardController', 
    * the enrollment card for students
    */
   var checkRoles = function(data) {
-    if (_.get(data, 'student')) {
+    $scope.isAdvisingStudentLookup = $route.current.isAdvisingStudentLookup;
+    if ($scope.isAdvisingStudentLookup || _.get(data, 'student')) {
       getBadges.then(loadEnrollmentData).then(loadAcademicPlan);
       loadHolds();
     } else {

--- a/src/assets/javascripts/angular/factories/advisorStudentOverviewFactory.js
+++ b/src/assets/javascripts/angular/factories/advisorStudentOverviewFactory.js
@@ -6,11 +6,11 @@ var angular = require('angular');
  * Advisor student overview factory
  */
 angular.module('calcentral.factories').factory('advisorStudentOverviewFactory', function($http) {
-  var getStudent = function(options) {
-    return $http.get('/api/student/' + options.uid);
+  var getAcademics = function(options) {
+    return $http.get('/api/advising/academics/' + options.uid);
   };
 
   return {
-    getStudent: getStudent
+    getAcademics: getAcademics
   };
 });

--- a/src/assets/javascripts/angular/factories/enrollmentFactory.js
+++ b/src/assets/javascripts/angular/factories/enrollmentFactory.js
@@ -3,9 +3,10 @@
 var angular = require('angular');
 
 /**
- * Factory for the enrollment information
+ * Factory for the enrollment information.
+ * The second set of URLs relate to Advisors doing student lookup, NOT a view-as mode.
  */
-angular.module('calcentral.factories').factory('enrollmentFactory', function(apiService) {
+angular.module('calcentral.factories').factory('enrollmentFactory', function(apiService, $route, $routeParams) {
   // var urlAcademicPlan = '/dummy/json/academic_plan.json';
   var urlAcademicPlan = '/api/campus_solutions/academic_plan';
   // var urlEnrollmentTerm = '/dummy/json/enrollment_term.json';
@@ -13,14 +14,24 @@ angular.module('calcentral.factories').factory('enrollmentFactory', function(api
   // var urlEnrollmentTerms = '/dummy/json/enrollment_terms.json';
   var urlEnrollmentTerms = '/api/campus_solutions/enrollment_terms';
 
+  // var urlAdvisingAcademicPlan = '/dummy/json/academic_plan.json';
+  var urlAdvisingAcademicPlan = '/api/advising/academic_plan/';
+  // var urlAdvisingEnrollmentTerm = '/dummy/json/enrollment_term.json';
+  var urlAdvisingEnrollmentTerm = '/api/advising/enrollment_term/';
+  // var urlAdvisingEnrollmentTerms = '/dummy/json/enrollment_terms.json';
+  var urlAdvisingEnrollmentTerms = '/api/advising/enrollment_terms/';
+
   var getAcademicPlan = function(options) {
-    return apiService.http.request(options, urlAcademicPlan);
+    var url = $route.current.isAdvisingStudentLookup ? urlAdvisingAcademicPlan + $routeParams.uid : urlAcademicPlan;
+    return apiService.http.request(options, url);
   };
   var getEnrollmentTerm = function(options) {
-    return apiService.http.request(options, urlEnrollmentTerm + '?term_id=' + options.termId);
+    var url = $route.current.isAdvisingStudentLookup ? urlAdvisingEnrollmentTerm + $routeParams.uid : urlEnrollmentTerm;
+    return apiService.http.request(options, url + '?term_id=' + options.termId);
   };
   var getEnrollmentTerms = function(options) {
-    return apiService.http.request(options, urlEnrollmentTerms);
+    var url = $route.current.isAdvisingStudentLookup ? urlAdvisingEnrollmentTerms + $routeParams.uid : urlEnrollmentTerms;
+    return apiService.http.request(options, url);
   };
 
   return {

--- a/src/assets/javascripts/angular/services/userService.js
+++ b/src/assets/javascripts/angular/services/userService.js
@@ -95,7 +95,7 @@ angular.module('calcentral.services').service('userService', function($http, $lo
     profile.actAsOptions = {
       canPost: !(_.get(profile, 'features.preventActingAsUsersFromPosting') &&
       (profile.actingAsUid || profile.delegateActingAsUid || profile.advisorActingAsUid)),
-      canSeeCSLinks: !(profile.delegateActingAsUid || profile.advisorActingAsUid),
+      canSeeCSLinks: !(profile.delegateActingAsUid || profile.advisorActingAsUid) && !$route.current.isAdvisingStudentLookup,
       isDirectlyAuthenticated: !(profile.actingAsUid || profile.delegateActingAsUid || profile.advisorActingAsUid)
     };
 

--- a/src/assets/templates/advisor_student_overview.html
+++ b/src/assets/templates/advisor_student_overview.html
@@ -11,6 +11,7 @@
     </div>
     <div class="medium-4 columns cc-column-last">
       <div data-ng-include="'widgets/final_exam_schedule.html'" data-ng-if="examSchedule.length"></div>
+      <div data-ng-include="'widgets/enrollment_card.html'" data-ng-if="api.user.profile.features.csEnrollmentCard"></div>
     </div>
   </div>
 </div>

--- a/src/assets/templates/widgets/enrollment/schedule.html
+++ b/src/assets/templates/widgets/enrollment/schedule.html
@@ -6,7 +6,7 @@
 ></div>
 
 <div class="cc-enrollment-card-section-content" data-ng-if="section.show">
-  <div data-ng-if="enrollmentTerm.isClassScheduleAvailable && api.user.profile.actAsOptions.isDirectlyAuthenticated">
+  <div data-ng-if="enrollmentTerm.isClassScheduleAvailable && !isAdvisingStudentLookup && api.user.profile.actAsOptions.isDirectlyAuthenticated">
     <a
       data-cc-outbound-enabled="true"
       data-ng-href="/college_scheduler/{{enrollmentTerm.acadCareer}}/{{enrollmentTerm.term}}">
@@ -16,7 +16,7 @@
   </div>
 
   <div
-    data-ng-if="!api.user.profile.actAsOptions.isDirectlyAuthenticated"
+    data-ng-if="isAdvisingStudentLookup || !api.user.profile.actAsOptions.isDirectlyAuthenticated"
     data-ng-include="'widgets/enrollment/enrollment_hide_links.html'">
   </div>
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-16749

Notables:
* student_overview_controller enforces `authorize_student_lookup` on all of its routes
* front-end enrollment-card code is reused with new hook added: `apiService.util.getAdvisingStudentLookupUID()`
* suppress magic URLs with expanded `canSeeCSLinks` logic in userService.js