### PR TITLE
SISRP-16402 Expose CS "Law" affiliation (of limited use at present)

### DIFF
--- a/app/models/user/aggregated_attributes.rb
+++ b/app/models/user/aggregated_attributes.rb
@@ -3,7 +3,7 @@ module User
     include CampusSolutions::ProfileFeatureFlagged
 
     # Conservative merge of roles from EDO
-    WHITELISTED_EDO_ROLES = [:student, :applicant, :advisor]
+    WHITELISTED_EDO_ROLES = [:student, :applicant, :advisor, :law]
 
     def initialize(uid, options={})
       super(uid, options)


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-16402

This will be our third way of identifying Law students, and it's the one of least utility, since it isn't explicitly tied to a particular academic term. The other two (term-specific) sources are already in use in production:

* MyBadges::StudentInfo (derived from MyAcademics::CollegeAndLevel)
* CampusSolutions::EnrollmentTerms'
