### PR TITLE
SISRP-17267 Retrofit rosters to query EdoOracle on non-legacy terms

### DIFF
--- a/app/models/rosters/campus.rb
+++ b/app/models/rosters/campus.rb
@@ -40,26 +40,19 @@ module Rosters
             ccn: section[:ccn],
             name: "#{course[:dept]} #{course[:catid]} #{section[:section_label]}"
           }
-
-          section_enrollments = CampusOracle::Queries.get_enrolled_students(section[:ccn], course[:term_yr], course[:term_cd])
+          section_enrollments = get_enrollments(section[:ccn], course[:term_yr], course[:term_cd])
           section_enrollments.each do |enr|
-            if (existing_entry = campus_enrollment_map[enr['ldap_uid']])
+            if (existing_entry = campus_enrollment_map[enr[:ldap_uid]])
               # We include waitlisted students in the roster. However, we do not show the official photo if the student
               # is waitlisted in ALL sections.
-              if existing_entry[:enroll_status] == 'W' &&
-                enr['enroll_status'] == 'E'
+              if existing_entry[:enroll_status] == 'W' && enr[:enroll_status] == 'E'
                 existing_entry[:enroll_status] = 'E'
               end
-              campus_enrollment_map[enr['ldap_uid']][:section_ccns] |= [section[:ccn]]
+              campus_enrollment_map[enr[:ldap_uid]][:section_ccns] |= [section[:ccn]]
             else
-              campus_enrollment_map[enr['ldap_uid']] = {
-                student_id: enr['student_id'],
-                first_name: enr['first_name'],
-                last_name: enr['last_name'],
-                email: enr['student_email_address'],
-                enroll_status: enr['enroll_status'],
+              campus_enrollment_map[enr[:ldap_uid]] = enr.slice(:student_id, :first_name, :last_name, :email, :enroll_status).merge({
                 section_ccns: [section[:ccn]]
-              }
+              })
             end
           end
         end

--- a/app/models/rosters/canvas.rb
+++ b/app/models/rosters/canvas.rb
@@ -27,27 +27,21 @@ module Rosters
           sis_id: sis_id
         }
 
-        section_enrollments = CampusOracle::Queries.get_enrolled_students(official_section[:ccn], official_section[:term_yr], official_section[:term_cd])
+        section_enrollments = get_enrollments(official_section[:ccn], official_section[:term_yr], official_section[:term_cd])
         section_enrollments.each do |enr|
-          if (existing_entry = campus_enrollment_map[enr['ldap_uid']])
+          if (existing_entry = campus_enrollment_map[enr[:ldap_uid]])
             existing_entry[:sections] << {id: section_ccn}
             existing_entry[:section_ccns] << section_ccn
             # We include waitlisted students in the roster. However, we do not show the official photo if the student
             # is waitlisted in ALL sections.
-            if existing_entry[:enroll_status] == 'W' &&
-              enr['enroll_status'] == 'E'
+            if existing_entry[:enroll_status] == 'W' && enr[:enroll_status] == 'E'
               existing_entry[:enroll_status] = 'E'
             end
           else
-            campus_enrollment_map[enr['ldap_uid']] = {
-              student_id: enr['student_id'],
-              first_name: enr['first_name'],
-              last_name: enr['last_name'],
-              email: enr['student_email_address'],
-              enroll_status: enr['enroll_status'],
+            campus_enrollment_map[enr[:ldap_uid]] = enr.slice(:student_id, :first_name, :last_name, :email, :enroll_status).merge({
               sections: [{id: section_ccn}],
               section_ccns: [section_ccn]
-            }
+            })
           end
         end
       end

--- a/spec/models/rosters/campus_spec.rb
+++ b/spec/models/rosters/campus_spec.rb
@@ -1,4 +1,4 @@
-describe 'Rosters::Campus' do
+describe Rosters::Campus do
   let(:term_yr) {'2014'}
   let(:term_cd) {'B'}
   let(:term_slug) {"#{term_yr}-#{term_cd}"}
@@ -57,35 +57,7 @@ describe 'Rosters::Campus' do
     }
   end
 
