### PR TITLE
SISRP-17895 Adapt CollegeAndLevel to end of Bear Facts data

### DIFF
--- a/app/models/berkeley/term_codes.rb
+++ b/app/models/berkeley/term_codes.rb
@@ -35,6 +35,15 @@ module Berkeley
       self.from_edo_id(edo_term_id).values_at(:term_yr, :term_cd).join '-'
     end
 
+    # Campus Solutions tends to call terms '2016 Fall' instead of the more idiomatic 'Fall 2016'.
+    def normalized_english(term_name)
+      if term_name.present? && (m = term_name.strip.match /\A(\d{4})\s(\w+)\Z/)
+        "#{m[2]} #{m[1]}"
+      else
+        term_name
+      end
+    end
+
     def to_english(term_yr, term_cd)
       term = codes[term_cd.to_sym]
       unless term

--- a/app/models/campus_solutions/billing.rb
+++ b/app/models/campus_solutions/billing.rb
@@ -20,14 +20,9 @@ module CampusSolutions
     end
 
     def normalize_term_names(billing)
-      # Force four-digit year to the end of the term description if present at the start.
-      if (term_name = billing['SUMMARY']['CURRENT_TERM']) && (m = term_name.strip.match /\A(\d{4})\s(\w+)\Z/)
-        billing['SUMMARY']['CURRENT_TERM'] = "#{m[2]} #{m[1]}"
-      end
+      billing['SUMMARY']['CURRENT_TERM'] = Berkeley::TermCodes.normalized_english billing['SUMMARY']['CURRENT_TERM']
       billing['ACTIVITY'].each do |activity_item|
-        if (term_name = activity_item['ITEM_TERM_DESCRIPTION']) && (m = term_name.strip.match /\A(\d{4})\s(\w+)\Z/)
-          activity_item['ITEM_TERM_DESCRIPTION'] = "#{m[2]} #{m[1]}"
-        end
+        activity_item['ITEM_TERM_DESCRIPTION'] = Berkeley::TermCodes.normalized_english activity_item['ITEM_TERM_DESCRIPTION']
       end
     end
 

--- a/app/models/campus_solutions/enrollment_term.rb
+++ b/app/models/campus_solutions/enrollment_term.rb
@@ -21,7 +21,7 @@ module CampusSolutions
       if enrollment_term['SCHEDULE_OF_CLASSES_PERIOD']
         format_cs_datetime(enrollment_term['SCHEDULE_OF_CLASSES_PERIOD'], '%Y-%m-%d')
       end
-      normalize_term_name enrollment_term
+      enrollment_term['TERM_DESCR'] = Berkeley::TermCodes.normalized_english enrollment_term['TERM_DESCR']
       {
         enrollment_term: enrollment_term
       }
@@ -31,13 +31,6 @@ module CampusSolutions
       if hash['DATETIME']
         hash['DATE'] = format_date strptime_in_time_zone(hash['DATETIME'], format)
         hash.delete 'DATETIME'
-      end
-    end
-
-    def normalize_term_name(enrollment_term)
-      # Force four-digit year to the end of the term description if present at the start.
-      if (term_name = enrollment_term['TERM_DESCR']) && (m = term_name.strip.match /\A(\d{4})\s(\w+)\Z/)
-        enrollment_term['TERM_DESCR'] = "#{m[2]} #{m[1]}"
       end
     end
 

--- a/app/models/my_academics/gpa_units.rb
+++ b/app/models/my_academics/gpa_units.rb
@@ -5,6 +5,7 @@ module MyAcademics
     include User::Student
 
     def merge(data)
+      # TODO This needs to be term-based, like CollegeAndLevel.
       data[:gpaUnits] = if legacy_user?
         oracle_gpa_units
       else

--- a/app/models/my_academics/transition_term.rb
+++ b/app/models/my_academics/transition_term.rb
@@ -3,6 +3,10 @@ module MyAcademics
     include AcademicsModule
     include ClassLogger
 
+    # TODO This class collapses two different feeds based on two different data sources and used in two different APIs. Fix!
+
+    # This is included in the MyAcademics::Merged feed, with transition-term based on what's in
+    # MyAcademics::CollegeAndLevel, and used to decide the currency of My Academics / Profile.
     def merge(data)
       college_and_level = data[:collegeAndLevel]
       if college_and_level && !college_and_level[:empty] && !college_and_level[:noStudentId]
@@ -16,7 +20,11 @@ module MyAcademics
       end
     end
 
+    # This is called directly from MyBadges::StudentInfo, with transition-term currently
+    # determined by whether CalCentral's "current" term differs from the BearFacts "current" term.
+    # It is displayed in My Academics / Status, Holds, and Blocks and in the Status popover.
     def regstatus_feed
+      # TODO LEGACY ONLY! Must be replaced before Settings.terms.legacy_cutoff.
       response = Regstatus::Proxy.new(user_id: @uid).get
       if response && response[:feed] && (reg_status = response[:feed]['regStatus'])
         {
@@ -29,6 +37,7 @@ module MyAcademics
     def transition_term(college_and_level)
       bucket = profile_bucket college_and_level
       return nil if bucket == 'current'
+      # TODO Replace by a flag within the CollegeAndLevel data structure.
       if feed = regstatus_feed
         feed.merge(isProfileCurrent: (bucket != 'past'))
       end

--- a/app/models/my_badges/student_info.rb
+++ b/app/models/my_badges/student_info.rb
@@ -8,6 +8,7 @@ module MyBadges
     end
 
     def get
+      # TODO THIS IS CURRENTLY COMPLETELY DEPENDENT ON LEGACY SYSTEMS AND WILL BREAK FOR ALL STUDENTS AS OF FALL 2016
       campus_attributes = CampusOracle::UserAttributes.new(user_id: @uid).get_feed
       result = {
         isLawStudent: law_student?,
@@ -55,6 +56,8 @@ module MyBadges
       end
     end
 
+    # "Holds" (the replacement for "Blocks" in the new SIS) are obtained by front-end code directly from a
+    # Campus Solutions API.
     def get_reg_blocks
       blocks_feed = Bearfacts::Regblocks.new({user_id: @uid}).get
       response = blocks_feed.slice(:empty, :errored, :noStudentId).merge({

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -424,6 +424,7 @@ features:
   class_enrollment_summer_2016: false
   course_manage_official_sections: false
   cs_academic_planner: false
+  cs_academic_profile_prefers_legacy: true
   cs_academic_progress_report: false
   cs_advising_gte_forms: false
   cs_advising_scheduler_view: false

--- a/src/assets/javascripts/angular/controllers/pages/academicsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicsController.js
@@ -135,6 +135,7 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
     $scope.isLSStudent = academicsService.isLSStudent($scope.collegeAndLevel);
     $scope.isUndergraduate = _.includes(_.get($scope.collegeAndLevel, 'careers'), 'Undergraduate');
     $scope.isProfileCurrent = !$scope.transitionTerm || $scope.transitionTerm.isProfileCurrent;
+    // The isEmpty check will be true if collegeAndLevel.errored or collegeAndLevel.empty.
     $scope.showProfileMessage = (!$scope.isProfileCurrent || !$scope.collegeAndLevel || _.isEmpty($scope.collegeAndLevel.careers));
 
     $scope.hasTeachingClasses = academicsService.hasTeachingClasses(data.teachingSemesters);


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17895

This preserves the current client-server contracts and front-end logic, although both are in desperate need of refactoring.

Next feeds which need to learn about life-after-BearFacts: GPA and StudentInfo (AKA RegStatus).