### PR TITLE
SISRP-18763, refactor out snake_case in search_users, uid_lookup and view_as templates

### DIFF
--- a/app/controllers/stored_users_controller.rb
+++ b/app/controllers/stored_users_controller.rb
@@ -7,8 +7,10 @@ class StoredUsersController < ApplicationController
 
   def get
     authorize_query_stored_users current_user
-    users_found = User::StoredUsers.get current_user.real_user_id
-    render json: { users: users_found }.to_json
+    saved_and_recent = User::StoredUsers.get current_user.real_user_id
+    camelize saved_and_recent[:saved]
+    camelize saved_and_recent[:recent]
+    render json: { users: saved_and_recent }.to_json
   end
 
   def store_saved_uid
@@ -40,6 +42,10 @@ class StoredUsersController < ApplicationController
 
   def uid_param
     params.require 'uid'
+  end
+
+  def camelize(users)
+    users.map! { |user| HashConverter.camelize user } if users
   end
 
   def error_response

--- a/spec/controllers/stored_users_controller_spec.rb
+++ b/spec/controllers/stored_users_controller_spec.rb
@@ -38,12 +38,12 @@ describe StoredUsersController do
 
       get :get
       expect(response).to be_success
-      json_response = JSON.parse response.body
-      expect(json_response['users']).to be_a Hash
-      expect(json_response['users']['saved']).to be_an Array
-      expect(json_response['users']['recent']).to be_an Array
-      expect(json_response['users']['saved'][0]['ldap_uid']).to eq '1'
-      expect(json_response['users']['recent'][0]['ldap_uid']).to eq '2'
+      users = JSON.parse(response.body)['users']
+      expect(users).to be_a Hash
+      expect(users['saved']).to be_an Array
+      expect(users['recent']).to be_an Array
+      expect(users['saved'][0]['ldapUid']).to eq '1'
+      expect(users['recent'][0]['ldapUid']).to eq '2'
     end
   end
 

--- a/spec/features/act_as_user_spec.rb
+++ b/spec/features/act_as_user_spec.rb
@@ -30,7 +30,7 @@ feature 'act_as_user' do
     response['uid'].should == '238382'
     visit '/api/view_as/my_stored_users'
     response = JSON.parse(page.body)
-    response['users']['recent'][0]['ldap_uid'].should == '2040'
+    response['users']['recent'][0]['ldapUid'].should == '2040'
   end
 
   scenario 'make sure admin users can act as a user who has never signed in before' do

