### PR TITLE
SISRP-18523, storeUserAsRecent on-click from search results, before view-as

### DIFF
--- a/app/controllers/stored_users_controller.rb
+++ b/app/controllers/stored_users_controller.rb
@@ -7,17 +7,22 @@ class StoredUsersController < ApplicationController
 
   def get
     authorize_query_stored_users current_user
-    users_found = User::StoredUsers.get(current_user.real_user_id)
+    users_found = User::StoredUsers.get current_user.real_user_id
     render json: { users: users_found }.to_json
   end
 
   def store_saved_uid
-    response = User::StoredUsers.store_saved_uid(current_user.real_user_id, params['uid'])
+    response = User::StoredUsers.store_saved_uid current_user.real_user_id, uid_param
+    render json: response.to_json
+  end
+
+  def store_recent_uid
+    response = User::StoredUsers.store_recent_uid current_user.real_user_id, uid_param
     render json: response.to_json
   end
 
   def delete_saved_uid
-    response = User::StoredUsers.delete_saved_uid(current_user.real_user_id, params['uid'])
+    response = User::StoredUsers.delete_saved_uid current_user.real_user_id, uid_param
     render json: response.to_json
   end
 
@@ -33,6 +38,10 @@ class StoredUsersController < ApplicationController
 
   private
 
+  def uid_param
+    params.require 'uid'
+  end
+
   def error_response
    result = { success: false, message: 'Please provide a numeric UID.' }
     respond_with(result) do |format|
@@ -42,7 +51,7 @@ class StoredUsersController < ApplicationController
 
   def numeric_uid?
     begin
-      Integer(params['uid'], 10)
+      Integer(uid_param, 10)
     rescue ArgumentError
       error_response
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,10 +132,11 @@ Calcentral::Application.routes.draw do
   get '/api/search_users/id_or_name/:input' => 'search_users#by_id_or_name', :defaults => { :format => 'json' }
 
   # View-as endpoints
-  get '/stored_users' => 'stored_users#get', :via => :get, :defaults => { :format => 'json' }
+  get '/api/view_as/my_stored_users' => 'stored_users#get', :defaults => { :format => 'json' }
+  post '/api/view_as/store_user_as_saved' => 'stored_users#store_saved_uid', defaults: { format: 'json' }
+  post '/api/view_as/store_user_as_recent' => 'stored_users#store_recent_uid', defaults: { format: 'json' }
   post '/act_as' => 'act_as#start'
   post '/stop_act_as' => 'act_as#stop'
-  post '/store_user/saved' => 'stored_users#store_saved_uid', via: :post, defaults: { format: 'json' }
   post '/delete_user/saved' => 'stored_users#delete_saved_uid', via: :post, defaults: { format: 'json' }
   post '/delete_users/recent' => 'stored_users#delete_all_recent', via: :post, defaults: { format: 'json' }
   post '/delete_users/saved' => 'stored_users#delete_all_saved', via: :post, defaults: { format: 'json' }

--- a/spec/controllers/stored_users_controller_spec.rb
+++ b/spec/controllers/stored_users_controller_spec.rb
@@ -1,23 +1,16 @@
 describe StoredUsersController do
 
-  before do
-    session['user_id'] = '1234'
-    User::Auth.stub(:where).and_return([User::Auth.new(uid: '1234', is_superuser: true, active: true)])
-  end
-
   let(:error_response) do
     {
       'success' => false,
       'message' => 'Please provide a numeric UID.'
     }
   end
-
   let(:success_response) do
       {
         'success' => true
       }
   end
-
   let(:users_found) do
     {
       :saved => [
@@ -32,85 +25,104 @@ describe StoredUsersController do
       ]
     }
   end
+  let(:session_user_id) { random_id }
+
+  before do
+    session['user_id'] = session_user_id
+    allow(User::Auth).to receive(:where).and_return [ User::Auth.new(uid: session_user_id, is_superuser: true, active: true) ]
+  end
 
   describe '#get' do
-
     it 'should return stored users' do
-      User::StoredUsers.should_receive(:get).with('1234').and_return(users_found)
+      User::StoredUsers.should_receive(:get).with(session_user_id).and_return users_found
 
       get :get
