### PR TITLE
SISRP-16788 - Enrollment - Law: show different text for advisors depending on program

### DIFF
--- a/public/dummy/json/holds_empty.json
+++ b/public/dummy/json/holds_empty.json
@@ -1,0 +1,6 @@
+{
+  "statusCode":200,
+  "feed":{
+    "serviceIndicators":[]
+  }
+}

--- a/public/dummy/json/holds_present.json
+++ b/public/dummy/json/holds_present.json
@@ -1,0 +1,18 @@
+{
+  "statusCode":200,
+  "feed":{
+    "serviceIndicators":[
+      {
+        "serviceIndicatorDescr":"AA - Advising Holds",
+        "startTerm":"2168",
+        "startTermDescr":"2016 Fall",
+        "startDate":null,
+        "reasonDescr":"Advisor Hold",
+        "amount":0.0,
+        "contactName":null,
+        "contactEmail":null,
+        "instructions":"You must see your College advisor immediately."
+      }
+    ]
+  }
+}

--- a/src/assets/javascripts/angular/controllers/widgets/enrollment/enrollmentCardController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/enrollment/enrollmentCardController.js
@@ -108,7 +108,6 @@ angular.module('calcentral.controllers').controller('EnrollmentCardController', 
     } else {
       data.sections = angular.copy(sections);
     }
-
     return data;
   };
 

