### PR TITLE
NOJIRA, base_proxy_spec no longer relies on real HTTP call

### DIFF
--- a/spec/lib/proxies/base_proxy_spec.rb
+++ b/spec/lib/proxies/base_proxy_spec.rb
@@ -1,22 +1,21 @@
 describe BaseProxy do
+  before {
+    allow_any_instance_of(Proxies::HttpClient).to receive(:get_response).and_return double
+  }
+  subject {
+    BaseProxy.new(settings, fake: true).get_response 'http://www.this-URL-is-not-used.com', (options = {})
+    options[:timeout]
+  }
 
   context 'a proxy class can have its own custom HTTP settings' do
     context 'actual YAML' do
-      subject {
-        BaseProxy.new(Settings.hub_edos_proxy, { fake: true }).get_response 'http://www.url.com', (options = { })
-        options[:timeout]
-      }
-      context 'http_timeout is an integer' do
-        it { should be_an Integer }
-        it { should be > 0 }
-      end
+      let(:settings) { Settings.hub_edos_proxy }
+      it { should be_an Integer }
+      it { should be > 0 }
     end
+
     context 'proper settings' do
-      subject {
-        settings = double(http_timeout_seconds: timeout_setting)
-        BaseProxy.new(settings, { fake: true }).get_response 'http://www.url.com', (options = { })
-        options[:timeout]
-      }
+      let(:settings) { double http_timeout_seconds: timeout_setting }
       context 'http_timeout is nil' do
         let(:timeout_setting) { nil }
         it { should be nil }
@@ -34,11 +33,8 @@ describe BaseProxy do
         it { should eq 10 }
       end
     end
+
     context 'missing or invalid settings' do
-      subject {
-        BaseProxy.new(settings, { fake: true }).get_response 'http://www.url.com', (options = { })
-        options[:timeout]
-      }
       context 'nil settings' do
         let(:settings) { nil }
         it { should be nil }


### PR DESCRIPTION
The Bamboo QA build just failed on `base_proxy_spec` because http://www.url.com was down.  The spec has nothing to do with actual HTTP call so we stub it out.