### PR TITLE
SISRP-19912 - Dev: emergency contact edit - backend prep work

### DIFF
--- a/app/controllers/campus_solutions/emergency_contacts_controller.rb
+++ b/app/controllers/campus_solutions/emergency_contacts_controller.rb
@@ -1,0 +1,9 @@
+module CampusSolutions
+  class EmergencyContactsController < CampusSolutionsController
+
+    def get
+      json_passthrough CampusSolutions::EmergencyContacts, user_id: session['user_id']
+    end
+
+  end
+end

--- a/app/models/campus_solutions/emergency_contacts.rb
+++ b/app/models/campus_solutions/emergency_contacts.rb
@@ -1,0 +1,57 @@
+module CampusSolutions
+  class EmergencyContacts < CachedProxy
+
+    include CampusSolutionsIdRequired
+    include EmergencyContactsFeatureFlagged
+
+    def initialize(options = {})
+      super options
+      initialize_mocks if @fake
+    end
+
+    def xml_filename
+      'emergency_contacts.xml'
+    end
+
+    def build_feed(response)
+      return {} unless is_feature_enabled or response.parsed_response.blank?
+      normalize_response(response).parsed_response
+    end
+
+    def normalize_response(response)
+      # Perform several checks and transforms on the response because the campus_solutions API
+      # returns inconsistently structured data.
+
+      container = response.parsed_response['STUDENTS']['STUDENT']['EMERGENCY_CONTACTS']
+      return response if container.blank?
+
+      contacts = container['EMERGENCY_CONTACT']
+
+      contacts.sort! do |left, right|
+        # Put the primary_contact with 'Y' at the head position, values being either 'Y' or 'N'
+        right['PRIMARY_CONTACT'] <=> left['PRIMARY_CONTACT']
+      end
+
+      contacts.each do |item|
+        # The campus_solutions API returns the following structure:
+        # When a contact has one phone, emergency_phone points to that phone;
+        # When a contact has more than one phone, then emergency_phone points to an array of phones;
+        # We fix that by making emergency_phone into an array, always.
+        phones = item['EMERGENCY_PHONES']
+
+        if phones
+          phones['EMERGENCY_PHONE'] = Array.wrap phones['EMERGENCY_PHONE']
+        else
+          item['EMERGENCY_PHONES'] = {"EMERGENCY_PHONE" => []}
+        end
+      end
+
+      response
+    end
+
+    def url
+      "#{@settings.base_url}/UcApiEmergencyContactGet.v1/?EMPLID=#{@campus_solutions_id}"
+    end
+
+  end
+end

--- a/app/models/campus_solutions/emergency_contacts_feature_flagged.rb
+++ b/app/models/campus_solutions/emergency_contacts_feature_flagged.rb
@@ -1,0 +1,7 @@
+module CampusSolutions
+  module EmergencyContactsFeatureFlagged
+    def is_feature_enabled
+      Settings.features.cs_profile_emergency_contacts
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -192,6 +192,7 @@ Calcentral::Application.routes.draw do
   get '/api/campus_solutions/billing' => 'campus_solutions/billing#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/slr_deeplink' => 'campus_solutions/slr_deeplink#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/fpp_enrollment' => 'campus_solutions/fpp_enrollment#get', :via => :get, :defaults => { :format => 'json' }
+  get '/api/campus_solutions/emergency_contacts' => 'campus_solutions/emergency_contacts#get', :via => :get, :defaults => { :format => 'json' }
   post '/api/campus_solutions/address' => 'campus_solutions/address#post', :via => :post, :defaults => { :format => 'json' }
   post '/api/campus_solutions/email' => 'campus_solutions/email#post', :via => :post, :defaults => { :format => 'json' }
   post '/api/campus_solutions/person_name' => 'campus_solutions/person_name#post', :via => :post, :defaults => { :format => 'json' }

