### PR TITLE
SISRP-18807 Distinguish enrolled courses from zero-position waitlisted courses

### DIFF
--- a/app/models/campus_oracle/user_courses/base.rb
+++ b/app/models/campus_oracle/user_courses/base.rb
@@ -172,6 +172,7 @@ module CampusOracle
         end
         # enroll_status and grade only apply to enrollment records and will be skipped for instructors.
         if row['enroll_status'] == 'W'
+          section_data[:waitlisted] = true
           section_data[:waitlistPosition] = row['wait_list_seq_num'].to_i
           section_data[:enroll_limit] = row['enroll_limit'].to_i
         end

--- a/app/models/edo_oracle/user_courses/base.rb
+++ b/app/models/edo_oracle/user_courses/base.rb
@@ -158,6 +158,7 @@ module EdoOracle
           section_data[:grade] = row['grade'].strip if row['grade'].present?
           section_data[:grading_basis] = row['grading_basis'] if section_data[:is_primary_section]
           if row['enroll_status'] == 'W'
+            section_data[:waitlisted] = true
             section_data[:waitlistPosition] = row['waitlist_position'].to_i
             section_data[:enroll_limit] = row['enroll_limit'].to_i
           end

--- a/app/models/my_classes/campus.rb
+++ b/app/models/my_classes/campus.rb
@@ -57,7 +57,8 @@ module MyClasses
           working_course[:listings].first[:courseCodeSection] = "#{section[:instruction_format]} #{section[:section_number]}"
           working_course[:site_url] << "/#{section[:instruction_format].downcase}-#{section[:section_number]}"
         end
-        if section[:waitlistPosition] && section[:waitlistPosition] > 0
+        if section[:waitlisted] && section[:waitlistPosition] && section[:waitlistPosition] > 0
+          working_course[:waitlisted] = true
           working_course[:enroll_limit] = section[:enroll_limit]
           working_course[:waitlistPosition] = section[:waitlistPosition]
         end

--- a/public/dummy/json/academics.json
+++ b/public/dummy/json/academics.json
@@ -518,6 +518,7 @@
               "schedules": [],
               "section_label": "DIS 005",
               "section_number": "005",
+              "waitlisted": true,
               "waitlistPosition": "3"
             },
             {

--- a/public/dummy/json/academics_transition_future_profile.json
+++ b/public/dummy/json/academics_transition_future_profile.json
@@ -499,6 +499,7 @@
               "schedules": [],
               "section_label": "DIS 005",
               "section_number": "005",
+              "waitlisted": true,
               "waitlistPosition": "3"
             },
             {

--- a/public/dummy/json/academics_transition_past_profile_not_registered.json
+++ b/public/dummy/json/academics_transition_past_profile_not_registered.json
@@ -499,6 +499,7 @@
               "schedules": [],
               "section_label": "DIS 005",
               "section_number": "005",
+              "waitlisted": true,
               "waitlistPosition": "3"
             },
             {

--- a/public/dummy/json/academics_transition_past_profile_registered.json
+++ b/public/dummy/json/academics_transition_past_profile_registered.json
@@ -499,6 +499,7 @@
               "schedules": [],
               "section_label": "DIS 005",
               "section_number": "005",
+              "waitlisted": true,
               "waitlistPosition": "3"
             },
             {

--- a/public/dummy/json/classes.json
+++ b/public/dummy/json/classes.json
@@ -26,6 +26,7 @@
           "schedules": [], "instructors": [{"name": "Gee Esai", "uid": "1111"}]}
       ],
       "role": "Student",
+      "waitlisted": true,
       "waitlistPosition": "2",
       "enroll_limit": "50",
       "emitter": "Campus"
@@ -105,6 +106,7 @@
         }
       ],
       "role": "Student",
+      "waitlisted": true,
       "waitlistPosition": "3",
       "enroll_limit": "20",
       "emitter": "Campus"

