### PR TITLE
SISRP-18350, view-as from Advisor dashboard needs logic of: ldap_uid OR ldapUid

### DIFF
--- a/src/assets/javascripts/angular/services/adminService.js
+++ b/src/assets/javascripts/angular/services/adminService.js
@@ -10,7 +10,7 @@ angular.module('calcentral.services').service('adminService', function(adminFact
       !apiService.user.profile.isViewer;
     var actAs = isAdvisorOnly ? adminFactory.advisorActAs : adminFactory.actAs;
     return actAs({
-      uid: user.ldap_uid
+      uid: getLdapUid(user)
     }).success(apiService.util.redirectToHome);
   };
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-18350

I missed an instance of `ldap_uid` v. `ldapUid` concern. View-as links from new student-lookup card need to use `getLdapUid(user)`.