### PR TITLE
CLC-6297, remove 'canvasEmail' from User::Api

### DIFF
--- a/app/models/user/api.rb
+++ b/app/models/user/api.rb
@@ -139,7 +139,6 @@ module User
       first_name = @user_attributes[:firstName]
       last_name = @user_attributes[:lastName]
       google_mail = User::Oauth2Data.get_google_email @uid
-      canvas_mail = User::Oauth2Data.get_canvas_email @uid
       current_user_policy = authentication_state.policy
       is_google_reminder_dismissed = User::Oauth2Data.is_google_reminder_dismissed(@uid)
       is_google_reminder_dismissed = is_google_reminder_dismissed && is_google_reminder_dismissed.present?
@@ -174,7 +173,6 @@ module User
         hasPhoto: !!User::Photo.fetch(@uid, @options),
         inEducationAbroadProgram: @user_attributes[:educationAbroad],
         googleEmail: google_mail,
-        canvasEmail: canvas_mail,
         officialBmailAddress: @user_attributes[:officialBmailAddress],
         primaryEmailAddress: @user_attributes[:primaryEmailAddress],
         preferredName: self.preferred_name,

--- a/public/dummy/json/status.json
+++ b/public/dummy/json/status.json
@@ -25,7 +25,6 @@
   "hasPhoto": true,
   "inEducationAbroadProgram": false,
   "googleEmail": "",
-  "canvasEmail": "",
   "lastName": "BABTREW",
   "preferredName": "BABTREW,IWQROE",
   "roles": {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6297

Removal of unused property in `/api/my/status` means one less db call.