### PR TITLE
SISRP-17479 Suppress CampusOracle-derived residency status and messaging

### DIFF
--- a/app/models/campus_oracle/user_attributes.rb
+++ b/app/models/campus_oracle/user_attributes.rb
@@ -25,12 +25,10 @@ module CampusOracle
         result[:roles] = roles_from_campus_row result
         result.merge! Berkeley::SpecialRegistrationProgram.attributes_from_code(result['reg_special_pgm_cd'])
 
-        if term_transition?
-          result[:california_residency] = nil
-          result[:reg_status][:transitionTerm] = true
-        else
-          result[:california_residency] = Berkeley::CalResidency.california_residency_from_campus_row result
-        end
+        result[:reg_status][:transitionTerm] = true if term_transition?
+
+        # SISRP-17479 CampusOracle residency information is no longer current and must be suppressed.
+        result[:california_residency] = nil
 
         result
       else

--- a/spec/models/campus_oracle/user_attributes_spec.rb
+++ b/spec/models/campus_oracle/user_attributes_spec.rb
@@ -28,8 +28,8 @@ describe CampusOracle::UserAttributes do
           it 'does not report term transition' do
             expect(subject[:reg_status]).not_to include(:transitionTerm)
           end
-          it 'includes residency status' do
-            expect(subject[:california_residency][:summary]).to eq 'Non-Resident'
+          it 'suppresses residency status' do
+            expect(subject[:california_residency]).to eq nil
           end
         end
         context 'term transition' do

--- a/src/assets/templates/academics_status_holds_blocks.html
+++ b/src/assets/templates/academics_status_holds_blocks.html
@@ -37,7 +37,7 @@
                 <span data-ng-bind="studentInfo.californiaResidency.summary"></span>
               </td>
             </tr>
-            <tr>
+            <tr data-ng-if="studentInfo.californiaResidency">
               <td colspan="2" data-cc-compile-directive="studentInfo.californiaResidency.explanation"></td>
             </tr>
           </tbody>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17479

Residency status is no longer being kept current in DB2, and must be suppressed in CalCentral until we switch to Campus Solutions as source of record. We've been told to suppress the accompanying message and link as well.