### PR TITLE
SISRP-21573, stray slash in URL (verify_sis_api_endpoints script)

### DIFF
--- a/script/sis/verify_sis_api_endpoints.sh
+++ b/script/sis/verify_sis_api_endpoints.sh
@@ -233,7 +233,7 @@ verify_cs 'cs_profile' "${yml_features_cs_profile}" \
 verify_cs "cs_sir" "${yml_features_cs_sir}" \
   "/UC_CC_CHECKLIST.v1/get/checklist?EMPLID=${CAMPUS_SOLUTIONS_ID}" \
   "/UC_DEPOSIT_AMT.v1/deposit/get?EMPLID=${CAMPUS_SOLUTIONS_ID}&ADM_APPL_NBR=00000087" \
-  "/UC_OB_HIGHER_ONE_URL_GET.v1/get/?EMPLID=${CAMPUS_SOLUTIONS_ID}"
+  "/UC_OB_HIGHER_ONE_URL_GET.v1/get?EMPLID=${CAMPUS_SOLUTIONS_ID}"
 
 verify_cs "cs_fin_aid" "${yml_features_cs_fin_aid}" \
   "/UC_FA_FINANCIAL_AID_DATA.v1/get?EMPLID=${CAMPUS_SOLUTIONS_ID}&INSTITUTION=UCB01&AID_YEAR=2016" \


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-21573

CS API is fine. Our verify script needed a fix.