-  let(:fake_students) do
-    [
-        {
-            'ldap_uid' => enrolled_student_login_id,
-            'enroll_status' => 'E',
-            'student_id' => enrolled_student_student_id,
-            'first_name' => 'First Name',
-            'last_name' => 'Last Name',
-            'student_email_address' => "#{enrolled_student_login_id}@example.com",
-        },
-        {
-            'ldap_uid' => waitlisted_student_login_id,
-            'enroll_status' => 'W',
-            'student_id' => waitlisted_student_student_id,
-            'first_name' => 'First Name',
-            'last_name' => 'Last Name',
-            'student_email_address' => "#{waitlisted_student_login_id}@example.com",
-        }
-    ]
-  end
-
-  context 'course with single section' do
-    before do
-      allow(CampusOracle::UserCourses::All).to receive(:new).with(user_id: user_id).and_return(double(get_all_campus_courses: fake_campus))
-      allow(CampusOracle::UserCourses::All).to receive(:new).with(user_id: student_user_id).and_return(double(get_all_campus_courses: fake_campus_student))
-      allow(CampusOracle::Queries).to receive(:get_enrolled_students).with(ccn1, term_yr, term_cd).and_return(fake_students)
-      allow(CampusOracle::Queries).to receive(:get_enrolled_students).with(ccn2, term_yr, term_cd).and_return(fake_students)
-    end
-
+  shared_examples 'a good and proper roster' do
     it 'should return a list of officially enrolled students for a course ccn' do
       model = Rosters::Campus.new(user_id, course_id: campus_course_id)
       feed = model.get_feed
@@ -101,15 +73,15 @@ describe 'Rosters::Campus' do
       student = feed[:students][0]
       expect(student[:id]).to eq enrolled_student_login_id
       expect(student[:student_id]).to eq enrolled_student_student_id
-      expect(student[:first_name].blank?).to be_falsey
-      expect(student[:last_name].blank?).to be_falsey
-      expect(student[:email].blank?).to be_falsey
+      expect(student[:first_name]).to be_present
+      expect(student[:last_name]).to be_present
+      expect(student[:email]).to be_present
       expect(student[:sections].length).to eq 2
       expect(student[:sections][0][:ccn]).to eq ccn1
       expect(student[:sections][0][:name]).to eq "INFO #{catid} LEC 001"
       expect(student[:sections][1][:ccn]).to eq ccn2
       expect(student[:sections][1][:name]).to eq "INFO #{catid} LAB 001"
-      expect(student[:profile_url].blank?).to be_falsey
+      expect(student[:profile_url]).to be_present
     end
 
     it 'should show official photo links for students who are not waitlisted in all sections' do
@@ -120,6 +92,88 @@ describe 'Rosters::Campus' do
       expect(feed[:students].index {|student| student[:id] == waitlisted_student_login_id &&
           student[:photo].nil?
       }).to_not be_nil