--- a/src/assets/javascripts/angular/controllers/widgets/userSearchController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/userSearchController.js
@@ -41,13 +41,11 @@ angular.module('calcentral.controllers').controller('UserSearchController', func
   };
 
   var decorate = function(users) {
-    var firstName = 'first_name';
-    var lastName = 'last_name';
     var missingName = 'Name Not Provided';
 
     angular.forEach(users, function(user) {
       // Normalize user's person name for the UI.
-      user.name = user.name || user.defaultName || (user[firstName] || '').concat(' ', user[lastName] || '');
+      user.name = user.name || user.defaultName || (user.firstName || '').concat(' ', user.lastName || '');
       // Guard against whitespace-only name.
       if (/^\s+$/.test(user.name)) {
         user.name = missingName;
@@ -82,13 +80,12 @@ angular.module('calcentral.controllers').controller('UserSearchController', func
   var updateSearchedUserSavedStates = function() {
     var searchedUsers = $scope.userSearch.tabs.search.users;
     var savedUsers = $scope.userSearch.tabs.saved.users;
-    var ldapUid = 'ldap_uid';
 
     _(searchedUsers).forEach(function(target) {
       var saved = false;
 
       _(savedUsers).forEach(function(source) {
-        if (target[ldapUid] === source[ldapUid]) {
+        if (adminService.getLdapUid(target) === adminService.getLdapUid(source)) {
           saved = true;
           // Exit the loop
           return false;

--- a/src/assets/templates/widgets/toolbox/uid_lookup.html
+++ b/src/assets/templates/widgets/toolbox/uid_lookup.html
@@ -25,8 +25,8 @@
           </thead>
           <tbody data-ng-repeat="user in admin.users">
             <tr>
-              <td data-ng-bind="user.ldap_uid"></td>
-              <td data-ng-bind="user.student_id || 'This user has no SID'"></td>
+              <td data-ng-bind="user.ldapUid"></td>
+              <td data-ng-bind="user.studentId || 'This user has no SID'"></td>
             </tr>
           </tbody>
         </table>

--- a/src/assets/templates/widgets/toolbox/user_search_results.html
+++ b/src/assets/templates/widgets/toolbox/user_search_results.html
@@ -16,10 +16,10 @@
     <ul class="cc-widget-list">
       <li data-ng-repeat="user in userSearch.selectedTab.users | limitTo: userSearch.selectedTab.label == 'Search' ? searchResultsViewLimit : ''">
         <div class="cc-user-search-item cc-clearfix">
-          <a href="/user/overview/{{user.ldap_uid}}" data-ng-click="user.storeAsRecent()">
+          <a href="/user/overview/{{user.ldapUid}}" data-ng-click="user.storeAsRecent()">
             <span data-ng-bind="user.name" data-ng-if="user.name"></span>
           </a>
-          (<span data-ng-bind="user.student_id"></span>)
+          (<span data-ng-bind="user.studentId"></span>)
           <div class="cc-right">
             <button class="cc-button-star" title="Delete {{user.name}}" type="button" data-ng-click="user.delete()" data-ng-if="user.saved">
               <span class="cc-visuallyhidden">Delete</span>

--- a/src/assets/templates/widgets/toolbox/view_as.html
+++ b/src/assets/templates/widgets/toolbox/view_as.html
@@ -25,8 +25,8 @@
       <div class="cc-toolbox-user-section">
         <ul data-ng-repeat="user in admin.userPool" data-ng-if="admin.userPool">
           <li>
-            UID: <button class="cc-button-link" data-ng-bind="user.ldap_uid" data-ng-click="admin.actAsUser(user)"></button>
-            (SID: <span data-ng-bind="user.student_id || 'none'"></span>)
+            UID: <button class="cc-button-link" data-ng-bind="user.ldapUid" data-ng-click="admin.actAsUser(user)"></button>
+            (SID: <span data-ng-bind="user.studentId || 'none'"></span>)
           </li>
         </ul>
       </div>
@@ -57,19 +57,19 @@
                 <tr data-ng-repeat="user in block.users track by $index">
                   <td class="cc-table-top-border">
                     <span class="cc-visuallyhidden">Act as </span>
-                    <button type="submit" class="cc-button-link" data-ng-click="admin.updateIDField(user.ldap_uid)" data-ng-bind="user.ldap_uid"></button>
+                    <button type="submit" class="cc-button-link" data-ng-click="admin.updateIDField(user.ldapUid)" data-ng-bind="user.ldapUid"></button>
                   </td>
                   <td class="cc-table-top-border">
-                    <span data-ng-bind="user.student_id || 'none'"></span>
+                    <span data-ng-bind="user.studentId || 'none'"></span>
                   </td>
                   <td class="cc-table-top-border cc-table-ellipsis">
-                    <span data-ng-if="!user.first_name || !user.last_name">none</span>
-                    <span data-ng-if="user.first_name && user.last_name" data-ng-bind="user.first_name"></span>
-                    <span data-ng-if="user.last_name && user.last_name" data-ng-bind="user.last_name"></span>
+                    <span data-ng-if="!user.firstName || !user.lastName">none</span>
+                    <span data-ng-if="user.firstName && user.lastName" data-ng-bind="user.firstName"></span>
+                    <span data-ng-if="user.lastName && user.lastName" data-ng-bind="user.lastName"></span>
                   </td>
                   <td class="cc-table-right cc-table-top-border">
-                    <span data-ng-if="block.storeUser && !user.saved"><button type="button" class="cc-button-link" data-ng-click="block.storeUser(user)">save <span class="cc-visuallyhidden" data-ng-bind="'UID ' + user.ldap_uid"></span></button></span>
-                    <span data-ng-if="block.clearUser"><button type="button" class="cc-button-link" data-ng-click="block.clearUser(user)">delete <span class="cc-visuallyhidden" data-ng-bind="'UID ' + user.ldap_uid"></span></button></span>
+                    <span data-ng-if="block.storeUser && !user.saved"><button type="button" class="cc-button-link" data-ng-click="block.storeUser(user)">save <span class="cc-visuallyhidden" data-ng-bind="'UID ' + user.ldapUid"></span></button></span>
+                    <span data-ng-if="block.clearUser"><button type="button" class="cc-button-link" data-ng-click="block.clearUser(user)">delete <span class="cc-visuallyhidden" data-ng-bind="'UID ' + user.ldapUid"></span></button></span>
                   </td>
                 </tr>
               </tbody>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-18763

The view-as templates have had a lot snake_case (e.g., ldap_uid). The work on Advisor student lookup has, at times, followed the same snake_case pattern because of shared code, causing bugs like SISRP-18763. It's time to refactor away the bad pattern.