-      expect(response.status).to eq(200)
-      json_response = JSON.parse(response.body)
-      expect(json_response['users']).to be_an_instance_of Hash
-      expect(json_response['users']['saved']).to be_an_instance_of Array
-      expect(json_response['users']['recent']).to be_an_instance_of Array
+      expect(response).to be_success
+      json_response = JSON.parse response.body
+      expect(json_response['users']).to be_a Hash
+      expect(json_response['users']['saved']).to be_an Array
+      expect(json_response['users']['recent']).to be_an Array
       expect(json_response['users']['saved'][0]['ldap_uid']).to eq '1'
       expect(json_response['users']['recent'][0]['ldap_uid']).to eq '2'
     end
-
   end
 
   describe '#store_saved_uid' do
-
     it 'should return error_response on invalid uid' do
       post :store_saved_uid, { format: 'json', uid: 'not_numeric' }
-      expect(response.status).to eq(400)
-      json_response = JSON.parse(response.body)
-      expect(json_response['success']).to eq false
+      expect(response.status).to eq 400
+      json_response = JSON.parse response.body
+      expect(json_response['success']).to be false
       expect(json_response['message']).to eq 'Please provide a numeric UID.'
     end
 
     it 'should return success_response on valid uid' do
-      User::StoredUsers.should_receive(:store_saved_uid).with('1234', '100').and_return(success_response)
+      User::StoredUsers.should_receive(:store_saved_uid).with(session_user_id, '100').and_return success_response
 
       post :store_saved_uid, { format: 'json', uid: '100' }
-      expect(response.status).to eq(200)
-      json_response = JSON.parse(response.body)
-      expect(json_response['success']).to eq true
+      expect(response).to be_success
+      json_response = JSON.parse response.body
+      expect(json_response['success']).to be true
+    end
+  end
+
+  describe '#store_recent_uid' do
+    it 'should return error_response on invalid uid' do
+      post :store_recent_uid, { format: 'json', uid: 'not_numeric' }
+      expect(response.status).to eq 400
+      json_response = JSON.parse response.body
+      expect(json_response['success']).to be false
+      expect(json_response['message']).to eq 'Please provide a numeric UID.'
     end
 
+    it 'should return success_response on valid uid' do
+      User::StoredUsers.should_receive(:store_recent_uid).with(session_user_id, '100').and_return success_response
+
+      post :store_recent_uid, { format: 'json', uid: '100' }
+      expect(response).to be_success
+      json_response = JSON.parse response.body
+      expect(json_response['success']).to be true
+    end
   end
 
   describe '#delete_saved_uid' do
-
     it 'should return error_response on invalid uid' do
       post :delete_saved_uid, { format: 'json', uid: 'not_numeric' }
-      expect(response.status).to eq(400)
-      json_response = JSON.parse(response.body)
-      expect(json_response['success']).to eq false
+      expect(response.status).to eq 400
+      json_response = JSON.parse response.body
+      expect(json_response['success']).to be false
       expect(json_response['message']).to eq 'Please provide a numeric UID.'
     end
 
     it 'should return success_response on valid uid' do
-      User::StoredUsers.should_receive(:delete_saved_uid).with('1234', '100').and_return(success_response)
+      User::StoredUsers.should_receive(:delete_saved_uid).with(session_user_id, '100').and_return success_response
 
       post :delete_saved_uid, { format: 'json', uid: '100' }
-      expect(response.status).to eq(200)
-      json_response = JSON.parse(response.body)
-      expect(json_response['success']).to eq true
+      expect(response).to be_success
+      json_response = JSON.parse response.body
+      expect(json_response['success']).to be true
     end
-
   end
 
   describe '#delete_all_recent' do
     it 'should return success_response' do
-      User::StoredUsers.should_receive(:delete_all_recent).with('1234').and_return(success_response)
+      User::StoredUsers.should_receive(:delete_all_recent).with(session_user_id).and_return success_response
 
       post :delete_all_recent, { format: 'json' }
-      expect(response.status).to eq(200)
-      json_response = JSON.parse(response.body)
-      expect(json_response['success']).to eq true
+      expect(response).to be_success
+      json_response = JSON.parse response.body
+      expect(json_response['success']).to be true
     end
   end
 
   describe '#delete_all_saved' do
     it 'should return success_response' do
