### PR TITLE
SISRP-18781 Enable SSL TLSv1.2 protocol for textbooks API, etc.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,9 @@ gem 'active_attr', '~> 0.8.5'
 # for production deployment
 gem 'jruby-activemq', '~> 5.13.0', git: 'https://github.com/ets-berkeley-edu/jruby-activemq.git'
 
+# To support TLSv1.2
+gem 'jruby-openssl', '~> 0.9.16'
+
 # Addressable is a replacement for the URI implementation that is part of Ruby's standard library.
 # https://github.com/sporkmonger/addressable
 gem 'addressable', '~> 2.3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.0)
       railties (>= 3.2.16)
+    jruby-openssl (0.9.16-java)
     json (1.8.3-java)
     jwt (1.5.4)
     kaminari (0.16.1)
@@ -484,6 +485,7 @@ DEPENDENCIES
   icalendar (~> 2.2.2)
   ims-lti!
   jruby-activemq (~> 5.13.0)!
+  jruby-openssl (~> 0.9.16)
   json (~> 1.8.0)
   link_header (~> 0.0.7)
   log4r (~> 1.1)


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-18781
