### PR TITLE
SISRP-18564, refresh user properties because canSeeCSLinks property is sensitive to the /user/overview route

### DIFF
--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -78,6 +78,8 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
 
   $scope.$on('calcentral.api.user.isAuthenticated', function(event, isAuthenticated) {
     if (isAuthenticated) {
+      // Refresh user properties because the actAsOptions.canSeeCSLinks property is sensitive to the /user/overview route.
+      apiService.user.fetch();
       loadProfile();
       loadAcademics();
     }


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-18564

The Jira description says "reload the page and all is good".  All is good because `apiService.user.fetch()` is invoked where route=`/user/overview`. The canSeeCSLinks property is sensitive to this route and suppresses all CS links.  The snippet below is from *routeConfigurations.js*:
```
  when('/user/overview/:uid', {
    templateUrl: 'user_overview.html',
    controller: 'UserOverviewController',
    isAdvisingStudentLookup: true
  }).
```