### PR TITLE
SISRP-17462, LDAP search by name with option to filter by role

### DIFF
--- a/app/models/calnet_ldap/parser.rb
+++ b/app/models/calnet_ldap/parser.rb
@@ -1,0 +1,28 @@
+module CalnetLdap
+  module Parser
+    include SafeUtf8Encoding
+
+    def parse(ldap_record)
+      affiliation_roles = Berkeley::UserRoles.roles_from_ldap_affiliations ldap_record
+      group_roles = Berkeley::UserRoles.roles_from_ldap_groups(ldap_record[:berkeleyeduismemberof], !!affiliation_roles[:exStudent])
+      roles = group_roles.merge affiliation_roles
+      {
+        email_address: string_attribute(ldap_record, :mail),
+        first_name: string_attribute(ldap_record, :berkeleyEduFirstName) || string_attribute(ldap_record, :givenname),
+        last_name: string_attribute(ldap_record, :berkeleyEduLastName) || string_attribute(ldap_record, :sn),
+        ldap_uid: string_attribute(ldap_record, :uid),
+        person_name: string_attribute(ldap_record, :displayname),
+        roles: roles,
+        student_id: string_attribute(ldap_record, :berkeleyedustuid),
+        official_bmail_address: string_attribute(ldap_record, :berkeleyeduofficialemail)
+      }
+    end
+
+    def string_attribute(ldap_record, key)
+      if (attribute = ldap_record[key].try(:first).try(:to_s))
+        safe_utf8 attribute
+      end
+    end
+
+  end
+end

--- a/app/models/calnet_ldap/user_attributes.rb
+++ b/app/models/calnet_ldap/user_attributes.rb
@@ -1,8 +1,8 @@
 module CalnetLdap
   class UserAttributes < BaseProxy
 
+    include Parser
     include Cache::UserCacheExpiry
-    extend SafeUtf8Encoding
 
     def initialize(options = {})
       super(Settings.ldap, options)
@@ -16,7 +16,7 @@ module CalnetLdap
 
     def get_feed_internal
       if (result = CalnetLdap::Client.new.search_by_uid @uid)
-        self.class.parse_result result
+        parse result
       else
         {}
       end
@@ -24,29 +24,7 @@ module CalnetLdap
 
     def self.get_bulk_attributes(uids)
       if (results = CalnetLdap::Client.new.search_by_uids uids)
-        results.map { |result| parse_result result }
-      end
-    end
-
-    def self.parse_result(result)
-      affiliation_roles = Berkeley::UserRoles.roles_from_ldap_affiliations result
-      group_roles = Berkeley::UserRoles.roles_from_ldap_groups(result[:berkeleyeduismemberof], !!affiliation_roles[:exStudent])
-      roles = group_roles.merge affiliation_roles
-      {
-        email_address: string_attribute(result, :mail),
-        first_name: string_attribute(result, :berkeleyEduFirstName) || string_attribute(result, :givenname),
-        last_name: string_attribute(result, :berkeleyEduLastName) || string_attribute(result, :sn),
-        ldap_uid: string_attribute(result, :uid),
-        person_name: string_attribute(result, :displayname),
-        roles: roles,
-        student_id: string_attribute(result, :berkeleyedustuid),
-        official_bmail_address: string_attribute(result, :berkeleyeduofficialemail)
-      }
-    end
-
-    def self.string_attribute(result, key)
-      if (attribute = result[key].try(:first).try(:to_s))
-        safe_utf8 attribute
+        results.map { |result| parse result }
       end
     end
 

--- a/app/models/user/search_users_by_name.rb
+++ b/app/models/user/search_users_by_name.rb
@@ -1,0 +1,25 @@
+module User
+  class SearchUsersByName
+    include CalnetLdap::Parser
+    extend Cache::Cacheable
+
+    def search_by(name, opts={})
+      results = CalnetLdap::Client.new.search_by_name(name, !!opts[:include_guest_users])
+      filter_by_roles results, opts[:roles]
+    end
+
+    private
+
+    def filter_by_roles(ldap_records, roles)
+      return [] if ldap_records.empty?
+      users = ldap_records.map { |ldap_record| self.parse ldap_record }
+      return users if roles.nil?
+      users.select { |user| matching_role? user, roles }
+    end
+
+    def matching_role?(user, roles=[])
+      !!((user_roles = user[:roles]) && roles.detect { |role| user_roles[role] })
+    end
+
+  end
+end

--- a/spec/models/user/search_users_by_name_spec.rb
+++ b/spec/models/user/search_users_by_name_spec.rb
@@ -1,0 +1,56 @@
+describe User::SearchUsersByName do
+  let(:name) { nil }
+  let(:roles_filter) { [] }
+  subject { User::SearchUsersByName.new.search_by name, { include_guest_users: true, roles: roles_filter } }
+
+  context 'perform no search if input is empty' do
+    context 'nil input' do
+      it { should be_empty }
+    end
+    context 'blank input' do
+      let(:name) { '    ' }
+      it { should be_empty }
+    end
+    context '\'Mr.\' and nothing else' do
+      let(:name) { 'Mr.' }
+      it { should be_empty }
+    end
+  end
+
+  context 'search all permutations of name' do
+    before do
+      expect(Net::LDAP::Filter).to receive(:eq).with('displayname', 'man* jo*')
+      expect(Net::LDAP::Filter).to receive(:eq).with('displayname', 'jo* man*')
+      expect(Net::LDAP).to receive(:new).and_return (ldap = double)
+      expect(ldap).to receive(:search).exactly(4).times.and_return []
+    end
+    context 'discard \'Jr.\'' do
+      let(:name) { ' man Jr., jo' }
+      it { should be_empty }
+    end
+    context 'discard \'M.A.\'' do
+      let(:name) { 'Jo  MAN M.A.' }
+      it { should be_empty }
+    end
+  end
+
+  context 'filter by role' do
+    let(:name) { random_name }
+    let(:roles_filter) { [:student, :recentStudent] }
+    before {
+      allow(CalnetLdap::Client).to receive(:new).and_return (client = double)
+      ldap_records = [:faculty, :student, :staff, :recentStudent, :exStudent]
+      allow(client).to receive(:search_by_name).with(name, true).and_return ldap_records
+      ldap_records.each do |record|
+        # To avoid a complex spec, each ldap_record translate very nicely into a user role.
+        user_roles = { roles: { record => true } }
+        allow_any_instance_of(CalnetLdap::Parser).to receive(:parse).with(record).and_return user_roles
+      end
+    }
+    it {
+      two_students = [ { roles: {student: true} }, { roles: {recentStudent: true} } ]
+      should eq two_students
+    }
+  end
+
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17462 and its parent https://jira.berkeley.edu/browse/SISRP-16693

The following searches are equivalent: "John Doe", "Doe, John", "Mr. John Doe", "John Doe" and "Doe Jr., John". This code tokenizes the incoming string and tosses out "Jr.", etc. In this example, we'd perform two LDAP searches on `displayname`:  'John* Doe*' and 'Doe* John*'.  In my own testing, this is what gets near feature parity with _berkeley.edu/directory_.  Note: these searches are not cached – whether they should be is debatable.  