### PR TITLE
SISRP-16435, links for Advisors: Multi-Year Academic Planner and Schedule Planner

### DIFF
--- a/app/controllers/advising_student_controller.rb
+++ b/app/controllers/advising_student_controller.rb
@@ -47,24 +47,15 @@ class AdvisingStudentController < ApplicationController
     links = json[:feed] && json[:feed][:ucAdvisingResources] && json[:feed][:ucAdvisingResources][:ucAdvisingLinks]
     if links
       # Advisors get only a subset of links
-      keys = [:ucServiceIndicator, :ucStudentAdvisor]
+      keys = [:ucServiceIndicator, :ucStudentAdvisor, :multiYearAcademicPlannerStudentSpecific, :schedulePlannerStudentSpecific]
       keys << :ucGteformsWorkcenter if Settings.features.cs_advising_gte_forms
       advising_links = links.select { |key| keys.include? key }
-      if (url = academic_planner_url)
-        advising_links[:ucAcademicPlanner] = { name: 'Academic Planner', url: url, isCsLink: true }
-      end
       json[:feed][:ucAdvisingResources][:ucAdvisingLinks] = advising_links
     end
     render json: json
   end
 
   private
-
-  def academic_planner_url
-    (feed = academic_plan_by_student_uid.get_feed_internal[:feed]) &&
-      (planner = feed[:updateAcademicPlanner]) &&
-      planner[:url]
-  end
 
   def academic_plan_by_student_uid
     model = CampusSolutions::MyAcademicPlan.new student_uid_param

--- a/app/models/campus_solutions/advising_resources.rb
+++ b/app/models/campus_solutions/advising_resources.rb
@@ -30,7 +30,17 @@ module CampusSolutions
     end
 
     def build_feed(response)
-      (response && response['ROOT']) || {}
+      return {} unless response && (feed = response['ROOT'])
+      links = (resources = feed['UC_ADVISING_RESOURCES']) && resources['UC_ADVISING_LINKS']
+      if links
+        # The following links are hard-coded, for now. Ideally they would be served by CS API but there is an urgent need
+        # thus we manage the content via CalCentral settings.
+        add_cs_link links, :multi_year_academic_planner, 'Multi-Year Academic Planner'
+        add_cs_link links, :schedule_planner, 'Schedule Planner'
+        add_cs_link links, :multi_year_academic_planner_student_specific, 'Multi-Year Academic Planner'
+        add_cs_link links, :schedule_planner_student_specific, 'Schedule Planner'
+      end
+      feed
     end
 
     def instance_key
@@ -45,6 +55,19 @@ module CampusSolutions
 
     def xml_filename
       'advising_resources.xml'
+    end
+
+    private
+
+    def add_cs_link(links, key, name)
+      value = Settings.campus_solutions_links.advising.send key
+      if value
+        links[key.to_s.upcase] = {
+          'NAME' => name,
+          'URL' => value,
+          'IS_CS_LINK' => true
+        }
+      end
     end
 
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -422,6 +422,13 @@ calnet_crosswalk_proxy:
   password: secret
   http_timeout_seconds: 30
 
+campus_solutions_links:
+  advising:
+    multi_year_academic_planner: 'https://bcs-web-dev-03.is.berkeley.edu:8443/psp/bcsdev_11/EMPLOYEE/HRMS/c/SCI_PLNR_ADMIN.SCI_PLNR_LAUNCH.GBL'
+    multi_year_academic_planner_student_specific: 'https://bcs-web-dev-03.is.berkeley.edu:8443/psp/bcsdev/EMPLOYEE/HRMS/c/SCI_PLNR_ADMIN.SCI_PLNR_LAUNCH.GBL?pslnkid=SCI_PLNR_LAUNCH_LNK&PORTALPARAM_PTCNAV=SCI_PLNR_LAUNCH_LNK&EOPP.SCNode=HRMS&EOPP.SCPortal=EMPLOYEE&EOPP.SCName=UC_CMPONENTS&EOPP.SCLabel=Academic%20Advisement&EOPP.SCFName=UC_CUSTOM_AA&EOPP.SCSecondary=true&EOPP.SCPTfname=UC_CUSTOM_AA&FolderPath=PORTAL_ROOT_OBJECT.UC_CMPONENTS.UC_CUSTOM_AA.SCI_PLNR_LAUNCH_LNK&IsFolder=false'
+    schedule_planner: 'https://bcs-web-dev-03.is.berkeley.edu:8443/psp/bcsdev/EMPLOYEE/HRMS/s/WEBLIB_PTPP_SC.HOMEPAGE.FieldFormula.IScript_AppHP?pt_fname=CO_EMPLOYEE_SELF_SERVICE&FolderPath=PORTAL_ROOT_OBJECT.CO_EMPLOYEE_SELF_SERVICE&IsFolder=true'
+    schedule_planner_student_specific: 'https://bcs-web-dev-03.is.berkeley.edu:8443/psp/bcsdev/EMPLOYEE/HRMS/c/SSR_ADVISEE_OVRD.SSS_STUDENT_CENTER.GBL?FolderPath=PORTAL_ROOT_OBJECT.CO_EMPLOYEE_SELF_SERVICE.HC_SS_ADVISOR_CTR_GBL.HC_SSS_STUDENT_CENTER_GBL&IsFolder=false&IgnoreParamTempl=FolderPath%2cIsFolder'
+
 # A feature will be disabled if the corresponding feature-flag is false or nil.
 features:
   advising: false

