### PR TITLE
SISRP-18516 Class Info enrollment tab front end

### DIFF
--- a/src/assets/javascripts/angular/configuration/routeConfiguration.js
+++ b/src/assets/javascripts/angular/configuration/routeConfiguration.js
@@ -36,6 +36,10 @@ angular.module('calcentral.config').config(function($routeProvider) {
     templateUrl: 'academics_classinfo.html',
     controller: 'AcademicsController'
   }).
+  when('/academics/teaching-semester/:teachingSemesterSlug/class/:classSlug/:category', {
+    templateUrl: 'academics_classinfo.html',
+    controller: 'AcademicsController'
+  }).
   when('/calcentral_update', {
     templateUrl: 'calcentral_update.html',
     controller: 'CalCentralUpdateController'

--- a/src/assets/javascripts/angular/controllers/pages/academicsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicsController.js
@@ -56,6 +56,34 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
     $scope.previousNextSemesterShow = (nextSemesterCompare || previousSemesterCompare);
   };
 
+  var setClassInfoCategories = function(teachingSemester) {
+    $scope.classInfoCategories = [
+      {
+        'title': 'Class Info',
+        'path': null
+      }
+    ];
+    if (teachingSemester) {
+      if (apiService.user.profile.features.classInfoEnrollmentTab && teachingSemester.campusSolutionsTerm) {
+        $scope.classInfoCategories.push({
+          'title': 'Enrollment',
+          'path': 'enrollment'
+        });
+      }
+      $scope.classInfoCategories.push({
+        'title': 'Roster',
+        'path': 'roster'
+      });
+    }
+    if ($routeParams.category) {
+      $scope.currentCategory = _.find($scope.classInfoCategories, {
+        'path': $routeParams.category
+      });
+    } else {
+      $scope.currentCategory = $scope.classInfoCategories[0];
+    }
+  };
+
   var fillSemesterSpecificPage = function(semesterSlug, data) {
     var isOnlyInstructor = !!$routeParams.teachingSemesterSlug;
     var selectedStudentSemester = academicsService.findSemester(data.semesters, semesterSlug, selectedStudentSemester);
@@ -114,6 +142,8 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
       $scope.selectedCourseCountSchedules = academicsService.countSectionItem($scope.selectedCourse, 'schedules');
       $scope.selectedCourseCountScheduledSections = academicsService.countSectionItem($scope.selectedCourse);
       $scope.selectedCourseLongInstructorsList = ($scope.selectedCourseCountScheduledSections > 5) || ($scope.selectedCourseCountInstructors > 10);
+
+      setClassInfoCategories(selectedTeachingSemester);
     }
   };
 
@@ -185,13 +215,6 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
         $scope.enrollmentVerificationLink = 'http://registrar.berkeley.edu/academic-records/verification-enrollment-degrees';
       }
     }
-  };
-
-  $scope.currentSelection = 'Class Info';
-  $scope.selectOptions = ['Class Info', 'Class Roster'];
-
-  $scope.switchSelectedOption = function(selectedOption) {
-    $scope.currentSelection = selectedOption;
   };
 
   // Wait until user profile is fully loaded before hitting academics data

--- a/src/assets/javascripts/angular/controllers/widgets/classInfoEnrollmentController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/classInfoEnrollmentController.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var angular = require('angular');
+var _ = require('lodash');
+
+angular.module('calcentral.controllers').controller('ClassInfoEnrollmentController', function(rosterFactory, $scope) {
+  var partitionStudentsByEnrollmentStatus = function() {
+    var partitions = _.partition($scope.students, {
+      'enroll_status': 'E'
+    });
+    $scope.enrolledStudents = partitions[0];
+    $scope.waitlistedStudents = partitions[1];
+  };
+
+  var getStudents = function() {
+    rosterFactory.getRoster('campus', $scope.campusCourseId).success(function(data) {
+      angular.extend($scope, data);
+      partitionStudentsByEnrollmentStatus();
+    }).error(function(data, status) {
+      angular.extend($scope, data);
+      $scope.errorStatus = status;
+    });
+  };
+
+  getStudents();
+});