+    end
+  end
+
+  context 'a course with one section' do
+    before do
+      allow(CampusOracle::UserCourses::All).to receive(:new).with(user_id: user_id).and_return(double(get_all_campus_courses: fake_campus))
+      allow(CampusOracle::UserCourses::All).to receive(:new).with(user_id: student_user_id).and_return(double(get_all_campus_courses: fake_campus_student))
+      expect(Berkeley::Terms).to receive(:legacy?).exactly(2).times.and_return is_legacy
+    end
+
+    context 'one-section course from legacy data' do
+      let(:is_legacy) { true }
+      before do
+        expect(CampusOracle::Queries).to receive(:get_enrolled_students).with(ccn1, term_yr, term_cd).and_return(fake_students)
+        expect(CampusOracle::Queries).to receive(:get_enrolled_students).with(ccn2, term_yr, term_cd).and_return(fake_students)
+      end
+      let(:fake_students) do
+        [
+          {
+            'ldap_uid' => enrolled_student_login_id,
+            'enroll_status' => 'E',
+            'student_id' => enrolled_student_student_id,
+            'first_name' => 'First Name',
+            'last_name' => 'Last Name',
+            'student_email_address' => "#{enrolled_student_login_id}@example.com",
+          },
+          {
+            'ldap_uid' => waitlisted_student_login_id,
+            'enroll_status' => 'W',
+            'student_id' => waitlisted_student_student_id,
+            'first_name' => 'First Name',
+            'last_name' => 'Last Name',
+            'student_email_address' => "#{waitlisted_student_login_id}@example.com",
+          }
+        ]
+      end
+      it_should_behave_like 'a good and proper roster'
+    end
+
+    context 'one-section course from Campus Solutions data' do
+      let(:is_legacy) { false }
+      let(:term_id) { Berkeley::TermCodes.to_edo_id(term_yr, term_cd) }
+      before do
+        expect(EdoOracle::Queries).to receive(:get_enrolled_students).with(ccn1, term_id).and_return enrollments
+        expect(EdoOracle::Queries).to receive(:get_enrolled_students).with(ccn2, term_id).and_return enrollments
+        expect(CalnetLdap::UserAttributes).to receive(:get_bulk_attributes)
+          .with([enrolled_student_login_id, waitlisted_student_login_id])
+          .exactly(2).times.and_return attributes
+      end
+      let(:enrollments) do
+        [
+          {
+            'ldap_uid' => enrolled_student_login_id,
+            'enroll_status' => 'E',
+            'student_id' => enrolled_student_student_id
+          },
+          {
+            'ldap_uid' => waitlisted_student_login_id,
+            'enroll_status' => 'W',
+            'student_id' => waitlisted_student_student_id
+          }
+        ]
+      end
+      let(:attributes) do
+        [
+          {
+            ldap_uid: enrolled_student_login_id,
+            student_id: enrolled_student_student_id,
+            first_name: 'First Name',
+            last_name: 'Last Name',
+            email_address: "#{enrolled_student_login_id}@example.com"
+          },
+          {
+            ldap_uid: waitlisted_student_login_id,
+            student_id: enrolled_student_student_id,
+            first_name: 'First Name',
+            last_name: 'Last Name',
+            email_address: "#{waitlisted_student_login_id}@example.com"
+          }
+        ]
+      end
+      it_should_behave_like 'a good and proper roster'
     end
   end
 

--- a/spec/models/rosters/canvas_spec.rb
+++ b/spec/models/rosters/canvas_spec.rb
@@ -1,5 +1,4 @@
 describe Rosters::Canvas do
-
   let(:teacher_login_id) { rand(99999).to_s }
   let(:course_id) { rand(99999) }
   let(:catid) {"#{rand(999)}"}
@@ -51,50 +50,18 @@ describe Rosters::Canvas do
     })
   end
 
-  context 'when students are enrolled in multiple sections' do
-    let(:student_in_discussion_section_login_id) { rand(99999).to_s }
-    let(:student_in_discussion_section_student_id) { rand(99999).to_s }
+  let(:student_in_discussion_section_login_id) { rand(99999).to_s }
+  let(:student_in_discussion_section_student_id) { rand(99999).to_s }
 
-    let(:student_not_in_discussion_section_login_id) { rand(99999).to_s }
-    let(:student_not_in_discussion_section_student_id) { rand(99999).to_s }
+  let(:student_not_in_discussion_section_login_id) { rand(99999).to_s }
+  let(:student_not_in_discussion_section_student_id) { rand(99999).to_s }
 
