### PR TITLE
SISRP-17213 Do not fetch or show unusable Higher One link

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,7 +58,12 @@ class ApplicationController < ActionController::Base
   def allow_if_advisor_view_as?
     true
   end
+  def allow_if_classic_view_as?
+    true
+  end
   def deny_if_filtered
+    deny_view_as = !allow_if_classic_view_as? && current_user.classic_viewing_as?
+    raise Pundit::NotAuthorizedError.new("By View As user #{current_user.original_user_id}") if deny_view_as
     deny_delegate = !allow_if_delegate_view_as? && current_user.authenticated_as_delegate?
     raise Pundit::NotAuthorizedError.new("By delegate #{current_user.original_delegate_user_id}") if deny_delegate
     deny_advisor = !allow_if_advisor_view_as? && current_user.authenticated_as_advisor?

--- a/app/controllers/campus_solutions/higher_one_url_controller.rb
+++ b/app/controllers/campus_solutions/higher_one_url_controller.rb
@@ -1,18 +1,16 @@
 module CampusSolutions
   class HigherOneUrlController < CampusSolutionsController
+    include AllowDelegateViewAs
+    include DisallowAdvisorViewAs
+    include DisallowClassicViewAs
+    before_filter :authorize_for_financial
 
     def get
-      model = CampusSolutions::MyHigherOneUrl.from_session proxy_args
+      options = {}
+      options[:delegate_uid] = current_user.original_delegate_user_id if current_user.authenticated_as_delegate?
+      model = CampusSolutions::MyHigherOneUrl.from_session(session, options)
       render json: model.get_feed_as_json
-    end
-
-    private
-
-    def proxy_args
-      delegate_uid = session[SessionKey.original_delegate_user_id]
-      delegate_uid ? session.merge(delegate_uid: delegate_uid) : session
     end
 
   end
 end
-

--- a/app/controllers/concerns/disallow_classic_view_as.rb
+++ b/app/controllers/concerns/disallow_classic_view_as.rb
@@ -1,0 +1,6 @@
+module DisallowClassicViewAs
+  # Indicates that controller endpoints are unavailable to classic View-As for service support staff.
+  def allow_if_classic_view_as?
+    false
+  end
+end

--- a/app/models/campus_solutions/my_higher_one_url.rb
+++ b/app/models/campus_solutions/my_higher_one_url.rb
@@ -9,14 +9,11 @@ module CampusSolutions
 
     def get_feed_internal
       return {} unless is_feature_enabled
+      proxy_args = {
+        user_id: @uid,
+        delegate_uid: @options[:delegate_uid]
+      }
       CampusSolutions::HigherOneUrl.new(proxy_args).get
-    end
-
-    private
-
-    def proxy_args
-      args = { user_id: @uid }
-      (delegate_uid = @options[:delegate_uid]) ? args.merge(delegate_uid: delegate_uid) : args
     end
 
   end

--- a/app/models/up_next/my_up_next.rb
+++ b/app/models/up_next/my_up_next.rb
@@ -11,6 +11,7 @@ module UpNext
     def init
       @begin_today = Time.zone.today.in_time_zone.to_datetime
       @next_day = begin_today.advance(:days => 1)
+      self
     end
 
     def get_feed_internal

--- a/lib/cache/cached_feed.rb
+++ b/lib/cache/cached_feed.rb
@@ -7,6 +7,7 @@ module Cache
     def init
       # override to do any initialization that requires database access or other expensive computation.
       # If you do expensive work from initialize, it will happen even when this object is cached -- not desirable!
+      self
     end
 
     def get_feed(force_cache_write=false)

