### PR TITLE
SISRP-21097 Queries and specs for EdoOracle::Calendar

### DIFF
--- a/app/models/edo_oracle/calendar.rb
+++ b/app/models/edo_oracle/calendar.rb
@@ -1,0 +1,65 @@
+module EdoOracle
+  class Calendar < EdoOracle::Connection
+    include ActiveRecordHelper
+
+    def self.get_all_courses
+      term_ids = get_campus_solutions_term_ids
+      safe_query <<-SQL
+        SELECT DISTINCT
+          mtg."term-id" AS term_id,
+          mtg."session-id" AS session_id,
+          sec."id" AS section_id,
+          sec."displayName" AS section_display_name,
+          sec."component-code" as instruction_format,
+          sec."sectionNumber" AS section_num,
+          mtg."number" AS meeting_num,
+          mtg."location-descr" AS location,
+          mtg."meetsDays" AS meeting_days,
+          mtg."startTime" AS meeting_start_time,
+          mtg."endTime" AS meeting_end_time,
+          mtg."startDate" AS meeting_start_date,
+          mtg."endDate" AS meeting_end_date
+        FROM
+          SISEDO.MEETINGV00_VW mtg
+          JOIN SISEDO.CLASSSECTIONV00_VW sec ON (
+          mtg."cs-course-id" = sec."cs-course-id" AND
+          mtg."term-id" = sec."term-id" AND
+          mtg."session-id" = sec."session-id" AND
+          mtg."offeringNumber" = sec."offeringNumber" AND
+          mtg."sectionNumber" = sec."sectionNumber")
+        WHERE
+          mtg."term-id" IN (#{term_ids.join ','})
+        ORDER BY term_id, session_id, section_id, meeting_num
+      SQL
+    end
+
+    def self.get_whitelisted_students_in_course(users, term_id, course_id)
+      return [] if users.blank?
+      users_clause = chunked_whitelist('enroll."CAMPUS_UID"', users.map(&:uid))
+      safe_query <<-SQL
+        SELECT DISTINCT
+          enroll."CAMPUS_UID" AS ldap_uid,
+          email."EMAIL_EMAILADDRESS" AS official_bmail_address
+        FROM SISEDO.ENROLLMENTV00_VW enroll
+          LEFT OUTER JOIN SISEDO.PERSON_EMAILV00_VW email ON (
+          enroll."STUDENT_ID" = email."PERSON_KEY" AND
+          email."EMAIL_TYPE_CODE" = 'CAMP')
+        WHERE
+          enroll."CLASS_SECTION_ID" = '#{course_id}'
+          AND enroll."TERM_ID" = '#{term_id}'
+          AND enroll."STDNT_ENRL_STATUS_CODE" != 'D'
+          #{users_clause}
+      SQL
+    end
+
+    def self.get_campus_solutions_term_ids
+      terms = [
+        Berkeley::Terms.fetch.current,
+        Berkeley::Terms.fetch.next,
+        Berkeley::Terms.fetch.future
+      ]
+      terms.map { |term| term.campus_solutions_id if term && !term.legacy? }.compact
+    end
+
+  end
+end

--- a/app/models/edo_oracle/connection.rb
+++ b/app/models/edo_oracle/connection.rb
@@ -5,6 +5,18 @@ module EdoOracle
       Settings.edodb
     end
 
+    def self.safe_query(sql)
+      result = []
+      return result if fake?
+      use_pooled_connection do
+        result = connection.select_all sql
+      end
+      stringify_ints! result
+    rescue => e
+      logger.error "Query failed: #{e.class}: #{e.message}\n #{e.backtrace.join("\n ")}"
+      []
+    end
+
     def self.stringified_columns
       %w(section_id campus-uid)
     end

--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -379,17 +379,5 @@ module EdoOracle
       SQL
     end
 
-    def self.safe_query(sql)
-      result = []
-      return result if fake?
-      use_pooled_connection do
-        result = connection.select_all sql
-      end
-      stringify_ints! result
-    rescue => e
-      logger.error "Query failed: #{e.class}: #{e.message}\n #{e.backtrace.join("\n ")}"
-      []
-    end
-
   end
 end

--- a/lib/oracle_base.rb
+++ b/lib/oracle_base.rb
@@ -42,4 +42,13 @@ class OracleBase < ActiveRecord::Base
   def self.stringified_columns
     []
   end
+
+  # Oracle has a limit of 1000 terms per expression, so whitelist predicates with more than 1000 entries must be
+  # constructed in chunks joined with OR.
+  def self.chunked_whitelist(column_name, terms=[])
+    predicates = terms.each_slice(1000).map do |slice|
+      "#{column_name} IN (#{slice.join ','})"
+    end
+    "AND (#{predicates.join ' OR '})"
+  end
 end

--- a/spec/models/edo_oracle/calendar_spec.rb
+++ b/spec/models/edo_oracle/calendar_spec.rb
@@ -1,0 +1,72 @@
+describe EdoOracle::Calendar do
+
+  context 'querying for courses' do
+    before do
+      allow(Berkeley::Terms).to receive(:fetch).and_return double(
+        current: double(campus_solutions_id: '2162', legacy?: spring_legacy),
+        next: double(campus_solutions_id: '2165', legacy?: summer_legacy),
+        future: double(campus_solutions_id: '2168', legacy?: fall_legacy)
+      )
+    end
+    shared_examples 'query for correct terms' do
+      it 'should include proper term sql' do
+        expect(EdoOracle::Calendar).to receive(:safe_query) do |sql|
+          expect(sql).to include expected_sql
+        end
+        EdoOracle::Calendar.get_all_courses
+      end
+    end
+    include_examples 'query for correct terms' do
+      let(:spring_legacy) { true }
+      let(:summer_legacy) { true }
+      let(:fall_legacy) { false }
+      let(:expected_sql) { 'mtg."term-id" IN (2168)' }
+    end
+    include_examples 'query for correct terms' do
+      let(:spring_legacy) { true }
+      let(:summer_legacy) { false }
+      let(:fall_legacy) { false }
+      let(:expected_sql) { 'mtg."term-id" IN (2165,2168)' }
+    end
+    include_examples 'query for correct terms' do
+      let(:spring_legacy) { false }
+      let(:summer_legacy) { false }
+      let(:fall_legacy) { false }
+      let(:expected_sql) { 'mtg."term-id" IN (2162,2165,2168)' }
+    end
+  end
+
+  context 'querying for students' do
+    let(:term_id) { '2168' }
+    let(:course_id) { '7309' }
+    let(:run_query) { EdoOracle::Calendar.get_whitelisted_students_in_course(users, term_id, course_id) }
+    context 'empty users list' do
+      let(:users) { [] }
+      it 'does not query and returns empty results' do
+        expect(EdoOracle::Calendar).not_to receive :safe_query
+        expect(run_query).to eq []
+      end
+    end
+    shared_examples 'properly chunked whitelist' do
+      it 'should include proper UID sql' do
+        expect(EdoOracle::Calendar).to receive(:safe_query) do |sql|
+          expect(sql).to include expected_sql
+        end
+        run_query
+      end
+    end
+    context 'fewer than 1000 users in whitelist' do
+      let(:users) { (100..105).map { |uid| double(uid: uid) } }
+      include_examples 'properly chunked whitelist' do
+        let(:expected_sql) { '(enroll."CAMPUS_UID" IN (100,101,102,103,104,105))' }
+      end
+    end
+    context 'more than 1000 users in whitelist' do
+      let(:users) { (1000..2005).map { |uid| double(uid: uid) } }
+      include_examples 'properly chunked whitelist' do
+        let(:expected_sql) { '1996,1997,1998,1999) OR enroll."CAMPUS_UID" IN (2000,2001,2002,2003,2004,2005))' }
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-21097

Some of our existing Oracle fanciness is moved into superclasses for reuse.

Also, CampusOracle::Calendar is explicitly told not to query CS terms.

*Note:* these new queries are not yet called in production. Nothing to QA for v78.