### PR TITLE
SISRP-17905 Remove unneeded section join in EdoOracle::Queries.get_enrolled_students

### DIFF
--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -282,20 +282,10 @@ module EdoOracle
           enroll."STDNT_ENRL_STATUS_CODE" AS enroll_status,
           trim(enroll."GRADING_BASIS_CODE") AS pnp_flag
         FROM SISEDO.ENROLLMENTV00_VW enroll
-        JOIN SISEDO.CLASSSECTIONV00_VW sec ON (
-          enroll."CLASS_SECTION_ID" = sec."id" AND
-          enroll."CS_COURSE_ID" = sec."cs-course-id" AND
-          enroll."STDNT_ENRL_STATUS_CODE" != 'D' AND
-          enroll."TERM_ID" = sec."term-id" AND
-          enroll."SESSION_ID" = sec."session-id" AND
-          enroll."OFFERINGNUMBER" = sec."offeringNumber" AND
-          enroll."CLASS_SECTIONNUMBER" = sec."sectionNumber"
-        )
         WHERE
           enroll."CLASS_SECTION_ID" = '#{section_id}' AND
           enroll."TERM_ID" = '#{term_id}'
         SQL
-        puts "SQL query: #{sql.inspect}"
         result = connection.select_all(sql)
       }
       stringify_ints! result


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17905

In a last review of the join revised at #5238, I made a rather obvious discovery, which is that the join is not necessary. All of the selected columns and all of the constraints come from the enrollments view; joining to the section view is an expensive no-op.

Also remove a stray `puts`.