### PR TITLE
SISRP-17759-Ruby ~ backend support for SLR deeplink fetch

### DIFF
--- a/app/controllers/campus_solutions/slr_deeplink_controller.rb
+++ b/app/controllers/campus_solutions/slr_deeplink_controller.rb
@@ -1,0 +1,9 @@
+module CampusSolutions
+  class SLRDeeplinkController < CampusSolutionsController
+
+    def get
+      json_passthrough CampusSolutions::SLRDeeplink, user_id: session['user_id']
+    end
+
+  end
+end

--- a/app/models/campus_solutions/slr_deeplink.rb
+++ b/app/models/campus_solutions/slr_deeplink.rb
@@ -1,0 +1,23 @@
+module CampusSolutions
+  class SLRDeeplink < Proxy
+
+    def initialize(options = {})
+      super options
+      initialize_mocks if @fake
+    end
+
+    def xml_filename
+      'slr_deeplink.xml'
+    end
+
+    def build_feed(response)
+      return {} if response.parsed_response.blank?
+      response.parsed_response
+    end
+
+    def url
+      "#{@settings.base_url}/UC_SR_SLR_LINKS.v1/UC_SR_SLR_LINKS_GET"
+    end
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -184,6 +184,7 @@ Calcentral::Application.routes.draw do
   get '/api/campus_solutions/advising_resources' => 'campus_solutions/advising_resources#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/ferpa_deeplink' => 'campus_solutions/ferpa_deeplink#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/billing' => 'campus_solutions/billing#get', :via => :get, :defaults => { :format => 'json' }
+  get '/api/campus_solutions/slr_deeplink' => 'campus_solutions/slr_deeplink#get', :via => :get, :defaults => { :format => 'json' }
   post '/api/campus_solutions/address' => 'campus_solutions/address#post', :via => :post, :defaults => { :format => 'json' }
   post '/api/campus_solutions/email' => 'campus_solutions/email#post', :via => :post, :defaults => { :format => 'json' }
   post '/api/campus_solutions/person_name' => 'campus_solutions/person_name#post', :via => :post, :defaults => { :format => 'json' }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -288,6 +288,7 @@ cache:
     CampusSolutions::NameType: <%= 29.days %>
     CampusSolutions::SirConfig: <%= 24.hours %>
     CampusSolutions::State: <%= 29.days %>
+    CampusSolutions::SLRDeeplink: <%= 24.hours %>
     CampusSolutions::Translate: <%= 24.hours %>
     CampusSolutions::DashboardUrl: <%= 29.days %>
 

--- a/fixtures/xml/campus_solutions/slr_deeplink.xml
+++ b/fixtures/xml/campus_solutions/slr_deeplink.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<ROOT>
+  <UC_SR_SLR_RESOURCES>
+    <UC_SLR_LINKS>
+      <UC_SLR_LINK>
+        <NAME>SLR_LINK</NAME>
+        <URL>https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/UC_SR_SLR.UC_SLR_STDNT.GBL</URL>
+        <IS_CS_LINK type="boolean">true</IS_CS_LINK>
+      </UC_SLR_LINK>
+    </UC_SLR_LINKS>
+  </UC_SR_SLR_RESOURCES>
+</ROOT>

--- a/spec/controllers/campus_solutions/slr_deeplink_controller_spec.rb
+++ b/spec/controllers/campus_solutions/slr_deeplink_controller_spec.rb
@@ -1,0 +1,23 @@
+describe CampusSolutions::SLRDeeplinkController do
+
+  let(:user_id) { '12345' }
+
+  context 'SLR feed' do
+    let(:feed) { :get }
+    it_behaves_like 'an unauthenticated user'
+
+    context 'authenticated user' do
+      let(:feed_key) { 'root' }
+      it_behaves_like 'a successful feed'
+      it 'has some field mapping info' do
+        session['user_id'] = user_id
+        get feed
+        json = JSON.parse(response.body)
+        expect(json['feed']['root']['ucSrSlrResources']['ucSlrLinks']['ucSlrLink']['isCsLink']).to eq(true)
+        expect(json['feed']['root']['ucSrSlrResources']['ucSlrLinks']['ucSlrLink']['name']).to eq("SLR_LINK")
+        expect(json['feed']['root']['ucSrSlrResources']['ucSlrLinks']['ucSlrLink']['url']).to eq("https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/UC_SR_SLR.UC_SLR_STDNT.GBL")
+      end
+    end
+  end
+
+end

--- a/spec/models/campus_solutions/slr_deeplink_spec.rb
+++ b/spec/models/campus_solutions/slr_deeplink_spec.rb
@@ -1,0 +1,24 @@
+describe CampusSolutions::SLRDeeplink do
+
+  shared_examples 'a proxy that gets data' do
+    subject { proxy.get }
+    it_should_behave_like 'a simple proxy that returns errors'
+    it_behaves_like 'a proxy that got data successfully'
+    it 'returns data with the expected structure' do
+      expect(subject[:feed][:root][:ucSrSlrResources][:ucSlrLinks][:ucSlrLink][:isCsLink]).to eq(true)
+      expect(subject[:feed][:root][:ucSrSlrResources][:ucSlrLinks][:ucSlrLink][:name]).to eq("SLR_LINK")
+      expect(subject[:feed][:root][:ucSrSlrResources][:ucSlrLinks][:ucSlrLink][:url]).to eq("https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/UC_SR_SLR.UC_SLR_STDNT.GBL")
+    end
+  end
+
+  context 'mock proxy' do
+    let(:proxy) { CampusSolutions::SLRDeeplink.new(fake: true) }
+    it_should_behave_like 'a proxy that gets data'
+  end
+
+  context 'real proxy', testext: true do
+    let(:proxy) { CampusSolutions::SLRDeeplink.new(fake: false) }
+    it_should_behave_like 'a proxy that gets data'
+  end
+
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17759

This PR adds ruby infrastructure for fetching statement of legal residency deeplink ~ detail jira at https://jira.berkeley.edu/browse/SISRP-16994