-    before do
-      stub_teacher_status(teacher_login_id, course_id)
-      allow_any_instance_of(Canvas::CourseSections).to receive(:official_section_identifiers).and_return(section_identifiers)
-      allow(CampusOracle::Queries).to receive(:get_enrolled_students).with(lecture_section_ccn, '2013', 'C').and_return(
-        [
-          {
-            'ldap_uid' => student_in_discussion_section_login_id,
-            'enroll_status' => 'E',
-            'student_id' => student_in_discussion_section_student_id,
-            'first_name' => 'Thurston',
-            'last_name' => "Howell #{student_in_discussion_section_login_id}",
-            'student_email_address' => "#{student_in_discussion_section_login_id}@example.com"
-          },
-          {
-            'ldap_uid' => student_not_in_discussion_section_login_id,
-            'enroll_status' => 'E',
-            'student_id' => student_not_in_discussion_section_student_id,
-            'first_name' => 'Clarence',
-            'last_name' => "Williams #{student_not_in_discussion_section_login_id}",
-            'student_email_address' => "#{student_not_in_discussion_section_login_id}@example.com"
-          }
-        ]
-      )
-      allow(CampusOracle::Queries).to receive(:get_enrolled_students).with(discussion_section_ccn, '2013', 'C').and_return(
-        [
-          {
-            'ldap_uid' => student_in_discussion_section_login_id,
-            'enroll_status' => 'E',
-            'student_id' => student_in_discussion_section_student_id,
-            'first_name' => 'Thurston',
-            'last_name' => "Howell #{student_in_discussion_section_login_id}",
-            'student_email_address' => "#{student_in_discussion_section_login_id}@example.com"
-          }
-        ]
-      )
-    end
+  before do
+    stub_teacher_status(teacher_login_id, course_id)
+    allow_any_instance_of(Canvas::CourseSections).to receive(:official_section_identifiers).and_return(section_identifiers)
+  end
 
+  shared_examples 'a good and proper roster' do
     it 'should return enrollments for each section' do
       feed = subject.get_feed
       expect(feed[:canvas_course][:id]).to eq course_id
@@ -141,153 +108,258 @@ describe Rosters::Canvas do
     end
   end
 
-  context 'when students are waitlisted' do
-    let(:enrolled_student_login_id) { rand(99999).to_s }
-    let(:enrolled_student_student_id) { rand(99999).to_s }
-
-    let(:waitlisted_student_login_id) { rand(99999).to_s }
-    let(:waitlisted_student_student_id) { rand(99999).to_s }
-
-    it 'should show official photo links for students who are not waitlisted in all sections' do
-      stub_teacher_status(teacher_login_id, course_id)
-      allow_any_instance_of(Canvas::CourseSections).to receive(:official_section_identifiers).and_return(
-        [
-          {
-            course_id: course_id,
-            id: lecture_section_id,
-            name: 'An Official Lecture Section',
-            sis_section_id: lecture_section_sis_id,
-            term_yr: '2013',
-            term_cd: 'C',
-            ccn: lecture_section_ccn
-          },
-          {
-            course_id: course_id,
-            id: discussion_section_id,
-            name: 'An Official Discussion Section',
-            sis_section_id: discussion_section_sis_id,
-            term_yr: '2013',
-            term_cd: 'C',
-            ccn: discussion_section_ccn
-          }
-        ]
-      )
-
-      # A student may be waitlisted in a secondary section but enrolled in a primary section.
+  context 'legacy data source' do
+    before do
+      allow(Berkeley::Terms).to receive(:legacy?).and_return true
       allow(CampusOracle::Queries).to receive(:get_enrolled_students).with(lecture_section_ccn, '2013', 'C').and_return(
         [
           {
-            'ldap_uid' => enrolled_student_login_id,
+            'ldap_uid' => student_in_discussion_section_login_id,
             'enroll_status' => 'E',
-            'student_id' => enrolled_student_student_id
+            'student_id' => student_in_discussion_section_student_id,
+            'first_name' => 'Thurston',
+            'last_name' => "Howell #{student_in_discussion_section_login_id}",
+            'student_email_address' => "#{student_in_discussion_section_login_id}@example.com"
           },
           {
-            'ldap_uid' => waitlisted_student_login_id,
-            'enroll_status' => 'W',
-            'student_id' => waitlisted_student_student_id
+            'ldap_uid' => student_not_in_discussion_section_login_id,
+            'enroll_status' => 'E',
+            'student_id' => student_not_in_discussion_section_student_id,
+            'first_name' => 'Clarence',
+            'last_name' => "Williams #{student_not_in_discussion_section_login_id}",
+            'student_email_address' => "#{student_not_in_discussion_section_login_id}@example.com"
           }
         ]
       )
       allow(CampusOracle::Queries).to receive(:get_enrolled_students).with(discussion_section_ccn, '2013', 'C').and_return(
         [
           {
-            'ldap_uid' => enrolled_student_login_id,
-            'enroll_status' => 'W',
-            'student_id' => enrolled_student_student_id
-          },
-          {
-            'ldap_uid' => waitlisted_student_login_id,
-            'enroll_status' => 'W',
-            'student_id' => waitlisted_student_student_id
+            'ldap_uid' => student_in_discussion_section_login_id,
+            'enroll_status' => 'E',
+            'student_id' => student_in_discussion_section_student_id,
+            'first_name' => 'Thurston',
+            'last_name' => "Howell #{student_in_discussion_section_login_id}",
+            'student_email_address' => "#{student_in_discussion_section_login_id}@example.com"
           }
         ]
       )
