### PR TITLE
CLC-6260 Use actual real correct EDODb column for department code

### DIFF
--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -15,7 +15,7 @@ module EdoOracle
       sec."term-id" AS term_id,
       TRIM(crs."title") AS course_title,
       TRIM(crs."transcriptTitle") AS course_title_short,
-      crs."academicDepartment-code" AS dept_name,
+      crs."subjectArea" AS dept_name,
       sec."primary" AS primary,
       sec."sectionNumber" AS section_num,
       sec."component-code" as instruction_format,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6260

#5201 was an honest try but wrong. The real equivalent to our legacy `dept_name` is not `academicDepartment-code` but `subjectArea` (e.g. "CATALAN" not "SPANPOR").