### PR TITLE
SISRP-19386 - Advisor Resource Link updates

### DIFF
--- a/app/models/campus_solutions/advising_resources.rb
+++ b/app/models/campus_solutions/advising_resources.rb
@@ -35,9 +35,8 @@ module CampusSolutions
       if links
         # The following links are hard-coded, for now. Ideally they would be served by CS API but there is an urgent need
         # thus we manage the content via CalCentral settings.
-        add_cs_link links, :multi_year_academic_planner, 'MULTI_YEAR_ACADEMIC_PLANNER', 'Multi-Year Academic Planner'
-        add_cs_link links, :schedule_planner, 'SCHEDULE_PLANNER', 'Schedule Planner'
-        add_cs_link links, :multi_year_academic_planner, 'MULTI_YEAR_ACADEMIC_PLANNER_STUDENT_SPECIFIC', 'Multi-Year Academic Planner', "?UCemplid=#{lookup_student_id}"
+        add_cs_link links, :multi_year_academic_planner_generic, 'MULTI_YEAR_ACADEMIC_PLANNER_GENERIC', 'Multi-Year Planner'
+        add_cs_link links, :multi_year_academic_planner, 'MULTI_YEAR_ACADEMIC_PLANNER_STUDENT_SPECIFIC', 'Multi-Year Planner', "?UCemplid=#{lookup_student_id}"
         add_cs_link links, :schedule_planner, 'SCHEDULE_PLANNER_STUDENT_SPECIFIC', 'Schedule Planner', "?EMPLID=#{lookup_student_id}"
       end
       feed

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -424,6 +424,7 @@ calnet_crosswalk_proxy:
 
 campus_solutions_links:
   advising:
+    multi_year_academic_planner_generic: ''
     multi_year_academic_planner: ''
     schedule_planner: ''
 

--- a/spec/controllers/campus_solutions/advising_resources_controller_spec.rb
+++ b/spec/controllers/campus_solutions/advising_resources_controller_spec.rb
@@ -29,7 +29,6 @@ describe CampusSolutions::AdvisingResourcesController do
           expect(link = resources['ucAdvisingLinks'][key]).to_not be_nil
           expect(link['isCsLink']).to be true
           expect(link['name']).to eq expected_name
-
         end
       end
 
@@ -41,8 +40,8 @@ describe CampusSolutions::AdvisingResourcesController do
       end
 
       context 'links from YAML settings' do
-        let(:key) { 'multiYearAcademicPlanner' }
-        let(:expected_name) { 'Multi-Year Academic Planner' }
+        let(:key) { 'multiYearAcademicPlannerGeneric' }
+        let(:expected_name) { 'Multi-Year Planner' }
 
         it_behaves_like 'a feed with advising resources'
       end

--- a/src/assets/templates/widgets/advisor/advising_links.html
+++ b/src/assets/templates/widgets/advisor/advising_links.html
@@ -47,9 +47,9 @@
       data-text="Schedule of Classes - Class Search"
     ></div>
   </li>
-  <li data-ng-if="ucAdvisingResources.ucAdvisingLinks.multiYearAcademicPlanner.url">
+  <li data-ng-if="ucAdvisingResources.ucAdvisingLinks.multiYearAcademicPlannerGeneric.url">
     <a
-      data-ng-href="{{ucAdvisingResources.ucAdvisingLinks.multiYearAcademicPlanner.url}}"
-    >Multi-Year Academic Planner</a>
+      data-ng-href="{{ucAdvisingResources.ucAdvisingLinks.multiYearAcademicPlannerGeneric.url}}"
+    >Multi-Year Planner</a>
   </li>
 </ul>

--- a/src/assets/templates/widgets/toolbox/user_preview.html
+++ b/src/assets/templates/widgets/toolbox/user_preview.html
@@ -104,10 +104,9 @@
                   ></div>
                 </div>
                 <div data-ng-if="ucAdvisingResources.ucAdvisingLinks.schedulePlannerStudentSpecific.url">
-                  <div
-                    data-cc-campus-solutions-link-item-directive
-                    data-link="ucAdvisingResources.ucAdvisingLinks.schedulePlannerStudentSpecific"
-                  ></div>
+                  <a
+                    data-ng-href="{{ucAdvisingResources.ucAdvisingLinks.schedulePlannerStudentSpecific.url}}"
+                    data-ng-bind="ucAdvisingResources.ucAdvisingLinks.schedulePlannerStudentSpecific.name"></a>
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-19386

* Changes link name to 'Multi-Year Planner' instead of 'Multi-Year Academic Planner'
* Removes unused generic 'Schedule Planner' link from feed.
* Adds generic 'Multi-Year Planner' link for use on 'Advising Resources' card
* Updates 'Schedule Planner' link under 'Personal Summary' card so that it opens in a new window