### PR TITLE
SISRP-18222 - 3-2-1 Columns in CalCentral

### DIFF
--- a/src/assets/stylesheets/_campus.scss
+++ b/src/assets/stylesheets/_campus.scss
@@ -1,7 +1,7 @@
 .cc-page-campus {
   overflow: hidden;
   .cc-widget {
-    width: 40%;
+    width: 60%;
   }
   @media #{$small-only} {
     .cc-widget {

--- a/src/assets/stylesheets/_foundation_overrides.scss
+++ b/src/assets/stylesheets/_foundation_overrides.scss
@@ -4,12 +4,11 @@ $body-font-family: Arial, sans-serif;
 $header-font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
 $primary-color: #2683bc;
 
-
 // Responsive
 $small-breakpoint: (767px);
-$medium-breakpoint: (768px);
+$medium-breakpoint: (1025px);
 $screen: "only screen";
 $small-up: $screen;
 $small-only: "#{$screen} and (max-width: #{$small-breakpoint})";
-$medium-up: "#{$screen} and (min-width:#{$medium-breakpoint})";
-$medium-only: "#{$screen} and (min-width:#{$medium-breakpoint})";
+$medium-up: "#{$screen} and (min-width:#{$small-breakpoint + 1})";
+$medium-only: "#{$screen} and (min-width:#{$small-breakpoint + 1}) and (max-width:#{$medium-breakpoint})";

--- a/src/assets/stylesheets/_widgets.scss
+++ b/src/assets/stylesheets/_widgets.scss
@@ -1,3 +1,10 @@
+.cc-two-column-layout {
+  .cc-column-2 {
+    .cc-widget {
+      margin-right: 0;
+    }
+  }
+}
 .cc-widget {
   background: $cc-color-white;
   margin: 15px 15px 0 0;
@@ -12,7 +19,7 @@
     clear: both;
   }
 }
-.cc-column-last {
+.cc-column-3 {
   .cc-widget {
     margin-right: 0;
   }
@@ -235,6 +242,14 @@
 
 .cc-widget-vertical-padding {
   padding: 5px 0;
+}
+
+@media #{$medium-only} {
+  .cc-column-2, .cc-column-3 {
+    .cc-widget {
+      margin-right: 0;
+    }
+  }
 }
 
 @media #{$small-only} {

--- a/src/assets/templates/academics.html
+++ b/src/assets/templates/academics.html
@@ -1,25 +1,32 @@
 <div class="cc-page-academics" data-cc-spinner-directive>
-  <div data-ng-if="canViewAcademics">
+  <div data-ng-if="canViewAcademics"
+    data-ng-class="{'cc-two-column-layout':(!api.user.profile.roles.student)}">
     <div class="column">
       <h1 class="cc-heading-page-title">My Academics</h1>
     </div>
 
-    <div class="medium-8 columns cc-academics-row-margin" data-ng-if="selectedTeachingSemester && !api.user.profile.hasStudentHistory && !api.user.profile.roles.student">
+    <div
+      class="medium-8 columns cc-academics-row-margin"
+      data-ng-if="selectedTeachingSemester && !api.user.profile.hasStudentHistory && !api.user.profile.roles.student">
       <div data-ng-include="'academics_semester_classes.html'"></div>
       <div data-ng-include="'widgets/final_exam_schedule.html'" data-ng-if="api.user.profile.sid && examSchedule.length && (selectedTeachingSemester.timeBucket === 'current')"></div>
     </div>
 
-    <div class="medium-4 columns cc-academics-row-margin" data-ng-if="api.user.profile.hasStudentHistory || api.user.profile.roles.student">
+    <div
+      class="medium-6 large-4 columns cc-academics-row-margin"
+      data-ng-if="api.user.profile.hasStudentHistory || api.user.profile.roles.student">
       <div data-ng-include src="'academics_student_profile.html'"></div>
       <div data-ng-include src="'academics_status_holds_blocks.html'" data-ng-if="showStatusAndBlocks"></div>
     </div>
 
-    <div class="medium-4 columns cc-academics-row-margin">
+    <div
+      data-ng-class="{'medium-6':(api.user.profile.roles.student), 'medium-4':(!api.user.profile.roles.student)}"
+      class="large-4 columns cc-column-2 cc-academics-row-margin">
       <div data-ng-include src="'academics_semesters.html'" data-ng-if="api.user.profile.hasStudentHistory && semesters.length"></div>
       <div data-ng-include src="'academics_teaching.html'" data-ng-if="!api.user.profile.delegateActingAsUid && (api.user.profile.roles.faculty || hasTeachingClasses)"></div>
     </div>
 
-    <div class="medium-4 columns cc-column-last">
+    <div class="medium-6 large-4 columns cc-column-3">
       <div data-ng-include="'widgets/enrollment_card_summer_2016.html'" data-ng-if="api.user.profile.features.classEnrollmentSummer2016 && api.user.profile.roles.student && !studentInfo.isLawStudent"></div>
 
       <div data-ng-include="'widgets/enrollment_card.html'" data-ng-if="api.user.profile.features.csEnrollmentCard"></div>

--- a/src/assets/templates/academics_booklist.html
+++ b/src/assets/templates/academics_booklist.html
@@ -10,7 +10,7 @@
       Book List
     </h1>
 
-    <div class="cc-widget medium-8 columns cc-academics-row-margin cc-clearfix">
+    <div class="cc-widget large-8 columns cc-academics-row-margin cc-clearfix">
       <div class="cc-widget-title">
         <div class="cc-left">
           <h2>Book List &raquo; <span data-ng-bind="semesterName"></span></h2>

--- a/src/assets/templates/academics_classinfo.html
+++ b/src/assets/templates/academics_classinfo.html
@@ -29,7 +29,7 @@
 
   <div data-ng-switch-when="Class Info" role="tabpanel" aria-live="polite">
 
-    <div class="medium-4 columns cc-academics-row-margin">
+    <div class="medium-6 large-4 columns cc-academics-row-margin">
       <div class="cc-widget">
         <div class="cc-widget-title">
           <h2>Class Information</h2>
@@ -104,7 +104,7 @@
       <div data-ng-if="selectedCourseLongInstructorsList" data-ng-include="'academics_class_sites.html'" ></div>
     </div>
 
-    <div class="medium-4 columns" data-ng-if="selectedCourseCountInstructors">
+    <div class="medium-6 large-4 cc-column-2 columns" data-ng-if="selectedCourseCountInstructors">
       <div class="cc-widget">
         <div class="cc-widget-title">
           <h2 data-ng-pluralize count="selectedCourseCountInstructors" when="{'1': 'Instructor', 'other': 'Instructors'}">Instructors</h2>
@@ -127,7 +127,7 @@
       <div data-ng-if="!selectedCourseLongInstructorsList" data-ng-include="'academics_class_sites.html'" ></div>
     </div>
 
-    <div class="medium-4 columns cc-column-last">
+    <div class="medium-6 large-4 columns cc-column-3">
 
       <div class="cc-widget cc-widget-webcast" data-ng-if="api.user.profile.features.videos">
         <div class="cc-widget-title">
@@ -177,7 +177,7 @@
     ></div>
   </div>
 
-  <div data-ng-switch-when="Roster" role="tabpanel" aria-live="polite" class="cc-clearfix">
+  <div data-ng-switch-when="Roster" role="tabpanel" aria-live="polite" class="cc-clearfix cc-column-3">
     <div class="cc-widget">
       <div class="cc-widget-title">
         <h2>Roster</h2>

--- a/src/assets/templates/academics_semester.html
+++ b/src/assets/templates/academics_semester.html
@@ -23,7 +23,7 @@
 
   </div>
 
-  <div class="medium-4 columns cc-column-last" data-ng-class="{'pull-8 cc-clearfix':(!selectedCourses.length && selectedSemester.timeBucket === 'future')}">
+  <div class="medium-4 columns cc-column-3" data-ng-class="{'pull-8 cc-clearfix':(!selectedCourses.length && selectedSemester.timeBucket === 'future')}">
     <div data-ng-include="'widgets/telebears.html'" data-ng-if="telebearsSemesters.length"></div>
 
     <div data-ng-include="'academics_final_grades.html'" data-ng-if="selectedStudentSemester && (selectedSemester.timeBucket === 'past') && !selectedSemester.gradingInProgress"></div>

--- a/src/assets/templates/billing_details.html
+++ b/src/assets/templates/billing_details.html
@@ -10,10 +10,10 @@
       </h1>
     </div>
 
-    <div class="medium-4 columns">
+    <div class="medium-4 columns cc-column-2">
       <div data-ng-include="'widgets/billing_summary.html'" data-onload="billingDetails=true"></div>
     </div>
-    <div class="medium-8 columns cc-column-last">
+    <div class="medium-8 columns cc-column-3">
       <div data-ng-include="'widgets/billing_activity.html'"></div>
     </div>
 

--- a/src/assets/templates/cars_details.html
+++ b/src/assets/templates/cars_details.html
@@ -13,7 +13,7 @@
     <div class="medium-4 columns">
       <div data-ng-include="'cars_summary.html'" data-onload="carsDetails=true"></div>
     </div>
-    <div class="medium-8 columns cc-column-last">
+    <div class="medium-8 columns cc-column-3">
       <div data-ng-include="'cars_activity.html'"></div>
     </div>
 

--- a/src/assets/templates/dashboard.html
+++ b/src/assets/templates/dashboard.html
@@ -1,17 +1,17 @@
 <div data-ng-if="api.user.profile.hasDashboardTab">
-  <div class="medium-3 columns">
+  <div class="medium-5 large-3 columns">
     <div data-ng-include="'widgets/sir/sir.html'" data-ng-if="api.user.profile.features.csSir && !api.user.profile.delegateActingAsUid"></div>
     <div data-ng-include="'widgets/up_next.html'" data-ng-if="!api.user.profile.isApplicantOnly"></div>
     <div data-ng-include="'widgets/my_classes.html'"></div>
     <div data-ng-include="'widgets/my_groups.html'"></div>
   </div>
 
-  <div class="medium-5 columns">
+  <div class="medium-7 large-5 columns cc-column-2">
     <div data-ng-include="'widgets/hookup_google_reminder.html'" data-ng-if="api.user.profile.officialBmailAddress"></div>
     <div data-ng-include="'widgets/tasks.html'"></div>
   </div>
 
-  <div class="medium-4 columns cc-column-last">
+  <div class="medium-7 large-4 columns cc-column-3">
     <div data-ng-include="'widgets/activity.html'"></div>
     <div data-ng-include="'widgets/toolbox/user_search.html'" data-ng-if="api.user.profile.features.csAdvisorStudentLookup && api.user.profile.roles.advisor"></div>
     <div data-ng-include="'widgets/advisor/resources.html'" data-ng-if="api.user.profile.roles.advisor"></div>

--- a/src/assets/templates/directives/finaid_permissions.html
+++ b/src/assets/templates/directives/finaid_permissions.html
@@ -1,4 +1,4 @@
-<div class="medium-8 medium-centered columns cc-column-last cc-clearfix-container">
+<div class="medium-8 medium-centered columns cc-column-3 cc-clearfix-container">
   <div class="cc-widget">
     <div class="cc-widget-title">
       <h2 data-ng-bind="title"></h2>

--- a/src/assets/templates/finaid.html
+++ b/src/assets/templates/finaid.html
@@ -14,15 +14,15 @@
     </div>
 
     <div data-ng-if="canSeeFinaidData">
-      <div class="medium-4 columns">
+      <div class="medium-6 large-4 columns">
         <div data-ng-include="'widgets/finaid_summary.html'"></div>
         <div data-ng-include="'widgets/finaid_communications.html'"></div>
         <div data-ng-include="'widgets/finaid_profile.html'"></div>
       </div>
-      <div class="medium-4 columns">
+      <div class="medium-6 large-4 columns cc-column-2">
         <div data-ng-include="'widgets/finaid_coa.html'"></div>
       </div>
-      <div class="medium-4 columns cc-column-last">
+      <div class="medium-6 large-4 columns cc-column-3">
         <div data-ng-include="'widgets/finaid_awards.html'"></div>
       </div>
     </div>

--- a/src/assets/templates/finaid_awards_compare.html
+++ b/src/assets/templates/finaid_awards_compare.html
@@ -15,7 +15,7 @@
     </div>
 
     <div data-ng-if="canSeeFinaidData">
-      <div class="large-8 medium-12 small-12 columns cc-column-last">
+      <div class="large-8 medium-12 columns cc-column-3">
         <div data-ng-include="'widgets/finaid_awards_compare_widget.html'"></div>
       </div>
     </div>

--- a/src/assets/templates/finaid_awards_term.html
+++ b/src/assets/templates/finaid_awards_term.html
@@ -14,7 +14,7 @@
     </div>
 
     <div data-ng-if="canSeeFinaidData">
-      <div data-ng-include="'widgets/finaid_awards_term_widget.html'" class="medium-8 medium-centered columns cc-column-last cc-clearfix-container"></div>
+      <div data-ng-include="'widgets/finaid_awards_term_widget.html'" class="medium-10 large-8 medium-centered columns cc-column-3 cc-clearfix-container"></div>
     </div>
 
   </div>

--- a/src/assets/templates/myfinances.html
+++ b/src/assets/templates/myfinances.html
@@ -5,18 +5,18 @@
       <h1 class="cc-heading-page-title">My Finances</h1>
     </div>
 
-    <div class="medium-4 columns" data-ng-if="!api.user.profile.isApplicantOnly">
+    <div class="medium-6 large-4 columns" data-ng-if="!api.user.profile.isApplicantOnly">
       <div data-ng-include="'cars_summary.html'"></div>
       <div data-ng-include="'widgets/billing_summary.html'" data-ng-if="api.user.profile.features.csBilling"></div>
       <div data-ng-include="'cal1card.html'"></div>
     </div>
 
-    <div class="medium-4 columns">
+    <div class="medium-6 large-4 cc-column-2 columns">
       <div data-ng-include="'widgets/finaid_summary.html'" data-ng-if="api.user.profile.features.csFinAid"></div>
       <div data-ng-include="'widgets/finaid_activity.html'" data-ng-if="!api.user.profile.isApplicantOnly"></div>
     </div>
 
-    <div class="medium-4 columns" data-ng-class="{'medium-pull-4':(api.user.profile.isApplicantOnly), 'cc-column-last':(!api.user.profile.isApplicantOnly)}">
+    <div class="medium-6 large-4 cc-column-3 columns" data-ng-class="{'medium-pull-4':(api.user.profile.isApplicantOnly), 'cc-column-3':(!api.user.profile.isApplicantOnly)}">
       <div data-ng-include="'widgets/finances_links.html'"></div>
     </div>
 

--- a/src/assets/templates/toolbox.html
+++ b/src/assets/templates/toolbox.html
@@ -3,15 +3,15 @@
     <div class="column">
       <h1 class="cc-heading-page-title">My Toolbox</h1>
     </div>
-    <div class="medium-4 columns">
+    <div class="medium-6 large-4 columns">
       <div data-ng-include="'widgets/toolbox/view_as.html'" data-ng-if="api.user.profile.isViewer || api.user.profile.isSuperuser || api.user.profile.roles.advisor"></div>
       <div data-ng-include="'widgets/toolbox/delegate_intro_to_calcentral.html'" data-ng-if="api.user.profile.isDelegateUser"></div>
     </div>
-    <div class="medium-4 columns">
+    <div class="medium-6 large-4 columns cc-column-2">
       <div data-ng-include="'widgets/toolbox/delegate_students.html'" data-ng-if="api.user.profile.isDelegateUser"></div>
       <div data-ng-include="'widgets/toolbox/uid_lookup.html'" data-ng-if="api.user.profile.isViewer || api.user.profile.isSuperuser || api.user.profile.roles.advisor"></div>
     </div>
-    <div class="medium-4 columns cc-column-last">
+    <div class="medium-6 large-4 columns cc-column-3">
       <div data-ng-include="'widgets/toolbox/api_test.html'" data-ng-if="api.user.profile.isSuperuser"></div>
       <div data-ng-include="'widgets/toolbox/academic_dates.html'" data-ng-if="api.user.profile.isDelegateUser"></div>
       <div data-ng-include="'widgets/toolbox/delegate_quick_links.html'" data-ng-if="api.user.profile.isDelegateUser"></div>

--- a/src/assets/templates/user_overview.html
+++ b/src/assets/templates/user_overview.html
@@ -6,10 +6,10 @@
     <div class="medium-4 columns">
       <div data-ng-include="'widgets/toolbox/user_preview.html'"></div>
     </div>
-    <div class="medium-4 columns">
+    <div class="medium-4 columns cc-column-2">
       <div data-ng-include="'widgets/student_university_requirements.html'" data-ng-if="targetUser.isLoading || !targetUser.campusSolutionsStudent && targetUser.roles.undergrad"></div>
     </div>
-    <div class="medium-4 columns cc-column-last">
+    <div class="medium-4 columns cc-column-3">
       <div data-ng-include="'widgets/final_exam_schedule.html'" data-ng-if="examSchedule.length"></div>
       <div data-ng-include="'widgets/enrollment_card.html'" data-ng-if="api.user.profile.features.csEnrollmentCard"></div>
     </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-18222

* Adds 2-column layout support to page templates
* Adjusts the My Campus widget width percentage for medium width devices (40% to 60%)
* Adds styles to support removal of right-gutter for 2nd column in 2-column layouts, as well as when medium viewport in use (which reduce to 2-column layout)
* Removes right gutter from Roster view when instructor viewing class page

