### PR TITLE
SISRP-17560 Correctly sort sparse EdoOracle course rows

### DIFF
--- a/app/models/edo_oracle/user_courses/base.rb
+++ b/app/models/edo_oracle/user_courses/base.rb
@@ -67,7 +67,8 @@ module EdoOracle
       end
 
       def row_to_feed_item(row, previous_item, cross_listing_tracker=nil)
-        unless (course_item = new_course_item(row, previous_item))
+        course_item = course_ids_from_row row
+        if course_item[:id] == previous_item[:id]
           previous_item[:sections] << row_to_section_data(row, cross_listing_tracker)
           nil
         else
@@ -86,12 +87,6 @@ module EdoOracle
             ]
           }
           course_item.merge(term_data).merge(course_data)
-        end
-      end
-
-      def new_course_item(row, previous_item)
-        if row.values_at('dept_name', 'catalog_id', 'term_id') != previous_item.values_at(:dept, :catid, :term_id)
-          course_ids_from_row row
         end
       end
 

--- a/spec/models/edo_oracle/user_courses/base_spec.rb
+++ b/spec/models/edo_oracle/user_courses/base_spec.rb
@@ -226,12 +226,25 @@ describe EdoOracle::UserCourses::Base do
       subject.find { |course| course[:course_code] == course_code }[:sections]
     end
 
-    it 'sorts out sections based on course code' do
-      expect(subject).to have(4).items
-      expect(get_sections 'MUSIC 74').to have(4).items
-      expect(get_sections 'MUSIC 99C').to have(1).items
-      expect(get_sections 'MUSIC C105').to have(1).items
-      expect(get_sections 'MEC ENG C112').to have(1).items
+    shared_examples 'proper section sorting' do
+      it 'sorts out sections based on course code' do
+        expect(subject).to have(4).items
+        expect(get_sections 'MUSIC 74').to have(4).items
+        expect(get_sections 'MUSIC 99C').to have(1).items
+        expect(get_sections 'MUSIC C105').to have(1).items
+        expect(get_sections 'MEC ENG C112').to have(1).items
+      end
+    end
+    include_examples 'proper section sorting'
+
+    context 'when dept_name and catalog_id are unavailable' do
+      before do
+        instructing_query_results[1].delete 'dept_name'
+        instructing_query_results[1].delete 'catalog_id'
+        instructing_query_results[3].delete 'dept_name'
+        instructing_query_results[3].delete 'catalog_id'
+      end
+      include_examples 'proper section sorting'
     end
 
     it 'adds de-duplicated secondaries to the right course' do


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17560

Follow-up to #5152 leverages that PR's `course_ids_from_row` implementation to ensure that rows are correctly sorted by course code even when `dept_name` and `catalog_id` are missing.