### PR TITLE
SISRP-19184 - Profile Contact Info: click edit and data vanishes

### DIFF
--- a/src/assets/templates/widgets/profile/address.html
+++ b/src/assets/templates/widgets/profile/address.html
@@ -5,7 +5,8 @@
   </label>
 </div>
 <div class="cc-select">
-  <select data-ng-options="country.country as country.descr for country in countries" data-ng-model="currentObject.data.country" id="cc-page-widget-profile-address-country" required aria-required="true" />
+  <select data-ng-options="country.country as country.descr for country in countries" data-ng-model="currentObject.data.country" id="cc-page-widget-profile-address-country" required aria-required="true">
+  </select>
 </div>
 
 <div data-cc-spinner-directive="currentObject.stateFieldLoading">

--- a/src/assets/templates/widgets/profile/contact_address_editor.html
+++ b/src/assets/templates/widgets/profile/contact_address_editor.html
@@ -12,7 +12,8 @@
           </label>
         </div>
         <div class="cc-select">
-          <select data-ng-options="type.fieldvalue as type.descr for type in types" data-ng-model="currentObject.data.type.code" id="cc-page-widget-profile-address-type" required aria-required="true" />
+          <select data-ng-options="type.fieldvalue as type.descr for type in types" data-ng-model="currentObject.data.type.code" id="cc-page-widget-profile-address-type" required aria-required="true">
+          </select>
         </div>
       </div>
       <div data-ng-if="!currentObject.isAdding">

--- a/src/assets/templates/widgets/profile/contact_email_editor.html
+++ b/src/assets/templates/widgets/profile/contact_email_editor.html
@@ -12,7 +12,8 @@
           </label>
         </div>
         <div class="cc-select">
-          <select data-ng-options="type.fieldvalue as type.xlatlongname for type in types" data-ng-model="currentObject.data.type.code"  id="cc-page-widget-profile-email-type" required aria-required="true" />
+          <select data-ng-options="type.fieldvalue as type.xlatlongname for type in types" data-ng-model="currentObject.data.type.code"  id="cc-page-widget-profile-email-type" required aria-required="true">
+          </select>
         </div>
       </div>
       <div data-ng-if="!currentObject.isAdding">

--- a/src/assets/templates/widgets/profile/contact_phone_editor.html
+++ b/src/assets/templates/widgets/profile/contact_phone_editor.html
@@ -12,7 +12,8 @@
           </label>
         </div>
         <div class="cc-select">
-          <select data-ng-options="type.fieldvalue as type.xlatlongname for type in types" data-ng-model="currentObject.data.type.code" id="cc-page-widget-profile-phone-type" required aria-required="true" />
+          <select data-ng-options="type.fieldvalue as type.xlatlongname for type in types" data-ng-model="currentObject.data.type.code" id="cc-page-widget-profile-phone-type" required aria-required="true">
+          </select>
         </div>
       </div>
       <div data-ng-if="!currentObject.isAdding">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-19184

According to this [W3 page (section 4.3)](https://www.w3.org/TR/html-markup/syntax.html), `<select>` elements are not void elements, and must have a closing `</select>` tag - otherwise, the `<select>` will eat up all of the elements underneath it, which is what it was doing when the "edit" button was being pushed.

This bug also lives in other places, primarily in Profile, so I've created [SISRP-19203](https://jira.berkeley.edu/browse/SISRP-19203) to ensure the other ones get cleaned up as well.

