### PR TITLE
SISRP-17294 Adapt bCourses maintenance scripts to new data sources

### DIFF
--- a/app/models/canvas_lti/sis_adapter.rb
+++ b/app/models/canvas_lti/sis_adapter.rb
@@ -6,7 +6,6 @@ module CanvasLti
       if Berkeley::Terms.legacy?(term_year, term_code)
         CampusOracle::Queries.get_enrolled_students(section_id, term_year, term_code)
       else
-        # TODO: Join results with user profile data (first_name, last_name, student_email_address, affiliations) from HubEdos or CalNet LDAP
         EdoOracle::Queries.get_enrolled_students(section_id, term_id(term_year, term_code))
       end
     end
@@ -15,9 +14,8 @@ module CanvasLti
       if Berkeley::Terms.legacy?(term_year, term_code)
         CampusOracle::Queries.get_section_instructors(term_year, term_code, section_id)
       else
-        # TODO: Join results with user profile data ('email_address', 'student_id', 'affiliations') from HubEdos or CalNet LDAP
         instructors = EdoOracle::Queries.get_section_instructors(term_id(term_year, term_code), section_id)
-        instructors = add_legacy_instructor_func(instructors)
+        add_legacy_instructor_func(instructors)
       end
     end
 

--- a/spec/models/canvas_csv/refresh_all_campus_data_spec.rb
+++ b/spec/models/canvas_csv/refresh_all_campus_data_spec.rb
@@ -49,7 +49,7 @@ describe CanvasCsv::RefreshAllCampusData do
           expect(section_ids.size).to eq 2
           expect(section_ids[0]).to eq "SEC:2014-B-2#{ccn}"
           expect(section_ids[1]).to eq "SEC:2014-B-1#{ccn}"
-          expect(known_users).to eq []
+          expect(known_users).to eq({})
           expect(options[:batch_mode]).to be_falsey
           expect(options[:cached_enrollments_provider]).to be_an_instance_of CanvasCsv::TermEnrollments
           double(refresh_sections_in_course: nil)
@@ -79,14 +79,14 @@ describe CanvasCsv::RefreshAllCampusData do
         before { allow_any_instance_of(Canvas::Report::Sections).to receive(:get_csv).and_return(sections_report_csv) }
         it 'passes only sections with course_id and section_id to site membership maintainer process for each course' do
           users_csv = subject.instance_eval { make_users_csv(@users_csv_filename) }
-          known_uids = []
+          known_users = {}
           term = subject.instance_eval { @term_to_memberships_csv_filename.keys[0] }
           enrollments_csv = subject.instance_eval { @term_to_memberships_csv_filename.values[0] }
           expected_course_id = 'CRS:COMPSCI-9D-2014-D'
           expected_sis_section_ids = ['SEC:2014-D-25123', 'SEC:2014-D-25124']
           sis_user_id_changes = { 'sis_login_id:7978' => '2018903' }
-          expect(CanvasCsv::SiteMembershipsMaintainer).to receive(:process).with(expected_course_id, expected_sis_section_ids, enrollments_csv, users_csv, known_uids, false, cached_enrollments_provider, sis_user_id_changes).once
-          subject.refresh_existing_term_sections(term, enrollments_csv, known_uids, users_csv, cached_enrollments_provider, sis_user_id_changes)
+          expect(CanvasCsv::SiteMembershipsMaintainer).to receive(:process).with(expected_course_id, expected_sis_section_ids, enrollments_csv, users_csv, known_users, false, cached_enrollments_provider, sis_user_id_changes).once
+          subject.refresh_existing_term_sections(term, enrollments_csv, known_users, users_csv, cached_enrollments_provider, sis_user_id_changes)
         end
       end
 

--- a/spec/models/canvas_lti/sis_adapter_spec.rb
+++ b/spec/models/canvas_lti/sis_adapter_spec.rb
@@ -41,10 +41,10 @@ describe CanvasLti::SisAdapter do
     describe '#get_section_instructors' do
       let(:dummy_instructors) {
         [
-          {'role_code' => 'PI'},    # Primary Instructor / Teaching and In Charge
-          {'role_code' => 'TNIC'},  # Teaching but Not in Charge
-          {'role_code' => 'ICNT'},  # In charge but not teaching
-          {'role_code' => 'INVT'},  # Teaching with Invalid Title
+          {'ldap_uid' => '1234', 'role_code' => 'PI'},    # Primary Instructor / Teaching and In Charge
+          {'ldap_uid' => '1235', 'role_code' => 'TNIC'},  # Teaching but Not in Charge
+          {'ldap_uid' => '1236', 'role_code' => 'ICNT'},  # In charge but not teaching
+          {'ldap_uid' => '1237', 'role_code' => 'INVT'},  # Teaching with Invalid Title
         ]
       }
       before { allow(EdoOracle::Queries).to receive(:get_section_instructors).and_return(dummy_instructors) }


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17294

This is mostly @redconfetti 's work. Thanks, Jason!

At present the changes have only been tested via RSpec. I haven't yet tried a script run (partly because of persistent "Faraday::SSLError certificate verify failed" issues).