### PR TITLE
SISRP-16933, advisors can only view-as students and applicants

### DIFF
--- a/app/controllers/advisor_act_as_controller.rb
+++ b/app/controllers/advisor_act_as_controller.rb
@@ -1,5 +1,5 @@
 class AdvisorActAsController < ActAsController
-  include CampusSolutions::ProfileFeatureFlagged
+  include AdvisorAuthorization
 
   skip_before_filter :check_reauthentication, :only => [:stop_advisor_act_as]
 
@@ -8,13 +8,6 @@ class AdvisorActAsController < ActAsController
   end
 
   def act_as_authorization(uid_param)
-    if is_cs_profile_feature_enabled
-      user_id = current_user.real_user_id
-      user_attributes = HubEdos::UserAttributes.new(user_id: user_id).get
-      authorized = user_attributes && user_attributes[:roles] && user_attributes[:roles][:advisor]
-      raise Pundit::NotAuthorizedError.new("User #{user_id} is not an Advisor and thus cannot view-as #{uid_param}") unless authorized
-    else
-      raise Pundit::NotAuthorizedError.new 'We cannot confirm your role as an Advisor because Campus Solutions is unavailable. Please contact us if the problem persists.'
-    end
+    authorize_advisor_view_as current_user.real_user_id, uid_param
   end
 end

--- a/app/controllers/campus_solutions/advising_resources_controller.rb
+++ b/app/controllers/campus_solutions/advising_resources_controller.rb
@@ -1,9 +1,17 @@
 module CampusSolutions
   class AdvisingResourcesController < CampusSolutionsController
+    include AdvisorAuthorization
+
+    before_action :authorize_advisor_access
 
     def get
-      authorize(current_user, :can_view_as_for_all_uids?)
       json_passthrough CampusSolutions::AdvisingResources, user_id: session['user_id'], student_uid: params['student_uid']
+    end
+
+    private
+
+    def authorize_advisor_access
+      require_advisor session['user_id']
     end
 
   end

--- a/app/controllers/concerns/advisor_authorization.rb
+++ b/app/controllers/concerns/advisor_authorization.rb
@@ -1,0 +1,22 @@
+module AdvisorAuthorization
+
+  def authorize_advisor_view_as(uid, student_uid)
+    require_advisor uid
+    qualified = student_or_applicant? student_uid
+    raise Pundit::NotAuthorizedError.new "#{uid} cannot view #{student_uid} because #{student_uid} does not qualify as a student" unless qualified
+  end
+
+  def require_advisor(uid)
+    user_attributes = User::AggregatedAttributes.new(uid).get_feed
+    authorized = user_attributes && user_attributes[:roles] && user_attributes[:roles][:advisor]
+    raise Pundit::NotAuthorizedError.new("User #{uid} is not an Advisor") unless authorized
+  end
+
+  private
+
+  def student_or_applicant?(uid)
+    @attributes = User::AggregatedAttributes.new(student_uid = uid).get_feed
+    @attributes[:roles][:student] || @attributes[:roles][:applicant]
+  end
+
+end

--- a/app/controllers/concerns/view_as_authorization.rb
+++ b/app/controllers/concerns/view_as_authorization.rb
@@ -1,0 +1,21 @@
+module ViewAsAuthorization
+  include AdvisorAuthorization
+
+  def authorize_user_lookup(current_user, lookup_uid)
+    return if can_view_as_for_all_uids? current_user
+    authorize_advisor_view_as current_user.real_user_id, lookup_uid
+  end
+
+  def authorize_query_stored_users(current_user)
+    return if can_view_as_for_all_uids? current_user
+    require_advisor current_user.real_user_id
+  end
+
+  private
+
+  def can_view_as_for_all_uids?(user)
+    raise Pundit::NotAuthorizedError.new('User information was not found in session.') unless user && user.policy
+    user.policy.can_view_as_for_all_uids?
+  end
+
+end

