### PR TITLE
SISRP-18730 - Create Back-End for Get FPP Enrollment API using Mock Fixture

### DIFF
--- a/app/controllers/campus_solutions/fpp_enrollment_controller.rb
+++ b/app/controllers/campus_solutions/fpp_enrollment_controller.rb
@@ -1,0 +1,12 @@
+module CampusSolutions
+  class FppEnrollmentController < CampusSolutionsController
+
+    include DisallowAdvisorViewAs
+    include DisallowClassicViewAs
+
+    def get
+      json_passthrough CampusSolutions::FppEnrollment
+    end
+
+  end
+end

--- a/app/models/campus_solutions/fpp_enrollment.rb
+++ b/app/models/campus_solutions/fpp_enrollment.rb
@@ -1,0 +1,26 @@
+module CampusSolutions
+  class FppEnrollment < GlobalCachedProxy
+
+    include BillingFeatureFlagged
+
+    def initialize(options = {})
+      super options
+      initialize_mocks if @fake
+    end
+
+    def xml_filename
+      'fpp_enrollment.xml'
+    end
+
+    def build_feed(response)
+      return {} if response.parsed_response.blank?
+      response.parsed_response
+    end
+
+    #TODO: Replace with actual API endpoint when ready.
+    def url
+      "#{@settings.base_url}/UC_FPP_ENROLLMENT_API.v1/UC_FPP_ENROLLMENT_API_GET"
+    end
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,6 +188,7 @@ Calcentral::Application.routes.draw do
   get '/api/campus_solutions/ferpa_deeplink' => 'campus_solutions/ferpa_deeplink#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/billing' => 'campus_solutions/billing#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/slr_deeplink' => 'campus_solutions/slr_deeplink#get', :via => :get, :defaults => { :format => 'json' }
+  get '/api/campus_solutions/fpp_enrollment' => 'campus_solutions/fpp_enrollment#get', :via => :get, :defaults => { :format => 'json' }
   post '/api/campus_solutions/address' => 'campus_solutions/address#post', :via => :post, :defaults => { :format => 'json' }
   post '/api/campus_solutions/email' => 'campus_solutions/email#post', :via => :post, :defaults => { :format => 'json' }
   post '/api/campus_solutions/person_name' => 'campus_solutions/person_name#post', :via => :post, :defaults => { :format => 'json' }

--- a/fixtures/xml/campus_solutions/fpp_enrollment.xml
+++ b/fixtures/xml/campus_solutions/fpp_enrollment.xml
@@ -1,0 +1,7 @@
+<UC_SF_FPP_ENROLL>
+  <FPP_ENROLL_URL>
+    <NAME>Activate Fee Payment Plan</NAME>
+    <URL>https://bcs-web-dev-02.is.berkeley.edu:8443/psc/bcscfg/EMPLOYEE/HRMS/c/SA_LEARNER_SERVICES.SSF_SS_PPL_ENRL.GBL</URL>
+    <IS_CS_LINK type="boolean">true</IS_CS_LINK>
+  </FPP_ENROLL_URL>
+</UC_SF_FPP_ENROLL>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-18730

Question regarding `CampusSolutions::GlobalCachedProxy`:
I can't think of a use case in which an invalid ID-less call would be made on this endpoint, especially since we are disallowing delegate and act-as access to this endpoint.  Can someone enlighten me as to the use of this passthrough in this specific case?