### PR TITLE
SISRP-17445, 404 on student overview if not directlyAuthenticated

### DIFF
--- a/app/policies/authentication_state_policy.rb
+++ b/app/policies/authentication_state_policy.rb
@@ -66,8 +66,8 @@ class AuthenticationStatePolicy
   end
 
   def can_view_as_for_all_uids?
-    # Delegate users are intentionally omitted.
-    return true if can_view_as?
+    return false unless @user.directly_authenticated? && (real_auth = @user.real_user_auth).active?
+    return true if real_auth.is_superuser? || real_auth.is_viewer?
     roles = HubEdos::UserAttributes.new(user_id: @user.real_user_id).get[:roles]
     !!roles[:advisor]
   end

--- a/src/assets/templates/advising_student.html
+++ b/src/assets/templates/advising_student.html
@@ -1,4 +1,4 @@
-<div data-ng-if="api.user.profile.features.csAdvisorStudentLookup && (api.user.profile.isViewer || api.user.profile.isSuperuser || api.user.profile.roles.advisor)">
+<div data-ng-if="api.user.profile.features.csAdvisorStudentLookup && api.user.profile.isDirectlyAuthenticated && (api.user.profile.isViewer || api.user.profile.isSuperuser || api.user.profile.roles.advisor)">
   <div class="row collapse">
     <div class="column">
       <h1 class="cc-heading-page-title"><a href="/">My Dashboard</a> &raquo; Student Overview</h1>
@@ -15,4 +15,4 @@
     </div>
   </div>
 </div>
-<div data-ng-include="'404.html'" data-ng-if="!api.user.profile.features.csAdvisorStudentLookup || (!api.user.profile.isViewer && !api.user.profile.isSuperuser && !api.user.profile.roles.advisor)"></div>
+<div data-ng-include="'404.html'" data-ng-if="!api.user.profile.features.csAdvisorStudentLookup || !api.user.profile.isDirectlyAuthenticated || (!api.user.profile.isViewer && !api.user.profile.isSuperuser && !api.user.profile.roles.advisor)"></div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17445

* add @user.directly_authenticated? to logic of `can_view_as_for_all_uids?`
* test coverage
* /advising/student/$UID gets 404 unless directly_authenticated