### PR TITLE
CLC-6299, Cal1card::Photo cache.expiration config to 4.hours

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -240,6 +240,8 @@ cache:
     User::AuthenticationValidator: <%= 8.hours %>
     User::AuthenticationValidator::short: <%= 5.minutes %>
     UserApiController: <%= 4.hours %>
+    Cal1card::Photo: <%= 4.hours %>
+
     Canvas::CourseStudents: <%= 15.minutes %>
     Canvas::CourseTeachers: <%= 5.minutes %>
     CanvasBackgroundJobs: <%= 24.hours %>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6299

A little tweak in support of `/api/my/status` performance.