### PR TITLE
SISRP-17510 Force canonical course-code sorting on EdoOracle::UserCourses

### DIFF
--- a/app/models/berkeley/course_codes.rb
+++ b/app/models/berkeley/course_codes.rb
@@ -3,8 +3,12 @@ module Berkeley
     extend self
 
     def comparable_course_code(course)
-      min_code = course[:listings].map { |l| l[:course_code] }.min
-      dept_name, catalog = min_code.rpartition(' ').values_at(0, 2)
+      course_code = if course[:listings]
+                      course[:listings].map { |l| l[:course_code] }.min
+                    else
+                      course[:course_code]
+                    end
+      dept_name, catalog = course_code.rpartition(' ').values_at(0, 2)
       catalog_prefix, catalog_root, catalog_suffix_1, catalog_suffix_2 = catalog.match(/([A-Z]?)(\d+)([A-Z]?)([A-Z]?)/).to_a.slice(1..4)
       [dept_name, catalog_root.to_i, catalog_prefix, catalog_suffix_1, catalog_suffix_2]
     end

--- a/app/models/edo_oracle/user_courses/all.rb
+++ b/app/models/edo_oracle/user_courses/all.rb
@@ -11,6 +11,7 @@ module EdoOracle
           campus_classes = {}
           merge_instructing campus_classes
           merge_enrollments campus_classes
+          sort_courses campus_classes
 
           # Sort the hash in descending order of semester.
           campus_classes = Hash[campus_classes.sort.reverse]
@@ -27,6 +28,7 @@ module EdoOracle
         cached_query "summary-#{@uid}" do
           campus_classes = {}
           merge_enrollments campus_classes
+          sort_courses campus_classes
           Hash[campus_classes.sort.reverse]
         end
       end

--- a/app/models/edo_oracle/user_courses/base.rb
+++ b/app/models/edo_oracle/user_courses/base.rb
@@ -90,6 +90,12 @@ module EdoOracle
         end
       end
 
+      def sort_courses(campus_classes)
+        campus_classes.each_value do |semester_classes|
+          semester_classes.sort_by! { |c| Berkeley::CourseCodes.comparable_course_code c }
+        end
+      end
+
       # Create IDs for a given course item:
       #   "id" : unique for the UserCourses feed across terms; used by Classes
       #   "slug" : URL-friendly ID without term information; used by Academics

--- a/app/models/edo_oracle/user_courses/selected_sections.rb
+++ b/app/models/edo_oracle/user_courses/selected_sections.rb
@@ -16,7 +16,8 @@ module EdoOracle
               previous_item = item
             end
           end
-          merge_detailed_section_data(campus_classes)
+          sort_courses campus_classes
+          merge_detailed_section_data campus_classes
           campus_classes
         end
       end

--- a/spec/models/edo_oracle/user_courses/base_spec.rb
+++ b/spec/models/edo_oracle/user_courses/base_spec.rb
@@ -126,20 +126,6 @@ describe EdoOracle::UserCourses::Base do
     let(:instructing_query_results) do
       [
         base_course_data.merge({
-          'cs_course_id' => '10001',
-          'instruction_format' => 'LEC',
-          'primary' => 'true',
-          'section_id' => '44206',
-          'section_num' => '001'
-        }),
-        base_course_data.merge({
-          'cs_course_id' => '10001',
-          'instruction_format' => 'LEC',
-          'primary' => 'true',
-          'section_id' => '44207',
-          'section_num' => '002'
-        }),
-        base_course_data.merge({
           'cs_course_id' => '20001',
           'catalog_id' => '99C',
           'catalog_prefix' => nil,
@@ -184,6 +170,20 @@ describe EdoOracle::UserCourses::Base do
           'section_id' => '54807',
           'section_num' => '001'
         }),
+        base_course_data.merge({
+          'cs_course_id' => '10001',
+          'instruction_format' => 'LEC',
+          'primary' => 'true',
+          'section_id' => '44206',
+          'section_num' => '001'
+        }),
+        base_course_data.merge({
+          'cs_course_id' => '10001',
+          'instruction_format' => 'LEC',
+          'primary' => 'true',
+          'section_id' => '44207',
+          'section_num' => '002'
+        })
       ]
     end
     let(:secondary_query_results) do
@@ -267,6 +267,13 @@ describe EdoOracle::UserCourses::Base do
       expect(get_sections('MUSIC 74').first).not_to include(:cross_listing_hash)
       expect(get_sections('MUSIC 99C').first).not_to include(:cross_listing_hash)
       expect(get_sections('MUSIC C105').first[:cross_listing_hash]).to eq get_sections('MEC ENG C112').first[:cross_listing_hash]
+    end
+
+    describe 'canonical course ordering' do
+      before { EdoOracle::UserCourses::Base.new(user_id: random_id).sort_courses feed }
+      it 'should order courses by code' do
+        expect(subject.map { |c| c[:course_code] }).to eq ['MEC ENG C112', 'MUSIC 74', 'MUSIC 99C', 'MUSIC C105']
+      end
     end
   end
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17510

EdoOracle doesn't guarantee the database-level sorting of course codes that we got from CampusOracle, so we must run feeds through our own Ruby sorter at a higher level. 