### PR TITLE
SISRP-20266 - Remove currentTerm displaying on Billing Summary

### DIFF
--- a/src/assets/javascripts/angular/controllers/pages/billingDetailsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/billingDetailsController.js
@@ -5,12 +5,16 @@ var angular = require('angular');
 angular.module('calcentral.controllers').controller('BillingDetailsController', function(apiService, financesFactory, $scope) {
   apiService.util.setTitle('My Finances');
   $scope.billingTerm = {
-    currentTerm: '',
+    // We want to show this text only during the transition period, so we'll remove this for GL7.
+    fallText: null,
     isLoading: true
   };
 
   var getCurrentTerm = function(data) {
-    $scope.billingTerm.currentTerm = data.data.feed.summary.currentTerm;
+    // Toggles the "Fall 2016" text needed for transition period, remove this for GL7.
+    if (data.data.feed.summary.currentTerm === 'Summer 2016' || data.data.feed.summary.currentTerm === 'Fall 2016') {
+      $scope.billingTerm.fallText = 'Fall 2016';
+    }
   };
 
   var loadBillingInfo = function() {

--- a/src/assets/javascripts/angular/controllers/widgets/billingController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/billingController.js
@@ -11,6 +11,8 @@ angular.module('calcentral.controllers').controller('BillingController', functio
     hasCarsActivity: false,
     isLoading: true,
     isLoadingCars: true,
+    // We want to show this subheader only during the transition period, so we'll remove this for GL7.
+    fallSubheader: null,
     sort: {
       column: 'itemEffectiveDate',
       descending: true
@@ -106,6 +108,11 @@ angular.module('calcentral.controllers').controller('BillingController', functio
 
   var parseBillingInfo = function(data) {
     var billing = _.get(data, 'data.feed');
+
+    // Toggles the "Fall 2016" subheader needed for transition period, remove this for GL7.
+    if (billing.summary.currentTerm === 'Summer 2016' || billing.summary.currentTerm === 'Fall 2016') {
+      $scope.billing.fallSubheader = 'Fall 2016';
+    }
 
     billing.summary = _.mapValues(billing.summary, function(value) {
       value = parseAmounts(value);

--- a/src/assets/javascripts/angular/controllers/widgets/carsController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/carsController.js
@@ -31,7 +31,8 @@ angular.module('calcentral.controllers').controller('CarsController', function(a
   $scope.activityLimit = 100;
 
   $scope.csActivity = {
-    currentTerm: '',
+    // We want to show this text only during the transition period, so we'll remove this for GL7.
+    fallText: null,
     hasCsActivity: false,
     isLoadingCs: true
   };
@@ -284,7 +285,10 @@ angular.module('calcentral.controllers').controller('CarsController', function(a
       if (data.feed.activity && data.feed.activity.length) {
         $scope.csActivity.hasCsActivity = true;
       }
-      $scope.csActivity.currentTerm = data.feed.summary.currentTerm;
+      // Toggles the "Fall 2016" text needed for transition period, remove this for GL7.
+      if (data.feed.summary.currentTerm === 'Summer 2016' || data.feed.summary.currentTerm === 'Fall 2016') {
+        $scope.csActivity.fallText = 'Fall 2016';
+      }
       $scope.csActivity.isLoadingCs = false;
     });
   };

--- a/src/assets/templates/billing_details.html
+++ b/src/assets/templates/billing_details.html
@@ -3,7 +3,7 @@
 
     <div class="column">
       <h1 class="cc-heading-page-title cc-print-hide">
-        <a href="/finances">My Finances</a> &raquo; Details (<span data-ng-bind="billingTerm.currentTerm"></span>)
+        <a href="/finances">My Finances</a> &raquo; Details <span data-ng-if="billingTerm.fallText" data-ng-bind-template="({{billingTerm.fallText}})"></span>
       </h1>
       <h1 class="cc-heading-page-title cc-hidden cc-print-show">
         My Finances for <span data-ng-bind="api.user.profile.fullName"></span>

--- a/src/assets/templates/cars_summary.html
+++ b/src/assets/templates/cars_summary.html
@@ -102,8 +102,8 @@
       You are seeing this message because CalCentral does not have CARS billing data for your account. If you are a new student, your account may not have been assessed charges yet. Please try again later. Current or former students should contact us for further assistance using the Feedback link below.
     </p>
     <div data-cc-spinner-directive="csActivity.isLoadingCs">
-      <div class="cc-page-myfinances-billing-summary-footnote cc-text-center" data-ng-if="api.user.profile.features.csBilling && carsDetails && csActivity.hasCsActivity">
-        <a href="/billing/details">View <span data-ng-bind="csActivity.currentTerm"></span> activity.</a>
+      <div class="cc-page-myfinances-billing-summary-footnote cc-text-center" data-ng-if="api.user.profile.features.csBilling && carsDetails && csActivity.hasCsActivity && csActivity.fallText">
+        <a href="/billing/details">View <span data-ng-bind="csActivity.fallText"></span> activity.</a>
       </div>
     </div>
   </div>

--- a/src/assets/templates/widgets/billing_summary.html
+++ b/src/assets/templates/widgets/billing_summary.html
@@ -2,7 +2,7 @@
   <div class="cc-widget-title">
     <h2 class="cc-left">
       Billing Summary
-      <span class="cc-widget-title-sub cc-text-uppercase" data-ng-bind="billing.data.summary.currentTerm"></span>
+      <span class="cc-widget-title-sub cc-text-uppercase" data-ng-if="billing.fallSubheader" data-ng-bind="billing.fallSubheader"></span>
     </h2>
     <a data-ng-if="!billingDetails && billing.data.activity" class="cc-right cc-widget-title-link" href="/billing/details">
       <strong>Details</strong>
@@ -43,13 +43,15 @@
       </li>
       <li data-ng-if="billing.data.summary.accountBalance !== '0.00'">
         <div class="cc-page-myfinances-account-summary-buttons cc-print-hide" data-ng-if="billing.data.summary.accountBalance !== '0.00'">
-          <a class="cc-button" data-cc-outbound-enabled="true" href="/higher_one/higher_one_url">Make Payment for <span data-ng-bind="billing.data.summary.currentTerm"></span></a>
+          <a class="cc-button" data-cc-outbound-enabled="true" href="/higher_one/higher_one_url">Make Payment
+            <span data-ng-if="billing.fallSubheader" data-ng-bind-template="for {{billing.fallSubheader}}"></span>
+          </a>
         </div>
       </li>
     </ul>
     <div data-cc-spinner-directive="billing.isLoadingCars">
-      <div class="cc-page-myfinances-billing-summary-footnote cc-text-center" data-ng-if=" billingDetails && billing.hasCarsActivity">
-        <a href="/finances/details">View transactions prior to <span data-ng-bind="billing.data.summary.currentTerm"></span>.</a>
+      <div class="cc-page-myfinances-billing-summary-footnote cc-text-center" data-ng-if="billingDetails && billing.hasCarsActivity && billing.fallSubheader">
+        <a href="/finances/details">View transactions prior to <span data-ng-bind="billing.fallSubheader"></span>.</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-20266

* I wanted to actually get your opinions on this PR before merging
* This goes in-hand with the "Prior to Fall 2016" subheading shown on the CARS Summary card
* The requirement is to show a "Fall 2016" subheading during the transition period.  Once CARS is retired, we'll want to remove the subheading - the problem is, that date is currently a moving target.
* This PR makes the subheading conditional on the "Current Term" that is being returned by the API.  Since CS "Current Term" is kind of funky, I've included "Summer 2016" as part of the conditional
* I think it'd be a good idea to create a new CalShare task (as opposed to a JIRA ticket), which acts as the source of record in SIS, to remove this code for GL7.  This ensures it won't fall through the cracks.
* Thoughts?