### PR TITLE
SISRP-17803 Filter out blank-ID instructor assignments from EDODb queries

### DIFF
--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -228,7 +228,8 @@ module EdoOracle
           )
           WHERE
             sec."id" = '#{section_id.to_s}' AND
-            sec."term-id" = '#{term_id.to_s}'
+            sec."term-id" = '#{term_id.to_s}' AND
+            TRIM(instr."instructor-id") IS NOT NULL
           ORDER BY
             role_code
         SQL


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17803

Thanks to CalCentral Bugfinder Squad, we now know that a database row with instructor name and blank instructor ID should not be interpreted as "valid instructor assignment with missing ID," but as "missing instructor assignment with erroneous name."