### PR TITLE
SISRP-18651 Add grade option, units, email address to campus roster feed

### DIFF
--- a/app/controllers/campus_rosters_controller.rb
+++ b/app/controllers/campus_rosters_controller.rb
@@ -15,7 +15,7 @@ class CampusRostersController < RostersController
 
   # GET /api/academics/rosters/campus/:campus_course_id
   def get_feed
-    feed = Rosters::Campus.new(session['user_id'], course_id: params['campus_course_id']).get_feed_filtered
+    feed = Rosters::Campus.new(session['user_id'], course_id: params['campus_course_id']).get_feed
     render :json => feed.to_json
   end
 

--- a/app/controllers/canvas_rosters_controller.rb
+++ b/app/controllers/canvas_rosters_controller.rb
@@ -18,7 +18,7 @@ class CanvasRostersController < RostersController
 
   # GET /api/academics/rosters/canvas/:canvas_course_id
   def get_feed
-    feed = Rosters::Canvas.new(session['user_id'], course_id: canvas_course_id).get_feed_filtered
+    feed = Rosters::Canvas.new(session['user_id'], course_id: canvas_course_id).get_feed
     render :json => feed.to_json
   end
 

--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -245,6 +245,7 @@ module EdoOracle
     # EDO equivalent of CampusOracle::Queries.get_enrolled_students
     # Changes:
     #   - 'ccn' replaced by 'section_id' argument
+    #   - 'pnp_flag' replaced by 'grading_basis'
     #   - 'term_yr' and 'term_yr' replaced by 'term_id'
     #   - 'calcentral_student_info_vw' data (first_name, last_name, student_email_address,
     #     affiliations) are not present as these are provided by the CalNet LDAP or HubEdos module.
@@ -254,7 +255,8 @@ module EdoOracle
           enroll."CAMPUS_UID" AS ldap_uid,
           enroll."STUDENT_ID" AS student_id,
           enroll."STDNT_ENRL_STATUS_CODE" AS enroll_status,
-          trim(enroll."GRADING_BASIS_CODE") AS pnp_flag
+          enroll."UNITS_TAKEN" AS units,
+          TRIM(enroll."GRADING_BASIS_CODE") AS grading_basis
         FROM SISEDO.ENROLLMENTV00_VW enroll
         WHERE
           enroll."CLASS_SECTION_ID" = '#{section_id}' AND

--- a/app/models/rosters/campus.rb
+++ b/app/models/rosters/campus.rb
@@ -55,6 +55,9 @@ module Rosters
                 section_ccns: [section[:ccn]]
               })
             end
+            if enr[:grade_option].present? && enr[:units].to_f.nonzero?
+              campus_enrollment_map[enr[:ldap_uid]].merge! enr.slice(:grade_option, :units)
+            end
           end
         end
       end

--- a/app/models/rosters/common.rb
+++ b/app/models/rosters/common.rb
@@ -22,13 +22,6 @@ module Rosters
       end
     end
 
-    # Serves feed without student email address included
-    def get_feed_filtered
-      feed = get_feed
-      feed[:students].each {|student| student.delete(:email) }
-      feed
-    end
-
     # Serves rosters in CSV format
     def get_csv
       CSV.generate do |csv|
@@ -85,6 +78,8 @@ module Rosters
           attrs[:email] = attrs.delete :email_address
           if (enrollment_row = enrollments_by_uid[attrs[:ldap_uid]].first)
             attrs[:enroll_status] = enrollment_row['enroll_status']
+            attrs[:grade_option] = Berkeley::GradeOptions.grade_option_from_basis enrollment_row['grading_basis']
+            attrs[:units] = enrollment_row['units'].to_s
           end
         end
       end

--- a/public/dummy/json/campus_rosters.json
+++ b/public/dummy/json/campus_rosters.json
@@ -1,0 +1,102 @@
+{
+  "campus_course": {
+    "id": "econ-100b-2016-D",
+    "name": "Economic Analysis--Macro"
+  },
+  "sections": [
+    {
+      "ccn": "14299",
+      "name": "ECON 100B LEC 001"
+    },
+    {
+      "ccn": "14300",
+      "name": "ECON 100B DIS 101"
+    },
+    {
+      "ccn": "14301",
+      "name": "ECON 100B DIS 102"
+    }
+  ],
+  "students": [
+    {
+      "email": "aaaa@berkeley.edu",
+      "enroll_status": "E",
+      "first_name": "PQQOTEQ",
+      "grade_option": "Letter",
+      "id": "11111111",
+      "last_name": "TITTEFWT",
+      "login_id": "11111111",
+      "photo": "/campus/econ-100b-2016-D/photo/11111111",
+      "profile_url": "https://calnet.berkeley.edu/directory/details.pl?uid=11111111",
+      "section_ccns": [
+        "14299",
+        "14300"
+      ],
+      "sections": [
+        {
+          "ccn": "14299",
+          "name": "ECON 100B LEC 001"
+        },
+        {
+          "ccn": "14300",
+          "name": "ECON 100B DIS 101"
+        }
+      ],
+      "student_id": "44444444",
+      "units": "4.0"
+    },
+    {
+      "email": "bbbb@berkeley.edu",
+      "enroll_status": "W",
+      "first_name": "OTQQ",
+      "grade_option": "Letter",
+      "id": "222222222",
+      "last_name": "SEFTT",
+      "login_id": "222222222",
+      "profile_url": "https://calnet.berkeley.edu/directory/details.pl?uid=222222222",
+      "section_ccns": [
+        "14299",
+        "14300"
+      ],
+      "sections": [
+        {
+          "ccn": "14299",
+          "name": "ECON 100B LEC 001"
+        },
+        {
+          "ccn": "14300",
+          "name": "ECON 100B DIS 101"
+        }
+      ],
+      "student_id": "555555",
+      "units": "4.0"
+    },
+    {
+      "email": "cccc@berkeley.edu",
+      "enroll_status": "E",
+      "first_name": "WWORRR",
+      "grade_option": "P/NP",
+      "id": "333333",
+      "last_name": "LBBERRR",
+      "login_id": "333333",
+      "photo": "/campus/econ-100b-2016-D/photo/333333",
+      "profile_url": "https://calnet.berkeley.edu/directory/details.pl?uid=333333",
+      "section_ccns": [
+        "14299",
+        "14301"
+      ],
+      "sections": [
+        {
+          "ccn": "14299",
+          "name": "ECON 100B LEC 001"
+        },
+        {
+          "ccn": "14301",
+          "name": "ECON 100B DIS 102"
+        }
+      ],
+      "student_id": "66666",
+      "units": "4.0"
+    }
+  ]
+}

