### PR TITLE
SISRP-17104 Cache fixes for CampusSolutions, HubEdos feeds

### DIFF
--- a/app/models/campus_solutions/my_academic_plan.rb
+++ b/app/models/campus_solutions/my_academic_plan.rb
@@ -1,8 +1,9 @@
 module CampusSolutions
   class MyAcademicPlan < UserSpecificModel
 
-    include Cache::LiveUpdatesEnabled
-    include Cache::JsonAddedCacher
+    include Cache::CachedFeed
+    include Cache::JsonifiedFeed
+    include Cache::UserCacheExpiry
     include EnrollmentCardFeatureFlagged
 
     attr_accessor :term_id

--- a/app/models/campus_solutions/my_aid_years.rb
+++ b/app/models/campus_solutions/my_aid_years.rb
@@ -1,9 +1,9 @@
 module CampusSolutions
   class MyAidYears < UserSpecificModel
 
-    include Cache::LiveUpdatesEnabled
-    include Cache::FreshenOnWarm
+    include Cache::CachedFeed
     include Cache::JsonAddedCacher
+    include Cache::UserCacheExpiry
     include CampusSolutions::FinaidFeatureFlagged
 
     def get_feed_internal

--- a/app/models/campus_solutions/my_billing.rb
+++ b/app/models/campus_solutions/my_billing.rb
@@ -1,9 +1,9 @@
 module CampusSolutions
   class MyBilling < UserSpecificModel
 
-    include Cache::LiveUpdatesEnabled
-    include Cache::FreshenOnWarm
-    include Cache::JsonAddedCacher
+    include Cache::CachedFeed
+    include Cache::JsonifiedFeed
+    include Cache::UserCacheExpiry
     include CampusSolutions::BillingFeatureFlagged
 
     def get_feed_internal

--- a/app/models/campus_solutions/my_enrollment_term.rb
+++ b/app/models/campus_solutions/my_enrollment_term.rb
@@ -1,8 +1,9 @@
 module CampusSolutions
   class MyEnrollmentTerm < UserSpecificModel
 
-    include Cache::LiveUpdatesEnabled
-    include Cache::JsonAddedCacher
+    include Cache::CachedFeed
+    include Cache::JsonifiedFeed
+    include Cache::UserCacheExpiry
     include Cache::RelatedCacheKeyTracker
     include EnrollmentCardFeatureFlagged
 

--- a/app/models/campus_solutions/my_enrollment_terms.rb
+++ b/app/models/campus_solutions/my_enrollment_terms.rb
@@ -2,7 +2,7 @@ module CampusSolutions
   class MyEnrollmentTerms < UserSpecificModel
 
     include Cache::CachedFeed
-    include Cache::JsonAddedCacher
+    include Cache::UserCacheExpiry
     include EnrollmentCardFeatureFlagged
 
     def get_feed_internal

--- a/app/models/campus_solutions/my_financial_aid_compare_awards_current.rb
+++ b/app/models/campus_solutions/my_financial_aid_compare_awards_current.rb
@@ -2,8 +2,8 @@ module CampusSolutions
   class MyFinancialAidCompareAwardsCurrent < UserSpecificModel
 
     include ClassLogger
-    include Cache::LiveUpdatesEnabled
-    include Cache::FreshenOnWarm
+    include Cache::CachedFeed
+    include Cache::UserCacheExpiry
     include Cache::JsonAddedCacher
     include Cache::RelatedCacheKeyTracker
     include CampusSolutions::FinancialAidCompareAwardsFeatureFlagged

--- a/app/models/campus_solutions/my_financial_aid_compare_awards_list.rb
+++ b/app/models/campus_solutions/my_financial_aid_compare_awards_list.rb
@@ -2,8 +2,8 @@ module CampusSolutions
   class MyFinancialAidCompareAwardsList < UserSpecificModel
 
     include ClassLogger
-    include Cache::LiveUpdatesEnabled
-    include Cache::FreshenOnWarm
+    include Cache::CachedFeed
+    include Cache::UserCacheExpiry
     include Cache::JsonAddedCacher
     include Cache::RelatedCacheKeyTracker
     include CampusSolutions::FinancialAidCompareAwardsFeatureFlagged

--- a/app/models/campus_solutions/my_financial_aid_compare_awards_prior.rb
+++ b/app/models/campus_solutions/my_financial_aid_compare_awards_prior.rb
@@ -2,8 +2,8 @@ module CampusSolutions
   class MyFinancialAidCompareAwardsPrior < UserSpecificModel
 
     include ClassLogger
-    include Cache::LiveUpdatesEnabled
-    include Cache::FreshenOnWarm
+    include Cache::CachedFeed
+    include Cache::UserCacheExpiry
     include Cache::JsonAddedCacher
     include Cache::RelatedCacheKeyTracker
     include CampusSolutions::FinancialAidCompareAwardsFeatureFlagged

