### PR TITLE
SISRP-17267 Rosters should rely on merged User::BasicAttributes layer

### DIFF
--- a/app/models/rosters/common.rb
+++ b/app/models/rosters/common.rb
@@ -81,7 +81,7 @@ module Rosters
       else
         term_id = Berkeley::TermCodes.to_edo_id(term_yr, term_cd)
         enrollments_by_uid = EdoOracle::Queries.get_enrolled_students(course_id, term_id).group_by { |row| row['ldap_uid'] }
-        CalnetLdap::UserAttributes.get_bulk_attributes(enrollments_by_uid.keys).each do |attrs|
+        User::BasicAttributes.attributes_for_uids(enrollments_by_uid.keys).each do |attrs|
           attrs[:email] = attrs.delete :email_address
           if (enrollment_row = enrollments_by_uid[attrs[:ldap_uid]].first)
             attrs[:enroll_status] = enrollment_row['enroll_status']

--- a/spec/models/rosters/campus_spec.rb
+++ b/spec/models/rosters/campus_spec.rb
@@ -147,7 +147,7 @@ describe Rosters::Campus do
       before do
         expect(EdoOracle::Queries).to receive(:get_enrolled_students).with(ccn1, term_id).and_return enrollments
         expect(EdoOracle::Queries).to receive(:get_enrolled_students).with(ccn2, term_id).and_return enrollments
-        expect(CalnetLdap::UserAttributes).to receive(:get_bulk_attributes)
+        expect(User::BasicAttributes).to receive(:attributes_for_uids)
           .with([enrolled_student_login_id, waitlisted_student_login_id])
           .exactly(2).times.and_return attributes
       end

--- a/spec/models/rosters/canvas_spec.rb
+++ b/spec/models/rosters/canvas_spec.rb
@@ -327,7 +327,7 @@ describe Rosters::Canvas do
           }
         ]
       )
-      expect(CalnetLdap::UserAttributes).to receive(:get_bulk_attributes)
+      expect(User::BasicAttributes).to receive(:attributes_for_uids)
         .with([student_in_discussion_section_login_id, student_not_in_discussion_section_login_id]).and_return(
           [
             {
@@ -346,7 +346,7 @@ describe Rosters::Canvas do
             }
           ]
         )
-      expect(CalnetLdap::UserAttributes).to receive(:get_bulk_attributes)
+      expect(User::BasicAttributes).to receive(:attributes_for_uids)
         .with([student_in_discussion_section_login_id]).and_return(
           [
             {


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17267

Corrective follow-up to #5162. In my haste to retrofit the rosters I neglected to honor my own abstraction layer.