### PR TITLE
CLC-6269 OEC: Tune error handling in ReportDiffTask

### DIFF
--- a/app/models/oec/report_diff_task.rb
+++ b/app/models/oec/report_diff_task.rb
@@ -59,6 +59,9 @@ module Oec
 
     def default_date_time
       date_time_of_most_recent Oec::Folder.sis_imports
+    rescue => e
+      log :error, "Error retrieving date of last SIS import: #{e.message}\n#{e.backtrace.join "\n\t"}"
+      @status = 'Error'
     end
 
     def report_diff(dept_code, sis_data, dept_data, keys)

--- a/app/models/oec/task.rb
+++ b/app/models/oec/task.rb
@@ -184,11 +184,12 @@ module Oec
         raise UnexpectedDataError, "#{self.class.name} requires a non-empty '#{@term_code}/#{category_name}' folder"
       end
       log :info, "#{self.class.name} will pull data from '#{@term_code}/#{category_name}/#{last.title}'"
-      DateTime.strptime(last.title, "#{self.class.date_format} #{self.class.timestamp_format}")
-    rescue => e
-      pattern = "#{Oec::Task.date_format}_#{Oec::Task.timestamp_format}"
-      log :error, "Folder in '#{@term_code}/#{category_name}' failed to match '#{pattern}'.\n#{e.message}\n#{e.backtrace.join "\n\t"}"
-      nil
+      datetime_format = "#{self.class.date_format} #{self.class.timestamp_format}"
+      begin
+        DateTime.strptime(last.title, datetime_format)
+      rescue
+        raise UnexpectedDataError, "Folder '#{@term_code}/#{category_name}/#{last.title}' failed to match datetime format '#{datetime_format}'"
+      end
     end
 
     def log(level, message, opts={})

--- a/spec/models/oec/sis_import_task_spec.rb
+++ b/spec/models/oec/sis_import_task_spec.rb
@@ -30,6 +30,7 @@ describe Oec::SisImportTask do
     let(:local_write) { false }
     before do
       expect(Oec::ReportDiffTask).to receive(:new).and_call_original
+      expect_any_instance_of(Oec::ReportDiffTask).to receive(:date_time_of_most_recent).and_return DateTime.now
       expect(fake_remote_drive).to receive(:check_conflicts_and_upload)
         .with(kind_of(Pathname), report_diff_logfile, 'text/plain', logs_today_folder, anything)
         .and_return mock_google_drive_item(report_diff_logfile)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6269

In order to do its job, ReportDiffTask needs the timestamp of the most recent SIS import. If it can't get that timestamp, it should say so and error out gracefully.