### PR TITLE
SISRP-17831 - Add SSO to HigherOne for Students and Delegates for Billing Summary

### DIFF
--- a/app/controllers/campus_solutions/higher_one_url_controller.rb
+++ b/app/controllers/campus_solutions/higher_one_url_controller.rb
@@ -6,10 +6,25 @@ module CampusSolutions
     before_filter :authorize_for_financial
 
     def get
+      model = model_from_session
+      render json: model.get_feed_as_json
+    end
+
+    def redirect
+      model = model_from_session
+      if (higher_one_url = model.get_higher_one_url)
+        redirect_to higher_one_url
+      else
+        redirect_to url_for_path '/404'
+      end
+    end
+
+    private
+
+    def model_from_session
       options = {}
       options[:delegate_uid] = current_user.original_delegate_user_id if current_user.authenticated_as_delegate?
-      model = CampusSolutions::MyHigherOneUrl.from_session(session, options)
-      render json: model.get_feed_as_json
+      CampusSolutions::MyHigherOneUrl.from_session(session, options)
     end
 
   end

--- a/app/models/campus_solutions/higher_one_url.rb
+++ b/app/models/campus_solutions/higher_one_url.rb
@@ -19,6 +19,11 @@ module CampusSolutions
       response.parsed_response
     end
 
+    def build_url
+      response = self.get
+      [:feed, :root, :higherOneUrl, :url].inject(response) { |hash, key| hash[key] if hash }
+    end
+
     def url
       query_args = @delegate_uid ? "DELEGATE_UID=#{@delegate_uid}" : "EMPLID=#{@campus_solutions_id}"
       "#{@settings.base_url}/UC_OB_HIGHER_ONE_URL_GET.v1/get?#{query_args}"

--- a/app/models/campus_solutions/my_higher_one_url.rb
+++ b/app/models/campus_solutions/my_higher_one_url.rb
@@ -9,11 +9,22 @@ module CampusSolutions
 
     def get_feed_internal
       return {} unless is_feature_enabled
+      proxy.get
+    end
+
+    def get_higher_one_url
+      return {} unless is_feature_enabled
+      proxy.build_url.strip
+    end
+
+    private
+
+    def proxy
       proxy_args = {
         user_id: @uid,
         delegate_uid: @options[:delegate_uid]
       }
-      CampusSolutions::HigherOneUrl.new(proxy_args).get
+      CampusSolutions::HigherOneUrl.new(proxy_args)
     end
 
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -210,6 +210,9 @@ Calcentral::Application.routes.draw do
   # Redirect to College Scheduler
   get '/college_scheduler/:acad_career/:term_id' => 'campus_solutions/college_scheduler#get'
 
+  # Redirect to HigherOne
+  get '/higher_one/higher_one_url' => 'campus_solutions/higher_one_url#redirect'
+
   # EDOs from integration hub
   get '/api/edos/student' => 'hub_edo#student', :via => :get, :defaults => { :format => 'json' }
   get '/api/edos/work_experience' => 'hub_edo#work_experience', :via => :get, :defaults => { :format => 'json' }

--- a/spec/controllers/campus_solutions/higher_one_url_controller_spec.rb
+++ b/spec/controllers/campus_solutions/higher_one_url_controller_spec.rb
@@ -1,6 +1,7 @@
 describe CampusSolutions::HigherOneUrlController do
 
   let(:user_id) { '12349' }
+  let(:higher_one_url) { 'https://commerce.cashnet.com/UCBpaytest?eusername=8062064084e9a8dff7a181266a3ed11e28b80eb30ab4fd84b9bc4de92394d884' }
 
   context 'higher one url feed' do
     let(:feed) { :get }
@@ -13,8 +14,19 @@ describe CampusSolutions::HigherOneUrlController do
         session['user_id'] = user_id
         get feed
         json = JSON.parse(response.body)
-        expect(json['feed']['root']['higherOneUrl']['url'].strip).to eq 'https://commerce.cashnet.com/UCBpaytest?eusername=8062064084e9a8dff7a181266a3ed11e28b80eb30ab4fd84b9bc4de92394d884'
+        expect(json['feed']['root']['higherOneUrl']['url'].strip).to eq higher_one_url
       end
+    end
+  end
+
+  context 'redirect as a student' do
+    before do
+      session['user_id'] = user_id
+    end
+    it 'redirects to higher one' do
+      get :redirect
+      expect(response.status).to eq 302
+      expect(response).to redirect_to higher_one_url
     end
   end
 

--- a/src/assets/templates/widgets/billing_summary.html
+++ b/src/assets/templates/widgets/billing_summary.html
@@ -43,7 +43,7 @@
       </li>
       <li data-ng-if="billing.data.summary.accountBalance !== '0.00'">
         <div class="cc-page-myfinances-account-summary-buttons cc-print-hide" data-ng-if="billing.data.summary.accountBalance !== '0.00'">
-          <a class="cc-button" href="">Make Payment for <span data-ng-bind="billing.data.summary.currentTerm"></span></a>
+          <a class="cc-button" data-cc-outbound-enabled="true" href="/higher_one/higher_one_url">Make Payment for <span data-ng-bind="billing.data.summary.currentTerm"></span></a>
         </div>
       </li>
     </ul>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17831

I left the "old" methods of polling for the HigherOne URL we use on the SIR card there.  I believe the plan was to QA both methods, and if this way was preferable, then we'd replace the functionality on the SIR card with this method?  cc @pfarestveit 

Let me know if I can make this better - it feels pretty un-DRY, but since these methods are so authentication-state-specific, I wasn't sure if I could make some of these shared variables between the two methods more global.

I also wasn't able to test the delegate part of this yet, I've created [SISRP-18446] (https://jira.berkeley.edu/browse/SISRP-18446) to address this.

Thanks! 