### PR TITLE
SISRP-17554 Return empty User::BasicAttributes for empty enrollments

### DIFF
--- a/app/models/user/basic_attributes.rb
+++ b/app/models/user/basic_attributes.rb
@@ -3,6 +3,7 @@ module User
     extend self
 
     def attributes_for_uids(uids)
+      return [] if uids.blank?
       uid_set = uids.to_set
       attrs = CampusOracle::Queries.get_basic_people_attributes(uids).map do |result|
         uid_set.delete result['ldap_uid']

--- a/spec/models/user/basic_attributes_spec.rb
+++ b/spec/models/user/basic_attributes_spec.rb
@@ -81,4 +81,9 @@ describe User::BasicAttributes do
     expect(aethelred[:email_address]).to eq 'inactive@berkeley.edu'
     expect(aethelred[:roles][:expiredAccount]).to eq true
   end
+
+  it 'handles empty arguments' do
+    expect(User::BasicAttributes.attributes_for_uids nil).to eq []
+    expect(User::BasicAttributes.attributes_for_uids []).to eq []
+  end
 end

--- a/src/assets/templates/widgets/roster.html
+++ b/src/assets/templates/widgets/roster.html
@@ -36,8 +36,8 @@
         <i class="fa fa-exclamation-triangle cc-icon-red"></i> You must be a teacher in this bCourses course to view official student rosters.
       </p>
 
-      <p data-ng-hide="students">
-        <i class="fa fa-exclamation-circle cc-icon-gold"></i> Students have not yet signed up for this class
+      <p data-ng-hide="students.length || errorStatus">
+        <i class="fa fa-exclamation-circle cc-icon-gold"></i> Students have not yet signed up for this class.
       </p>
     </div>
   </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17554

Avoid generating invalid SQL when passed an empty array.

Also make the rosters front end do the right thing when handed an empty array of students, and fix the longstanding annoyance where "Students have not yet signed up for this class" always appears beneath the "You must be a teacher in this bCourses course" auth failure message.