-      feed = subject.get_feed
-      expect(feed[:sections].length).to eq 2
-      expect(feed[:students].length).to eq 2
-
-      enrolled_student = feed[:students].find {|student| student[:login_id] == enrolled_student_login_id}
-      expect(enrolled_student).to_not be_nil
-      expect(enrolled_student[:photo]).to_not be_blank
-
-      waitlisted_student = feed[:students].find {|student| student[:login_id] == waitlisted_student_login_id}
-      expect(waitlisted_student).to_not be_nil
-      expect(waitlisted_student[:photo]).to be_nil
     end
 
-    it 'should only download photo data for officially fully enrolled students' do
-      stub_teacher_status(teacher_login_id, course_id)
-      allow_any_instance_of(Canvas::CourseSections).to receive(:official_section_identifiers).and_return(
-        [
-          {
-            course_id: course_id,
-            id: lecture_section_id,
-            name: 'An Official Lecture Section',
-            sis_section_id: lecture_section_sis_id,
-            term_yr: "2013",
-            term_cd: "C",
-            ccn: lecture_section_ccn
-          }
-        ]
-      )
-      allow(CampusOracle::Queries).to receive(:get_enrolled_students).with(lecture_section_ccn, '2013', 'C').and_return(
-        [
-          {
-            'ldap_uid' => enrolled_student_login_id,
-            'enroll_status' => 'E',
-            'student_id' => enrolled_student_student_id
-          },
-          {
-            'ldap_uid' => waitlisted_student_login_id,
-            'enroll_status' => 'W',
-            'student_id' => waitlisted_student_student_id
-          }
-        ]
-      )
-      photo_data = rand(99999999)
-      allow_any_instance_of(Cal1card::Photo).to receive(:get_feed).and_return(
-        {
-          length: 42,
-          photo: photo_data
-        }
-      )
-      enrolled_photo = subject.photo_data_or_file(enrolled_student_login_id)
-      expect(enrolled_photo[:data]).to eq photo_data
-      expect(enrolled_photo[:size]).to eq 42
-      expect(enrolled_photo[:filename]).to be_nil
-      waitlisted_photo = subject.photo_data_or_file(waitlisted_student_login_id)
-      expect(waitlisted_photo).to be_nil
+    include_examples 'a good and proper roster'
+
+    context 'when students are waitlisted' do
+      let(:enrolled_student_login_id) { rand(99999).to_s }
+      let(:enrolled_student_student_id) { rand(99999).to_s }
+
+      let(:waitlisted_student_login_id) { rand(99999).to_s }
+      let(:waitlisted_student_student_id) { rand(99999).to_s }
+
+      it 'should show official photo links for students who are not waitlisted in all sections' do
+        stub_teacher_status(teacher_login_id, course_id)
+        allow_any_instance_of(Canvas::CourseSections).to receive(:official_section_identifiers).and_return(
+            [
+              {
+                course_id: course_id,
+                id: lecture_section_id,
+                name: 'An Official Lecture Section',
+                sis_section_id: lecture_section_sis_id,
+                term_yr: '2013',
+                term_cd: 'C',
+                ccn: lecture_section_ccn
+              },
+              {
+                course_id: course_id,
+                id: discussion_section_id,
+                name: 'An Official Discussion Section',
+                sis_section_id: discussion_section_sis_id,
+                term_yr: '2013',
+                term_cd: 'C',
+                ccn: discussion_section_ccn
+              }
+            ]
+          )
+
+        # A student may be waitlisted in a secondary section but enrolled in a primary section.
+        allow(CampusOracle::Queries).to receive(:get_enrolled_students).with(lecture_section_ccn, '2013', 'C').and_return(
+            [
+              {
+                'ldap_uid' => enrolled_student_login_id,
+                'enroll_status' => 'E',
+                'student_id' => enrolled_student_student_id
+              },
+              {
+                'ldap_uid' => waitlisted_student_login_id,
+                'enroll_status' => 'W',
+                'student_id' => waitlisted_student_student_id
+              }
+            ]
+          )
+        allow(CampusOracle::Queries).to receive(:get_enrolled_students).with(discussion_section_ccn, '2013', 'C').and_return(
+            [
+              {
+                'ldap_uid' => enrolled_student_login_id,
+                'enroll_status' => 'W',
+                'student_id' => enrolled_student_student_id
+              },
+              {
+                'ldap_uid' => waitlisted_student_login_id,
+                'enroll_status' => 'W',
+                'student_id' => waitlisted_student_student_id
+              }
+            ]
+          )
+        feed = subject.get_feed
+        expect(feed[:sections].length).to eq 2
+        expect(feed[:students].length).to eq 2
+
+        enrolled_student = feed[:students].find {|student| student[:login_id] == enrolled_student_login_id}
+        expect(enrolled_student).to_not be_nil
+        expect(enrolled_student[:photo]).to_not be_blank
+
+        waitlisted_student = feed[:students].find {|student| student[:login_id] == waitlisted_student_login_id}
+        expect(waitlisted_student).to_not be_nil
+        expect(waitlisted_student[:photo]).to be_nil
+      end
+
+      it 'should only download photo data for officially fully enrolled students' do
+        stub_teacher_status(teacher_login_id, course_id)
+        allow_any_instance_of(Canvas::CourseSections).to receive(:official_section_identifiers).and_return(
+            [
+              {
+                course_id: course_id,
+                id: lecture_section_id,
+                name: 'An Official Lecture Section',
+                sis_section_id: lecture_section_sis_id,
+                term_yr: "2013",
+                term_cd: "C",
+                ccn: lecture_section_ccn
+              }
+            ]
+          )
+        allow(CampusOracle::Queries).to receive(:get_enrolled_students).with(lecture_section_ccn, '2013', 'C').and_return(
+            [
+              {
+                'ldap_uid' => enrolled_student_login_id,
+                'enroll_status' => 'E',
+                'student_id' => enrolled_student_student_id
+              },
+              {
+                'ldap_uid' => waitlisted_student_login_id,
+                'enroll_status' => 'W',
+                'student_id' => waitlisted_student_student_id
+              }
+            ]
+          )
+        photo_data = rand(99999999)
+        allow_any_instance_of(Cal1card::Photo).to receive(:get_feed).and_return(
+            {
+              length: 42,
+              photo: photo_data
+            }
+          )
+        enrolled_photo = subject.photo_data_or_file(enrolled_student_login_id)
+        expect(enrolled_photo[:data]).to eq photo_data
+        expect(enrolled_photo[:size]).to eq 42
+        expect(enrolled_photo[:filename]).to be_nil
+        waitlisted_photo = subject.photo_data_or_file(waitlisted_student_login_id)
+        expect(waitlisted_photo).to be_nil
+      end
+    end
+
+    context 'when profile URL requested for LDAP ID' do
+      let(:student_canvas_id) { rand(999999) }
+      let(:student_sis_login_id) { rand(999999).to_s }
+      let(:student_sis_user_id) { rand(999999).to_s }
+
+      before do
+        allow_any_instance_of(Canvas::SisUserProfile).to receive(:get).and_return(
+            {
+              'id' => student_canvas_id,
+              'login_id' => student_sis_login_id,
+              'sis_user_id' => student_sis_user_id,
+              'sis_login_id' => student_sis_login_id
+            }
+          )
+      end
+
+      it 'returns a correctly formatted URL' do
+        profile_url = subject.profile_url_for_ldap_id(student_sis_login_id)
+        expect(profile_url).to eq "#{Settings.canvas_proxy.url_root}/courses/#{course_id}/users/#{student_canvas_id}"
+      end
+
+      context 'when no logins match LDAP ID' do
+        before { allow_any_instance_of(Canvas::SisUserProfile).to receive(:get).and_return nil }
+        it 'returns nil' do
+          profile_url = subject.profile_url_for_ldap_id(student_sis_login_id)
+          expect(profile_url).to eq nil
+        end
+      end
     end
   end
 
