### PR TITLE
SISRP-20582 - CampusSolutions::FinancialAidCompareAwardsList - NoMethodError undefined method (v77 load test on May 31)

### DIFF
--- a/app/models/campus_solutions/financial_aid_compare_awards_list.rb
+++ b/app/models/campus_solutions/financial_aid_compare_awards_list.rb
@@ -19,13 +19,14 @@ module CampusSolutions
       return {} if response.parsed_response.blank?
       feed = response.parsed_response['ROOT'] || response.parsed_response[error_response_root_xml_node] || {}
 
-      feed['AWARD_PARMS']['DATA'] = feed['AWARD_PARMS']['DATA'].sort.reverse.map do |label|
-        {
-           csDate: label,
-           date: format_date(strptime_in_time_zone(label, '%Y-%m-%d-%H.%M.%S'))
-        }
+      if (feed['AWARD_PARMS'])
+        feed['AWARD_PARMS']['DATA'] = feed['AWARD_PARMS']['DATA'].sort.reverse.map do |label|
+          {
+             csDate: label,
+             date: format_date(strptime_in_time_zone(label, '%Y-%m-%d-%H.%M.%S'))
+          }
+        end
       end
-
       feed
     end
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-20582

* The iterating `format_date` function was running on all `feed` hashes, even empty ones, causing the NoMethodError
* Made the function conditional on the existence of `['AWARD_PARMS']`