### PR TITLE
CLC-6318, change default webcast_proxy to webcast-cc-staging

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -185,9 +185,9 @@ textbooks_proxy:
 
 webcast_proxy:
   fake: false
-  base_url: 'https://webcast-cc-dev.ets.berkeley.edu'
-  username: 'secret'
-  password: 'secret'
+  base_url: 'https://webcast-cc-staging.ets.berkeley.edu'
+  username: ''
+  password: ''
 
 audio_proxy:
   base_url: 'https://wbe-itunes.berkeley.edu'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6318
* `webcast-cc-staging` holds a closer copy of production data
* QA dept can override this config when testing Course Capture end-to-end.