### PR TITLE
SISRP-19189 - Reorder Links as shown in Design for Financial Resources

### DIFF
--- a/public/json/campuslinks.json
+++ b/public/json/campuslinks.json
@@ -2681,24 +2681,6 @@
       ]
     },
     {
-      "name": "Registration Fees",
-      "description": "Required Berkeley fees to be a Registered Student",
-      "url": "http://registrar.berkeley.edu/Registration/feesched.html",
-      "roles": {
-        "student": true,
-        "applicant": true,
-        "staff": false,
-        "faculty": false,
-        "exStudent": true
-      },
-      "categories": [
-        {
-          "topcategory": "Finances",
-          "subcategory": "Billing \u0026 Payments"
-        }
-      ]
-    },
-    {
       "name": "Research",
       "description": "Directory of UC Berkeley research programs",
       "url": "http://berkeley.edu/research/",

--- a/src/assets/javascripts/angular/controllers/widgets/financesLinksController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/financesLinksController.js
@@ -1,14 +1,19 @@
 'use strict';
 
 var angular = require('angular');
+var _ = require('lodash');
 
 /**
  * Footer controller
  */
 angular.module('calcentral.controllers').controller('FinancesLinksController', function(apiService, campusLinksFactory, financesLinksFactory, $scope) {
   $scope.isLoading = true;
-  $scope.campuslinks = {
-    data: {}
+  $scope.campusLinks = {
+    data: {},
+    linkOrder: ['Payment Options', 'Tuition and Fees', 'Billing FAQ', 'FAFSA', 'Dream Act Application', 'Financial Aid & Scholarships Office',
+                'MyFinAid (aid prior to Fall 2016)', 'Cost of Attendance', 'Graduate Financial Support', 'Work-Study', 'Financial Literacy',
+                'National Student Loan Database System', 'Loan Repayment Calculator', 'Federal Student Loans', 'Student Advocates Office',
+                'Berkeley International Office', 'Have a loan?', 'Withdrawing or Canceling?', 'Schedule & Deadlines', 'Summer Session', 'Cal Student Central']
   };
   $scope.delegateAccess = {
     title: 'Authorize others to access your billing information'
@@ -46,8 +51,24 @@ angular.module('calcentral.controllers').controller('FinancesLinksController', f
     }
   };
 
+  var matchLinks = function(campusLinks, matchLink) {
+    return _.find(campusLinks, function(link) {
+      return link.name === matchLink;
+    });
+  };
+
+  var sortCampusLinks = function(campusLinks) {
+    var orderedLinks = [];
+    for (var i = 0; i < $scope.campusLinks.linkOrder.length; i++) {
+      var matchedLink = matchLinks(campusLinks, $scope.campusLinks.linkOrder[i]);
+      orderedLinks.push(matchedLink);
+    }
+    $scope.campusLinks.data.links = orderedLinks;
+  };
+
   var parseCampusLinks = function(data) {
-    angular.extend($scope.campuslinks.data, data);
+    angular.extend($scope.campusLinks.data, data);
+    sortCampusLinks($scope.campusLinks.data.links);
   };
 
   /**

--- a/src/assets/templates/widgets/finances_links.html
+++ b/src/assets/templates/widgets/finances_links.html
@@ -3,13 +3,11 @@
     <h2>Financial Resources</h2>
   </div>
   <div data-cc-spinner-directive="isLoading">
-    <div class="cc-list-link-container" data-ng-repeat="subcategory in campuslinks.data.subcategories">
+    <div class="cc-list-link-container" data-ng-repeat="subcategory in campusLinks.data.subcategories">
       <h3>{{subcategory}}</h3>
       <ul class="cc-list-links">
-        <li data-ng-repeat="link in campuslinks.data.links | orderBy:'name' | campusLinksSubcategoryFilter:subcategory">
-          <a data-ng-href="{{link.url}}"
-            data-ng-click="api.analytics.trackExternalLink('Campus links', subcategory, link.url)"
-            title="{{link.description}}">{{link.name}}</a>
+        <li data-ng-if="subcategory === 'Billing & Payments'">
+          <a data-ng-href="/profile/delegate" data-ng-attr-title="{{$parent.delegateAccess.title}}">Delegate Access</a>
         </li>
         <li data-ng-if="subcategory === 'Billing & Payments'">
           <a data-ng-href="{{$parent.eft.eftLink.url}}" data-ng-attr-title="{{$parent.eft.eftLink.title}}">Electronic Funds Transfer / EFT </a>
@@ -30,7 +28,12 @@
             <strong>Manage Account</strong>
           </a>
         </li>
-        <li data-ng-if="subcategory === 'Billing & Payments'">
+        <li data-ng-repeat-start="link in campusLinks.data.links | campusLinksSubcategoryFilter:subcategory">
+          <a data-ng-href="{{link.url}}"
+            data-ng-click="api.analytics.trackExternalLink('Campus links', subcategory, link.url)"
+            title="{{link.description}}">{{link.name}}</a>
+        </li>
+        <li data-ng-if="subcategory === 'Billing & Payments' && $index === 1">
           <a data-ng-href="{{$parent.fpp.fppLink.url}}" data-ng-attr-title="{{$parent.fpp.fppLink.title}}">Tuition and Fees Payment Plan</a>
           <a class="cc-list-links-nested-dash"
               data-ng-href="{{$parent.fpp.data.fppEnrollUrl.url}}"
@@ -38,10 +41,7 @@
               data-ng-if="$parent.fpp.data.fppEnrollUrl.url"><strong>Activate Plan</strong>
           </a>
         </li>
-        <li data-ng-if="subcategory === 'Billing & Payments'">
-          <a data-ng-href="/profile/delegate" data-ng-attr-title="{{$parent.delegateAccess.title}}">Delegate Access</a>
-        </li>
-        <li data-ng-if="subcategory === 'Billing & Payments'">
+        <li data-ng-repeat-end data-ng-if="subcategory === 'Billing & Payments' && $index === 1">
           <a data-ng-href="{{$parent.taxForm.taxFormLink.url}}" data-ng-attr-title="{{$parent.taxForm.taxFormLink.title}}">Tax 1098-T Form</a>
           <a class="cc-list-links-nested-dash"
              data-ng-href="{{$parent.taxForm.viewFormLink.url}}"


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-19189

* Had to get rid of the "Registration Fees" campus links JSON object, since it was actually a duplicate of "Tuition and Fees" (just changed the name)
* Uses `data-ng-repeat-start` and `data-ng-repeat-end` to insert custom list items into an `ngRepeat` iterating through an array at a certain index
* Found out that the HTML for the EFT status items are not matching up with the design, created [SISRP-21011](https://jira.berkeley.edu/browse/SISRP-21011) to fix that
* Changed `campuslinks` to `campusLinks` just to keep casing consistent with the rest of the variables