### PR TITLE
SISRP-18057 Add HubEdos::Registrations proxy

### DIFF
--- a/app/models/hub_edos/registrations.rb
+++ b/app/models/hub_edos/registrations.rb
@@ -1,0 +1,46 @@
+module HubEdos
+  class Registrations < Proxy
+
+    include CampusSolutions::AcademicProfileFeatureFlagged
+    include Cache::UserCacheExpiry
+
+    def initialize(options = {})
+      super(options)
+      @term_id = options[:term_id]
+    end
+
+    def url
+      "#{@settings.base_url}/#{@campus_solutions_id}/registrations?term-id=#{@term_id}"
+    end
+
+    def json_filename
+      'hub_registrations.json'
+    end
+
+    def include_fields
+      %w(affiliations registrations)
+    end
+
+    def get
+      return {} unless is_feature_enabled
+      response = self.class.smart_fetch_from_cache(id: instance_key) do
+        get_internal
+      end
+      decorate_internal_response response
+    end
+
+    def build_feed(response)
+      resp = parse_response response
+      get_students(resp)
+    end
+
+    def instance_key
+      "#{@uid}-#{@term_id}"
+    end
+
+    def wrapper_keys
+      %w(apiResponse response any)
+    end
+
+  end
+end

--- a/app/models/hub_edos/response_handler.rb
+++ b/app/models/hub_edos/response_handler.rb
@@ -3,16 +3,12 @@ module HubEdos
 
     def get_students(response)
       return [] unless response.is_a? Hash
-      # We are temporarily handling both GL4 and GL5 wrapper formats for backwards compatibility.
-      wrapper_keys = if response['apiResponse']
-                       # GL5 format
-                       %w(apiResponse response any students)
-                     else
-                       # GL4 format
-                       %w(studentResponse students students)
-                     end
       students = wrapper_keys.inject(response) { |feed, key| (feed.is_a?(Hash) && feed[key]) || [] }
       students.respond_to?(:each) ? students : []
+    end
+
+    def wrapper_keys
+      %w(apiResponse response any students)
     end
 
   end

--- a/fixtures/json/hub_registrations.json
+++ b/fixtures/json/hub_registrations.json
@@ -1,0 +1,128 @@
+{
+  "apiResponse": {
+    "source": "UCB-SIS-STUDENT",
+    "correlationId": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+    "responseType": "http://bmeta.berkeley.edu/student/studentV0.xsd/studentRegistrations",
+    "response": {
+      "any": {
+        "identifier": {
+          "type": "student-id",
+          "id": "11667051",
+          "disclose": false
+        },
+        "confidential": false,
+        "affiliations": [
+          {
+            "type": {
+              "code": "EMPLOYEE",
+              "description": "Employee"
+            },
+            "detail": "Active",
+            "status": {
+              "code": "ACT",
+              "description": "Active"
+            },
+            "fromDate": "2016-04-20"
+          },
+          {
+            "type": {
+              "code": "INSTRUCTOR",
+              "description": "Instructor"
+            },
+            "detail": "Inactive",
+            "status": {
+              "code": "INA",
+              "description": "Inactive"
+            },
+            "fromDate": "2016-02-26"
+          },
+          {
+            "type": {
+              "code": "LAW",
+              "description": "Law School Student"
+            },
+            "detail": "Active",
+            "status": {
+              "code": "ACT",
+              "description": "Active"
+            },
+            "fromDate": "2015-12-17"
+          },
+          {
+            "type": {
+              "code": "STUDENT",
+              "description": ""
+            },
+            "detail": "",
+            "status": {
+              "code": "ACT",
+              "description": "Active"
+            },
+            "fromDate": "2015-12-17"
+          }
+        ],
+        "registrations": [
+          {
+            "term": {
+              "id": "2168",
+              "name": "2016 Fall",
+              "academicYear": "2017"
+            },
+            "academicCareer": {
+              "code": "LAW",
+              "description": "Law"
+            },
+            "eligibleToRegister": true,
+            "registered": false,
+            "disabled": false,
+            "athlete": false,
+            "intendsToGraduate": false,
+            "academicLevel": {
+              "level": {
+                "code": "GR",
+                "description": "Graduate"
+              }
+            },
+            "termUnits": [
+              {
+                "type": {
+                  "description": "Total"
+                },
+                "unitsMin": 0,
+                "unitsMax": 0,
+                "unitsEnrolled": 0,
+                "unitsWaitlisted": 0
+              },
+              {
+                "type": {
+                  "description": "For GPA"
+                },
+                "unitsEnrolled": 0,
+                "unitsWaitlisted": 0
+              },
+              {
+                "type": {
+                  "description": "Not For GPA"
+                },
+                "unitsEnrolled": 0,
+                "unitsWaitlisted": 0
+              }
+            ],
+            "termGPA": {
+              "type": {
+                "description": "Term GPA"
+              },
+              "average": 0
+            },
+            "specialStudyPrograms": [],
+            "withdrawalCancel": {
+              "type": {},
+              "reason": {}
+            },
+            "new": false
+          }
+        ]
+      }
+    }
+  }
+}

--- a/spec/models/hub_edos/registrations_spec.rb
+++ b/spec/models/hub_edos/registrations_spec.rb
@@ -1,0 +1,17 @@
+describe HubEdos::Registrations do
+
+  context 'mock proxy' do
+    let(:proxy) { HubEdos::Registrations.new(fake: true, user_id: '61889', term_id: '2168') }
+    subject { proxy.get }
+
+    it_behaves_like 'a proxy that properly observes the academic profile feature flag'
+    it_should_behave_like 'a simple proxy that returns errors'
+
+    it 'returns data with the expected structure' do
+      expect(subject[:feed]['registrations']).to be
+      expect(subject[:feed]['registrations'][0]['academicCareer']['code']).to eq('LAW')
+      expect(subject[:feed]['registrations'].size).to eq(1)
+    end
+  end
+
+end

--- a/spec/models/hub_edos/response_handler_spec.rb
+++ b/spec/models/hub_edos/response_handler_spec.rb
@@ -17,30 +17,6 @@ describe HubEdos::ResponseHandler do
 
   subject { Worker.new.fetch_first_postal_code parsed_response }
 
-  context 'GL4 wrapper format' do
-    let(:parsed_response) do
-      {
-        'studentResponse' => {
-          'students' => {
-            'students' => [
-              {
-                'addresses' => [
-                  {
-                    'postalCode' => '454554',
-                    'countryCode' => 'USA'
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      }
-    end
-    it 'should find postal code' do
-      expect(subject).to eq({ postalCode: '454554' })
-    end
-  end
-
   context 'GL5 wrapper format' do
     let(:parsed_response) {
       {


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-18057

This will be needed to check CS for academic status in non-"current" terms, thus allowing us to (for example) know whether someone should be treated as a Law student in the Class Enrollment card for a future term.

(The PR also scrapes GoLive 4 API formats into the dustbin of history.)