-      User::StoredUsers.should_receive(:delete_all_saved).with('1234').and_return(success_response)
+      User::StoredUsers.should_receive(:delete_all_saved).with(session_user_id).and_return success_response
 
       post :delete_all_saved, { format: 'json' }
-      expect(response.status).to eq(200)
-      json_response = JSON.parse(response.body)
-      expect(json_response['success']).to eq true
+      expect(response).to be_success
+      json_response = JSON.parse response.body
+      expect(json_response['success']).to be true
     end
   end
 

--- a/spec/features/act_as_user_spec.rb
+++ b/spec/features/act_as_user_spec.rb
@@ -1,18 +1,18 @@
-feature "act_as_user" do
+feature 'act_as_user' do
   before do
-    @target_uid = "978966"
+    @target_uid = '978966'
     @fake_events_list = GoogleApps::EventsList.new(fake: true)
     User::Auth.new_or_update_superuser! '238382'
     User::Auth.new_or_update_superuser! '2040'
     User::Data.create({uid: '238382'})
     User::Data.create({uid: '2040'})
-    Settings.features.stub(:reauthentication).and_return(false)
+    allow(Settings.features).to receive(:reauthentication).and_return false
   end
 
   scenario 'switch to another user and back while using a super-user' do
     # disabling the cache_warmer while we're switching back and forth between users
     # The switching back triggers a cache invalidation, while the warming thread is still running.
