### PR TITLE
SISRP-18965 - 5.6 - My Dashboard (Student) - Status, Blocks and Holds - Add Pre-Fall 2016 Terms to Registrations Feed, Refactor Reg

### DIFF
--- a/app/models/berkeley/term_codes.rb
+++ b/app/models/berkeley/term_codes.rb
@@ -35,6 +35,11 @@ module Berkeley
       self.from_edo_id(edo_term_id).values_at(:term_yr, :term_cd).join '-'
     end
 
+    def slug_to_edo_id(slug)
+      code = self.from_slug slug
+      self.to_edo_id(code[:term_yr], code[:term_cd])
+    end
+
     # Campus Solutions tends to call terms '2016 Fall' instead of the more idiomatic 'Fall 2016'.
     def normalized_english(term_name)
       if term_name.present? && (m = term_name.strip.match /\A(\d{4})\s(\w+)\Z/)

--- a/app/models/my_registrations/my_registrations.rb
+++ b/app/models/my_registrations/my_registrations.rb
@@ -1,6 +1,7 @@
 module MyRegistrations
   class MyRegistrations < UserSpecificModel
 
+    include Berkeley::UserRoles
     include Cache::CachedFeed
     include Cache::JsonAddedCacher
     include Cache::UserCacheExpiry
@@ -9,8 +10,9 @@ module MyRegistrations
       registrations = get_registrations
       terms = get_terms
       {
-        :affiliations => registrations["affiliations"],
-        :registrations => match_terms(registrations["registrations"], terms)
+        affiliations: registrations['affiliations'],
+        terms: terms,
+        registrations: match_terms(registrations['registrations'], terms)
       }
     end
 
@@ -20,33 +22,80 @@ module MyRegistrations
     end
 
     def get_terms
-      berkeleyTerms = Berkeley::Terms.fetch
-      {
-        :current => berkeleyTerms.current ? berkeleyTerms.current.campus_solutions_id : nil,
-        :running => berkeleyTerms.running ? berkeleyTerms.running.campus_solutions_id : nil,
-        :sis_current_term => berkeleyTerms.sis_current_term ? berkeleyTerms.sis_current_term.campus_solutions_id : nil,
-        :next => berkeleyTerms.next ? berkeleyTerms.next.campus_solutions_id : nil,
-        :future => berkeleyTerms.future ? berkeleyTerms.future.campus_solutions_id : nil,
-        :previous => berkeleyTerms.previous ? berkeleyTerms.previous.campus_solutions_id : nil,
-        :grading_in_progress => berkeleyTerms.grading_in_progress ? berkeleyTerms.grading_in_progress.campus_solutions_id : nil
-      }
+      berkeley_terms = Berkeley::Terms.fetch
+      terms = {}
+      # ':previous' and ':grading_in_progress' methods are not included here because Campus::Oracle does not keep information prior to the current term.
+      # These methods should be added in Spring 2017, once CS will start sending back Fall 2016 data.
+      [:current, :running, :sis_current_term, :next, :future].each do |term_method|
+        term = berkeley_terms.send term_method
+        if term
+          terms[term_method] = {id: term.campus_solutions_id, name: term.to_english}
+        # Often ':future' will be nil, but during Spring terms, it should send back data for the upcoming Fall semester.
+        else
+          terms[term_method] = nil
+        end
+      end
+      terms
     end
 
     private
 
     # Match registration terms with Berkeley::Terms-defined terms.
     def match_terms(registrations, terms)
-      matchedTerms = {}
+      legacy_cutoff = Berkeley::TermCodes.slug_to_edo_id(Settings.terms.legacy_cutoff)
+      matched_terms = {}
       terms.each do |key, value|
+        next if (value.nil? || matched_terms[value[:id]].present?)
         # Array format due to the possibility of a single term containing multiple academic career registrations
-        matchedTerms[key] = []
+        matched_terms[value[:id]] = []
+        # If the term is less than or equal to Settings.terms.legacy_cutoff, parse it as we would a legacy term.
+        if (value[:id].to_i <= legacy_cutoff.to_i)
+          matched_terms[value[:id]].push parse_legacy_term(key, value[:id], value[:name])
+        end
         registrations.each do |registration|