--- a/fixtures/xml/campus_solutions/emergency_contacts.xml
+++ b/fixtures/xml/campus_solutions/emergency_contacts.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0"?>
+<STUDENTS xmlns="http://bcs.is.berkeley.edu">
+  <STUDENT>
+    <EMERGENCY_CONTACTS>
+      <EMERGENCY_CONTACT type="boolean">
+        <student-id>24172048</student-id>
+        <CONTACT_NAME>Chet</CONTACT_NAME>
+        <ADDRESS1>123 4th St.</ADDRESS1>
+        <ADDRESS2>Apt. XYZ</ADDRESS2>
+        <ADDRESS3>Aisle 3</ADDRESS3>
+        <ADDRESS4/>
+        <ADDR_FIELD1/>
+        <ADDR_FIELD2/>
+        <ADDR_FIELD3/>
+        <CITY>Antioch</CITY>
+        <COUNTRY>USA</COUNTRY>
+        <COUNTRY_DESCR>United States</COUNTRY_DESCR>
+        <COUNTY>Contra Costa</COUNTY>
+        <HOUSE_TYPE/>
+        <NUM1/>
+        <NUM2/>
+        <STATE>CA</STATE>
+        <STATE_DESCR>California</STATE_DESCR>
+        <POSTAL>94509</POSTAL>
+        <ADDRESS_TYPE/>
+        <GEO_CODE/>
+        <IN_CITY_LIMIT/>
+        <SAME_ADDRESS_EMPL>N</SAME_ADDRESS_EMPL>
+        <SAME_PHONE_EMPL>N</SAME_PHONE_EMPL>
+        <EMAIL_ADDR>contact@foobarbaz.quux</EMAIL_ADDR>
+        <RELATIONSHIP>FR</RELATIONSHIP>
+        <RELATIONSHIP_DESCR>Friend</RELATIONSHIP_DESCR>
+        <PRIMARY_CONTACT>N</PRIMARY_CONTACT>
+        <FORMATTED_ADDRESS>
+          123 4th St.\nApt. XYZ\nAisle 3\nAntioch, California 94509
+        </FORMATTED_ADDRESS>
+      </EMERGENCY_CONTACT>
+      <EMERGENCY_CONTACT type="boolean">
+        <student-id>24172048</student-id>
+        <CONTACT_NAME>Mom</CONTACT_NAME>
+        <ADDRESS1>6966 PARKSIDE AVENUE</ADDRESS1>
+        <ADDRESS2/>
+        <ADDRESS3/>
+        <ADDRESS4/>
+        <ADDR_FIELD1/>
+        <ADDR_FIELD2/>
+        <ADDR_FIELD3/>
+        <CITY>SAN DIEGO</CITY>
+        <COUNTRY>USA</COUNTRY>
+        <COUNTRY_DESCR>United States</COUNTRY_DESCR>
+        <COUNTY/>
+        <HOUSE_TYPE/>
+        <NUM1/>
+        <NUM2/>
+        <STATE>CA</STATE>
+        <STATE_DESCR>California</STATE_DESCR>
+        <POSTAL>92139-3832</POSTAL>
+        <ADDRESS_TYPE>HOME</ADDRESS_TYPE>
+        <GEO_CODE/>
+        <IN_CITY_LIMIT/>
+        <SAME_ADDRESS_EMPL>Y</SAME_ADDRESS_EMPL>
+        <SAME_PHONE_EMPL>Y</SAME_PHONE_EMPL>
+        <EMAIL_ADDR/>
+        <RELATIONSHIP>P</RELATIONSHIP>
+        <RELATIONSHIP_DESCR>Parent</RELATIONSHIP_DESCR>
+        <PRIMARY_CONTACT>Y</PRIMARY_CONTACT>
+        <FORMATTED_ADDRESS>
+          6966 PARKSIDE AVENUE\nSAN DIEGO, California 92139-3832
+        </FORMATTED_ADDRESS>
+        <EMERGENCY_PHONES>
+          <EMERGENCY_PHONE>
+            <PRIMARY_PHONE>Y</PRIMARY_PHONE>
+            <PHONE_TYPE>LOCL</PHONE_TYPE>
+            <PHONE_TYPE_DESCR>Local</PHONE_TYPE_DESCR>
+            <PHONE>619/370-4644</PHONE>
+            <EXTENSION/>
+            <COUNTRY_CODE/>
+          </EMERGENCY_PHONE>
+        </EMERGENCY_PHONES>
+      </EMERGENCY_CONTACT>
+      <EMERGENCY_CONTACT type="boolean">
+        <student-id>24172048</student-id>
+        <CONTACT_NAME>Nancy</CONTACT_NAME>
+        <ADDRESS1>567 8th Ave.</ADDRESS1>
+        <ADDRESS2/>
+        <ADDRESS3/>
+        <ADDRESS4/>
+        <ADDR_FIELD1/>
+        <ADDR_FIELD2/>
+        <ADDR_FIELD3/>
+        <CITY>New York</CITY>
+        <COUNTRY>USA</COUNTRY>
+        <COUNTRY_DESCR>United States</COUNTRY_DESCR>
+        <COUNTY/>
+        <HOUSE_TYPE/>
+        <NUM1/>
+        <NUM2/>
+        <STATE>NY</STATE>
+        <STATE_DESCR>New York</STATE_DESCR>
+        <POSTAL>10001</POSTAL>
+        <ADDRESS_TYPE/>
+        <GEO_CODE/>
+        <IN_CITY_LIMIT/>
+        <SAME_ADDRESS_EMPL>N</SAME_ADDRESS_EMPL>
+        <SAME_PHONE_EMPL>N</SAME_PHONE_EMPL>
+        <EMAIL_ADDR/>
+        <RELATIONSHIP>SB</RELATIONSHIP>
+        <RELATIONSHIP_DESCR>Sibling</RELATIONSHIP_DESCR>
+        <PRIMARY_CONTACT>N</PRIMARY_CONTACT>
+        <FORMATTED_ADDRESS>567 8th Ave.\nNew York, New York 10001</FORMATTED_ADDRESS>
+        <EMERGENCY_PHONES>
+          <EMERGENCY_PHONE>
+            <PRIMARY_PHONE>N</PRIMARY_PHONE>
+            <PHONE_TYPE/>
+            <PHONE_TYPE_DESCR/>
+            <PHONE>123/456-7890</PHONE>
+            <EXTENSION>121</EXTENSION>
+            <COUNTRY_CODE/>
+          </EMERGENCY_PHONE>
+        </EMERGENCY_PHONES>
+      </EMERGENCY_CONTACT>
+      <EMERGENCY_CONTACT type="boolean">
+        <student-id>24172048</student-id>
+        <CONTACT_NAME>PhoneGuy</CONTACT_NAME>
+        <ADDRESS1/>
+        <ADDRESS2/>
+        <ADDRESS3/>
+        <ADDRESS4/>
+        <ADDR_FIELD1/>
+        <ADDR_FIELD2/>
+        <ADDR_FIELD3/>
+        <CITY/>
+        <COUNTRY>USA</COUNTRY>
+        <COUNTRY_DESCR>United States</COUNTRY_DESCR>
+        <COUNTY/>
+        <HOUSE_TYPE/>
+        <NUM1/>
+        <NUM2/>
+        <STATE/>
+        <STATE_DESCR/>
+        <POSTAL/>
+        <ADDRESS_TYPE/>
+        <GEO_CODE/>
+        <IN_CITY_LIMIT/>
+        <SAME_ADDRESS_EMPL>N</SAME_ADDRESS_EMPL>
+        <SAME_PHONE_EMPL>N</SAME_PHONE_EMPL>
+        <EMAIL_ADDR/>
+        <RELATIONSHIP>R</RELATIONSHIP>
+        <RELATIONSHIP_DESCR>Other Relative</RELATIONSHIP_DESCR>
+        <PRIMARY_CONTACT>N</PRIMARY_CONTACT>
+        <FORMATTED_ADDRESS/>
+        <EMERGENCY_PHONES>
+          <EMERGENCY_PHONE>
+            <PRIMARY_PHONE>N</PRIMARY_PHONE>
+            <PHONE_TYPE/>
+            <PHONE_TYPE_DESCR/>
+            <PHONE>123/456-7890</PHONE>
+            <EXTENSION/>
+            <COUNTRY_CODE/>
+          </EMERGENCY_PHONE>
+          <EMERGENCY_PHONE>
+            <PRIMARY_PHONE>N</PRIMARY_PHONE>
+            <PHONE_TYPE>BUSN</PHONE_TYPE>
+            <PHONE_TYPE_DESCR>Business</PHONE_TYPE_DESCR>
+            <PHONE>987/654-3210</PHONE>
+            <EXTENSION>9876</EXTENSION>
+            <COUNTRY_CODE/>
+          </EMERGENCY_PHONE>
+          <EMERGENCY_PHONE>
+            <PRIMARY_PHONE>N</PRIMARY_PHONE>
+            <PHONE_TYPE>CAMP</PHONE_TYPE>
+            <PHONE_TYPE_DESCR>Campus</PHONE_TYPE_DESCR>
+            <PHONE>876/543-2109</PHONE>
+            <EXTENSION/>
+            <COUNTRY_CODE/>
+          </EMERGENCY_PHONE>
+          <EMERGENCY_PHONE>
+            <PRIMARY_PHONE>N</PRIMARY_PHONE>
+            <PHONE_TYPE>CELL</PHONE_TYPE>
+            <PHONE_TYPE_DESCR>Mobile</PHONE_TYPE_DESCR>
+            <PHONE>654.321.0987</PHONE>
+            <EXTENSION/>
+            <COUNTRY_CODE/>
+          </EMERGENCY_PHONE>
+          <EMERGENCY_PHONE>
+            <PRIMARY_PHONE>N</PRIMARY_PHONE>
+            <PHONE_TYPE>HOME</PHONE_TYPE>
+            <PHONE_TYPE_DESCR>Home/Permanent</PHONE_TYPE_DESCR>
+            <PHONE>765/432-1098</PHONE>
+            <EXTENSION/>
+            <COUNTRY_CODE/>
+          </EMERGENCY_PHONE>
+          <EMERGENCY_PHONE>
+            <PRIMARY_PHONE>N</PRIMARY_PHONE>
+            <PHONE_TYPE>INTL</PHONE_TYPE>
+            <PHONE_TYPE_DESCR>International</PHONE_TYPE_DESCR>
+            <PHONE>011/011-0111</PHONE>
+            <EXTENSION/>
+            <COUNTRY_CODE/>
+          </EMERGENCY_PHONE>
+          <EMERGENCY_PHONE>
+            <PRIMARY_PHONE>N</PRIMARY_PHONE>
+            <PHONE_TYPE>LOCL</PHONE_TYPE>
+            <PHONE_TYPE_DESCR>Local</PHONE_TYPE_DESCR>
+            <PHONE>415/415-4154</PHONE>
+            <EXTENSION/>
+            <COUNTRY_CODE/>
+          </EMERGENCY_PHONE>
+          <EMERGENCY_PHONE>
+            <PRIMARY_PHONE>N</PRIMARY_PHONE>
+            <PHONE_TYPE>OTR</PHONE_TYPE>
+            <PHONE_TYPE_DESCR>Other</PHONE_TYPE_DESCR>
+            <PHONE>000.000.0000</PHONE>
+            <EXTENSION/>
+            <COUNTRY_CODE/>
+          </EMERGENCY_PHONE>
+        </EMERGENCY_PHONES>
+      </EMERGENCY_CONTACT>
+    </EMERGENCY_CONTACTS>
+  </STUDENT>
+</STUDENTS>

