### PR TITLE
CLC-6276, prepare CalCentral's course-capture controller for Fall 2016 / EDO db

### DIFF
--- a/app/controllers/mediacasts_controller.rb
+++ b/app/controllers/mediacasts_controller.rb
@@ -6,18 +6,33 @@ class MediacastsController < ApplicationController
     @options = options
   end
 
-  # GET /api/media/:year/:term_code/:dept/:catalog_id
+  # GET /api/media/:term_yr/:term_cd/:dept_name/:catalog_id
   def get_media
-    term_yr = params['year']
-    term_cd = params['term_code']
-    dept_name = params['dept']
-    catalog_id = params['catalog_id']
-    # TODO NEEDS TO BE CHANGED FOR FALL 2016.
-    sections = CampusOracle::Queries.get_all_course_sections(term_yr, term_cd, dept_name, catalog_id)
-    ccn_list = sections.map { |section| section['course_cntl_num'].to_i }
-    policy = policy(Berkeley::Course.new @options)
+    term_yr = params.require 'term_yr'
+    term_cd = params.require 'term_cd'
+    dept_name = params.require 'dept_name'
+    catalog_id = params.require 'catalog_id'
     uid = session['user_id']
-    render :json => Webcast::Merged.new(uid, policy, term_yr, term_cd, ccn_list, @options).get_feed
+
+    policy = policy Berkeley::Course.new @options
+    ccn_list = ccn_list(term_yr, term_cd, dept_name, catalog_id)
+    proxy = Webcast::Merged.new uid, policy, term_yr, term_cd, ccn_list, @options
+    render :json => proxy.get_feed
+  end
+
+  private
+
+  def ccn_list(term_yr, term_cd, dept_name, catalog_id)
+    legacy = Berkeley::Terms.legacy? term_yr, term_cd
+    sections = legacy ?
+      CampusOracle::Queries.get_all_course_sections(term_yr, term_cd, dept_name, catalog_id) :
+      EdoOracle::Queries.get_all_course_sections(term_id(term_yr, term_cd), dept_name, catalog_id)
+    key = legacy ? 'course_cntl_num' : 'section_id'
+    sections.map { |section| section[key].to_i }
+  end
+
+  def term_id(term_yr, term_cd)
+    Berkeley::TermCodes.to_edo_id term_yr, term_cd
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Calcentral::Application.routes.draw do
   get '/api/my/campuslinks/refresh' => 'my_campus_links#refresh', :defaults => { :format => 'json' }
   get '/api/my/updated_feeds' => 'is_updated#list', :defaults => {:format => 'json'}
   get '/api/service_alerts' => 'service_alerts#get_feed', :as => :service_alerts, :defaults => { :format => 'json' }
-  get '/api/media/:year/:term_code/:dept/:catalog_id' => 'mediacasts#get_media', :defaults => { :format => 'json' }
+  get '/api/media/:term_yr/:term_cd/:dept_name/:catalog_id' => 'mediacasts#get_media', :defaults => { :format => 'json' }
 
   # Google API writing endpoints
   post '/api/my/event' => 'my_events#create', via: :post, defaults: { format: 'json' }

--- a/fixtures/webcast/warehouse/webcast.json
+++ b/fixtures/webcast/warehouse/webcast.json
@@ -2073,6 +2073,23 @@
         }
       ],
       "audioOnly": false
+    },
+    {
+      "year": 2016,
+      "semester": "Fall",
+      "ccn": 30598,
+      "deptName": "XASTRON",
+      "catalogId": "10",
+      "public": false,
+      "youTubePlaylist": "PL-XXv-cvA_iAn6Qt6B7D-phRT0Ld1GOUV",
+      "recordings": [
+        {
+          "lecture": "2016-08-25: A Grand Tour of the Cosmos",
+          "youTubeId": "E8WBr8u7YoI",
+          "recordingStartUTC": "2015-08-25T15:07:00-08:00"
+        }
+      ],
+      "audioOnly": false
     }
   ]
 }

--- a/spec/controllers/mediacasts_controller_spec.rb
+++ b/spec/controllers/mediacasts_controller_spec.rb
@@ -1,90 +1,179 @@
 describe MediacastsController do
 