--- a/spec/models/campus_oracle/user_courses/all_spec.rb
+++ b/spec/models/campus_oracle/user_courses/all_spec.rb
@@ -94,10 +94,9 @@ describe CampusOracle::UserCourses::All do
     courses = client.get_all_campus_courses
     courses["2014-C"].length.should == 1
     course_primary = courses["2014-C"][0][:sections][0]
-    course_primary[:waitlistPosition].should == 42
-    course_primary[:enroll_limit].should == 5000
-    course_primary[:waitlistPosition].to_s.should == '42'
-    course_primary[:enroll_limit].to_s.should == '5000'
+    expect(course_primary[:waitlisted]).to eq true
+    expect(course_primary[:waitlistPosition]).to eq 42
+    expect(course_primary[:enroll_limit]).to eq 5000
   end
 
   it 'should return a shallower summary of enrollment data on request', :if => CampusOracle::Connection.test_data? do

--- a/spec/models/campus_oracle/user_courses/base_spec.rb
+++ b/spec/models/campus_oracle/user_courses/base_spec.rb
@@ -85,7 +85,12 @@ describe CampusOracle::UserCourses::Base do
           expect(section[:pnp_flag]).to eq enrollment['pnp_flag']
           expect(section[:section_number]).to eq enrollment['section_num']
           expect(section[:units]).to eq enrollment['unit']
-          expect(section[:waitlistPosition]).to eq enrollment['wait_list_seq_num'] if enrollment['enroll_status'] == 'W'
+          if enrollment['enroll_status'] == 'W'
+            expect(section[:waitlisted]).to eq true
+            expect(section[:waitlistPosition]).to eq enrollment['wait_list_seq_num']
+          else
+            expect(section).not_to include :waitlisted
+          end
         end
       end
       it 'includes only non-blank grades' do

--- a/spec/models/edo_oracle/user_courses/base_spec.rb
+++ b/spec/models/edo_oracle/user_courses/base_spec.rb
@@ -148,8 +148,9 @@ describe EdoOracle::UserCourses::Base do
         if enrollment['enroll_status'] == 'W'
           expect(section[:enroll_limit]).to eq enrollment['enroll_limit'].to_i
           expect(section[:waitlistPosition]).to eq enrollment['wait_list_seq_num'].to_i
+          expect(section[:waitlisted]).to eq true
         else
-          expect(section).not_to include(:enroll_limit, :waitlistPosition)
+          expect(section).not_to include(:enroll_limit, :waitlistPosition, :waitlisted)
         end
         expect(section).not_to include :cross_listing_hash
       end
@@ -367,7 +368,7 @@ describe EdoOracle::UserCourses::Base do
             :section_number, :waitlist_limit
           )
           expect(section.keys).to include(:units) if section[:is_primary_section]
-          expect(section.keys).not_to include(:grading_basis, :waitlistPosition)
+          expect(section.keys).not_to include(:grading_basis, :waitlistPosition, :waitlisted)
         end
       end
     end

--- a/spec/models/my_classes/campus_spec.rb
+++ b/spec/models/my_classes/campus_spec.rb
@@ -100,7 +100,7 @@ describe MyClasses::Campus do
           [subject, fake_sections[0..1]].transpose.each do |course, enrollment|
             expect(course[:listings].first[:courseCodeSection]).to eq "#{enrollment[:instruction_format]} #{enrollment[:section_number]}"
             expect(course[:sections][0][:ccn]).to eq enrollment[:ccn]
-            if (enrollment[:waitlistPosition] > 0)
+            if (enrollment[:waitlisted])
               expect(course[:enroll_limit]).to eq enrollment[:enroll_limit]
               expect(course[:waitlistPosition]).to eq enrollment[:waitlistPosition]
             end
@@ -135,6 +135,7 @@ describe MyClasses::Campus do
             pnp_flag: 'N ',
             unit: '2',
             section_number: '021',
+            waitlisted: true,
             waitlistPosition: 2
           },
           {
@@ -145,6 +146,7 @@ describe MyClasses::Campus do
             pnp_flag: 'N ',
             unit: '0',
             section_number: '200',
+            waitlisted: true,
             waitlistPosition: 0
           }
         ]}
