### PR TITLE
SISRP-17616 Use translation table when joining class and section by displayName

### DIFF
--- a/app/models/edo_oracle/user_courses/base.rb
+++ b/app/models/edo_oracle/user_courses/base.rb
@@ -117,7 +117,7 @@ module EdoOracle
         {
           catid: catalog_id,
           course_catalog: catalog_id,
-          course_code: row['display_name'],
+          course_code: "#{dept_name} #{catalog_id}",
           dept: dept_name,
           id: "#{slug}-#{term_code}",
           slug: slug


### PR DESCRIPTION
Under the wide umbrella of https://jira.berkeley.edu/browse/SISRP-17616, change course-section join to run through a display-name translation table.

Also remove unnecessary LEFT OUTER qualifiers from instructor, enrollment and meeting joins.