### PR TITLE
SISRP-18739, if search input is 'Doe' then search LDAP with *Doe*

### DIFF
--- a/spec/models/calnet_ldap/client_spec.rb
+++ b/spec/models/calnet_ldap/client_spec.rb
@@ -101,13 +101,13 @@ describe CalnetLdap::Client do
       expect(ldap).to receive(:search).exactly(expected_ldap_searches).times.and_return [ double ]
     end
     context 'do not include guest user search' do
-      let(:expected_ldap_searches) { 2 }
+      let(:expected_ldap_searches) { 1 }
       it 'should only ' do
         expect(subject.search_by_name('John Doe', false)).to_not be_empty
       end
     end
     context 'include guest user search' do
-      let(:expected_ldap_searches) { 4 }
+      let(:expected_ldap_searches) { 2 }
       it 'should only ' do
         expect(subject.search_by_name('John Doe', true)).to_not be_empty
       end

--- a/spec/models/user/search_users_by_name_spec.rb
+++ b/spec/models/user/search_users_by_name_spec.rb
@@ -98,7 +98,7 @@ describe User::SearchUsersByName do
         expect(Net::LDAP::Filter).to receive(:eq).with('displayname', 'man* jo*')
         expect(Net::LDAP::Filter).to receive(:eq).with('displayname', 'jo* man*')
         expect(Net::LDAP).to receive(:new).and_return (ldap = double)
-        expect(ldap).to receive(:search).exactly(4).times.and_return []
+        expect(ldap).to receive(:search).exactly(2).times.and_return []
       end
       context 'discard \'Jr.\'' do
         let(:name) { ' man Jr., jo' }


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-18739

Based on feedback from @raydavis and @paulkerschen in PR #5353 

I'm now using `Net::LDAP::Filter.intersect` to construct chain all filters before running the LDAP search. If the input is a single token then the constructed filter is: `first_name=Doe* OR last_name=Doe*`.