-          if (value == registration["term"]["id"])
-            matchedTerms[key].push(registration)
+          if (value[:id] == registration['term']['id'])
+            matched_terms[value[:id]].push(registration)
           end
         end
       end
-      matchedTerms
+      matched_terms
+    end
+
+    def parse_legacy_term(term_name, term_id, term_english)
+      term_code = Berkeley::TermCodes.from_edo_id(term_id)
+      result = CampusOracle::Queries.get_person_attributes(@uid, term_code[:term_yr], term_code[:term_cd])
+      return if result.nil?
+      if result
+        result[:reg_status] = Notifications::RegStatusTranslator.new.translate_for_feed result['reg_status_cd']
+        result[:reg_status][:education_level] = Notifications::EducLevelTranslator.new.translate result['educ_level']
+        result[:reg_status].merge! Berkeley::SpecialRegistrationProgram.attributes_from_code(result['reg_special_pgm_cd'])
+        result[:roles] = roles_from_campus_row result
+      end
+      response = {
+        is_legacy: true,
+        reg_status: result[:reg_status],
+        roles: result[:roles]
+      }
+
+      # This logic is only used for transition terms, as shown in MyBadges::StudentInfo
+      if (term_transition? && result[:reg_status][:summary] != 'Registered')
+        response[:reg_status] = {
+            code: " ",
+            summary: "Not registered for #{term_english}",
+            explanation: nil,
+            needsAction: false
+        }
+      end
+
+      if (term_name == :current || term_name == :running)
+        result[:reg_status][:transitionTerm] = true if term_transition?
+      end
+
+      HashConverter.camelize response
+    end
+
+    def term_transition?
+      Berkeley::Terms.fetch.current.sis_term_status != 'CT'
     end
 
   end