--- a/fixtures/xml/campus_solutions/emergency_contacts_empty.xml
+++ b/fixtures/xml/campus_solutions/emergency_contacts_empty.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<STUDENTS xmlns="http://bcs.is.berkeley.edu"><STUDENT><EMERGENCY_CONTACTS/></STUDENT></STUDENTS>

--- a/spec/controllers/campus_solutions/emergency_contacts_controller_spec.rb
+++ b/spec/controllers/campus_solutions/emergency_contacts_controller_spec.rb
@@ -1,0 +1,12 @@
+describe CampusSolutions::EmergencyContactsController do
+  context 'emergency contacts feed' do
+    let(:feed) { :get }
+    it_behaves_like 'an unauthenticated user'
+
+    context 'authenticated user' do
+      let(:user_id) { '1024600' }
+      let(:feed_key) { 'students' }
+      it_behaves_like 'a successful feed'
+    end
+  end
+end

--- a/spec/controllers/campus_solutions/language_code_controller_spec.rb
+++ b/spec/controllers/campus_solutions/language_code_controller_spec.rb
@@ -1,5 +1,5 @@
 describe CampusSolutions::LanguageCodeController do
-  context 'language feed' do
+  context 'language codes feed' do
     let(:feed) { :get }
     it_behaves_like 'an unauthenticated user'
     context 'authenticated user' do