--- a/src/assets/javascripts/angular/directives/academicsClassInfoEnrollmentDirective.js
+++ b/src/assets/javascripts/angular/directives/academicsClassInfoEnrollmentDirective.js
@@ -1,0 +1,34 @@
+/* jshint camelcase: false */
+'use strict';
+
+var angular = require('angular');
+
+angular.module('calcentral.directives').directive('ccAcademicsClassInfoEnrollmentDirective', function() {
+  return {
+    scope: true,
+    link: function(scope, elem, attrs) {
+      scope.studentInSectionFilter = function(student) {
+        return (!scope.selectedSection || student.section_ccns.indexOf(scope.selectedSection.ccn) !== -1);
+      };
+
+      scope.$watch(
+        function() {
+          return scope.$eval(attrs.students);
+        },
+        function(newValue) {
+          scope.students = newValue;
+        }
+      );
+
+      scope.seatsAvailable = scope.$eval(attrs.seatsAvailable);
+      scope.showPosition = scope.$eval(attrs.showPosition);
+      scope.studentRole = (attrs.title === 'Wait List') ? 'waitlisted' : 'enrolled';
+      scope.tableSort = {
+        'column': (scope.showPosition ? 'waitlist_position' : 'last_name'),
+        'reverse': false
+      };
+      scope.title = attrs.title;
+    },
+    templateUrl: 'directives/academics_class_info_enrollment.html'
+  };
+});

--- a/src/assets/javascripts/angular/directives/sortableColumnDirective.js
+++ b/src/assets/javascripts/angular/directives/sortableColumnDirective.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var angular = require('angular');
+
+angular.module('calcentral.directives').directive('ccSortableColumnDirective', function() {
+  return {
+    scope: true,
+    link: function(scope, elem, attrs) {
+      scope.sortAttribute = attrs.ccSortableColumnDirective;
+      scope.columnHeading = attrs.columnHeading;
+      scope.applySort = function(sortAttribute) {
+        scope.tableSort.reverse = (scope.tableSort.column === sortAttribute ? !scope.tableSort.reverse : false);
+        scope.tableSort.column = sortAttribute;
+      };
+    },
+    templateUrl: 'directives/sortable_column.html'
+  };
+});

--- a/src/assets/stylesheets/_academics.scss
+++ b/src/assets/stylesheets/_academics.scss
@@ -64,8 +64,35 @@
     margin-bottom: 10px;
     margin-top: 0;
   }
