### PR TITLE
[QA] SISRP-21615 Use EDO DB, not LDAP, as student id source in rosters

### DIFF
--- a/app/models/rosters/common.rb
+++ b/app/models/rosters/common.rb
@@ -85,6 +85,7 @@ module Rosters
             attrs[:email] = attrs.delete :email_address
             attrs[:majors] = section_enrollments_by_uid[attrs[:ldap_uid]].collect { |e| e['major'] }
             if (enrollment_row = section_enrollments_by_uid[attrs[:ldap_uid]].first)
+              attrs[:student_id] = enrollment_row['student_id']
               attrs[:terms_in_attendance] = terms_in_attendance_code(enrollment_row['terms_in_attendance_group'], enrollment_row['academic_program_code'])
               attrs[:enroll_status] = enrollment_row['enroll_status']
               attrs[:grade_option] = Berkeley::GradeOptions.grade_option_from_basis enrollment_row['grading_basis']

--- a/spec/models/rosters/common_spec.rb
+++ b/spec/models/rosters/common_spec.rb
@@ -305,15 +305,19 @@ describe Rosters::Common do
       it 'returns student basic attributes and enrollment status grouped by section id, redundancy permitted' do
         expect(enrollments[section_id_one][0][:email]).to eq 'pambeesly@berkeley.edu'
         expect(enrollments[section_id_one][0][:enroll_status]).to eq 'E'
+        expect(enrollments[section_id_one][0][:student_id]).to eq '22200666'
         expect(enrollments[section_id_one][0][:units]).to eq '4'
         expect(enrollments[section_id_one][1][:email]).to eq 'kellykapoor@berkeley.edu'
         expect(enrollments[section_id_one][1][:enroll_status]).to eq 'E'
+        expect(enrollments[section_id_one][1][:student_id]).to eq '22200555'
         expect(enrollments[section_id_one][1][:units]).to eq '4'
         expect(enrollments[section_id_one][2][:email]).to eq 'kevinmalone@berkeley.edu'
         expect(enrollments[section_id_one][2][:enroll_status]).to eq 'W'
+        expect(enrollments[section_id_one][2][:student_id]).to eq '22200444'
         expect(enrollments[section_id_one][2][:units]).to eq '4'
         expect(enrollments[section_id_two][0][:email]).to eq 'kevinmalone@berkeley.edu'
         expect(enrollments[section_id_two][0][:enroll_status]).to eq 'W'
+        expect(enrollments[section_id_two][0][:student_id]).to eq '22200444'
         expect(enrollments[section_id_two][0][:units]).to eq '4'
       end
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-21615

QA version of #5553