-    Cache::UserCacheWarmer.stub(:warm).and_return(nil)
+    allow(Cache::UserCacheWarmer).to receive(:warm).and_return nil
     login_with_cas '238382'
     suppress_rails_logging {
       act_as_user '2040'
@@ -28,21 +28,21 @@ feature "act_as_user" do
     response = JSON.parse(page.body)
     response['isLoggedIn'].should be_truthy
     response['uid'].should == '238382'
-    visit '/stored_users'
+    visit '/api/view_as/my_stored_users'
     response = JSON.parse(page.body)
     response['users']['recent'][0]['ldap_uid'].should == '2040'
   end
 
-  scenario "make sure admin users can act as a user who has never signed in before" do
-    Cache::UserCacheWarmer.stub(:warm).and_return(nil)
-    super_user_uid = "238382"
+  scenario 'make sure admin users can act as a user who has never signed in before' do
+    allow(Cache::UserCacheWarmer).to receive(:warm).and_return nil
+    super_user_uid = '238382'
     act_as_uid = @target_uid
     # act_as user has never logged in
     User::Data.where(:uid => act_as_uid).first.should be_nil
     # log into CAS with the super user
     login_with_cas super_user_uid
     # stub out the environment, faking as production
-    Settings.application.stub(:layer).and_return("production")
+    allow(Settings.application).to receive(:layer).and_return 'production'
     # make the act_as request
     page.driver.post '/act_as', {:uid => act_as_uid}
     # failing attempts will redirect to the root_path, giving a 302 statusCode
@@ -51,13 +51,13 @@ feature "act_as_user" do
   end
 
 
-  scenario "make sure admin users don't modify database records of the users they view" do
-    Cache::UserCacheWarmer.stub(:warm).and_return(nil)
+  scenario 'make sure admin users don\'t modify database records of the users they view' do
+    allow(Cache::UserCacheWarmer).to receive(:warm).and_return nil
 
-    # you don't want the admin user to record a first log for a "viewed as" user that does not exist in the database
+    # you don't want the admin user to record a first log for a 'viewed as' user that does not exist in the database
     impossible_uid = '78903478484358033984502345858034583043548034580'
     User::Data.where(:uid => impossible_uid).should be_empty
-    login_with_cas "238382" # super user
+    login_with_cas '238382' # super user
     suppress_rails_logging {
       act_as_user impossible_uid
     }
@@ -65,16 +65,16 @@ feature "act_as_user" do
     page.status_code.should == 204
     User::Data.where(:uid => impossible_uid).should be_empty
 
-    # you don't want the admin user to record a visit that's wasn't really made by the "viewed as" user
+    # you don't want the admin user to record a visit that's wasn't really made by the 'viewed as' user
     visit '/api/my/status'
     page.status_code.should == 200
     User::Visit.where(:uid => '4').should be_empty
 
-    # you don't want the admin user to delete an existing "viewed as" user's data row
-    viewed_user_uid = "2040"
+    # you don't want the admin user to delete an existing 'viewed as' user's data row
+    viewed_user_uid = '2040'
     User::Data.where(:uid => viewed_user_uid).should_not be_empty
     suppress_rails_logging {
-      act_as_user "2040"
+      act_as_user '2040'
     }
     page.driver.post '/api/my/opt_out'
     page.status_code.should == 403
@@ -83,134 +83,133 @@ feature "act_as_user" do
     viewed_user.uid.should == viewed_user_uid
   end
 
-  scenario "check the footer message for a user that has logged in" do
+  scenario 'check the footer message for a user that has logged in' do
     # disabling the cache_warmer while we're switching back and forth between users
     # The switching back triggers a cache invalidation, while the warming thread is still running.
-    Cache::UserCacheWarmer.stub(:warm).and_return(nil)
+    allow(Cache::UserCacheWarmer).to receive(:warm).and_return nil
 
-    login_with_cas "238382"
+    login_with_cas '238382'
     act_as_user '2040'
 
     page.driver.post '/api/my/record_first_login'
     page.status_code.should == 204
 
-    visit "/api/my/status"
+    visit '/api/my/status'
     response = JSON.parse(page.body)
     response['uid'].should == '2040'
     response['firstLoginAt'].should be_nil
 
-    # visit "/settings"
+    # visit '/settings'
     # html = page.body
     # page.body.should =~ /You're currently viewing as.+first logged in on/m
     # Note: it's possible to check for hardcoded text with regular expressions on the
     # rendered html, but there's no apparent way to detect the text rendered by angular
   end
 
-  scenario "check the footer message for a user that has never logged in" do
-    target_uid = "211159"
-    login_with_cas "238382"
+  scenario 'check the footer message for a user that has never logged in' do
+    target_uid = '211159'
+    login_with_cas '238382'
     act_as_user target_uid
 
     page.driver.post '/api/my/record_first_login'
     page.status_code.should == 204
 
-    visit "/api/my/status"
+    visit '/api/my/status'
     response = JSON.parse(page.body)
     response['uid'].should == target_uid
     response['firstLoginAt'].should be_nil
 
-    # visit "/settings"
+    # visit '/settings'
     # html = page.body
     # page.body.should =~ /You're currently viewing as.+who has never logged in to CalCentral/m
     # Note: it's possible to check for hardcoded text with regular expressions on the
     # rendered html, but there's no apparent way to detect the text rendered by angular
   end
 
-  scenario "check the act-as footer text" do
+  scenario 'check the act-as footer text' do
     # disabling the cache_warmer while we're switching back and forth between users
     # The switching back triggers a cache invalidation, while the warming thread is still running.
-    Cache::UserCacheWarmer.stub(:warm).and_return(nil)
-    login_with_cas "238382"
-    act_as_user "2040"
-    visit "/api/my/status"
+    allow(Cache::UserCacheWarmer).to receive(:warm).and_return nil
+    login_with_cas '238382'
+    act_as_user '2040'
+    visit '/api/my/status'
     response = JSON.parse(page.body)
-    response["isLoggedIn"].should be_truthy
-    response["uid"].should == "2040"
+    response['isLoggedIn'].should be_truthy
+    response['uid'].should == '2040'
 
-    act_as_user "978966"
-    visit "/api/my/status"
+    act_as_user '978966'
+    visit '/api/my/status'
     response = JSON.parse(page.body)
-    response["isLoggedIn"].should be_truthy
-    response["uid"].should == "978966"
+    response['isLoggedIn'].should be_truthy
+    response['uid'].should == '978966'
 
-    act_as_user "211159"
-    visit "/api/my/status"
+    act_as_user '211159'
+    visit '/api/my/status'
     response = JSON.parse(page.body)
-    response["isLoggedIn"].should be_truthy
-    response["uid"].should == "211159"
+    response['isLoggedIn'].should be_truthy
+    response['uid'].should == '211159'
 
     # make sure you can act-as someone with no user_auth record
-    act_as_user "904715"
-    visit "/api/my/status"
+    act_as_user '904715'
+    visit '/api/my/status'
     response = JSON.parse(page.body)
-    response["isLoggedIn"].should be_truthy
-    response["uid"].should == "904715"
+    response['isLoggedIn'].should be_truthy
+    response['uid'].should == '904715'
 
     stop_act_as_user
-    visit "/api/my/status"
+    visit '/api/my/status'
     response = JSON.parse(page.body)
-    response["isLoggedIn"].should be_truthy
-    response["uid"].should == "238382"
+    response['isLoggedIn'].should be_truthy
+    response['uid'].should == '238382'
   end
 
-  scenario "provide faulty param while switching users" do
-    Cache::UserCacheWarmer.stub(:warm).and_return(nil)
-    login_with_cas "238382"
+  scenario 'provide faulty param while switching users' do
+    allow(Cache::UserCacheWarmer).to receive(:warm).and_return nil
+    login_with_cas '238382'
     suppress_rails_logging {
-      act_as_user "gobbly-gook"
+      act_as_user 'gobbly-gook'
     }
-    visit "/api/my/status"
+    visit '/api/my/status'
     response = JSON.parse(page.body)
-    response["isLoggedIn"].should be_truthy
-    response["uid"].should == "238382"
+    response['isLoggedIn'].should be_truthy
+    response['uid'].should == '238382'
   end
 
-  scenario "making sure act_as doesn't expose google data", :testext => true do
-    Cache::UserCacheWarmer.stub(:warm).and_return(nil)
-    GoogleApps::Proxy.stub(:access_granted?).and_return(true)
-    GoogleApps::EventsList.stub(:new).and_return(@fake_events_list)
+  scenario 'making sure act_as doesn\'t expose google data', :testext => true do
+    allow(Cache::UserCacheWarmer).to receive(:warm).and_return nil
+    allow(GoogleApps::Proxy).to receive(:access_granted?).and_return true
+    allow(GoogleApps::EventsList).to receive(:new).and_return @fake_events_list
     %w(238382 2040 11002820).each do |user|
       login_with_cas user
-      visit "/api/my/up_next"
+      visit '/api/my/up_next'
       response = JSON.parse(page.body)
-      response["items"].empty?.should be_falsey
+      response['items'].empty?.should be_falsey
       Rails.cache.exist?(UpNext::MyUpNext.cache_key(user)).should be_truthy
     end
-    login_with_cas "238382"
-    act_as_user "2040"
-    visit "/api/my/up_next"
+    login_with_cas '238382'
+    act_as_user '2040'
+    visit '/api/my/up_next'
     response = JSON.parse(page.body)
-    response["items"].empty?.should be_truthy
+    response['items'].empty?.should be_truthy
   end
 
-  context "with an invalid user" do
+  context 'with an invalid user' do
     before do
       fake_uid_proxy = CalnetCrosswalk::ByUid.new
       allow(fake_uid_proxy).to receive(:lookup_ldap_uid).and_return(nil)
       allow(CalnetCrosswalk::ByUid).to receive(:new).and_return(fake_uid_proxy)
     end
-    scenario "make sure you cannot act as an invalid user" do
-      Cache::UserCacheWarmer.stub(:warm).and_return(nil)
-      invalid_uid = "89923458987947"
-      login_with_cas "238382"
+    scenario 'make sure you cannot act as an invalid user' do
+      allow(Cache::UserCacheWarmer).to receive(:warm).and_return nil
+      invalid_uid = '89923458987947'
+      login_with_cas '238382'
       suppress_rails_logging {
         act_as_user invalid_uid
       }
-      visit "/api/my/status"
+      visit '/api/my/status'
       response = JSON.parse(page.body)
-      response["isLoggedIn"].should be_truthy
-      response["uid"].should == "238382"
+      response['isLoggedIn'].should be_truthy
+      response['uid'].should == '238382'
     end
   end
 end
-

--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -31,11 +31,12 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
   };
 
   var loadProfile = function() {
+    var targetUserUid = $routeParams.uid;
     advisingFactory.getStudent({
-      uid: $routeParams.uid
+      uid: targetUserUid
     }).success(function(data) {
       angular.extend($scope.targetUser, _.get(data, 'attributes'));
-      $scope.targetUser.ldapUid = $routeParams.uid;
+      $scope.targetUser.ldapUid = targetUserUid;
       $scope.targetUser.addresses = apiService.profile.fixFormattedAddresses(_.get(data, 'contacts.feed.student.addresses'));
       $scope.targetUser.phones = _.get(data, 'contacts.feed.student.phones');
       $scope.targetUser.emails = _.get(data, 'contacts.feed.student.emails');
@@ -44,7 +45,7 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
       apiService.util.setTitle($scope.targetUser.defaultName);
       // Get links to advising resources
       advisingFactory.getAdvisingResources({
-        uid: $routeParams.uid
+        uid: targetUserUid
       }).then(function(data) {
         $scope.ucAdvisingResources = _.get(data, 'data.feed.ucAdvisingResources');
       });

--- a/src/assets/javascripts/angular/controllers/widgets/userSearchController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/userSearchController.js
@@ -48,6 +48,11 @@ angular.module('calcentral.controllers').controller('UserSearchController', func
       // Normalize user's person name for the UI.
       user.name = user.name || (user[firstName] || '').concat(' ', user[lastName] || '');
 
+      user.storeAsRecent = function() {
+        adminFactory.storeUserAsRecent({
+          uid: adminService.getLdapUid(user)
+        });
+      };
       user.save = function() {
         adminFactory.storeUser({
           uid: adminService.getLdapUid(user)

--- a/src/assets/javascripts/angular/factories/adminFactory.js
+++ b/src/assets/javascripts/angular/factories/adminFactory.js
@@ -15,8 +15,9 @@ angular.module('calcentral.factories').factory('adminFactory', function(apiServi
   var stopActAsUrl = '/stop_act_as';
   var stopAdvisorActAsUrl = '/stop_advisor_act_as';
   var stopDelegateActAsUrl = '/stop_delegate_act_as';
-  var storedUsersUrl = '/stored_users';
-  var storeSavedUserUrl = '/store_user/saved';
+  var storedUsersUrl = '/api/view_as/my_stored_users';
+  var storeSavedUserUrl = '/api/view_as/store_user_as_saved';
+  var storeRecentUserUrl = '/api/view_as/store_user_as_recent';
   var deleteSavedUserUrl = '/delete_user/saved';
   var deleteAllRecentUsersUrl = '/delete_users/recent';
   var deleteAllSavedUsersUrl = '/delete_users/saved';
@@ -65,6 +66,10 @@ angular.module('calcentral.factories').factory('adminFactory', function(apiServi
     return $http.post(storeSavedUserUrl, options);
   };
 
+  var storeUserAsRecent = function(options) {
+    return $http.post(storeRecentUserUrl, options);
+  };
+
   var deleteUser = function(options) {
     return $http.post(deleteSavedUserUrl, options);
   };
@@ -89,6 +94,7 @@ angular.module('calcentral.factories').factory('adminFactory', function(apiServi
     stopAdvisorActAs: stopAdvisorActAs,
     stopDelegateActAs: stopDelegateActAs,
     storeUser: storeUser,
+    storeUserAsRecent: storeUserAsRecent,
     userLookup: userLookup,
     searchUsers: searchUsers,
     userLookupByUid: userLookupByUid

--- a/src/assets/templates/widgets/toolbox/user_search_results.html
+++ b/src/assets/templates/widgets/toolbox/user_search_results.html
@@ -14,7 +14,7 @@
     <ul class="cc-widget-list">
       <li data-ng-repeat="user in userSearch.selectedTab.users | limitTo: userSearch.selectedTab.label == 'Search' ? searchResultsViewLimit : ''">
         <div class="cc-user-search-item cc-clearfix">
-          <a href="/user/overview/{{user.ldap_uid}}">
+          <a href="/user/overview/{{user.ldap_uid}}" data-ng-click="user.storeAsRecent()">
             <span data-ng-bind="user.name" data-ng-if="user.name"></span>
           </a>
           (<span data-ng-bind="user.student_id"></span>)


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-18523

Notes:
* get and post stored_users grouped in routes under `/api/view_as/`
* in user-search-results we `storeAsRecent()` on-click to see user overview
* spec tidying