### PR TITLE
SISRP-17782, Advising student overview: GTE forms and Academic Planner links

### DIFF
--- a/src/assets/templates/widgets/toolbox/user_preview.html
+++ b/src/assets/templates/widgets/toolbox/user_preview.html
@@ -72,17 +72,39 @@
       <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="ucAdvisingResources.ucAdvisingLinks">
         <table class="cc-widget-profile-table">
           <tbody>
-          <tr>
-            <th>Advising Resources</th>
-            <td>
-              <div data-ng-if="ucAdvisingResources.ucAdvisingLinks.ucServiceIndicator">
-                <div data-cc-campus-solutions-link-item-directive data-link="ucAdvisingResources.ucAdvisingLinks.ucServiceIndicator"></div>
-              </div>
-              <div data-ng-if="ucAdvisingResources.ucAdvisingLinks.ucStudentAdvisor">
-                <a data-ng-href="{{ucAdvisingResources.ucAdvisingLinks.ucStudentAdvisor.url}}">Advising Assignments</a>
-              </div>
-            </td>
-          </tr>
+            <tr>
+              <th>
+                Advising Resources
+              </th>
+              <td>
+                <div data-ng-if="ucAdvisingResources.ucAdvisingLinks.ucServiceIndicator">
+                  <div
+                    data-cc-campus-solutions-link-item-directive
+                    data-link="ucAdvisingResources.ucAdvisingLinks.ucServiceIndicator"
+                  ></div>
+                </div>
+                <div data-ng-if="ucAdvisingResources.ucAdvisingLinks.ucStudentAdvisor">
+                  <div
+                    data-cc-campus-solutions-link-item-directive
+                    data-link="ucAdvisingResources.ucAdvisingLinks.ucStudentAdvisor"
+                    data-text="Advising Assignments"
+                  ></div>
+                </div>
+                <div data-ng-if="ucAdvisingResources.ucAdvisingLinks.ucGteformsWorkcenter && api.user.profile.features.csAdvisingGteForms">
+                  <div
+                    data-cc-campus-solutions-link-item-directive
+                    data-link="ucAdvisingResources.ucAdvisingLinks.ucGteformsWorkcenter"
+                    data-text="Student Forms"
+                  ></div>
+                </div>
+                <div data-ng-if="ucAdvisingResources.ucAdvisingLinks.ucAcademicPlanner">
+                  <div
+                    data-cc-campus-solutions-link-item-directive
+                    data-link="ucAdvisingResources.ucAdvisingLinks.ucAcademicPlanner"
+                  ></div>
+                </div>
+              </td>
+            </tr>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17782
https://jira.berkeley.edu/browse/SISRP-17783

Two new links on student overview card:
* 'GTE Forms' if feature flag cs_advising_gte_forms is true (GoLive 5.6)
* 'Academic Planner' by student_uid w/ underlying feature flag hook

Template gets a bit of cleanup, too.