### PR TITLE
SISRP-19804 - Add EFT Proxy Information, Update Back-End for Actual Response

### DIFF
--- a/app/models/eft/my_eft_enrollment.rb
+++ b/app/models/eft/my_eft_enrollment.rb
@@ -4,6 +4,7 @@ module Eft
     include Cache::JsonifiedFeed
     include Cache::FeedExceptionsHandled
     include Cache::UserCacheExpiry
+    include CampusSolutions::CampusSolutionsIdRequired
     include Proxies::HttpClient
     include Proxies::Mockable
     include ClassLogger
@@ -16,7 +17,13 @@ module Eft
     end
 
     def default_message_on_exception
-      'Failed to connect with EFT system.'
+      "Failed to connect with EFT system"
+    end
+
+    def lookup_student_id
+      if @uid
+        @campus_solutions_id = CalnetCrosswalk::ByUid.new(user_id: @uid).lookup_campus_solutions_id
+      end
     end
 
     def get_feed_internal
@@ -25,17 +32,18 @@ module Eft
     end
 
     def get_parsed_response
-      url = "#{@settings.base_url}/student/#{@uid}"
+      lookup_student_id
+      url = "#{@settings.base_url}eft_status?studentId=#{@campus_solutions_id}"
       logger.info "get_parsed_response: Fake = #{@fake}; Making request to #{url} on behalf of user #{@uid}; cache expiration #{self.class.expires_in}"
       response = get_response(
         url,
-        basic_auth: {username: @settings.username, password: @settings.password},
+        headers: {"token" => "#{@settings.token}"},
         on_error: {rescue_status: 404}
       )
       feed = {statusCode: response.code}
       if response.code == 404
         logger.debug "404 response from EFT Enrollment API for user #{@uid}"
-        feed.merge(body: 'No EFT data could be found for your account.')
+        response["errorMessage"] ? feed.merge(errorMessage: response["errorMessage"]) : feed.merge(errorMessage: "No EFT data could be found for your account")
       else
         logger.debug "EFT remote response: #{response.inspect}"
         feed.merge response.parsed_response

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -156,9 +156,9 @@ calmail_proxy:
 
 eft_proxy:
   fake: true
-  base_url: 'https://example.com'
-  usermname: 'some_username'
-  password: 'some_password'
+  # QA Environment
+  base_url: 'https://eftstudent-qa.berkeley.edu/api/'
+  token: 'secret'
 
 regstatus_proxy:
   fake: false

--- a/fixtures/json/eft_enrollment.json
+++ b/fixtures/json/eft_enrollment.json
@@ -1,7 +1,7 @@
 {
-   "data": {
-        "transaction-status": "Confirmed",
-        "eft-is-active": true,
-        "account-number": 4252
+   "statusCode":200,
+   "data":{
+      "eftStatus": "active",
+      "accountNumber": "6456"
    }
 }


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-19804

* Removed some unnecessary class inclusions, as the incoming feed is already JSON'd (I hope this is correct)
* Removed custom error handling, since the error messages coming from EFT should be more helpful in determining any problems
* Good ol' Oski info
* I do have a security token to enable this proxy (currently just for its QA environment) - what would be the best way to communicate this to all developers?