--- a/app/models/campus_solutions/my_financial_aid_data.rb
+++ b/app/models/campus_solutions/my_financial_aid_data.rb
@@ -2,9 +2,9 @@ module CampusSolutions
   class MyFinancialAidData < UserSpecificModel
 
     include ClassLogger
-    include Cache::LiveUpdatesEnabled
-    include Cache::FreshenOnWarm
-    include Cache::JsonAddedCacher
+    include Cache::CachedFeed
+    include Cache::JsonifiedFeed
+    include Cache::UserCacheExpiry
     include Cache::RelatedCacheKeyTracker
     include CampusSolutions::FinaidFeatureFlagged
 

--- a/app/models/campus_solutions/my_financial_aid_funding_sources.rb
+++ b/app/models/campus_solutions/my_financial_aid_funding_sources.rb
@@ -2,8 +2,8 @@ module CampusSolutions
   class MyFinancialAidFundingSources < UserSpecificModel
 
     include ClassLogger
-    include Cache::LiveUpdatesEnabled
-    include Cache::FreshenOnWarm
+    include Cache::CachedFeed
+    include Cache::UserCacheExpiry
     include Cache::JsonAddedCacher
     include Cache::RelatedCacheKeyTracker
     include CampusSolutions::FinaidFeatureFlagged

--- a/app/models/campus_solutions/my_financial_aid_funding_sources_term.rb
+++ b/app/models/campus_solutions/my_financial_aid_funding_sources_term.rb
@@ -2,8 +2,8 @@ module CampusSolutions
   class MyFinancialAidFundingSourcesTerm < UserSpecificModel
 
     include ClassLogger
-    include Cache::LiveUpdatesEnabled
-    include Cache::FreshenOnWarm
+    include Cache::CachedFeed
+    include Cache::UserCacheExpiry
     include Cache::JsonAddedCacher
     include Cache::RelatedCacheKeyTracker
     include CampusSolutions::FinaidFeatureFlagged

--- a/app/models/campus_solutions/my_holds.rb
+++ b/app/models/campus_solutions/my_holds.rb
@@ -1,10 +1,10 @@
 module CampusSolutions
   class MyHolds < UserSpecificModel
 
-    include Cache::LiveUpdatesEnabled
-    include Cache::FreshenOnWarm
-    include Cache::JsonAddedCacher
-    include CampusSolutions::HoldsFeatureFlagged
+    include Cache::CachedFeed
+    include Cache::JsonifiedFeed
+    include Cache::UserCacheExpiry
+     include CampusSolutions::HoldsFeatureFlagged
 
     def get_feed_internal
       return {} unless is_feature_enabled

--- a/app/models/hub_edos/my_student.rb
+++ b/app/models/hub_edos/my_student.rb
@@ -2,7 +2,8 @@ module HubEdos
   class MyStudent < UserSpecificModel
 
     include ClassLogger
-    include Cache::LiveUpdatesEnabled
+    include Cache::CachedFeed
+    include Cache::UserCacheExpiry
     # Needed to expire cache entries specific to Viewing-As users alongside original user's cache.
     include Cache::RelatedCacheKeyTracker
     include CampusSolutions::ProfileFeatureFlagged

--- a/app/models/hub_edos/my_work_experience.rb
+++ b/app/models/hub_edos/my_work_experience.rb
@@ -2,9 +2,9 @@ module HubEdos
   class MyWorkExperience < UserSpecificModel
 
     include ClassLogger
-    include Cache::LiveUpdatesEnabled
-    include Cache::FreshenOnWarm
-    include Cache::JsonAddedCacher
+    include Cache::CachedFeed
+    include Cache::JsonifiedFeed
+    include Cache::UserCacheExpiry
     include CampusSolutions::ProfileFeatureFlagged
 
     def get_feed_internal


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17104

Last batch for now. Similar problems doubtlessly lurk in other classes, but the changes thus far cover the feeds directly involved in SISRP-16997 and make a pretty big QA footprint.

* LiveUpdatesEnabled with FreshenOnWarm bypasses the feed's configured lifespan while the user is logged in by forcing a feed refresh every 5 minutes. We don't want to hit external APIs that often, so this should only be done if the feed is made up of other source feeds all of which are themselves cached, the idea being to catch them not long after they expire.
* All server-side feeds marked as LiveUpdatesEnabled will react to the 5-minute ping. But the only ones which get checked by the browser are the 6 listed in "updatedFeedsService.js". The others won't be noticed on the front-end until the user refreshes their page, just as if LiveUpdatesEnabled wasn't there, and so the server-side CPU activity is pointless. (Selenium-script warning: removing LiveUpdatesEnabled also removes  the feed's injected "lastModified" and "feedName" properties.)
* If a feed is only called by a controller, JsonifiedFeed can save CPU and memory by caching only the JSON version. (JsonifiedFeed is incompatible with LiveUpdatesEnabled and FilteredViewAsFeed.)
* UserCacheExpiry tells HotPlate to force a refresh when it reaches that UID. It can help us out with production issues via "/api/cache/warm/:uid", which starts a single-person HotPlate run.