@@ -9,4 +9,3 @@ describe CampusSolutions::LanguageCodeController do
     end
   end
 end
-

--- a/spec/models/campus_solutions/emergency_contacts_spec.rb
+++ b/spec/models/campus_solutions/emergency_contacts_spec.rb
@@ -1,0 +1,49 @@
+describe CampusSolutions::EmergencyContacts do
+
+  let(:user_id) {'1024600'}
+
+  shared_examples 'a proxy that gets data' do
+    let(:proxy) { CampusSolutions::EmergencyContacts.new(fake: true, user_id: user_id) }
+    subject { proxy.get }
+    it_should_behave_like 'a simple proxy that returns errors'
+    it_behaves_like 'a proxy that properly observes the emergency contact feature flag'
+    it_behaves_like 'a proxy that got data successfully'
+    it 'returns data with the expected structure' do
+
+      # Guard against the empty feed when testing against real proxy with testext context
+      students_feed = subject[:feed][:students]
+      if students_feed
+        emergency_contacts = students_feed[:student][:emergencyContacts][:emergencyContact]
+        expect(emergency_contacts.length).to be
+
+        # primary contact always at head position
+        primary = emergency_contacts[0]
+        expect(primary[:primaryContact]).to eq "Y"
+        if primary[:emergencyPhones][:emergencyPhone].length > 0
+          expect(primary[:emergencyPhones][:emergencyPhone][0][:primaryPhone]).to eq "Y"
+        end
+
+        # subsequent contacts
+        i = 1
+        while i < emergency_contacts.length
+          contact = emergency_contacts[i]
+          i += 1
+          expect(contact[:primaryContact]).to eq "N"
+          if contact[:emergencyPhones][:emergencyPhone].length > 0
+            expect(contact[:emergencyPhones][:emergencyPhone][0][:primaryPhone]).to eq "N"
+          end
+        end
+      end
+    end
+  end
+
+  context 'mock proxy' do
+    let(:fake_proxy) { true }
+    it_should_behave_like 'a proxy that gets data'
+  end
+
+  context 'real proxy', testext: true do
+    let(:fake_proxy) { false }
+    it_should_behave_like 'a proxy that gets data'
+  end
+end

