### PR TITLE
CLC-6239 Switch bCourses user account data source to Oracle-LDAP merge

### DIFF
--- a/app/models/canvas_csv/add_new_users.rb
+++ b/app/models/canvas_csv/add_new_users.rb
@@ -41,7 +41,7 @@ module CanvasCsv
     def load_new_active_users
       @new_active_sis_users = []
       new_active_user_uids.each_slice(1000) do |uid_group|
-        @new_active_sis_users.concat CampusOracle::Queries.get_basic_people_attributes(uid_group)
+        @new_active_sis_users.concat User::BasicAttributes.attributes_for_uids(uid_group)
       end
       @new_active_sis_users
     end
@@ -50,7 +50,7 @@ module CanvasCsv
     def process_new_users
       logger.warn "#{@new_active_sis_users.length} new user accounts detected. Adding to SIS User Import CSV"
       @new_active_sis_users.each do |new_user|
-        new_canvas_user = canvas_user_from_campus_row new_user
+        new_canvas_user = canvas_user_from_campus_attributes new_user
         add_user_to_import new_canvas_user
       end
       @new_active_sis_users = nil

--- a/app/models/canvas_csv/site_memberships_maintainer.rb
+++ b/app/models/canvas_csv/site_memberships_maintainer.rb
@@ -193,7 +193,7 @@ module CanvasCsv
       logger.debug "Adding UID #{login_uid} to SIS Section: #{sis_section_id} as role: #{canvas_api_role}"
       @enrollments_csv_output << {
         'course_id' => @sis_course_id,
-        'user_id' => derive_sis_user_id(campus_data_row),
+        'user_id' => derive_sis_user_id(User::BasicAttributes.transform_campus_row campus_data_row),
         'role' => api_role_to_csv_role(canvas_api_role),
         'section_id' => sis_section_id,
         'status' => 'active'
@@ -214,7 +214,7 @@ module CanvasCsv
     def add_user_if_new(campus_data_row)
       uid = campus_data_row['ldap_uid']
       unless @known_users.include?(uid)
-        @users_csv_output << canvas_user_from_campus_row(campus_data_row)
+        @users_csv_output << canvas_user_from_campus_attributes(User::BasicAttributes.transform_campus_row campus_data_row)
         @known_users << uid
       end
     end

--- a/app/models/mailing_lists/site_mailing_list.rb
+++ b/app/models/mailing_lists/site_mailing_list.rb
@@ -243,15 +243,15 @@ module MailingLists
       add_member_proxy = Calmail::AddListMember.new
 
       course_users.map{ |user| user['login_id'] }.each_slice(1000) do |uid_slice|
-        user_slice = CampusOracle::Queries.get_basic_people_attributes uid_slice
+        user_slice = User::BasicAttributes.attributes_for_uids uid_slice
         user_slice.each do |user|
-          if (user_address = user['email_address'])
+          if (user_address = user[:email_address])
             user_address.downcase!
             addresses_to_remove.delete user_address
             unless list_address_set.include? user_address
               population_results[:add][:total] += 1
               logger.debug "Adding address #{user_address}"
-              proxy_response = add_member_proxy.add_member(self.list_name, user_address, "#{user['first_name']} #{user['last_name']}")
+              proxy_response = add_member_proxy.add_member(self.list_name, user_address, "#{user[:first_name]} #{user[:last_name]}")
               if proxy_response[:response] && proxy_response[:response][:added]
                 population_results[:add][:success] += 1
               else
@@ -259,7 +259,7 @@ module MailingLists
               end
             end
           else
-            logger.warn "No email address found for UID #{user['ldap_uid']}"
+            logger.warn "No email address found for UID #{user[:ldap_uid]}"
           end
         end
       end

--- a/spec/models/canvas_csv/add_new_users_spec.rb
+++ b/spec/models/canvas_csv/add_new_users_spec.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 describe CanvasCsv::AddNewUsers do
 
   let(:user_report_csv_string) do
@@ -15,8 +13,8 @@ describe CanvasCsv::AddNewUsers do
   let(:sis_active_uids) { %w(946122 946123 946124 946125 946126 946127).to_set }
   let(:sis_active_people) do
     [
-      {'ldap_uid'=>'946122', 'first_name'=>'Charmaine', 'last_name'=>'D\'Silva', 'email_address'=>'charmainedsilva@example.com', 'student_id'=>'22729405'},
-      {'ldap_uid'=>'946127', 'first_name'=>'Dwight', 'last_name'=>'Schrute', 'email_address'=>'dschrute@schrutefarms.com', 'student_id'=>nil},
+      {ldap_uid: '946122', first_name: 'Charmaine', last_name: 'D\'Silva', email_address: 'charmainedsilva@example.com', student_id: '22729405'},
+      {ldap_uid: '946127', first_name: 'Dwight', last_name: 'Schrute', email_address: 'dschrute@schrutefarms.com', student_id: nil},
     ]
   end
 
@@ -33,7 +31,7 @@ describe CanvasCsv::AddNewUsers do
     allow(DateTime).to receive(:now).and_return(fake_now_datetime)
     allow_any_instance_of(Canvas::Report::Users).to receive(:get_csv).and_return(user_report_csv)
     allow(CampusOracle::Queries).to receive(:get_all_active_people_uids).and_return(sis_active_uids)
-    allow(CampusOracle::Queries).to receive(:get_basic_people_attributes).and_return(sis_active_people)
+    allow(User::BasicAttributes).to receive(:attributes_for_uids).and_return(sis_active_people)
 
     # have to mock the responses due to dependency on Campus Oracle data
     allow(subject).to receive(:derive_sis_user_id).with(sis_active_people[0]).and_return('22729405')
@@ -114,24 +112,24 @@ describe CanvasCsv::AddNewUsers do
 
   describe '#load_new_active_users' do
     it 'loads new active users into array' do
-      expect(CampusOracle::Queries).to receive(:get_basic_people_attributes).with(['946122','946127']).and_return(sis_active_people)
+      expect(User::BasicAttributes).to receive(:attributes_for_uids).with(['946122','946127']).and_return(sis_active_people)
       subject.load_new_active_users
       loaded_users = subject.instance_eval { @new_active_sis_users }
       expect(loaded_users).to be_an_instance_of Array
       expect(loaded_users.count).to eq 2
       expect(loaded_users[0]).to be_an_instance_of Hash
       expect(loaded_users[1]).to be_an_instance_of Hash
-      expect(loaded_users[0]['ldap_uid']).to eq '946122'
-      expect(loaded_users[0]['first_name']).to eq 'Charmaine'
-      expect(loaded_users[0]['last_name']).to eq 'D\'Silva'
-      expect(loaded_users[1]['ldap_uid']).to eq '946127'
-      expect(loaded_users[1]['first_name']).to eq 'Dwight'
-      expect(loaded_users[1]['last_name']).to eq 'Schrute'
+      expect(loaded_users[0][:ldap_uid]).to eq '946122'
+      expect(loaded_users[0][:first_name]).to eq 'Charmaine'
+      expect(loaded_users[0][:last_name]).to eq 'D\'Silva'
+      expect(loaded_users[1][:ldap_uid]).to eq '946127'
+      expect(loaded_users[1][:first_name]).to eq 'Dwight'
+      expect(loaded_users[1][:last_name]).to eq 'Schrute'
     end
 
     it 'loads empty array when no new active users' do
       allow(subject).to receive(:new_active_user_uids).and_return([])
-      expect(CampusOracle::Queries).to_not receive(:get_basic_people_attributes)
+      expect(User::BasicAttributes).to_not receive(:attributes_for_uids)
       subject.load_new_active_users
       loaded_users = subject.instance_eval { @new_active_sis_users }
       expect(loaded_users).to eq []

--- a/spec/models/canvas_csv/base_spec.rb
+++ b/spec/models/canvas_csv/base_spec.rb
@@ -6,10 +6,10 @@ describe CanvasCsv::Base do
     context 'when all users known' do
       before do
         people_attributes = [
-          { 'ldap_uid'=>'1234', 'first_name'=>'John', 'last_name'=>'Smith',  'email_address'=>'johnsmith@example.com', 'student_id'=>nil, 'affiliations'=>'EMPLOYEE-TYPE-ACADEMIC' },
-          { 'ldap_uid'=>'1235', 'first_name'=>'Jane', 'last_name'=>'Smith', 'email_address'=>'janesmith@example.com', 'student_id'=>nil, 'affiliations'=>'EMPLOYEE-TYPE-ACADEMIC' },
+          { ldap_uid: '1234', first_name: 'John', last_name: 'Smith', email_address: 'johnsmith@example.com', student_id: nil, roles: {faculty: true} },
+          { ldap_uid: '1235', first_name: 'Jane', last_name: 'Smith', email_address: 'janesmith@example.com', student_id: nil, roles: {faculty: true} },
         ]
-        expect(CampusOracle::Queries).to receive(:get_basic_people_attributes).with(['1234','1235']).and_return people_attributes
+        expect(User::BasicAttributes).to receive(:attributes_for_uids).with(['1234','1235']).and_return people_attributes
       end
 
       it 'should assemble array with user attribute hashes' do
@@ -32,6 +32,9 @@ describe CanvasCsv::Base do
     end
 
     context 'when querying many user records from the DB' do
+      before do
+        allow(CalnetLdap::UserAttributes).to receive(:get_bulk_attributes).and_return []
+      end
       it 'should find all available ones' do
         known_first = ['238382', '2040']
         known_last = ['3060', '211159', '238382']

--- a/spec/models/mailing_lists/site_mailing_list_spec.rb
+++ b/spec/models/mailing_lists/site_mailing_list_spec.rb
@@ -174,6 +174,10 @@ describe MailingLists::SiteMailingList do
         let(:ray) { {'login_id' => '67890', 'first_name' => 'Ray', 'last_name' => 'Davis', 'email_address' => 'raydavis@berkeley.edu'}  }
         let(:paul) { {'login_id' => '65536', 'first_name' => 'Paul', 'last_name' => 'Kerschen', 'email_address' => 'kerschen@berkeley.edu'}  }
 
+        def basic_attributes(user)
+          %w(first_name last_name email_address).inject({}) { |attrs, key| attrs.merge(key.to_sym => user[key]) }
+        end
+
         before do
           allow(Canvas::CourseUsers).to receive(:new).and_return course_users
           allow(Calmail::ListMembers).to receive(:new).and_return list_members
@@ -182,7 +186,7 @@ describe MailingLists::SiteMailingList do
           allow(Calmail::RemoveListMember).to receive(:new).and_return fake_remove_proxy
 
           expect(course_users).to receive(:course_users).exactly(1).times.and_return(statusCode: 200, body: fake_site_users)
-          expect(CampusOracle::Queries).to receive(:get_basic_people_attributes).exactly(1).times.and_return fake_site_users
+          expect(User::BasicAttributes).to receive(:attributes_for_uids).exactly(1).times.and_return(fake_site_users.map { |user| basic_attributes user })
         end
 
         def expect_empty_population_results(list, action)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6239

Most of this PR teaches bCourses to accept the slightly more abstracted User::BasicAttributes structure in lieu of an Oracle row. 

The only (intended) change to logic is removal of the code path that handles Oracle-LDAP disjuncture.