### PR TITLE
SISRP-17963, advisor auth check in view-as must know diff between UID and SID

### DIFF
--- a/app/controllers/concerns/advisor_authorization.rb
+++ b/app/controllers/concerns/advisor_authorization.rb
@@ -10,24 +10,24 @@ module AdvisorAuthorization
 
   def authorize_advisor_view_as(uid, student_uid)
     require_advisor uid
-    unless qualifies_as_student? student_uid
-      raise Pundit::NotAuthorizedError.new "#{student_uid} does not appear to be a current, recent, or incoming student."
+    student = user_attributes student_uid
+    authorized = (roles = student[:roles]) && (roles[:applicant] || roles[:student] || roles[:recentStudent])
+    unless authorized
+      message_prefix = "User with UID #{student_uid}"
+      message_prefix.concat " / SID #{student[:studentId]}" if student[:studentId]
+      raise Pundit::NotAuthorizedError.new "#{message_prefix} does not appear to be a current, recent, or incoming student."
     end
   end
 
   def require_advisor(uid)
-    authorized = (roles = user_roles uid) && roles[:advisor]
-    raise Pundit::NotAuthorizedError.new("User #{uid} is not an Advisor") unless authorized
+    authorized = (user = user_attributes uid) && user[:roles] && user[:roles][:advisor]
+    raise Pundit::NotAuthorizedError.new("User (UID: #{uid}) is not an Advisor") unless authorized
   end
 
   private
 
-  def qualifies_as_student?(uid)
-    (roles = user_roles uid) && (roles[:applicant] || roles[:student] || roles[:recentStudent])
-  end
-
-  def user_roles(uid)
-    User::AggregatedAttributes.new(uid).get_feed[:roles]
+  def user_attributes(uid)
+    User::AggregatedAttributes.new(uid).get_feed
   end
 
 end

--- a/app/controllers/search_users_controller.rb
+++ b/app/controllers/search_users_controller.rb
@@ -2,20 +2,24 @@ class SearchUsersController < ApplicationController
   include ViewAsAuthorization
 
   def search_users
-    authorize_user_lookup current_user, (uid = uid_param)
-    users_found = User::SearchUsers.new(id: uid).search_users
+    users_found = authorize_results User::SearchUsers.new(id: id_param).search_users
     render json: { users: users_found }.to_json
   end
 
   def search_users_by_uid
-    authorize_user_lookup current_user, (uid = uid_param)
-    users_found = User::SearchUsersByUid.new(id: uid).search_users_by_uid
+    users_found = authorize_results User::SearchUsersByUid.new(id: id_param).search_users_by_uid
     render json: { users: users_found }.to_json
   end
 
   private
 
-  def uid_param
+  def authorize_results(users)
+    users.each do |user|
+      authorize_user_lookup current_user, user['ldap_uid']
+    end
+  end
+
+  def id_param
     params.require 'id'
   end
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17963

Notes:
* Because the incoming `id` might be UID or SID, we must move the advisor-authorization check *after* the SearchUsers call. At that point, we use `user['ldap_uid']` and remove all doubt concerning id type.
* I had to improve the error message because a search on SID would return an error message containing only the corresponding UID. That would certainly confuse an Advisor. We now have both in the message.