### PR TITLE
SISRP-16933, surface 403 error message on View As widget

### DIFF
--- a/app/controllers/act_as_controller.rb
+++ b/app/controllers/act_as_controller.rb
@@ -1,5 +1,5 @@
 class ActAsController < ApplicationController
-
+  include ViewAsAuthorization
   include ClassLogger
 
   skip_before_filter :check_reauthentication, :only => [:stop_act_as]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -113,6 +113,11 @@ class ApplicationController < ActionController::Base
 
   def user_not_authorized(error)
     Rails.logger.warn "Unauthorized request made by UID: #{session['user_id']} to #{controller_name}\##{action_name}: #{error.message}"
+    render_403 error
+  end
+
+  def render_403(error)
+    # Subclasses might render JSON including error message.
     render :nothing => true, :status => 403
   end
 

--- a/app/controllers/concerns/advisor_authorization.rb
+++ b/app/controllers/concerns/advisor_authorization.rb
@@ -1,9 +1,18 @@
 module AdvisorAuthorization
 
+  def render_403(error)
+    if error.respond_to? :message
+      render json: { :error => error.message }.to_json, :status => 403
+    else
+      render :nothing => true, :status => 403
+    end
+  end
+
   def authorize_advisor_view_as(uid, student_uid)
     require_advisor uid
-    qualified = student_or_applicant? student_uid
-    raise Pundit::NotAuthorizedError.new "#{uid} cannot view #{student_uid} because #{student_uid} does not qualify as a student" unless qualified
+    unless student_or_applicant? student_uid
+      raise Pundit::NotAuthorizedError.new "#{student_uid} does not appear to be a current, recent, or incoming student."
+    end
   end
 
   def require_advisor(uid)

--- a/src/assets/javascripts/angular/controllers/widgets/adminController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/adminController.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var angular = require('angular');
+var _ = require('lodash');
 
 /**
  * Admin controller
@@ -84,8 +85,9 @@ angular.module('calcentral.controllers').controller('AdminController', function(
 
   var handleLookupUserError = function(data) {
     var response = {};
-    if (data.error) {
-      response.error = data.error;
+    var errorMessage = data.error || _.get(data, 'data.error');
+    if (errorMessage) {
+      response.error = errorMessage;
     } else if (data.status === 403) {
       response.error = 'You are not authorized to view the requested user data.';
     } else {


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-16933

The view-as related controllers, which include *AdvisorAuthorization*, override new `render_403(error)` in *ApplicationController*. This gives Advisors an explanation for denied access to non-student UIDs.