### PR TITLE
SISRP-16088, all tabs are wired to save, delete and view-as user

### DIFF
--- a/app/models/user/stored_users.rb
+++ b/app/models/user/stored_users.rb
@@ -29,7 +29,8 @@ module User
       uid_hash = {}
 
       users_found.each do |user|
-        uid_hash[user['ldap_uid']] = user
+        user.symbolize_keys!
+        uid_hash[user[:ldap_uid]] = user
       end
 
       saved_uid_set = Set.new
@@ -38,14 +39,16 @@ module User
         user = uid_hash[entry[:stored_uid]]
         if user.present?
           saved_uid_set.add entry[:stored_uid]
+          user[:saved] = true
           users[:saved] << user
         end
       end
 
       uid_entries[:recent].each do |entry|
-        user = uid_hash[entry[:stored_uid]]
+        uid = entry[:stored_uid]
+        user = uid_hash[uid]
         if user.present?
-          users[:recent] << user.merge('saved' => saved_uid_set.include?(entry[:stored_uid]))
+          users[:recent] << user.merge(saved: saved_uid_set.include?(uid))
         end
       end
 

--- a/spec/models/user/stored_users_spec.rb
+++ b/spec/models/user/stored_users_spec.rb
@@ -70,8 +70,8 @@ describe User::StoredUsers do
 
       users = User::StoredUsers.get(owner_uid)
 
-      expect(users[:saved][0]['ldap_uid']).to eq stored_uid
-      expect(users[:recent][0]['ldap_uid']).to eq stored_uid
+      expect(users[:saved][0][:ldap_uid]).to eq stored_uid
+      expect(users[:recent][0][:ldap_uid]).to eq stored_uid
     end
 
     it 'should report whether recent uids are saved' do
@@ -88,8 +88,8 @@ describe User::StoredUsers do
       User::StoredUsers.store_recent_uid(owner_uid, unsaved_uid)
 
       users = User::StoredUsers.get(owner_uid)
-      expect(users[:recent]).to include({'ldap_uid' => saved_uid, 'saved' => true})
-      expect(users[:recent]).to include({'ldap_uid' => unsaved_uid, 'saved' => false})
+      expect(users[:recent]).to include({ldap_uid: saved_uid, saved: true})
+      expect(users[:recent]).to include({ldap_uid: unsaved_uid, saved: false})
     end
 
   end

--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -1,4 +1,3 @@
-/* jshint camelcase: false */
 'use strict';
 
 var angular = require('angular');
