### PR TITLE
SISRP-17285 Adapt textbook API requests to Campus Solutions course data

### DIFF
--- a/app/models/textbooks/proxy.rb
+++ b/app/models/textbooks/proxy.rb
@@ -9,15 +9,23 @@ module Textbooks
 
     def initialize(options = {})
       @section_numbers = options[:section_numbers]
-      @course_catalog = options[:course_catalog]
       @dept = options[:dept]
       @slug = options[:slug]
-      @term = get_term(@slug)
+      @course_catalog = format_course_catalog options[:course_catalog]
+      @term = get_term @slug
 
       super(Settings.textbooks_proxy, options)
       initialize_mocks if @fake
     end
 
+    def format_course_catalog(course_catalog)
+      if Berkeley::Terms.fetch.campus[@slug].legacy?
+        course_catalog
+      else
+        # For Campus Solutions terms, course catalogs must be zero-padded to at least three characters.
+        course_catalog.rjust(3, '0')
+      end
+    end
 
     def google_book(isbn)
       google_book_url = 'https://www.googleapis.com/books/v1/volumes?q=isbn:' + isbn

--- a/spec/support/cacheable_expectations.rb
+++ b/spec/support/cacheable_expectations.rb
@@ -4,6 +4,12 @@ shared_context 'it writes to the cache' do
   end
 end
 
+shared_context 'it writes to the cache at least once' do
+  before do
+    expect(Rails.cache).to receive(:write).at_least :once
+  end
+end
+
 shared_context 'short-lived cache write of NilClass on failures' do
   before do
     Rails.cache.should_receive(:write).with(


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-17285

Two new requirements for a happy Fall 2016 textbooks feed:
- Query by five-digit course id, not three-digit section number;
- Zero-pad catalog id to at least three characters.