--- a/app/controllers/search_users_controller.rb
+++ b/app/controllers/search_users_controller.rb
@@ -1,15 +1,22 @@
 class SearchUsersController < ApplicationController
+  include ViewAsAuthorization
 
   def search_users
-    authorize(current_user, :can_view_as_for_all_uids?)
-    users_found = User::SearchUsers.new(id: params['id']).search_users
+    authorize_user_lookup current_user, (uid = uid_param)
+    users_found = User::SearchUsers.new(id: uid).search_users
     render json: { users: users_found }.to_json
   end
 
   def search_users_by_uid
-    authorize(current_user, :can_view_as_for_all_uids?)
-    users_found = User::SearchUsersByUid.new(id: params['id']).search_users_by_uid
+    authorize_user_lookup current_user, (uid = uid_param)
+    users_found = User::SearchUsersByUid.new(id: uid).search_users_by_uid
     render json: { users: users_found }.to_json
+  end
+
+  private
+
+  def uid_param
+    params.require 'id'
   end
 
 end

--- a/app/controllers/stored_users_controller.rb
+++ b/app/controllers/stored_users_controller.rb
@@ -1,10 +1,12 @@
 class StoredUsersController < ApplicationController
+  include ViewAsAuthorization
+
   before_filter :authenticate
   before_filter :numeric_uid?, except: [:get, :delete_all_recent, :delete_all_saved]
   respond_to :json
 
   def get
-    authorize(current_user, :can_view_as_for_all_uids?)
+    authorize_query_stored_users current_user
     users_found = User::StoredUsers.get(current_user.real_user_id)
     render json: { users: users_found }.to_json
   end

--- a/app/policies/authentication_state_policy.rb
+++ b/app/policies/authentication_state_policy.rb
@@ -66,10 +66,9 @@ class AuthenticationStatePolicy
   end
 
   def can_view_as_for_all_uids?
-    return false unless @user.directly_authenticated? && (real_auth = @user.real_user_auth).active?
-    return true if real_auth.is_superuser? || real_auth.is_viewer?
-    roles = HubEdos::UserAttributes.new(user_id: @user.real_user_id).get[:roles]
-    !!roles[:advisor]
+    @user.directly_authenticated? &&
+      (real_auth = @user.real_user_auth).active? &&
+      (real_auth.is_superuser? || real_auth.is_viewer?)
   end
 
   def can_view_webcast_sign_up?

--- a/spec/controllers/concerns/advisor_authorization_spec.rb
+++ b/spec/controllers/concerns/advisor_authorization_spec.rb
@@ -1,0 +1,54 @@
+describe AdvisorAuthorization do
+
+  let(:filter) { Class.new { extend AdvisorAuthorization } }
+  let(:user_id) { random_id }
+  let(:is_advisor) { false }
+  before {
+    allow(User::AggregatedAttributes).to receive(:new).with(user_id).and_return double get_feed: { roles: { advisor: is_advisor } }
+  }
+
+  describe '#authorize_advisor_view_as' do
+    let(:student_uid) { random_id }
+    let(:is_student) { false }
+    before {
+      allow(User::AggregatedAttributes).to receive(:new).with(student_uid).and_return double get_feed: { roles: { student: is_student } }
+    }
+    subject { filter.authorize_advisor_view_as user_id, student_uid }
+
+    context 'non-advisor looking up student' do
+      let(:is_student) { true }
+      it 'should fail' do
+        expect{ subject }.to raise_error
+      end
+    end
+    context 'advisor looking up non-student' do
+      let(:is_advisor) { true }
+      it 'should fail' do
+        expect{ subject }.to raise_error
+      end
+    end
+    context 'advisor looking up student' do
+      let(:is_advisor) { true }
+      let(:is_student) { true }
+      it 'should pass' do
+        expect{ subject }.to_not raise_error
+      end
+    end
+  end
+
+  describe '#require_advisor' do
+    subject { filter.require_advisor user_id }
+    context 'ordinary user' do
+      it 'should fail' do
+        expect{ subject }.to raise_error
+      end
+    end
+    context 'advisor' do
+      let(:is_advisor) { true }
+      it 'should pass' do
+        expect{ subject }.to_not raise_error
+      end
+    end
+  end
+
+end