-  context 'when profile URL requested for LDAP ID' do
-    let(:student_canvas_id) { rand(999999) }
-    let(:student_sis_login_id) { rand(999999).to_s }
-    let(:student_sis_user_id) { rand(999999).to_s }
-
+  context 'Campus Solutions data source' do
+    let(:term_id) { Berkeley::TermCodes.to_edo_id('2013', 'C') }
     before do
-      allow_any_instance_of(Canvas::SisUserProfile).to receive(:get).and_return(
-        {
-           'id' => student_canvas_id,
-           'login_id' => student_sis_login_id,
-           'sis_user_id' => student_sis_user_id,
-           'sis_login_id' => student_sis_login_id
-        }
+      allow(Berkeley::Terms).to receive(:legacy?).and_return false
+      expect(EdoOracle::Queries).to receive(:get_enrolled_students).with(lecture_section_ccn, term_id).and_return(
+        [
+          {
+            'ldap_uid' => student_in_discussion_section_login_id,
+            'enroll_status' => 'E',
+            'student_id' => student_in_discussion_section_student_id
+          },
+          {
+            'ldap_uid' => student_not_in_discussion_section_login_id,
+            'enroll_status' => 'E',
+            'student_id' => student_not_in_discussion_section_student_id
+          }
+        ]
       )
+      expect(EdoOracle::Queries).to receive(:get_enrolled_students).with(discussion_section_ccn, term_id).and_return(
+        [
+          {
+            'ldap_uid' => student_in_discussion_section_login_id,
+            'enroll_status' => 'E',
+            'student_id' => student_in_discussion_section_student_id,
+            'first_name' => 'Thurston',
+            'last_name' => "Howell #{student_in_discussion_section_login_id}",
+            'student_email_address' => "#{student_in_discussion_section_login_id}@example.com"
+          }
+        ]
+      )
+      expect(CalnetLdap::UserAttributes).to receive(:get_bulk_attributes)
+        .with([student_in_discussion_section_login_id, student_not_in_discussion_section_login_id]).and_return(
+          [
+            {
+              ldap_uid: student_in_discussion_section_login_id,
+              student_id: student_in_discussion_section_student_id,
+              first_name: 'Thurston',
+              last_name: "Howell #{student_in_discussion_section_login_id}",
+              email_address: "#{student_in_discussion_section_login_id}@example.com"
+            },
+            {
+              ldap_uid: student_not_in_discussion_section_login_id,
+              student_id: student_not_in_discussion_section_student_id,
+              first_name: 'Clarence',
+              last_name: "Williams #{student_not_in_discussion_section_login_id}",
+              email_address: "#{student_not_in_discussion_section_login_id}@example.com"
+            }
+          ]
+        )
+      expect(CalnetLdap::UserAttributes).to receive(:get_bulk_attributes)
+        .with([student_in_discussion_section_login_id]).and_return(
+          [
+            {
+              ldap_uid: student_in_discussion_section_login_id,
+              student_id: student_in_discussion_section_student_id,
+              first_name: 'Thurston',
+              last_name: "Howell #{student_in_discussion_section_login_id}",
+              email_address: "#{student_in_discussion_section_login_id}@example.com"
+            }
+          ]
+        )
     end
-
-    it 'returns a correctly formatted URL' do
-      profile_url = subject.profile_url_for_ldap_id(student_sis_login_id)
-      expect(profile_url).to eq "#{Settings.canvas_proxy.url_root}/courses/#{course_id}/users/#{student_canvas_id}"
-    end
-
-    context 'when no logins match LDAP ID' do
-      before { allow_any_instance_of(Canvas::SisUserProfile).to receive(:get).and_return nil }
-      it 'returns nil' do
-        profile_url = subject.profile_url_for_ldap_id(student_sis_login_id)
-        expect(profile_url).to eq nil
-      end
-    end
+    include_examples 'a good and proper roster'
   end
 
   def stub_teacher_status(teacher_login_id, canvas_course_id)


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17267