### PR TITLE
CLC-6308 Make Webmock gem available under production RAILS_ENV

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,9 @@ gem 'net-ssh', '~>2.9.2' # v3 requires Ruby 2.0
 
 gem 'icalendar', '~> 2.2.2'
 
+# Fake proxies
+gem 'webmock', '~> 1.20.4'
+
 ##################################
 # Front-end Gems for Rails Admin #
 ##################################
@@ -142,8 +145,6 @@ group :development, :test , :testext do
   gem 'spork','1.0.0rc0'
   gem 'guard-spork'
   gem 'spork-rails'
-
-  gem 'webmock', '~> 1.20.4'
 end
 
 group :development do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6308

Master-branch version of #5392.