--- a/src/assets/javascripts/angular/factories/holdsFactory.js
+++ b/src/assets/javascripts/angular/factories/holdsFactory.js
@@ -6,6 +6,8 @@ var angular = require('angular');
  * Holds Factory
  */
 angular.module('calcentral.factories').factory('holdsFactory', function(apiService) {
+  // var url = '/dummy/json/holds_empty.json';
+  // var url = '/dummy/json/holds_present.json';
   var url = '/api/campus_solutions/holds';
 
   var getHolds = function(options) {

--- a/src/assets/stylesheets/_enrollment_card.scss
+++ b/src/assets/stylesheets/_enrollment_card.scss
@@ -6,7 +6,7 @@
     padding-bottom: 0;
   }
   .cc-enrollment-card-advisors-list {
-    margin: 10px 10px 0;
+    margin: 10px 0 0;
     > li {
       &:not(:last-child) {
         margin-bottom: 10px;

--- a/src/assets/templates/widgets/enrollment/adjust.html
+++ b/src/assets/templates/widgets/enrollment/adjust.html
@@ -1,7 +1,7 @@
 <div
   data-cc-enrollment-card-header-directive
   data-count="$index + 1"
-  data-date="{{enrollmentTerm.enrollmentPeriod[0] && !enrollment.isLawStudent ? 'After ' + (enrollmentTerm.enrollmentPeriod[0].date.epoch * 1000 | date:'MMM d'): ''}}"
+  data-date="{{enrollmentTerm.enrollmentPeriod[0] && !enrollmentTerm.isLawStudent ? 'After ' + (enrollmentTerm.enrollmentPeriod[0].date.epoch * 1000 | date:'MMM d'): ''}}"
   data-title="section.title"
 ></div>
 

--- a/src/assets/templates/widgets/enrollment/adjust_enrolled.html
+++ b/src/assets/templates/widgets/enrollment/adjust_enrolled.html
@@ -38,13 +38,13 @@
     data-link="enrollmentTerm.links.gradeBase"
     data-text="Change Grading Option"
     data-cache="enrollment"
-    data-ng-if="enrollmentTerm.isGradeBaseAvailable && !enrollment.isLawStudent"
+    data-ng-if="enrollmentTerm.isGradeBaseAvailable && !enrollmentTerm.isLawStudent"
   ></div>
   <div
     data-cc-campus-solutions-link-item-directive
     data-link="enrollmentTerm.links.withdrawFromSemester"
     data-text="Withdraw"
-    data-ng-if="enrollmentTerm.enrollmentPeriod[0] && !enrollment.isLawStudent"
+    data-ng-if="enrollmentTerm.enrollmentPeriod[0] && !enrollmentTerm.isLawStudent"
     data-cache="enrollment"
   ></div>
 </div>

--- a/src/assets/templates/widgets/enrollment/consult_advisor.html
+++ b/src/assets/templates/widgets/enrollment/consult_advisor.html
@@ -1,34 +1,56 @@
-<div data-cc-spinner-directive="enrollment.holds.isLoading">
+<div class="cc-enrollment-card-advisors-consult" data-cc-spinner-directive="enrollment.holds.isLoading">
+
   <div data-ng-if="enrollment.holds.hasHolds" class="cc-flex">
     <div>
       <i class="fa fa-exclamation-circle cc-icon-red cc-enrollment-card-icon"></i>
     </div>
     <div>
-      You have a hold that may affect your ability to enroll in classes.
-      Consult with an advisor.
+      You have a hold that may affect your ability to enroll in classes. Consult with an advisor.
     </div>
   </div>
-  <div data-ng-if="!enrollment.holds.hasHolds" class="cc-enrollment-card-advisors-consult">
+
+  <div data-ng-if="!enrollment.holds.hasHolds">
     Consult with an advisor if you have any questions.
   </div>
-</div>
 
-<ul class="cc-enrollment-card-advisors-list" data-ng-if="enrollmentTerm.advisors.length && api.user.profile.features.csAdvisingShowAdvisors">
-  <li data-ng-repeat="advisor in enrollmentTerm.advisors">
-    <div>
-      <a
-        data-ng-href="https://calnet.berkeley.edu/directory/details.pl?uid={{advisor.id}}"
-        data-ng-bind="advisor.name"
-      ></a>
-    </div>
-    <div>
-      <span data-ng-bind="advisor.program" class="cc-text-light cc-text-small"></span>
-    </div>
-    <div>
-      <a
-        data-ng-href="mailto:{{advisor.emailAddress}}"
-        data-ng-bind="advisor.emailAddress"
-      ></a>
-    </div>
-  </li>
-</ul>
+  <div data-ng-if="enrollmentTerm.isLawStudent">
+    <ul class="cc-list-bullets">
+      <li>
+        JD students should contact
+        <a href="https://www.law.berkeley.edu/students/student-services/">Student Services</a>.
+      </li>
+      <li>
+        LLM and JSD students should contact the Advanced Degree Program Office at
+        <a href="mailto:llm@law.berkeley.edu">llm@law.berkeley.edu</a>.
+      </li>
+      <li>
+        JSP students should contact Margo Rodriguez at
+        <a href="mailto:mrodriguez@law.berkeley.edu">mrodriguez@law.berkeley.edu</a>.
+      </li>
+    </ul>
+  </div>
+
+  <div data-ng-if="!enrollmentTerm.isLawStudent">
+    <!-- This presentation not yet in use. See SISRP-15831 -->
+    <ul class="cc-enrollment-card-advisors-list" data-ng-if="enrollmentTerm.advisors.length && api.user.profile.features.csAdvisingShowAdvisors">
+      <li data-ng-repeat="advisor in enrollmentTerm.advisors">
+        <div>
+          <a
+            data-ng-href="https://calnet.berkeley.edu/directory/details.pl?uid={{advisor.id}}"
+            data-ng-bind="advisor.name"
+          ></a>
+        </div>
+        <div>
+          <span data-ng-bind="advisor.program" class="cc-text-light cc-text-small"></span>
+        </div>
+        <div>
+          <a
+            data-ng-href="mailto:{{advisor.emailAddress}}"
+            data-ng-bind="advisor.emailAddress"
+          ></a>
+        </div>
+      </li>
+    </ul>
+  </div>
+
+</div>

--- a/src/assets/templates/widgets/enrollment/consult_advisor.html
+++ b/src/assets/templates/widgets/enrollment/consult_advisor.html
@@ -31,7 +31,6 @@
   </div>
 
   <div data-ng-if="!enrollmentTerm.isLawStudent">
-    <!-- This presentation not yet in use. See SISRP-15831 -->
     <ul class="cc-enrollment-card-advisors-list" data-ng-if="enrollmentTerm.advisors.length && api.user.profile.features.csAdvisingShowAdvisors">
       <li data-ng-repeat="advisor in enrollmentTerm.advisors">
         <div>

--- a/src/assets/templates/widgets/enrollment/decide.html
+++ b/src/assets/templates/widgets/enrollment/decide.html
@@ -1,13 +1,13 @@
 <div
   data-cc-enrollment-card-header-directive
   data-count="$index + 1"
-  data-date="{{enrollmentTerm.enrollmentPeriod[0] && !enrollment.isLawStudent ? (enrollmentTerm.enrollmentPeriod[0].date.epoch * 1000 | date:'h:mm a') : ''}}"
-  data-date-important="{{enrollmentTerm.enrollmentPeriod[0] && !enrollment.isLawStudent ? (enrollmentTerm.enrollmentPeriod[0].date.epoch * 1000 | date:'EEE MMM d'): ''}}"
+  data-date="{{enrollmentTerm.enrollmentPeriod[0] && !enrollmentTerm.isLawStudent ? (enrollmentTerm.enrollmentPeriod[0].date.epoch * 1000 | date:'h:mm a') : ''}}"
+  data-date-important="{{enrollmentTerm.enrollmentPeriod[0] && !enrollmentTerm.isLawStudent ? (enrollmentTerm.enrollmentPeriod[0].date.epoch * 1000 | date:'EEE MMM d'): ''}}"
   data-title="section.title"
 ></div>
 
 <div class="cc-enrollment-card-section-content" data-ng-if="section.show">
-  <div data-ng-if="api.user.profile.actAsOptions.canSeeCSLinks && !enrollment.isLawStudent">
+  <div data-ng-if="api.user.profile.actAsOptions.canSeeCSLinks && !enrollmentTerm.isLawStudent">
     <div data-ng-if="enrollmentTerm.isClassScheduleAvailable">
       <span
         data-cc-campus-solutions-link-item-directive
@@ -20,7 +20,7 @@
   <div data-ng-if="!enrollmentTerm.isClassScheduleAvailable">
     Ability to enroll coming soon. Please try again later.
   </div>
-  <div data-ng-if="!enrollment.isLawStudent">
+  <div data-ng-if="!enrollmentTerm.isLawStudent">
     Learn more about <a href="http://registrar.berkeley.edu/Records/tbinfo.html">enrollment rules and information</a>.
   </div>
 
@@ -30,8 +30,8 @@
   </div>
 
   <div data-ng-if="enrollmentTerm.enrollmentPeriod.length">
-    <div data-ng-if="enrollment.isLawStudent" class="cc-enrollment-card-margin-bottom">
-      Enrollment periods are open until add/drop deadline. Maximum unit limits include both enrolled and waitlisted classes.
+    <div data-ng-if="enrollmentTerm.isLawStudent" class="cc-enrollment-card-margin-bottom">
+      Below are your enrollment appointment start times. You will have continuous access to the system until the semester's add/drop deadline:
     </div>
     <h4 class="cc-enrollment-card-headersub-title">Enrollment Period</h4>
     <div class="cc-table">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-16788

* Adds static advisor contact list for display to Berkeley Law students
* Modifies text in appointment time section. Fixes logic for detecting if student is a Law student (see  [SISRP-17895](https://jira.berkeley.edu/browse/SISRP-17895))
* Fixes logic for displaying date in Enrollment Adjust section template, and fixing the exclusion of the 'Change Grading Option' and 'Withdraw' links
* Adds dummy feeds for holdsFactory