### PR TITLE
SISRP-18781 CLC-6325 Remove memory-killing jruby-openssl; disables textbooks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,9 +60,6 @@ gem 'active_attr', '~> 0.8.5'
 # for production deployment
 gem 'jruby-activemq', '~> 5.13.0', git: 'https://github.com/ets-berkeley-edu/jruby-activemq.git'
 
-# To support TLSv1.2
-gem 'jruby-openssl', '~> 0.9.16'
-
 # Addressable is a replacement for the URI implementation that is part of Ruby's standard library.
 # https://github.com/sporkmonger/addressable
 gem 'addressable', '~> 2.3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,6 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.0)
       railties (>= 3.2.16)
-    jruby-openssl (0.9.16-java)
     json (1.8.3-java)
     jwt (1.5.4)
     kaminari (0.16.1)
@@ -485,7 +484,6 @@ DEPENDENCIES
   icalendar (~> 2.2.2)
   ims-lti!
   jruby-activemq (~> 5.13.0)!
-  jruby-openssl (~> 0.9.16)
   json (~> 1.8.0)
   link_header (~> 0.0.7)
   log4r (~> 1.1)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6325
https://jira.berkeley.edu/browse/SISRP-18781

CalCentral is unable to sustain even a light load with this version of the jruby-openssl Gem.

Unfortunately, that means losing support for the SSL TLSv1.2 protocol, and another release with broken "Textbooks" and "Book List" functionality.