@@ -174,6 +176,7 @@ describe MyClasses::Campus do
             is_primary_section: true,
             unit: '2',
             section_number: '021',
+            waitlisted: true,
             waitlistPosition: 2
           },
           {

--- a/src/assets/javascripts/angular/services/academicsService.js
+++ b/src/assets/javascripts/angular/services/academicsService.js
@@ -107,7 +107,7 @@ angular.module('calcentral.services').service('academicsService', function() {
       var sections = [];
       for (var j = 0; j < course.sections.length; j++) {
         var section = course.sections[j];
-        if ((findWaitlisted && section.waitlistPosition) || (!findWaitlisted && !section.waitlistPosition)) {
+        if ((findWaitlisted && section.waitlisted) || (!findWaitlisted && !section.waitlisted)) {
           sections.push(section);
         }
       }

--- a/src/assets/templates/academics_semester_classes.html
+++ b/src/assets/templates/academics_semester_classes.html
@@ -58,7 +58,9 @@
                 </td>
                 <td data-ng-bind="course.title"></td>
                 <td>
-                  <strong data-ng-bind="section.waitlistPosition"></strong> on list of class of <strong data-ng-bind="section.enroll_limit"></strong>
+                  <div data-ng-if="section.waitlisted && section.waitlistPosition">
+                    <strong data-ng-bind="section.waitlistPosition"></strong> on list of class of <strong data-ng-bind="section.enroll_limit"></strong>
+                  </div>
                 </td>
               </tr>
             </tbody>

--- a/src/assets/templates/widgets/my_classes.html
+++ b/src/assets/templates/widgets/my_classes.html
@@ -25,12 +25,12 @@
               <div class="cc-ellipsis cc-widget-classes-title" data-ng-repeat="listing in class.listings">
                 <a data-ng-click="api.analytics.trackExternalLink('My Classes', class.emitter, class.site_url)"
                    data-ng-href="{{class.site_url}}">
-                  <strong data-ng-bind="listing.course_code" data-ng-class="{'cc-italic': class.waitlistPosition}"></strong>
-                  <strong data-ng-bind="listing.courseCodeSection" data-ng-class="{'cc-italic': class.waitlistPosition}"></strong>
+                  <strong data-ng-bind="listing.course_code" data-ng-class="{'cc-italic': class.waitlisted}"></strong>
+                  <strong data-ng-bind="listing.courseCodeSection" data-ng-class="{'cc-italic': class.waitlisted}"></strong>
                 </a>
               </div>
-              <span class="cc-text-light" data-ng-show="class.waitlistPosition" data-ng-bind-template="- #{{ class.waitlistPosition }} on the wait list"></span>
-              <div class="cc-ellipsis cc-text-light cc-widget-classes-subtitle" data-ng-class="{'cc-italic': class.waitlistPosition}" data-ng-show="!!class.name" data-ng-bind="class.name"></div>
+              <span class="cc-text-light" data-ng-show="class.waitlisted" data-ng-bind-template="- #{{ class.waitlistPosition }} on the wait list"></span>
+              <div class="cc-ellipsis cc-text-light cc-widget-classes-subtitle" data-ng-class="{'cc-italic': class.waitlisted}" data-ng-show="!!class.name" data-ng-bind="class.name"></div>
               <ul class="cc-widget-sublist">
                 <li class="cc-widget-icon-container" data-ng-repeat="subclass in class.subclasses">
                   <div class="cc-icon cc-widget-icon" data-ng-class="{'bCourses':'cc-icon-bcourses'}[subclass.emitter]">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-18807

Various bits of CalCentral code have used "has waitlist position of zero?" as shorthand for "is not waitlisted in this section?" This will no longer fly in the EDO DB world, which conceives positionless waitlists for non-enrollment sections. Accordingly we need an explicit `waitlisted` section property.