--- a/spec/controllers/campus_solutions/advising_resources_controller_spec.rb
+++ b/spec/controllers/campus_solutions/advising_resources_controller_spec.rb
@@ -10,7 +10,7 @@ describe CampusSolutions::AdvisingResourcesController do
     end
 
     context 'no advisor privileges' do
-      let(:user_roles) { {staff: true, student: true} }
+      let(:user_roles) { { staff: true, student: true } }
       it 'returns forbidden' do
         get feed
         expect(response.status).to eq 403
@@ -18,15 +18,35 @@ describe CampusSolutions::AdvisingResourcesController do
     end
 
     context 'advisor privileges' do
-      let(:user_roles) { {staff: true, advisor: true} }
+      let(:user_roles) { { staff: true, advisor: true } }
       let(:feed_key) { 'ucAdvisingResources' }
-      it_behaves_like 'a successful feed'
-      it 'includes specific mock data' do
-        get feed
-        json = JSON.parse(response.body)
-        expect(json['feed']['ucAdvisingResources']['ucAdvisingLinks']['ucAdviseeStudentCenter']['url'].strip).to eq(
-          'https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SSR_ADVISEE_OVRD.SSS_STUDENT_CENTER.GBL?')
+
+      shared_examples 'a feed with advising resources' do
+        it 'contains advising links' do
+          get feed
+          json = JSON.parse response.body
+          expect(resources = json['feed']['ucAdvisingResources']).to_not be_nil
+          expect(link = resources['ucAdvisingLinks'][key]).to_not be_nil
+          expect(link['isCsLink']).to be true
+          expect(link['name']).to eq expected_name
+
+        end
+      end
+
+      context 'links from the CS API' do
+        let(:key) { 'ucAdviseeStudentCenter' }
+        let(:expected_name) { 'Advisee Student Center' }
+
+        it_behaves_like 'a feed with advising resources'
+      end
+
+      context 'links from YAML settings' do
+        let(:key) { 'multiYearAcademicPlanner' }
+        let(:expected_name) { 'Multi-Year Academic Planner' }
+
+        it_behaves_like 'a feed with advising resources'
       end
     end
   end
+
 end

--- a/src/assets/templates/widgets/advisor/advising_links.html
+++ b/src/assets/templates/widgets/advisor/advising_links.html
@@ -47,4 +47,18 @@
       data-text="Schedule of Classes - Class Search"
     ></div>
   </li>
+  <li data-ng-if="ucAdvisingResources.ucAdvisingLinks.multiYearAcademicPlanner.url">
+    <div
+      data-cc-campus-solutions-link-item-directive
+      data-link="ucAdvisingResources.ucAdvisingLinks.multiYearAcademicPlanner"
+      data-text="Multi-Year Academic Planner"
+    ></div>
+  </li>
+  <li data-ng-if="ucAdvisingResources.ucAdvisingLinks.schedulePlanner.url">
+    <div
+      data-cc-campus-solutions-link-item-directive
+      data-link="ucAdvisingResources.ucAdvisingLinks.schedulePlanner"
+      data-text="Schedule Planner"
+    ></div>
+  </li>
 </ul>

--- a/src/assets/templates/widgets/toolbox/user_preview.html
+++ b/src/assets/templates/widgets/toolbox/user_preview.html
@@ -97,10 +97,16 @@
                     data-text="Student Forms"
                   ></div>
                 </div>
-                <div data-ng-if="ucAdvisingResources.ucAdvisingLinks.ucAcademicPlanner">
+                <div data-ng-if="ucAdvisingResources.ucAdvisingLinks.multiYearAcademicPlannerStudentSpecific">
                   <div
                     data-cc-campus-solutions-link-item-directive
-                    data-link="ucAdvisingResources.ucAdvisingLinks.ucAcademicPlanner"
+                    data-link="ucAdvisingResources.ucAdvisingLinks.multiYearAcademicPlannerStudentSpecific"
+                  ></div>
+                </div>
+                <div data-ng-if="ucAdvisingResources.ucAdvisingLinks.schedulePlannerStudentSpecific">
+                  <div
+                    data-cc-campus-solutions-link-item-directive
+                    data-link="ucAdvisingResources.ucAdvisingLinks.schedulePlannerStudentSpecific"
                   ></div>
                 </div>
               </td>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-16435
https://jira.berkeley.edu/browse/SISRP-19058 (remove Academic Planner link on Advising Student Profile card)

* Generic Advising Resources card gets: multi_year_academic_planner, schedule_planner
* Student Profile card for Advisors gets: multi_year_academic_planner_student_specific, schedule_planner_student_specific

Eventually these links should be served by CS API but there is an urgent need. Thus we manage them via CalCentral settings.