--- a/public/dummy/json/status.json
+++ b/public/dummy/json/status.json
@@ -1,4 +1,3 @@
-
 {
   "isBasicAuthEnabled": false,
   "isLoggedIn": true,
@@ -10,30 +9,47 @@
   "actingAsUid": "1051203",
   "isSuperuser": false,
   "isViewer": false,
-  "first_login_at": "2014-02-05T05:37:02-08:00",
-  "first_name": "IWQROE",
+  "firstLoginAt": "2014-02-05T05:37:02-08:00",
+  "firstName": "IWQROE",
   "fullName": "IWQROE BABTREW",
   "isGoogleReminderDismissed": false,
+  "isCalendarOptedIn": false,
   "hasCanvasAccount": true,
   "hasGoogleAccessToken": false,
   "hasStudentHistory": false,
   "hasInstructorHistory": false,
+  "hasDashboardTab": true,
   "hasAcademicsTab": true,
+  "canViewGrades": false,
   "hasFinancialsTab": true,
   "hasToolboxTab": true,
+  "hasPhoto": true,
+  "inEducationAbroadProgram": false,
   "googleEmail": "",
   "canvasEmail": "",
-  "last_name": "BABTREW",
-  "preferred_name": "BABTREW,IWQROE",
+  "lastName": "BABTREW",
+  "preferredName": "BABTREW,IWQROE",
   "roles": {
     "student": true,
     "registered": true,
     "exStudent": false,
     "faculty": false,
     "staff": false,
-    "guest": false
+    "guest": false,
+    "concurrentEnrollmentStudent": false,
+    "expiredAccount": false
   },
   "uid": "61889",
+  "sid": null,
+  "campusSolutionsID": null,
+  "isCampusSolutionsStudent": true,
+  "isDelegateUser": false,
+  "showSisProfileUI": true,
+  "isDirectlyAuthenticated": true,
+  "advisorActingAsUid": false,
+  "delegateActingAsUid": false,
+  "canSeeCSLinks": true,
+  "canActOnFinances": true,
   "lastModified": {
     "hash": "c7e1f3df2ddb1dbf46b0d285185b1af03d20089e",
     "timestamp": {
@@ -42,6 +58,7 @@
       "dateString": "3/13"
     }
   },
-  "feedName": "User::Api"
+  "feedName": "User::Api",
+  "youtubeSplashId": "Yc3z0TIl_Fc"
 }
 

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -68,6 +68,8 @@ describe User::Api do
       expect(api[:campusSolutionsID]).to eq 'CC12345678'
       expect(api[:sid]).to eq '1234567890'
       expect(api[:delegateViewAsPrivileges]).to be_nil
+      expect(api[:isDirectlyAuthenticated]).to be true
+      expect(api[:canActOnFinances]).to be true
     end
   end
 
@@ -132,6 +134,8 @@ describe User::Api do
           expect(api[:hasToolboxTab]).to be true
           expect(api[:delegateViewAsPrivileges]).to be_nil
           expect(api[:hasPhoto]).to be false
+          expect(api[:isDirectlyAuthenticated]).to be true
+          expect(api[:canActOnFinances]).to be true
         end
       end
       context 'view-as session' do
@@ -155,6 +159,8 @@ describe User::Api do
             expect(privileges).to be_a Hash
             expect(privileges).to include financial: false, viewEnrollments: false, viewGrades: true, phone: false
             expect(api[:hasPhoto]).to be false
+            expect(api[:isDirectlyAuthenticated]).to be false
+            expect(api[:canActOnFinances]).to be false
           end
         end
         context 'tabs per privileges' do
@@ -163,6 +169,8 @@ describe User::Api do
             expect(api[:hasAcademicsTab]).to be true
             expect(api[:canViewGrades]).to be false
             expect(api[:hasPhoto]).to be false
+            expect(api[:isDirectlyAuthenticated]).to be false
+            expect(api[:canActOnFinances]).to be false
           end
         end
         context 'tabs per privileges' do
@@ -173,6 +181,8 @@ describe User::Api do
             expect(api[:hasFinancialsTab]).to be true
             expect(api[:delegateViewAsPrivileges]).to include financial: true, viewEnrollments: false, viewGrades: false, phone: false
             expect(api[:hasPhoto]).to be false
+            expect(api[:isDirectlyAuthenticated]).to be false
+            expect(api[:canActOnFinances]).to be true
           end
         end
       end

--- a/src/assets/javascripts/angular/controllers/widgets/sir/sirItemReceivedController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/sir/sirItemReceivedController.js
@@ -7,7 +7,7 @@ var _ = require('lodash');
  * SIR (Statement of Intent to Register) item receid controller
  * This controller will be executed when the current checklist item is in received status
  */