--- a/spec/controllers/campus_rosters_controller_spec.rb
+++ b/spec/controllers/campus_rosters_controller_spec.rb
@@ -29,7 +29,7 @@ describe CampusRostersController do
   context "when serving course rosters feed" do
 
     it_should_behave_like "an api endpoint" do
-      before { allow_any_instance_of(Rosters::Campus).to receive(:get_feed_filtered).and_raise(RuntimeError, "Something went wrong") }
+      before { allow_any_instance_of(Rosters::Campus).to receive(:get_feed).and_raise(RuntimeError, "Something went wrong") }
       let(:make_request) { get :get_feed, campus_course_id: campus_course_id }
     end
 

--- a/spec/controllers/canvas_rosters_controller_spec.rb
+++ b/spec/controllers/canvas_rosters_controller_spec.rb
@@ -107,7 +107,7 @@ describe CanvasRostersController do
   context 'when serving course rosters feed' do
 
     it_should_behave_like 'an api endpoint' do
-      before { allow_any_instance_of(Rosters::Canvas).to receive(:get_feed_filtered).and_raise(RuntimeError, 'Something went wrong') }
+      before { allow_any_instance_of(Rosters::Canvas).to receive(:get_feed).and_raise(RuntimeError, 'Something went wrong') }
       let(:make_request) { get :get_feed, canvas_course_id: 'embedded' }
     end
 

--- a/spec/models/edo_oracle/queries_spec.rb
+++ b/spec/models/edo_oracle/queries_spec.rb
@@ -165,7 +165,7 @@ describe EdoOracle::Queries, :ignore => true do
   end
 
   describe '.get_enrolled_students', :textext => true do
-    let(:expected_keys) { ['ldap_uid', 'student_id', 'enroll_status', 'pnp_flag'] }
+    let(:expected_keys) { ['ldap_uid', 'student_id', 'enroll_status', 'units', 'grading_basis'] }
     it 'returns enrollments for section' do
       results = EdoOracle::Queries.get_enrolled_students(section_ids[0], fall_term_id)
       results.each do |enrollment|

--- a/spec/models/rosters/common_spec.rb
+++ b/spec/models/rosters/common_spec.rb
@@ -26,6 +26,7 @@ describe Rosters::Common do
           ],
           :photo => '/canvas/1/photo/9016',
           :profile_url => 'http://example.com/courses/733/users/9016',
+          :units => '4.0'
         },
         {
           :enroll_status => 'W',
@@ -41,6 +42,7 @@ describe Rosters::Common do
           ],
           :photo => '/canvas/1/photo/9017',
           :profile_url => 'http://example.com/courses/733/users/9017',
+          :units => '3.0'
         },
         {
           :enroll_status => 'C',
@@ -55,6 +57,7 @@ describe Rosters::Common do
           ],
           :photo => '/canvas/1/photo/9018',
           :profile_url => 'http://example.com/courses/733/users/9018',
+          :units => '3.0'
         },
       ]
     }
@@ -63,16 +66,6 @@ describe Rosters::Common do
 
   context 'when serving roster feed based content' do
     before { allow_any_instance_of(Rosters::Common).to receive(:get_feed_internal).and_return(fake_feed) }
-
-    describe '#get_feed_filtered' do
-      it 'should return feed without student email addresses' do
-        feed = subject.get_feed_filtered
-        feed[:students].length.should == 3
-        expect(feed[:students][0].has_key?(:email)).to eq false
-        expect(feed[:students][1].has_key?(:email)).to eq false
-        expect(feed[:students][2].has_key?(:email)).to eq false
-      end
-    end
 
     describe '#get_csv' do
       it "returns rosters csv" do


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-18651

- Add grade option and units to enrollment query and roster feed, making sure the graded component is the section used;
- Stop filtering out email addresses;
- Clear up some existing confusion in the enrollment query between legacy 'pnp_flag' and new 'grading_basis.'