### PR TITLE
SISRP-19020 - Residency: Haas EWMBA student showing "California Residency" with blank status

### DIFF
--- a/src/assets/templates/academics_status_holds_blocks.html
+++ b/src/assets/templates/academics_status_holds_blocks.html
@@ -30,7 +30,7 @@
               <td colspan="2" data-ng-bind-html="studentInfo.regStatus.explanation"></td>
             </tr>
           </tbody>
-          <tbody data-ng-if="!residency.isLoading">
+          <tbody data-ng-if="!residency.isLoading && residency.description">
             <tr>
               <th class="cc-table-subheader" scope="row">California Residency</th>
               <td>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-19020

Suppresses residency block in template, if `residency.description` is not set by the controller's `parseCalResidency()` function - i.e., when `residency` is empty in the feed.

Also adding spinner for the residency block in loading state and when `residency.description` is not yet set.