-angular.module('calcentral.controllers').controller('SirItemReceivedController', function(sirFactory, $interval, $scope, $q) {
+angular.module('calcentral.controllers').controller('SirItemReceivedController', function(sirFactory, apiService, $interval, $scope, $q) {
   // The Higher One URL expires after 5 minutes, so we refresh it every 4.5 minutes
   var expireTimeMilliseconds = 4.5 * 60 * 1000;
 
@@ -39,12 +39,14 @@ angular.module('calcentral.controllers').controller('SirItemReceivedController',
    * Parse the deposit information.
    * Contains the deposit amount & date
    */
-  var parseDepostInformation = function(data) {
+  var parseDepositInformation = function(data) {
     $scope.sirReceivedItem.depositInfo = _.get(data, 'data.feed.depositResponse.deposit');
     $scope.sirReceivedItem.hasDeposit = !!_.get(data, 'data.feed.depositResponse.deposit.dueAmt');
     $scope.sirReceivedItem.isLoading = false;
 
-    startHigherOneUrlInterval();
+    if (apiService.user.profile.canActOnFinances) {
+      startHigherOneUrlInterval();
+    }
 
     return $q.resolve($scope.sirReceivedItem);
   };
@@ -52,16 +54,16 @@ angular.module('calcentral.controllers').controller('SirItemReceivedController',
   /**
    * Get information about the deposit, whether you still need to pay or not
    */
-  var getDepostInformation = function() {
+  var getDepositInformation = function() {
     return sirFactory.getDeposit({
       params: {
         'admApplNbr': _.get($scope, 'item.checkListMgmtAdmp.admApplNbr')
       }
-    }).then(parseDepostInformation);
+    }).then(parseDepositInformation);
   };
 
   var init = function() {
-    getDepostInformation();
+    getDepositInformation();
   };
 
   init();

--- a/src/assets/javascripts/angular/services/userService.js
+++ b/src/assets/javascripts/angular/services/userService.js
@@ -93,10 +93,8 @@ angular.module('calcentral.services').service('userService', function($http, $lo
 
     // Set whether the current user can POST information when acting as someone
     profile.actAsOptions = {
-      canPost: !(_.get(profile, 'features.preventActingAsUsersFromPosting') &&
-      (profile.actingAsUid || profile.delegateActingAsUid || profile.advisorActingAsUid)),
-      canSeeCSLinks: !(profile.delegateActingAsUid || profile.advisorActingAsUid) && !$route.current.isAdvisingStudentLookup,
-      isDirectlyAuthenticated: !(profile.actingAsUid || profile.delegateActingAsUid || profile.advisorActingAsUid)
+      canPost: !(_.get(profile, 'features.preventActingAsUsersFromPosting') && !profile.isDirectlyAuthenticated),
+      canSeeCSLinks: (profile.canSeeCSLinks && !$route.current.isAdvisingStudentLookup)
     };
 
     return profile;

--- a/src/assets/templates/widgets/enrollment/schedule.html
+++ b/src/assets/templates/widgets/enrollment/schedule.html
@@ -6,7 +6,7 @@
 ></div>
 
 <div class="cc-enrollment-card-section-content" data-ng-if="section.show">
-  <div data-ng-if="enrollmentTerm.isClassScheduleAvailable && !isAdvisingStudentLookup && api.user.profile.actAsOptions.isDirectlyAuthenticated">
+  <div data-ng-if="enrollmentTerm.isClassScheduleAvailable && !isAdvisingStudentLookup && api.user.profile.isDirectlyAuthenticated">
     <a
       data-cc-outbound-enabled="true"
       data-ng-href="/college_scheduler/{{enrollmentTerm.acadCareer}}/{{enrollmentTerm.term}}">
@@ -16,7 +16,7 @@
   </div>
 
   <div
-    data-ng-if="isAdvisingStudentLookup || !api.user.profile.actAsOptions.isDirectlyAuthenticated"
+    data-ng-if="isAdvisingStudentLookup || !api.user.profile.isDirectlyAuthenticated"
     data-ng-include="'widgets/enrollment/enrollment_hide_links.html'">
   </div>
 

--- a/src/assets/templates/widgets/sir/sir_item_received.html
+++ b/src/assets/templates/widgets/sir/sir_item_received.html
@@ -7,10 +7,10 @@
       Your program requires a deposit of <strong data-ng-bind="sirReceivedItem.depositInfo.dueAmt | currency"></strong>
       by <span data-ng-bind="api.date.moment(sirReceivedItem.depositInfo.dueDt, 'YYYY-MM-DD').format('MMMM Do, YYYY')"></span>. Your payment will need time to process and may not be reflected immediately in your account.
     </div>
-    <div data-ng-if="sirReceivedItem.higherOneUrl && api.user.profile.actAsOptions.canPost" class="cc-widget-sir-button-container">
+    <div data-ng-if="api.user.profile.canActOnFinances && sirReceivedItem.higherOneUrl" class="cc-widget-sir-button-container">
       <a class="cc-button cc-button-blue" data-ng-href="{{sirReceivedItem.higherOneUrl}}">Pay Deposit</a>
     </div>
-    <div data-ng-if="sirReceivedItem.higherOneUrl && !api.user.profile.actAsOptions.canPost" class="cc-widget-sir-button-container">
+    <div data-ng-if="!api.user.profile.canActOnFinances" class="cc-widget-sir-button-container">
       <i class="fa fa-exclamation-triangle cc-icon-gold"></i> You are not allowed to pay the deposit when viewing as.
     </div>
   </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17213

* Fixes some broken Higher One controller logic.
* Completes our menu of View-As authorization options.
* Centralizes session-state-dependent elements of the User::Api feed in the merged model class.
* Reduces duplication of back-end and front-end authorization logic.
* Fixes a little annoyance for us Rails console users (not being able to type User::Api.new(uid).init.get_feed)

@christianvuerings, so far I've been unable to find a way to test the front-end changes.

@johncrossman , I'd appreciate your eyes on this one, too. Thanks!