--- a/spec/controllers/concerns/view_as_authorization_spec.rb
+++ b/spec/controllers/concerns/view_as_authorization_spec.rb
@@ -1,0 +1,68 @@
+describe ViewAsAuthorization do
+
+  let(:filter) { Class.new { extend ViewAsAuthorization } }
+  let(:can_view_as_for_all_uids) { false }
+  let(:policy) { double(can_view_as_for_all_uids?: can_view_as_for_all_uids) }
+  let(:current_user) { double real_user_id: random_id, policy: policy }
+  let(:is_advisor) { false }
+  before {
+    allow(User::AggregatedAttributes).to receive(:new).with(current_user.real_user_id).and_return double get_feed: { roles: { advisor: is_advisor } }
+  }
+
+  describe '#authorize_user_lookup' do
+    let(:student_uid) { random_id }
+    let(:is_student) { false }
+    before {
+      allow(User::AggregatedAttributes).to receive(:new).with(student_uid).and_return double get_feed: { roles: { student: is_student } }
+    }
+    subject { filter.authorize_user_lookup current_user, student_uid }
+
+    context 'non-advisor looking up student' do
+      let(:is_student) { true }
+      it 'should fail' do
+        expect{ subject }.to raise_error
+      end
+    end
+    context 'advisor looking up non-student' do
+      let(:is_advisor) { true }
+      it 'should fail' do
+        expect{ subject }.to raise_error
+      end
+    end
+    context 'super-user' do
+      let(:can_view_as_for_all_uids) { true }
+      it 'should pass' do
+        expect{ subject }.to_not raise_error
+      end
+    end
+    context 'advisor looking up student' do
+      let(:is_advisor) { true }
+      let(:is_student) { true }
+      it 'should pass' do
+        expect{ subject }.to_not raise_error
+      end
+    end
+  end
+
+  describe '#authorize_query_stored_users' do
+    subject { filter.authorize_query_stored_users current_user }
+    context 'ordinary user' do
+      it 'should fail' do
+        expect{ subject }.to raise_error
+      end
+    end
+    context 'advisor' do
+      let(:is_advisor) { true }
+      it 'should pass' do
+        expect{ subject }.to_not raise_error
+      end
+    end
+    context 'super-user' do
+      let(:can_view_as_for_all_uids) { true }
+      it 'should pass' do
+        expect{ subject }.to_not raise_error
+      end
+    end
+  end
+
+end

--- a/spec/policies/authentication_state_policy_spec.rb
+++ b/spec/policies/authentication_state_policy_spec.rb
@@ -219,7 +219,7 @@ describe AuthenticationStatePolicy do
     context 'advisor' do
       let(:advisor) { true }
       let(:user_id) {average_joe_uid}
-      its(:can_view_as_for_all_uids?) { is_expected.to be true }
+      its(:can_view_as_for_all_uids?) { is_expected.to be false }
     end
     context 'inactive advisor' do
       let(:advisor) { true }

--- a/src/assets/javascripts/angular/controllers/widgets/adminController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/adminController.js
@@ -86,6 +86,8 @@ angular.module('calcentral.controllers').controller('AdminController', function(
     var response = {};
     if (data.error) {
       response.error = data.error;
+    } else if (data.status === 403) {
+      response.error = 'You are not authorized to view the requested user data.';
     } else {
       response.error = 'There was a problem searching for that user.';
     }


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-16933

This PR does not include additional user attribute based on LDAP: STUDENT-STATUS-EXPIRED status. My next PR will have that portion.

Advisors had been riding the coattails of `policy.can_view_as_for_all_uids?` but no more. With this PR, advisors can only view-as students and applicants. The level of view-as power is relevant when querying stored_users, initiating view-as session and viewing student profile. It is those controllers which now reference filters in `AdvisorAuthorization` and `ViewAsAuthorization`.
 