### PR TITLE
SISRP-19251, default for advising links is blank URL

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -424,10 +424,10 @@ calnet_crosswalk_proxy:
 
 campus_solutions_links:
   advising:
-    multi_year_academic_planner: 'https://bcs-web-dev-03.is.berkeley.edu:8443/psp/bcsdev_11/EMPLOYEE/HRMS/c/SCI_PLNR_ADMIN.SCI_PLNR_LAUNCH.GBL'
-    multi_year_academic_planner_student_specific: 'https://bcs-web-dev-03.is.berkeley.edu:8443/psp/bcsdev/EMPLOYEE/HRMS/c/SCI_PLNR_ADMIN.SCI_PLNR_LAUNCH.GBL?pslnkid=SCI_PLNR_LAUNCH_LNK&PORTALPARAM_PTCNAV=SCI_PLNR_LAUNCH_LNK&EOPP.SCNode=HRMS&EOPP.SCPortal=EMPLOYEE&EOPP.SCName=UC_CMPONENTS&EOPP.SCLabel=Academic%20Advisement&EOPP.SCFName=UC_CUSTOM_AA&EOPP.SCSecondary=true&EOPP.SCPTfname=UC_CUSTOM_AA&FolderPath=PORTAL_ROOT_OBJECT.UC_CMPONENTS.UC_CUSTOM_AA.SCI_PLNR_LAUNCH_LNK&IsFolder=false'
-    schedule_planner: 'https://bcs-web-dev-03.is.berkeley.edu:8443/psp/bcsdev/EMPLOYEE/HRMS/s/WEBLIB_PTPP_SC.HOMEPAGE.FieldFormula.IScript_AppHP?pt_fname=CO_EMPLOYEE_SELF_SERVICE&FolderPath=PORTAL_ROOT_OBJECT.CO_EMPLOYEE_SELF_SERVICE&IsFolder=true'
-    schedule_planner_student_specific: 'https://bcs-web-dev-03.is.berkeley.edu:8443/psp/bcsdev/EMPLOYEE/HRMS/c/SSR_ADVISEE_OVRD.SSS_STUDENT_CENTER.GBL?FolderPath=PORTAL_ROOT_OBJECT.CO_EMPLOYEE_SELF_SERVICE.HC_SS_ADVISOR_CTR_GBL.HC_SSS_STUDENT_CENTER_GBL&IsFolder=false&IgnoreParamTempl=FolderPath%2cIsFolder'
+    multi_year_academic_planner: ''
+    multi_year_academic_planner_student_specific: ''
+    schedule_planner: ''
+    schedule_planner_student_specific: ''
 
 # A feature will be disabled if the corresponding feature-flag is false or nil.
 features:


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-19251

Re: `campus_solutions_links.advising`. Default URLs are blank, for now.