@@ -36,7 +35,7 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
       uid: $routeParams.uid
     }).success(function(data) {
       angular.extend($scope.targetUser, _.get(data, 'attributes'));
-      $scope.targetUser.ldap_uid = $routeParams.uid;
+      $scope.targetUser.ldapUid = $routeParams.uid;
       $scope.targetUser.addresses = apiService.profile.fixFormattedAddresses(_.get(data, 'contacts.feed.student.addresses'));
       $scope.targetUser.phones = _.get(data, 'contacts.feed.student.phones');
       $scope.targetUser.emails = _.get(data, 'contacts.feed.student.emails');

--- a/src/assets/javascripts/angular/controllers/widgets/adminController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/adminController.js
@@ -1,4 +1,3 @@
-/* jshint camelcase: false */
 'use strict';
 
 var angular = require('angular');
@@ -19,13 +18,13 @@ angular.module('calcentral.controllers').controller('AdminController', function(
 
   $scope.admin.storeSavedUser = function(user) {
     return adminFactory.storeUser({
-      uid: user.ldap_uid
+      uid: adminService.getLdapUid(user)
     }).success(getStoredUsersUncached);
   };
 
   $scope.admin.deleteSavedUser = function(user) {
     return adminFactory.deleteUser({
-      uid: user.ldap_uid
+      uid: adminService.getLdapUid(user)
     }).success(getStoredUsersUncached);
   };
 
@@ -113,7 +112,7 @@ angular.module('calcentral.controllers').controller('AdminController', function(
     $scope.admin.actAsErrorStatus = '';
     $scope.admin.userPool = [];
 
-    if (user && user.ldap_uid) {
+    if (adminService.getLdapUid(user)) {
       return adminService.actAs(user);
     }
 
@@ -144,7 +143,7 @@ angular.module('calcentral.controllers').controller('AdminController', function(
 
     var lastUser = $scope.admin.storedUsers.recent[0];
     // Display the last acted as UID in the "View as" input box
-    $scope.admin.actAs.id = parseInt(lastUser && lastUser.ldap_uid, 10) || '';
+    $scope.admin.actAs.id = parseInt(adminService.getLdapUid(lastUser), 10) || '';
   };
 
   /**

--- a/src/assets/javascripts/angular/controllers/widgets/userSearchController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/userSearchController.js
@@ -6,24 +6,24 @@ var _ = require('lodash');
 /**
  * Search and view-as users.
  */
-angular.module('calcentral.controllers').controller('UserSearchController', function(adminFactory, apiService, $scope) {
+angular.module('calcentral.controllers').controller('UserSearchController', function(adminFactory, adminService, apiService, $scope) {
   $scope.userSearch = {
     title: 'View as',
     tabs: {
       search: {
         label: 'Search',
-        inProgress: false,
-        users: null
+        queryRunning: false,
+        users: []
       },
       saved: {
         label: 'Saved',
-        isLoading: true,
-        users: null
+        isLoading: false,
+        users: []
       },
       recent: {
         label: 'Recent',
-        isLoading: true,
-        users: null
+        isLoading: false,
+        users: []
       }
     }
   };
@@ -35,49 +35,74 @@ angular.module('calcentral.controllers').controller('UserSearchController', func
     };
   };
 
-  var loadStoredUsers = function(tab, refresh) {
-    if (refresh || $scope.userSearch.tabs.saved.users === null) {
-      adminFactory.getStoredUsers().success(function(data) {
-        $scope.userSearch.tabs.saved.users = _.get(data, 'users.saved');
-        $scope.userSearch.tabs.recent.users = _.get(data, 'users.recent');
-        if (tab.users === null || tab.users.length === 0) {
+  var decorate = function(users) {
+    angular.forEach(users, function(user) {
+      user.actAs = function() {
+        adminService.actAs(user);
+      };
+      user.save = function() {
+        adminFactory.storeUser({
+          uid: adminService.getLdapUid(user)
+        }).success(refreshStoredUsers);
+      };
+      user.delete = function() {
+        return adminFactory.deleteUser({
+          uid: adminService.getLdapUid(user)
+        }).success(refreshStoredUsers);
+      };
+    });
+    return users;
+  };
+
+  var getStoredUsers = function() {
+    return adminFactory.getStoredUsers({
+      refreshCache: true
+    });
+  };
+
+  var refreshStoredUsers = function() {
+    var tabs = $scope.userSearch.tabs;
+    getStoredUsers().success(function(data) {
+      angular.forEach([tabs.saved, tabs.recent], function(tab) {
+        tab.isLoading = true;
+        tab.users = decorate(_.get(data, 'users.' + tab.label.toLowerCase()));
+        if (tab.users.length === 0) {
           tab.message = 'No ' + tab.label.toLowerCase() + ' items.';
         }
-      }).error(function(data, status) {
+        tab.isLoading = false;
+      });
+    }).error(function(data, status) {
+      angular.forEach([tabs.saved, tabs.recent], function(tab) {
         reportError(tab, status, data.error);
       });
-    }
-    tab.isLoading = false;
+    });
   };
 
   $scope.userSearch.byNameOrId = function() {
     $scope.userSearch.tabs.search.message = null;
-    $scope.userSearch.tabs.search.inProgress = true;
+    $scope.userSearch.tabs.search.queryRunning = true;
     var nameOrId = $scope.userSearch.tabs.search.nameOrId;
     adminFactory.searchUsers(nameOrId).success(function(data) {
       if (!data.users || data.users.length === 0) {
         $scope.userSearch.tabs.search.message = 'Your search on ' + nameOrId + ' did not match any users.';
       }
-      $scope.userSearch.tabs.search.users = data.users;
+      $scope.userSearch.tabs.search.users = decorate(data.users);
     }).error(function(data, status) {
       reportError($scope.userSearch.tabs.search, status, data.error);
     }).finally(function() {
-      $scope.userSearch.tabs.search.inProgress = false;
+      $scope.userSearch.tabs.search.queryRunning = false;
     });
   };
 
   $scope.userSearch.loadTab = function(tab) {
-    tab.message = '';
     $scope.userSearch.selectedTab = tab;
-    if (tab !== $scope.userSearch.tabs.search) {
-      loadStoredUsers(tab, false);
-    }
   };
 
   var init = function() {
     if (apiService.user.profile.roles.advisor) {
       $scope.userSearch.title = 'Student Lookup';
       $scope.userSearch.loadTab($scope.userSearch.tabs.search);
+      refreshStoredUsers();
     }
   };
 

--- a/src/assets/javascripts/angular/services/adminService.js
+++ b/src/assets/javascripts/angular/services/adminService.js
@@ -14,7 +14,15 @@ angular.module('calcentral.services').service('adminService', function(adminFact
     }).success(apiService.util.redirectToHome);
   };
 
+  var getLdapUid = function(user) {
+    if (user === null) {
+      return null;
+    }
+    return ('ldap_uid' in user) ? user.ldap_uid : user.ldapUid;
+  };
+
   return {
-    actAs: actAs
+    actAs: actAs,
+    getLdapUid: getLdapUid
   };
 });

--- a/src/assets/templates/widgets/toolbox/user_search.html
+++ b/src/assets/templates/widgets/toolbox/user_search.html
@@ -30,8 +30,8 @@
             </div>
           </div>
           <p data-ng-bind="userSearch.tabs.search.message"></p>
-          <div data-cc-spinner-directive="userSearch.tabs.search.inProgress">
-            <div data-ng-if="userSearch.currentTab.error && !userSearch.tabs.search.inProgress">
+          <div data-cc-spinner-directive="userSearch.tabs.search.queryRunning">
+            <div data-ng-if="userSearch.currentTab.error && !userSearch.tabs.search.queryRunning">
               <h3 data-ng-bind="userSearch.currentTab.error.summary"></h3>
               <div data-ng-bind="userSearch.currentTab.error.description"></div>
             </div>

--- a/src/assets/templates/widgets/toolbox/user_search_results.html
+++ b/src/assets/templates/widgets/toolbox/user_search_results.html
@@ -16,6 +16,13 @@
           </a>
         </div>
         <div>(<span data-ng-bind="user.student_id"></span>)</div>
+        <div>
+          <button class="cc-button-link" data-ng-click="user.delete()" data-ng-if="user.saved">Delete</button>
+          <button class="cc-button-link" data-ng-click="user.save()" data-ng-if="!user.saved">Save</button>
+        </div>
+        <div>
+          <button class="cc-button-link" data-ng-click="user.actAs()">view as</button>
+        </div>
       </div>
     </div>
   </li>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-16088

All three tabs (search, saved and recent) will shuffle user list and available links based on latest stored_users in db. To avoid complexity in the js I added a 'saved' property to server-side user searches. E.g., each user in search results has the flag.

A little cleanup:
* symbolize keys in stored_users 
* fewer js files offending the camelcase rule