### PR TITLE
SISRP-19757 Remove thread-unsafe Webmock gem from production builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,9 +95,6 @@ gem 'net-ssh', '~>2.9.2' # v3 requires Ruby 2.0
 
 gem 'icalendar', '~> 2.2.2'
 
-# Fake proxies
-gem 'webmock', '~> 1.20.4'
-
 ##################################
 # Front-end Gems for Rails Admin #
 ##################################
@@ -145,6 +142,9 @@ group :development, :test , :testext do
   gem 'spork','1.0.0rc0'
   gem 'guard-spork'
   gem 'spork-rails'
+
+  # Webmock is not thread-safe and should never be enabled in production-like environments.
+  gem 'webmock', '~> 1.20.4'
 end
 
 group :development do


### PR DESCRIPTION
Master version of https://github.com/ets-berkeley-edu/calcentral/pull/5431

I've added a comment for safety.