--- a/public/dummy/json/my_registrations.json
+++ b/public/dummy/json/my_registrations.json
@@ -1,165 +1,158 @@
 {
-  "affiliations":[
+  "affiliations": [
     {
-      "type":{
-        "code":"STUDENT",
-        "description":""
+      "type": {
+        "code": "STUDENT",
+        "description": ""
       },
-      "detail":"",
-      "status":{
-        "code":"ACT",
-        "description":"Active"
+      "detail": "",
+      "status": {
+        "code": "ACT",
+        "description": "Active"
       },
-      "fromDate":"2015-12-17"
+      "fromDate": "2015-12-14"
     },
     {
-      "type":{
-        "code":"UNDERGRAD",
-        "description":"Undergraduate Student"
+      "type": {
+        "code": "UNDERGRAD",
+        "description": "Undergraduate Student"
       },
-      "detail":"Active",
-      "status":{
-        "code":"ACT",
-        "description":"Active"
+      "detail": "Active",
+      "status": {
+        "code": "ACT",
+        "description": "Active"
       },
-      "fromDate":"2015-12-17"
+      "fromDate": "2015-12-14"
     }
   ],
-  "registrations":{
-    "current":[],
-    "running":[],
-    "sis_current_term":[],
-    "next":[
+  "terms": {
+    "current": {
+      "id": "2165",
+      "name": "Summer 2016"
+    },
+    "running": {
+      "id": "2165",
+      "name": "Summer 2016"
+    },
+    "sis_current_term": {
+      "id": "2168",
+      "name": "Fall 2016"
+    },
+    "next": {
+      "id": "2168",
+      "name": "Fall 2016"
+    },
+    "future": null,
+    "grading_in_progress": null
+  },
+  "registrations": {
+    "2165": [
       {
-        "term":{
-          "id":"2168",
-          "name":"2016 Fall",
-          "academicYear":"2017"
+        "is_legacy": true,
+        "reg_status": {
+          "code": "S",
+          "summary": "Registered",
+          "explanation": "You are officially registered for this term and are entitled to access campus services.",
+          "needsAction": false,
+          "education_level": "Senior ",
+          "transitionTerm": true
         },
-        "academicCareer":{
-          "code":"GRAD",
-          "description":"Graduate"
-        },
-        "eligibleToRegister":true,
-        "registered":true,
-        "disabled":false,
-        "athlete":false,
-        "intendsToGraduate":false,
-        "academicLevel":{
-          "level":{
-            "code":"GR",
-            "description":"Graduate"
-          }
-        },
-        "termUnits":[
-          {
-            "type":{
-              "description":"Total"
-            },
-            "unitsMin":0,
-            "unitsMax":0,
-            "unitsEnrolled":0,
-            "unitsWaitlisted":0
-          },
-          {
-            "type":{
-              "description":"For GPA"
-            },
-            "unitsEnrolled":1,
-            "unitsWaitlisted":0
-          },
-          {
-            "type":{
-              "description":"Not For GPA"
-            },
-            "unitsEnrolled":0,
-            "unitsWaitlisted":0
-          }
-        ],
-        "termGPA":{
-          "type":{
-            "description":"Term GPA"
-          },
-          "average":0
-        },
-        "specialStudyPrograms":[],
-        "withdrawalCancel":{
-          "type":{},
-          "reason":{}
-        },
-        "new":true
-      },
-      {
-        "term":{
-          "id":"2168",
-          "name":"2016 Fall",
-          "academicYear":"2017"
-        },
-        "academicCareer":{
-          "code":"UGRD",
-          "description":"Undergraduate"
-        },
-        "eligibleToRegister":true,
-        "registered":true,
-        "disabled":false,
-        "athlete":false,
-        "intendsToGraduate":false,
-        "academicLevel":{
-          "level":{
-            "code":"10",
-            "description":"Freshman"
-          }
-        },
-        "termUnits":[
-          {
-            "type":{
-              "description":"Total"
-            },
-            "unitsMin":0,
-            "unitsMax":0,
-            "unitsEnrolled":0,
-            "unitsWaitlisted":0
-          },
-          {
-            "type":{
-              "description":"For GPA"
-            },
-            "unitsEnrolled":4,
-            "unitsWaitlisted":0
-          },
-          {
-            "type":{
-              "description":"Not For GPA"
-            },
-            "unitsEnrolled":0,
-            "unitsWaitlisted":0
-          }
-        ],
-        "termGPA":{
-          "type":{
-            "description":"Term GPA"
-          },
-          "average":0
-        },
-        "specialStudyPrograms":[],
-        "withdrawalCancel":{
-          "type":{},
-          "reason":{}
-        },
-        "new":false
+        "roles": {
+          "student": true,
+          "registered": true,
+          "exStudent": false,
+          "faculty": false,
+          "staff": true,
+          "guest": false,
+          "concurrentEnrollmentStudent": false,
+          "undergrad": true,
+          "expiredAccount": false
+        }
       }
     ],
-    "future":[],
-    "previous":[],
-    "grading_in_progress":[]
-  },
-  "lastModified":{
-    "hash":"5e333cacd0fb52f9cac1d5e429453172e29dafdd",
-    "timestamp":{
-      "epoch":1464024101,
-      "dateTime":"2016-05-23T10:21:41-07:00",
-      "dateString":"5/23"
-    }
-  },
-  "feedName":"MyRegistrations::MyRegistrations"
+    "2168": [
+      {
+        "term": {
+          "id": "2168",
+          "name": "2016 Fall",
+          "academicYear": "2017"
+        },
+        "academicCareer": {
+          "code": "UGRD",
+          "description": "Undergraduate"
+        },
+        "eligibleToRegister": true,
+        "registered": true,
+        "disabled": false,
+        "athlete": false,
+        "intendsToGraduate": false,
+        "academicLevel": {
+          "level": {
+            "code": "30",
+            "description": "Junior"
+          }
+        },
+        "termUnits": [
+          {
+            "type": {
+              "code": "Total",
+              "description": "Total"
+            },
+            "unitsMin": 0,
+            "unitsMax": 0,
+            "unitsEnrolled": 0,
+            "unitsWaitlisted": 0,
+            "unitsTaken": 0,
+            "unitsPassed": 0,
+            "unitsIncomplete": 0,
+            "unitsTransferEarned": 0,
+            "unitsTransferAccepted": 0,
+            "unitsTest": 0,
+            "unitsOther": 0
+          },
+          {
+            "type": {
+              "code": "For GPA",
+              "description": "For GPA"
+            },
+            "unitsMin": 0,
+            "unitsMax": 0,
+            "unitsEnrolled": 4,
+            "unitsWaitlisted": 0,
+            "unitsTaken": 0,
+            "unitsPassed": 0,
+            "unitsIncomplete": 0,
+            "unitsTransferEarned": 0
+          },
+          {
+            "type": {
+              "code": "Not For GPA",
+              "description": "Not For GPA"
+            },
+            "unitsMin": 0,
+            "unitsMax": 0,
+            "unitsEnrolled": 0,
+            "unitsWaitlisted": 0,
+            "unitsTaken": 0,
+            "unitsPassed": 0,
+            "unitsIncomplete": 0,
+            "unitsTransferEarned": 0
+          }
+        ],
+        "termGPA": {
+          "type": {
+            "description": "Term GPA"
+          },
+          "average": 0,
+          "source": "UCB"
+        },
+        "specialStudyPrograms": [],
+        "withdrawalCancel": {
+          "type": {},
+          "reason": {}
+        },
+        "new": false
+      }
+    ]
+  }
 }

--- a/src/assets/javascripts/angular/controllers/widgets/academicsStatusHoldsBlocksController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/academicsStatusHoldsBlocksController.js
@@ -6,13 +6,19 @@ var _ = require('lodash');
 /**
  * Academics status, holds & blocks controller
  */
-angular.module('calcentral.controllers').controller('AcademicsStatusHoldsBlocksController', function(apiService, profileFactory, slrDeeplinkFactory, residencyMessageFactory, $scope) {
+angular.module('calcentral.controllers').controller('AcademicsStatusHoldsBlocksController', function(apiService, profileFactory, slrDeeplinkFactory, residencyMessageFactory, registrationsFactory, $scope) {
   // Data for studentInfo and csHolds are pulled by the AcademicsController that
   // governs the academics template. The statusHoldsBlocks segment watches those
   // for changes in order to display the corresponding UI elements.
   $scope.statusHoldsBlocks = {};
+  $scope.regStatus = {
+    summary: null,
+    explanation: null,
+    needsAction: null,
+    isLoading: true
+  };
 
-  $scope.$watchGroup(['studentInfo.regStatus.code', 'api.user.profile.features.csHolds'], function(newValues) {
+  $scope.$watchGroup(['regStatus.summary', 'api.user.profile.features.csHolds'], function(newValues) {
     var enabledSections = [];
 
     if (newValues[0] !== null && newValues[0] !== undefined) {
@@ -35,6 +41,56 @@ angular.module('calcentral.controllers').controller('AcademicsStatusHoldsBlocksC
     $scope.slr.deeplink = _.get(data, 'data.feed.root.ucSrSlrResources.ucSlrLinks.ucSlrLink');
     $scope.slr.isErrored = _.get(data, 'data.errored');
     $scope.slr.isLoading = false;
+  };
+
+  var getRegistrations = function() {
+    registrationsFactory.getRegistrations()
+      .then(parseRegistrations);
+  };
+
+  /**
+   * Checks to see whether the registration is on or before Settings.terms.legacy_cutoff.
+   * This code should be able to be removed by Fall 2016, when we should start getting term data exclusively from the hub.
+   * There is also the possibility of the hub bringing over more than one registration for a term.  This will be addressed
+   * in the redesign for Status/Blocks/Holds, slated for GL6.
+   */
+  var parseRegistrations = function(data) {
+    var currentTerm = data.data.terms.current.id;
+    var regStatus = data.data.registrations[currentTerm];
+
+    if (regStatus[0].isLegacy) {
+      parseLegacyTerm(regStatus[0]);
+    } else {
+      parseCsTerm(regStatus[0]);
+    }
+
+    return;
+  };
+
+  /**
+   * Parses any terms past the legacy cutoff.  Mirrors current functionality for now, but this will be changed in redesigns slated
+   * for GL6.
+   */
+  var parseCsTerm = function(term) {
+    if (term.registered === true) {
+      $scope.regStatus.summary = 'Registered';
+      $scope.regStatus.explanation = 'You are officially registered for this term and are entitled to access campus services.';
+      $scope.regStatus.needsAction = false;
+    }
+    if (term.registered === false) {
+      $scope.regStatus.summary = 'Not Registered';
+      $scope.regStatus.explanation = 'In order to be officially registered, you must pay at least 20% of your tuition and fees, have no outstanding holds, and be enrolled in at least one class.';
+      $scope.regStatus.needsAction = true;
+    }
+  };
+
+  /**
+   * Parses any terms on or before the legacy cutoff.  Mirrors current functionality, this should be able to be removed in Fall 2016.
+   */
+  var parseLegacyTerm = function(term) {
+    $scope.regStatus.summary = term.regStatus.summary;
+    $scope.regStatus.explanation = term.regStatus.explanation;
+    $scope.regStatus.needsAction = term.regStatus.needsAction;
   };
 
   var getSlrDeeplink = function() {
@@ -104,6 +160,7 @@ angular.module('calcentral.controllers').controller('AcademicsStatusHoldsBlocksC
     getPerson()
     .then(parsePerson)
     .then(getSlrDeeplink)
+    .then(getRegistrations)
     .then(function() {
       $scope.residency.isLoading = false;
     });

--- a/src/assets/javascripts/angular/factories/registrationsFactory.js
+++ b/src/assets/javascripts/angular/factories/registrationsFactory.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var angular = require('angular');
+
+/**
+ * Registrations Factory
+ */
+angular.module('calcentral.factories').factory('registrationsFactory', function(apiService) {
+  var url = '/api/my/registrations';
+  // var url = '/dummy/json/my_registrations.json'
+
+  var getRegistrations = function(options) {
+    return apiService.http.request(options, url);
+  };
+
+  return {
+    getRegistrations: getRegistrations
+  };
+});

--- a/src/assets/templates/academics_status_holds_blocks.html
+++ b/src/assets/templates/academics_status_holds_blocks.html
@@ -20,13 +20,13 @@
               <th class="cc-table-subheader" scope="row">Registration</td>
               <td>
                 <i class="cc-icon fa"
-                   data-ng-class="{true:'fa-check-circle cc-icon-green',false:'fa-exclamation-circle cc-icon-red'}[studentInfo.regStatus.summary=='Registered']" data-ng-if="studentInfo.regStatus.summary === 'Registered' || studentInfo.regStatus.needsAction">
+                   data-ng-class="{true:'fa-check-circle cc-icon-green',false:'fa-exclamation-circle cc-icon-red'}[regStatus.summary=='Registered']" data-ng-if="regStatus.summary === 'Registered' || regStatus.needsAction">
                 </i>
-                <span data-ng-bind="studentInfo.regStatus.summary"></span>
+                <span data-ng-bind="regStatus.summary"></span>
               </td>
             </tr>
             <tr data-ng-if="api.user.profile.features.regstatus">
-              <td colspan="2" data-ng-bind-html="studentInfo.regStatus.explanation"></td>
+              <td colspan="2" data-ng-bind-html="regStatus.explanation"></td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-18965

* For Fall 2016 regstatus, I focused on keeping the exact same design as we do now
* Instead of detangling `academicsController.js`, I decided to insert the new feed into `academicsStatusHoldsBlocks.js`.  This will also reduce the number of extra calls needed when placing this card onto the Advisor - Student Overview page (which is the next step).
* Will need to apply the same refactoring to `academicsController.js` as well though, but that will be post GL5.6.
* I also had to simplify the Rspec tests, since `CampusOracle::Queries` does not have any information on any terms prior to the "current" term.  What it does have, though, does suffice to test the functionality of the model.
* I know this is asking a lot, but it would be great if I could get reviewed/merged sometime today if possible.  Trying to place this card onto Student Overview before the branch gets cut tomorrow.  It's a hefty one though, so I understand the need to carefully take the time to review.
* Thanks a bunch @paulkerschen once again for the direction.