### PR TITLE
SISRP-18908 - Return Holds Section to Status, Holds, & Blocks

### DIFF
--- a/src/assets/javascripts/angular/controllers/widgets/academicsStatusHoldsBlocksController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/academicsStatusHoldsBlocksController.js
@@ -15,12 +15,14 @@ angular.module('calcentral.controllers').controller('AcademicsStatusHoldsBlocksC
   $scope.$watchGroup(['studentInfo.regStatus.code', 'api.user.profile.features.csHolds'], function(newValues) {
     var enabledSections = [];
 
-    if (newValues[0] !== null || newValues[1]) {
+    if (newValues[0] !== null) {
       enabledSections.push('Status');
     }
-    if (newValues[2]) {
+
+    if (newValues[1]) {
       enabledSections.push('Holds');
     }
+
     enabledSections.push('Blocks');
 
     $scope.statusHoldsBlocks.enabledSections = enabledSections;


### PR DESCRIPTION
More info at:
https://jira.berkeley.edu/browse/SISRP-18908

I left the whole `$watchGroup` logic in there because I'm not exactly sure how the behavior of `studentInfo.regStatus.code` works over time.

@johncrossman, let me know if I should PR this against QA Branch as well.