+  .cc-academics-class-enrollment-select {
+    margin: 5px;
+    width: 50%;
+  }
+  .cc-academics-class-enrollment-table {
+    margin: 10px 0;
+  }
+  .cc-academics-class-enrollment-table-head {
+    background-color: $cc-color-light-medium-grey;
+    margin: 5px;
+    th {
+      color: $cc-color-white;
+      padding: 5px;
+    }
+  }
+  .cc-academics-class-enrollment-table-row {
+    td {
+      padding: 5px;
+    }
+  }
+  .cc-academics-class-enrollment-text {
+    font-size: 13px;
+  }
   .cc-academics-class-info {
     margin-bottom: 10px;
+  }
+  .cc-academics-class-info-category-button {
+    display: inline-block;
+    text-align: center;
   }
   .cc-academics-class-primary-row {
     font-weight: bold;
@@ -243,7 +270,7 @@
   .cc-academics-teaching-button-group {
     float: right;
     margin-right: 10px;
-    width: 200px;
+    width: 300px;
   }
   .cc-academics-teaching-class {
     font-size: 12px;

--- a/src/assets/stylesheets/_useful.scss
+++ b/src/assets/stylesheets/_useful.scss
@@ -35,6 +35,9 @@
 .cc-clearfix-container:after {
   clear: both;
 }
+.cc-clickable {
+  cursor: pointer;
+}
 .cc-ellipsis {
   display: block;
   overflow: hidden;
@@ -51,6 +54,11 @@
 }
 .cc-inline-block {
   display: inline-block;
+}
+// As distinct from cc-visuallyhidden, this does not display but takes up space; useful for show/hide without layout jitters.
+.cc-invisible {
+  cursor: default;
+  visibility: hidden;
 }
 .cc-italic {
   font-style: italic;

--- a/src/assets/templates/academics_classinfo.html
+++ b/src/assets/templates/academics_classinfo.html
@@ -2,7 +2,7 @@
   class="cc-page-academics"
   data-cc-spinner-directive
   data-ng-show="canViewAcademics"
-  data-ng-switch data-on="currentSelection"
+  data-ng-switch data-on="currentCategory.title"
 >
   <div>
     <h1 class="cc-heading-page-title">
@@ -11,15 +11,16 @@
       <span data-ng-bind="selectedCourse.course_code"></span>
       <span data-ng-if="selectedSection" data-ng-bind-template=" &raquo; {{selectedSection.section_label}}"></span>
       <div class="cc-academics-teaching-button-group" data-ng-if="isInstructorOrGsi">
-        <ul class="cc-button-group cc-even-{{selectOptions.length}}" role="tablist">
-          <li data-ng-repeat="selectOption in selectOptions">
-            <button class="cc-button"
-              data-ng-click="switchSelectedOption(selectOption)"
-              data-ng-class="{'cc-button-selected cc-button-selected-roster':(currentSelection === selectOption)}"
-              aria-selected="{{currentSelection === selectOption}}"
+        <ul class="cc-button-group cc-even-{{classInfoCategories.length}}" role="tablist">
+          <li data-ng-repeat="classInfoCategory in classInfoCategories">
+            <a class="cc-button cc-academics-class-info-category-button"
+              data-cc-accessible-focus-directive=""
+              data-ng-class="{'cc-button-selected cc-button-selected-roster':(currentCategory === classInfoCategory)}"
+              aria-selected="{{currentCategory === classInfoCategory}}"
               role="tab"
-              data-ng-bind="selectOption">
-            </button>
+              data-ng-bind="classInfoCategory.title"
+              data-ng-href="{{selectedCourse.url}}/{{classInfoCategory.path}}">
+            </a>
           </li>
         </ul>
       </div>
@@ -154,13 +155,32 @@
         </div>
       </div>
     </div>
-
   </div>
 
-  <div data-ng-switch-when="Class Roster" role="tabpanel" aria-live="polite" class="cc-clearfix">
+  <div data-ng-switch-when="Enrollment" role="tabpanel" aria-live="polite" class="cc-clearfix" data-ng-controller="ClassInfoEnrollmentController" data-cc-spinner-directive>
+    <div data-ng-if="errorStatus">
+      There was an error retrieving enrollment data.
+    </div>
+    <div class="medium-6 columns cc-academics-row-margin"
+         data-cc-academics-class-info-enrollment-directive
+         data-seats-available="selectedCourse.waitlistLimit"
+         data-show-position="true"
+         data-students="waitlistedStudents"
+         data-title="Wait List"
+    ></div>
+    <div class="medium-6 columns cc-academics-row-margin"
+         data-cc-academics-class-info-enrollment-directive
+         data-seats-available="selectedCourse.enrollLimit"
+         data-show-position="false"
+         data-students="enrolledStudents"
+         data-title="Enrolled"
+    ></div>
+  </div>
+
+  <div data-ng-switch-when="Roster" role="tabpanel" aria-live="polite" class="cc-clearfix">
     <div class="cc-widget">
       <div class="cc-widget-title">
-        <h2>Class Roster</h2>
+        <h2>Roster</h2>
       </div>
       <div data-ng-include src="'canvas_embedded/roster.html'"></div>
     </div>

--- a/src/assets/templates/directives/academics_class_info_enrollment.html
+++ b/src/assets/templates/directives/academics_class_info_enrollment.html
@@ -1,0 +1,59 @@
+<div class="cc-widget">
+  <div class="cc-widget-title">
+    <h2 class="cc-left" data-ng-bind="title"></h2>
+    <div class="cc-select cc-right cc-academics-class-enrollment-select">
+      <label for="section-select" class="cc-visuallyhidden">Filter by Section</label>
+      <select id="section-select" class="cc-roster-select bc-canvas-embedded-roster-select"
+              data-ng-options="section as section.name for section in sections track by section.ccn"
+              data-ng-model="selectedSection"
+              data-ng-change="accessibilityAnnounce('Enrollment filtered by section')">
+        <option value="">All Sections</option>
+      </select>
+    </div>
+  </div>
+  <div class="cc-widget-padding">
+    <div class="cc-academics-class-enrollment-text">
+      Total: <strong data-ng-bind="students.length"></strong> |
+      Available: <strong data-ng-bind="seatsAvailable"></strong>
+    </div>
+    <div class="cc-table cc-academics-class-enrollment-table">
+      <table>
+        <thead class="cc-academics-class-enrollment-table-head">
+          <th data-ng-show="showPosition" data-cc-sortable-column-directive="waitlist_position" data-column-heading="Pos"></th>
+          <th data-cc-sortable-column-directive="last_name" data-column-heading="Name"></th>
+          <th data-cc-sortable-column-directive="units" data-column-heading="Units"></th>
+          <th data-cc-sortable-column-directive="grade_option" data-column-heading="Grade"></th>
+          <th data-cc-sortable-column-directive="student_id" data-column-heading="SID"></th>
+        </thead>
+        <tbody data-ng-repeat="student in filteredStudents = (students | filter:studentInSectionFilter | orderBy:tableSort.column:tableSort.reverse)"
+               data-ng-class-even="'cc-academics-even'"
+               data-ng-if="students.length">
+          <tr class="cc-academics-class-enrollment-table-row">
+            <td data-ng-if="showPosition">
+              <strong data-ng-bind="student.waitlist_position"></strong>
+            </td>
+            <td>
+              <a data-ng-if="student.email" data-ng-href="mailto:{{student.email}}">
+                <span data-ng-bind="student.last_name"></span>,
+                <span data-ng-bind="student.first_name"></span>
+              </a>
+              <div data-ng-if="!student.email">
+                <span data-ng-bind="student.last_name"></span>,
+                <span data-ng-bind="student.first_name"></span>
+              </div>
+            </td>
+            <td data-ng-bind="student.units"></td>
+            <td data-ng-bind="student.grade_option"></td>
+            <td data-ng-bind="student.student_id"></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="cc-academics-class-enrollment-text" data-ng-if="!students.length">
+      No students are currently <span data-ng-bind="studentRole"></span> in this class.
+    </div>
+    <div class="cc-academics-class-enrollment-text" data-ng-if="students.length && !filteredStudents.length">
+      No students are currently <span data-ng-bind="studentRole"></span> in this section.
+    </div>
+  </div>
+</div>

--- a/src/assets/templates/directives/sortable_column.html
+++ b/src/assets/templates/directives/sortable_column.html
@@ -1,0 +1,4 @@
+<div class="cc-clickable" data-ng-click="applySort(sortAttribute)" data-cc-accessible-focus-directive>
+  <span data-ng-bind="columnHeading"></span>
+  <span class="fa" data-ng-class="{'cc-invisible': (tableSort.column !== sortAttribute), 'fa-caret-down': !tableSort.reverse, 'fa-caret-up': tableSort.reverse}"></span>
+</div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-18516

Class Info pages for instructors get a new "Enrollment" tab between "Class Info" and "Roster," if it's a Campus Solutions term and the feature flag is turned on. Per requirements, each tab position gets its own URL, and tabs are changed from buttons to links.

Enrollment and waitlist summaries surface the fields we can currently get without database overhead (name, SID, email, units and grade option). More fields may come later. Tables are sortable and reverse-sortable by column, and like rosters can be filtered by section.