-  # Test data has no entry with a single digit CCN. Using the ccn_sets below, we expect 'No Webcast data found' for
-  # each single digit ccn.
-  let(:law_2723) { {:dept_name => 'LAW', :catalog_id => '2723', :term_yr => '2008', :term_cd => 'D', :ccn_set => [1, 49688, 2]} }
-  let(:chem_101) { {:dept_name => 'CHEM', :catalog_id => '101', :term_yr => '2014', :term_cd => 'B', :ccn_set => [1, 2, 3]} }
-  let(:malay_100A) { {:dept_name => 'MALAY/I', :catalog_id => '100A', :term_yr => '2014', :term_cd => 'D', :ccn_set => [85006]} }
+  let(:params) {
+    {
+      term_yr: course[:term_yr],
+      term_cd: course[:term_cd],
+      dept_name: course[:dept_name],
+      catalog_id: course[:catalog_id]
+    }
+  }
+  before do
+    session['user_id'] = random_id
+    allow(Settings.webcast_proxy).to receive(:fake).and_return true
+    expect(Berkeley::Terms).to receive(:legacy?).and_return legacy
+  end
 
-  before { session['user_id'] = rand(99999).to_s }
-
-  describe 'when serving webcast recordings' do
-    context 'when Webcast feature flag is false' do
-      before { Settings.features.videos = false }
-      after { Settings.features.videos = true }
-      it 'should return no videos' do
-        json = post_course law_2723
-        expect(json[:videos]).to be_nil
-      end
-    end
-
-    context 'fetching fake data' do
-      before do
-        expect(Settings.webcast_proxy).to receive(:fake).at_most(4).and_return(true)
-      end
-
-      context 'when no Webcast recordings found' do
-        it 'should campus_db query results are empty' do
-          term_yr = '2014'
-          term_cd = 'D'
-          dept_name = 'ECON'
-          catalog_id = '101'
-          CampusOracle::Queries.should_receive(:get_all_course_sections).with(term_yr, term_cd, dept_name, catalog_id).and_return []
-          post :get_media, year: term_yr, term_code: term_cd, dept: dept_name, catalog_id: catalog_id
-          expect(response.status).to eq 200
-          json = JSON.parse response.body
-          expect(json['media']).to be_nil
-        end
-
-        it 'should pay attention to term code' do
-          json = post_course chem_101
-          expect(json['media']).to be_nil
-        end
-      end
-
-      context 'when Webcast recordings found' do
-        before(:each) do
-          courses_list = [
+  shared_examples 'a course with recordings' do
+    before do
+      courses_list = [
+        {
+          classes: [
             {
-              :classes=>[
+              sections: [
                 {
-                  :sections=>[
-                    { :ccn=>'85006', :section_number=>'201', :instruction_format=>'LEC' }
-                  ]
+                  ccn: expected_ccn.to_s,
+                  section_number: random_id,
+                  instruction_format: 'LEC'
                 }
               ]
             }
           ]
-          expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).once.and_return courses_list
-        end
-        it 'should escape special characters in dept name' do
-          json = post_course malay_100A
-          # This course happens to have zero YouTube videos
-          course = json['media'][0]
-          expect(course['ccn']).to eq '85006'
-          expect(course['videos']).to be_empty
-          expect(course['iTunes']['audio']).to be_nil
-          expect(course['iTunes']['video']).to include '819827828'
-        end
+        }
+      ]
+      expect(MyAcademics::Teaching).to receive(:new).and_return (teaching = double)
+      expect(teaching).to receive(:courses_list_from_ccns).once.and_return courses_list
+    end
+    it 'should have audio and/or video' do
+      get :get_media, params
+      expect(response).to be_success
+      media = JSON.parse(response.body)['media'][0]
+      expect(media['ccn']).to eq expected_ccn
+      expect(media['videos']).to eq expected_videos
+      itunes_audio = media['iTunes']['audio']
+      itunes_video = media['iTunes']['video']
+      if expected_itunes_audio
+        expect(itunes_audio).to include expected_itunes_audio
+      else
+        expect(itunes_audio).to be_nil
+      end
+      if expected_itunes_video
+        expect(itunes_video).to include expected_itunes_video
+      else
+        expect(itunes_video).to be_nil
       end
     end
   end
 
-  private
+  shared_examples 'a course with no recordings' do
+    it 'should report no videos' do
+      get :get_media, params
+      expect(response).to be_success
+      videos = JSON.parse(response.body)[:videos]
+      expect(videos).to be_nil
+    end
+  end
 
-  def post_course(course)
-    # :year/:term_code/:dept/:catalog_id
-    term_yr = course[:term_yr]
-    term_cd = course[:term_cd]
-    dept_name = course[:dept_name]
-    catalog_id = course[:catalog_id]
-    # Add leading zero to CCN to verify proper handling
-    query_results = []
-    course[:ccn_set].each {|ccn| query_results << { 'course_cntl_num' => "0#{ccn}" }}
-    CampusOracle::Queries.should_receive(:get_all_course_sections).with(term_yr, term_cd, dept_name, catalog_id).and_return query_results
-    post :get_media, year: term_yr, term_code: term_cd, dept: dept_name, catalog_id: catalog_id
-    expect(response.status).to eq 200
-    JSON.parse response.body
+  describe 'course data from EDO Oracle' do
+    let(:legacy) { false }
+    before do
+      query_results = course[:ccn_set].map { |ccn| { 'section_id' => ccn.to_s } }
+      term_id = Berkeley::TermCodes.to_edo_id course[:term_yr], course[:term_cd]
+      expect(EdoOracle::Queries).to receive(:get_all_course_sections).with(
+        term_id,
+        course[:dept_name],
+        course[:catalog_id]).and_return query_results
+    end
+
+    context 'course with recordings' do
+      it_should_behave_like 'a course with recordings' do
+        let(:astro_ccn_with_recordings) { 30598 }
+        let(:course) {
+          {
+            term_yr: '2016',
+            term_cd: 'D',
+            dept_name: 'XASTRON',
+            catalog_id: '10',
+            ccn_set: [ astro_ccn_with_recordings ]
+          }
+        }
+        let(:expected_ccn) { astro_ccn_with_recordings.to_s }
+        let(:expected_videos) {
+          [
+            {
+              'lecture' => '2016-08-25: A Grand Tour of the Cosmos',
+              'youTubeId' => 'E8WBr8u7YoI',
+              'recordingStartUTC' => '2015-08-25T15:07:00-08:00'
+            }
+          ]
+        }
+        let(:expected_itunes_audio) { nil }
+        let(:expected_itunes_video) { nil }
+      end
+    end
+  end
+
+  describe 'course data from legacy Oracle' do
+    let(:legacy) { true }
+
+    before do
+      query_results = course[:ccn_set].map { |ccn| { 'course_cntl_num' => ccn.to_s } }
+      expect(CampusOracle::Queries).to receive(:get_all_course_sections).with(
+        course[:term_yr],
+        course[:term_cd],
+        course[:dept_name],
+        course[:catalog_id]).and_return query_results
+    end
+
+    context 'feature flag is false' do
+      it_should_behave_like 'a course with no recordings' do
+        let(:law_ccn_with_recordings) { 49688 }
+        let(:course) {
+          {
+            term_yr: '2008',
+            term_cd: 'D',
+            dept_name: 'LAW',
+            catalog_id: '2723',
+            ccn_set: [ 1, law_ccn_with_recordings, 2 ]
+          }
+        }
+        before { allow(Settings.features).to receive(:videos).and_return false }
+      end
+    end
+    context 'empty ccn array' do
+      it_should_behave_like 'a course with no recordings' do
+        let(:course) {
+          {
+            term_yr: '2014',
+            term_cd: 'D',
+            dept_name: 'ECON',
+            catalog_id: '101',
+            ccn_set: []
+          }
+        }
+      end
+    end
+    context 'not one ccn has associated videos' do
+      it_should_behave_like 'a course with no recordings' do
+        let(:course) {
+          {
+            term_yr: '2014',
+            term_cd: 'B',
+            dept_name: 'CHEM',
+            catalog_id: '101',
+            ccn_set: [1, 2, 3]
+          }
+        }
+      end
+    end
+    context 'course with recordings' do
+      it_should_behave_like 'a course with recordings' do
+        let(:malay_ccn_with_recordings) { 85006 }
+        let(:course) {
+          {
+            term_yr: '2014',
+            term_cd: 'D',
+            dept_name: 'MALAY/I',
+            catalog_id: '100A',
+            ccn_set: [ malay_ccn_with_recordings ]
+          }
+        }
+        let(:expected_ccn) { malay_ccn_with_recordings.to_s }
+        let(:expected_videos) { [] }
+        let(:expected_itunes_audio) { nil }
+        let(:expected_itunes_video) { '819827828' }
+      end
+    end
   end
 
 end

--- a/spec/models/edo_oracle/queries_spec.rb
+++ b/spec/models/edo_oracle/queries_spec.rb
@@ -28,7 +28,7 @@ describe EdoOracle::Queries, :ignore => true do
   let(:fall_term_id) { terms[0].campus_solutions_id }
 
   # BIOLOGY 1A - Fall 2016
-  let(:section_ids) { ['13572', '31352'] }
+  let(:section_ids) { %w(13572 31352) }
 
   it_behaves_like 'an Oracle driven data source' do
     subject { EdoOracle::Queries }
@@ -57,7 +57,7 @@ describe EdoOracle::Queries, :ignore => true do
     it 'fetches expected data' do
       results = EdoOracle::Queries.get_instructing_sections(uid, [term])
       expect(results.count).to eq 17
-      expected_keys = ['course_title', 'course_title_short', 'dept_name', 'catalog_id', 'primary', 'section_num', 'instruction_format', 'primary_associated_section_id', 'catalog_root', 'catalog_prefix', 'catalog_suffix', 'enroll_limit', 'waitlist_limit']
+      expected_keys = %w(course_title course_title_short dept_name catalog_id primary section_num instruction_format primary_associated_section_id catalog_root catalog_prefix catalog_suffix enroll_limit waitlist_limit)
       results.each do |result|
         expect(result['term_id']).to eq '2102'
         expect(result).to have_keys(expected_keys)
@@ -71,7 +71,7 @@ describe EdoOracle::Queries, :ignore => true do
     it 'fetches expected data' do
       results = EdoOracle::Queries.get_enrolled_sections(uid, [term])
       expect(results.count).to eq 5
-      expected_keys = ['section_id', 'term_id', 'course_title', 'course_title_short', 'dept_name', 'primary', 'section_num', 'instruction_format', 'primary_associated_section_id', 'course_display_name', 'section_display_name', 'catalog_id', 'catalog_root', 'catalog_prefix', 'catalog_suffix', 'enroll_limit', 'enroll_status', 'waitlist_position', 'units', 'grade', 'grading_basis']
+      expected_keys = %w(section_id term_id course_title course_title_short dept_name primary section_num instruction_format primary_associated_section_id course_display_name section_display_name catalog_id catalog_root catalog_prefix catalog_suffix enroll_limit enroll_status waitlist_position units grade grading_basis)
       results.each do |result|
         expect(result['term_id']).to eq '2102'
         expect(result).to have_keys(expected_keys)
@@ -85,7 +85,7 @@ describe EdoOracle::Queries, :ignore => true do
       expect(results.count).to eq 2
       expect(results[0]['section_id']).to eq '13572'
       expect(results[1]['section_id']).to eq '31352'
-      expected_keys = ['course_title', 'course_title_short', 'dept_name', 'catalog_id', 'primary', 'section_num', 'instruction_format', 'primary_associated_section_id', 'catalog_root', 'catalog_prefix', 'catalog_suffix']
+      expected_keys = %w(course_title course_title_short dept_name catalog_id primary section_num instruction_format primary_associated_section_id catalog_root catalog_prefix catalog_suffix)
       results.each do |result|
         expect(result['term_id']).to eq '2168'
         expected_keys.each do |expected_key|
@@ -99,10 +99,38 @@ describe EdoOracle::Queries, :ignore => true do
     it 'returns a set of secondary sections' do
       results = EdoOracle::Queries.get_associated_secondary_sections(fall_term_id, '31586')
       expect(results).to be_present
-      expected_keys = ['course_title', 'course_title_short', 'dept_name', 'catalog_id', 'primary', 'section_num', 'instruction_format', 'primary_associated_section_id', 'catalog_root', 'catalog_prefix', 'catalog_suffix']
+      expected_keys = %w(course_title course_title_short dept_name catalog_id primary section_num instruction_format primary_associated_section_id catalog_root catalog_prefix catalog_suffix)
       results.each do |result|
         expect(result).to have_keys(expected_keys)
         expect(result['section_display_name']).to eq 'ESPM 155AC'
+        expect(result['instruction_format']).to eq 'DIS'
+        expect(result['primary']).to eq 'false'
+        expect(result['term_id']).to eq fall_term_id
+      end
+    end
+  end
+
+  describe '.get_all_course_sections', testext: true do
+    it 'returns all sections per department and catalog_id' do
+      results = EdoOracle::Queries.get_all_course_sections '2168', 'XASTRON', '10'
+      expect(results).to be_present
+      expected_keys = %w(course_title course_title_short dept_name catalog_id primary section_num instruction_format primary_associated_section_id catalog_root catalog_prefix catalog_suffix)
+      results.each do |result|
+        expect(result).to have_keys(expected_keys)
+        expect(result['section_display_name']).to eq 'XASTRON 10'
+        expect(result['term_id']).to eq fall_term_id
+      end
+    end
+  end
+
+  describe '.get_course_secondary_sections', testext: true do
+    it 'returns secondary sections per department and catalog_id' do
+      results = EdoOracle::Queries.get_course_secondary_sections '2168', 'XASTRON', '10'
+      expect(results).to be_present
+      expected_keys = %w(course_title course_title_short dept_name catalog_id primary section_num instruction_format primary_associated_section_id catalog_root catalog_prefix catalog_suffix)
+      results.each do |result|
+        expect(result).to have_keys(expected_keys)
+        expect(result['section_display_name']).to eq 'XASTRON 10'
         expect(result['instruction_format']).to eq 'DIS'
         expect(result['primary']).to eq 'false'
         expect(result['term_id']).to eq fall_term_id
@@ -114,7 +142,7 @@ describe EdoOracle::Queries, :ignore => true do
     it 'returns meetings for section id specified' do
       results = EdoOracle::Queries.get_section_meetings(fall_term_id, section_ids[0])
       expect(results.count).to eq 1
-      expected_keys = ['section_id', 'term_id', 'session_id', 'location', 'meeting_days', 'meeting_start_time', 'meeting_end_time', 'print_in_schedule_of_classes']
+      expected_keys = %w(section_id term_id session_id location meeting_days meeting_start_time meeting_end_time print_in_schedule_of_classes)
       results.each do |result|
         expect(result['section_id']).to eq '26340'
         expect(result['term_id']).to eq '2168'
@@ -125,7 +153,7 @@ describe EdoOracle::Queries, :ignore => true do
   end
 
   describe '.get_section_instructors', :testext => true do
-    let(:expected_keys) { ['person_name', 'first_name', 'last_name', 'ldap_uid', 'role_code', 'role_description'] }
+    let(:expected_keys) { %w(person_name first_name last_name ldap_uid role_code role_description) }
     it 'returns instructors for section' do
       results = EdoOracle::Queries.get_section_instructors(fall_term_id, section_ids[0])
       results.each do |result|
@@ -135,7 +163,7 @@ describe EdoOracle::Queries, :ignore => true do
   end
 
   describe '.terms', :testext => true do
-    let(:expected_keys) { ['term_code', 'term_name', 'term_start_date', 'term_end_date'] }
+    let(:expected_keys) { %w(term_code term_name term_start_date term_end_date) }
     it 'returns terms' do
       results = EdoOracle::Queries.terms
       results.each do |result|
@@ -165,7 +193,7 @@ describe EdoOracle::Queries, :ignore => true do
   end
 
   describe '.get_enrolled_students', :textext => true do
-    let(:expected_keys) { ['ldap_uid', 'student_id', 'enroll_status', 'waitlist_position', 'units', 'grading_basis'] }
+    let(:expected_keys) { %w(ldap_uid student_id enroll_status waitlist_position units grading_basis) }
     it 'returns enrollments for section' do
       results = EdoOracle::Queries.get_enrolled_students(section_ids[0], fall_term_id)
       results.each do |enrollment|

--- a/spec/models/webcast/recordings_spec.rb
+++ b/spec/models/webcast/recordings_spec.rb
@@ -6,7 +6,7 @@ describe Webcast::Recordings do
     context 'data organized by ccn' do
       let(:recordings) { Webcast::Recordings.new({:fake => true}).get }
       it 'should return a lot of playlists' do
-        expect(recordings[:courses].keys.length).to eq 22
+        expect(recordings[:courses].keys.length).to eq 23
         law_2723 = recordings[:courses]['2008-D-49688']
         expect(law_2723).to_not be_nil
         expect(law_2723[:recordings]).to have(12).items


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6276
* If `Berkeley::Terms.legacy? term_yr, term_cd` then `CampusOracle::Queries` else `EdoOracle::Queries`. 
* Change to `routes.rb` does not change feed URL signature. 
* Test coverage

I revised PR #5419 by removing the no-op bits of `ORDER BY`