### PR TITLE
SISRP-18979, remove hasCanvasAccount which is only used by spec

### DIFF
--- a/app/models/user/api.rb
+++ b/app/models/user/api.rb
@@ -163,7 +163,6 @@ module User
         givenFullName: given_first_name + ' ' + @user_attributes[:familyName],
         isGoogleReminderDismissed: is_google_reminder_dismissed,
         isCalendarOptedIn: is_calendar_opted_in,
-        hasCanvasAccount: Canvas::Proxy.has_account?(@uid),
         hasGoogleAccessToken: GoogleApps::Proxy.access_granted?(@uid),
         hasStudentHistory: has_student_history,
         hasInstructorHistory: has_instructor_history,

--- a/public/dummy/json/status.json
+++ b/public/dummy/json/status.json
@@ -14,7 +14,6 @@
   "fullName": "IWQROE BABTREW",
   "isGoogleReminderDismissed": false,
   "isCalendarOptedIn": false,
-  "hasCanvasAccount": true,
   "hasGoogleAccessToken": false,
   "hasStudentHistory": false,
   "hasInstructorHistory": false,

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -56,7 +56,6 @@ describe User::Api do
     it 'should return a user data structure' do
       api = User::Api.new(uid).get_feed
       expect(api[:preferredName]).to eq preferred_name
-      expect(api[:hasCanvasAccount]).to_not be_nil
       expect(api[:isCalendarOptedIn]).to_not be_nil
       expect(api[:isCampusSolutionsStudent]).to be true
       expect(api[:isDelegateUser]).to be false
@@ -227,14 +226,6 @@ describe User::Api do
 
   context 'session metadata' do
     let(:delegate_students) { {} }
-    it 'should return whether the user is registered with Canvas' do
-      expect(Canvas::Proxy).to receive(:has_account?).and_return(true, false)
-      api = User::Api.new(uid).get_feed
-      expect(api[:hasCanvasAccount]).to be true
-      Rails.cache.clear
-      api = User::Api.new(uid).get_feed
-      expect(api[:hasCanvasAccount]).to be false
-    end
     it 'should have a null first_login time for a new user' do
       api = User::Api.new(uid).get_feed
       expect(api[:firstLoginAt]).to be_nil


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-18979

The May 09 load test failed to complete (twice!) due to max'ing out of db connections, Apache threads, etc. Another symptom: Instructure reported OutOfMemory via Canvas API response. We don't know cause(s) of load test failure yet. But, two CalCentral feeds logged many SLOW PROXYs:
* /api/my/status
* /api/my/activities

In the process of scrutinizing that code I came across the apparently unused `hasCanvasAccount` which I believe is the only Canvas dependency in `/api/my/status`. I see no reason not to remove it.