### PR TITLE
SISRP-18733 More workarounds for spotty EDO DB data

### DIFF
--- a/app/models/edo_oracle/user_courses/base.rb
+++ b/app/models/edo_oracle/user_courses/base.rb
@@ -72,6 +72,8 @@ module EdoOracle
         course_item = course_ids_from_row row
         if course_item[:id] == previous_item[:id]
           previous_section = previous_item[:sections].last
+          # Odd database joins will occasionally give us null course titles, which we can replace from later rows.
+          previous_item[:name] = row['course_title'] if previous_item[:name].blank?
           # Duplicate CCNs indicate duplicate section listings. The only possibly useful information in these repeated
           # listings is a more relevant associated-primary ID for secondary sections.
           if (row['section_id'].to_s == previous_section[:ccn]) && !to_boolean(row['primary'])

--- a/spec/models/edo_oracle/user_courses/base_spec.rb
+++ b/spec/models/edo_oracle/user_courses/base_spec.rb
@@ -119,6 +119,15 @@ describe EdoOracle::UserCourses::Base do
     it 'de-duplicates sections differing only by primary_associated_section_id' do
       expect(course[:sections].size).to eq 3
     end
+    context 'some rows missing course name' do
+      before do
+        enrollment_query_results.first.delete 'course_title'
+        enrollment_query_results.first.delete 'course_title_short'
+      end
+      it 'prefers present to blank course title' do
+        expect(course[:name]).to eq 'Introduction to Selected Musics of the World'
+      end
+    end
     it 'prefers a primary_associated_section_id matching a section in the result set' do
       expect(course[:sections][2][:associated_primary_id]).to eq '44203'
     end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-18733

Some gymnastics that I wish weren't necessary.

For complex reasons having to do with EDO DB implementation, checking for an 'ACTIVE' status code under ON rather than WHERE will screen out a small class of valid courses that exist in the cross-listing table as 'ACTIVE', but in the course table as 'DEPRECATED'.

However, for complex reasons having to do with EDO DB implementation, rewriting the query in this way will result in duplicate results for a small class of courses that link to both active, correctly formatted department names (e.g., 'PHYS ED') and deprecated, incorrectly formatted department names ('PHYSED') through the course/class translation table.

However, for complex reasons having to do with EDO DB implementation, we can screen out the duplicate results if we drop some of our more specific database-level column ordering. 

Further, for complex reasons having to do with EDO DB implementation, database-level ordering was inconsistent in any case and we're already resorting at a higher level in Ruby. Therefore dropping the database ordering has no impact on UX. 