### PR TITLE
SISRP-19171 - 5.4 - Delegated Access - In Linking Your Account page both Security key and Email address fields having a white space is graying out the Link Button

### DIFF
--- a/src/assets/templates/widgets/delegate/linking.html
+++ b/src/assets/templates/widgets/delegate/linking.html
@@ -19,7 +19,7 @@
         </label>
       </div>
       <div>
-        <input type="text" id="cc-delegate-linking-key" maxlength="20" data-ng-model="delegate.currentObject.data.securityKey" data-ng-pattern="/^[\S]+$/" data-ng-trim="false" required aria-required="true" />
+        <input type="text" id="cc-delegate-linking-key" maxlength="20" data-ng-model="delegate.currentObject.data.securityKey" data-ng-pattern="/^[\s]*[\S]+[\s]*$/" required aria-required="true" />
       </div>
       <div>
         <label for="cc-delegate-linking-email">
@@ -27,7 +27,7 @@
         </label>
       </div>
       <div>
-        <input type="text" id="cc-delegate-linking-email" maxlength="254" data-ng-model="delegate.currentObject.data.proxyEmailAddress" data-ng-pattern="/^[\S]+$/" data-ng-trim="false" required aria-required="true" />
+        <input type="text" id="cc-delegate-linking-email" maxlength="254" data-ng-model="delegate.currentObject.data.proxyEmailAddress" data-ng-pattern="/^[\s]*[\S]+[\s]*$/" required aria-required="true" />
       </div>
       <div>
         <input type="checkbox" id="cc-delegate-linking-terms" data-ng-model="delegate.currentObject.data.agreeToTerms" required aria-required="true">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-19171

Note: this is a **5.6** change.

Fixes the Delegated Access linking account input whitespace problem.  The updated `data-ng-pattern` directive now allows leading, trailing whitespace in the text inputs.  The `data-ng-trim="false"` directive is removed so that angular trims the field values before applying them to the model.