--- a/spec/support/campus_solutions_helper_module.rb
+++ b/spec/support/campus_solutions_helper_module.rb
@@ -108,4 +108,8 @@ module CampusSolutionsHelperModule
     it_behaves_like 'a proxy that observes a feature flag'
   end
 
+  shared_examples 'a proxy that properly observes the emergency contact feature flag' do
+    let(:flag) { :cs_profile_emergency_contacts }
+    it_behaves_like 'a proxy that observes a feature flag'
+  end
 end

--- a/src/assets/javascripts/angular/controllers/widgets/profile/emergencyContactController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/profile/emergencyContactController.js
@@ -1,20 +1,41 @@
 'use strict';
 
 var angular = require('angular');
+var _ = require('lodash');
 
 /**
  * Emergency Contact controller
  */
 angular.module('calcentral.controllers').controller('EmergencyContactController', function(apiService, profileFactory, $scope, $q) {
-  var parsePerson = function(data) {
-    apiService.profile.parseSection($scope, data, 'emergencyContacts');
-    $scope.items.content = apiService.profile.fixFormattedAddresses($scope.items.content);
+
+  angular.extend($scope, {
+    items: {
+      content: []
+    }
+  });
+
+  var fixFormattedAddress = function(emergencyContact) {
+    emergencyContact.formattedAddress = emergencyContact.formattedAddress || '';
+
+    if (emergencyContact.formattedAddress) {
+      emergencyContact.formattedAddress = apiService.profile.fixFormattedAddress(emergencyContact.formattedAddress);
+    }
   };
 
-  var getPerson = profileFactory.getPerson().then(parsePerson);
+  var parseEmergencyContacts = function(data) {
+    var emergencyContacts = _.get(data, 'data.feed.students.student.emergencyContacts.emergencyContact') || [];
+
+    _(emergencyContacts).each(function(emergencyContact) {
+      fixFormattedAddress(emergencyContact);
+    });
+
+    $scope.items.content = emergencyContacts;
+  };
+
+  var getEmergencyContacts = profileFactory.getEmergencyContacts().then(parseEmergencyContacts);
 
   var loadInformation = function() {
-    $q.all(getPerson).then(function() {
+    $q.all(getEmergencyContacts).then(function() {
       $scope.isLoading = false;
     });
   };

--- a/src/assets/javascripts/angular/factories/profileFactory.js
+++ b/src/assets/javascripts/angular/factories/profileFactory.js
@@ -9,6 +9,7 @@ angular.module('calcentral.factories').factory('profileFactory', function(apiSer
   var urlAddressFields = '/api/campus_solutions/address_label';
   var urlCountries = '/api/campus_solutions/country';
   var urlDeleteLanguage = '/api/campus_solutions/language';
+  var urlEmergencyContacts = '/api/campus_solutions/emergency_contacts';
   // var urlLanguageCodes = '/dummy/json/language_codes.json';
   var urlLanguageCodes = '/api/campus_solutions/language_code';
   // var urlPerson = '/dummy/json/student_with_languages.json';
@@ -52,6 +53,9 @@ angular.module('calcentral.factories').factory('profileFactory', function(apiSer
   };
   var getCountries = function(options) {
     return apiService.http.request(options, urlCountries);
+  };
+  var getEmergencyContacts = function(options) {
+    return apiService.http.request(options, urlEmergencyContacts);
   };
   var getLanguageCodes = function(options) {
     return apiService.http.request(options, urlLanguageCodes);
@@ -112,6 +116,7 @@ angular.module('calcentral.factories').factory('profileFactory', function(apiSer
     getCountries: getCountries,
     getCurrencies: getCurrencies,
     getAddressFields: getAddressFields,
+    getEmergencyContacts: getEmergencyContacts,
     getLanguageCodes: getLanguageCodes,
     getPerson: getPerson,
     getStates: getStates,

--- a/src/assets/javascripts/angular/services/profileService.js
+++ b/src/assets/javascripts/angular/services/profileService.js
@@ -85,7 +85,14 @@ angular.module('calcentral.services').service('profileService', function() {
   };
 
   /**
-   * Prepare formattedAddress by replacing '\\n' with '\n'.
+   * Process a single formattedAddress by replacing '\\n' with '\n'.
+   */
+  var fixFormattedAddress = function(formattedAddress) {
+    return formattedAddress.replace(/\\n/g, '\n');
+  };
+
+  /**
+   * Process an array of formattedAddresses by replacing '\\n' with '\n'.
    */
   var fixFormattedAddresses = function(addresses) {
     if (!addresses) {
@@ -199,6 +206,7 @@ angular.module('calcentral.services').service('profileService', function() {
     filterTypes: filterTypes,
     findPreferred: findPreferred,
     findPrimary: findPrimary,
+    fixFormattedAddress: fixFormattedAddress,
     fixFormattedAddresses: fixFormattedAddresses,
     matchFields: matchFields,
     parseSection: parseSection,

--- a/src/assets/templates/widgets/profile/emergency_contact.html
+++ b/src/assets/templates/widgets/profile/emergency_contact.html
@@ -1,19 +1,26 @@
-<div class="cc-page-widget-profile-section" data-ng-controller="EmergencyContactController">
-  <div class="cc-page-widget-profile-section-label" data-ng-pluralize count="items.content.length" when="{'1': 'Emergency Contact', 'other': 'Emergency Contacts'}">
-    </div>
+<div class="cc-page-widget-profile-section" data-ng-controller="EmergencyContactController" data-cc-spinner-directive="isLoading">
+
+  <div class="cc-page-widget-profile-section-label" data-ng-pluralize count="items.content.length" when="{'1': 'Emergency Contact', 'other': 'Emergency Contacts'}"></div>
+
   <div class="cc-page-widget-profile-section-content">
     <div data-ng-repeat="emergencyContact in items.content" class="cc-page-widget-profile-section-content-item">
       <div>
-        <strong data-ng-bind="emergencyContact.name"></strong>
-        <span data-ng-if="emergencyContact.relationship.description" data-ng-bind-template="- {{emergencyContact.relationship.description}}"><span>
-        <span data-ng-if="emergencyContact.preferred">(primary contact)</span>
+        <strong data-ng-bind="emergencyContact.contactName"></strong>
+        <span data-ng-if="emergencyContact.relationshipDescr" data-ng-bind-template="- {{emergencyContact.relationshipDescr}}"></span>
+        <span data-ng-if="emergencyContact.primaryContact === 'Y'">
+          (primary contact)
+        </span>
       </div>
-      <div data-ng-repeat="phone in emergencyContact.phones">
-        <span data-ng-bind="phone.number"></span>
+      <div data-ng-repeat="emergencyPhone in emergencyContact.emergencyPhones.emergencyPhone">
+        <span data-ng-bind="emergencyPhone.phone"></span>
+        <p class="cc-visuallyhidden" data-ng-if="emergencyPhone.phoneTypeDescr">
+          (<span data-ng-bind-template="{{emergencyPhone.phoneTypeDescr}} phone"></span>)
+        </p>
       </div>
-      <div data-ng-bind="emergencyContact.email.emailAddress"></div>
-      <div class="cc-text-pre-line cc-page-widget-profile-margin-top" data-ng-bind="emergencyContact.address.formattedAddress"></div>
+      <div data-ng-bind="emergencyContact.emailAddr"></div>
+      <div class="cc-text-pre-line cc-page-widget-profile-margin-top" data-ng-bind="emergencyContact.formattedAddress"></div>
     </div>
+
     <div data-ng-if="!items.content.length" class="cc-page-widget-profile-section-not-available">
       There are no emergency contacts available.
     </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-19912

This is behind the feature flag, 'cs_profile_emergency_contacts'

Part of the longer SISRP-10778 story.  This PR is for work required to get a student's emergency contact data from the *correct* GET endpoint, instead of the hub's edos/student feed.

The fixture and the model spec are lengthy in order to verify certain transformations are done in the ruby so we don't have to do it in the JavaScript.

The JavaScript and template are modified to use the new data structure, but the UI is left in read-only state.
