### PR TITLE
CLC-6361 Adapt OEC queries to EDO DB source

### DIFF
--- a/app/models/campus_oracle/calendar.rb
+++ b/app/models/campus_oracle/calendar.rb
@@ -48,7 +48,7 @@ module CampusOracle
             and c.term_yr = #{term_yr.to_i}
             and c.term_cd = #{connection.quote(term_cd)}
             and c.course_cntl_num = #{ccn.to_i}
-        #{users_clause}
+            and #{users_clause}
           order by p.ldap_uid
         SQL
         result = connection.select_all(sql)

--- a/app/models/campus_oracle/oec.rb
+++ b/app/models/campus_oracle/oec.rb
@@ -1,0 +1,154 @@
+module CampusOracle
+  class Oec < Connection
+    include ActiveRecordHelper
+    extend ::Oec::Queries
+
+    def self.get_courses(term_code, filter_clause)
+      term_yr, term_cd = term_code.split('-')
+      result = []
+      use_pooled_connection {
+        sql = <<-SQL
+          select distinct c.term_yr, c.term_cd, c.course_cntl_num, p.ldap_uid,
+            c.term_yr || '-' || c.term_cd || '-' || lpad(c.course_cntl_num, 5, '0') AS course_id,
+            c.dept_name || ' ' || c.catalog_id || ' ' || c.instruction_format || ' ' || c.section_num || ' ' || c.course_title_short AS course_name,
+            c.cross_listed_flag,
+            c.dept_name,
+            c.catalog_id,
+            c.instruction_format,
+            c.section_num,
+            c.primary_secondary_cd,
+            c.course_title_short,
+            CASE WHEN p.student_id IS NULL THEN 'UID:' || p.ldap_uid ELSE '' || p.student_id END AS sis_id,
+            p.first_name,
+            p.last_name,
+            p.email_address,
+            p.affiliations,
+            i.instructor_func,
+            (
+              select count(*)
+              from calcentral_class_roster_vw r
+              where r.enroll_status != 'D'
+                and #{columns_are_equal('r', 'c', 'term_yr', 'term_cd', 'course_cntl_num')}
+                and rownum < 2
+            ) as enrollment_count,
+            '23' AS blue_role,
+            (
+              select listagg(lpad(course_cntl_num, 5, '0'), ',') within group (order by course_cntl_num)
+              from calcentral_cross_listing_vw
+              where term_yr = c.term_yr and term_cd = c.term_cd and crosslist_hash = x.crosslist_hash
+            ) AS cross_listed_ccns,
+            (
+              select listagg(lpad(course_cntl_num, 5, '0'), ',') within group (order by course_cntl_num)
+              from calcentral_class_schedule_vw l
+              where #{not_null('s', 'building_name', 'room_number', 'meeting_days', 'meeting_start_time')}
+                and #{columns_are_equal('l', 'c', 'term_yr', 'term_cd')}
+                and #{columns_are_equal('l', 's', 'building_name', 'room_number', 'meeting_days', 'meeting_start_time', 'meeting_start_time_ampm_flag', 'meeting_end_time', 'meeting_end_time_ampm_flag')}
+                having count(*) > 1
+            ) AS co_scheduled_ccns
+          from calcentral_course_info_vw c
+          left outer join calcentral_cross_listing_vw x ON (#{columns_are_equal('c', 'x', 'term_yr', 'term_cd', 'course_cntl_num')})
+          left outer join calcentral_class_schedule_vw s ON (
+            #{columns_are_equal('c', 's', 'term_yr', 'term_cd', 'course_cntl_num')}
+            and #{not_null('s', 'building_name', 'room_number', 'meeting_days', 'meeting_start_time')})
+          left outer join calcentral_course_instr_vw i ON (#{columns_are_equal('c', 'i', 'term_yr', 'term_cd', 'course_cntl_num')})
+          left outer join calcentral_person_info_vw p ON (p.ldap_uid = i.instructor_ldap_uid)
+          where c.term_yr = '#{term_yr}' and c.term_cd = '#{term_cd}'
+            and c.section_cancel_flag is null
+            and #{filter_clause}
+          order by c.catalog_id, c.course_cntl_num, p.ldap_uid
+        SQL
+        result = connection.select_all(sql)
+      }
+      stringify_ints! result
+    end
+
+    def self.get_enrollments(term_code, select_clause, ccns_clause)
+      term_yr, term_cd = term_code.split('-')
+      result = []
+      use_pooled_connection {
+        sql = <<-SQL
+          #{select_clause}
+          left outer join calcentral_course_info_vw c ON (c.course_cntl_num = r.course_cntl_num)
+          where
+              c.term_yr = '#{term_yr}' and c.term_cd = '#{term_cd}'
+              and c.section_cancel_flag is null
+              and #{ccns_clause}
+              and (r.enroll_status = 'E' OR r.enroll_status = 'C')
+              and #{columns_are_equal('c', 'r', 'term_yr', 'term_cd')}
+          order by ldap_uid
+        SQL
+        result = connection.select_all(sql)
+      }
+      stringify_ints! result
+    end
+
+    def self.depts_clause(course_codes, import_all)
+      return if course_codes.blank?
+      subclauses = course_codes.group_by(&:dept_name).map do |dept_name, codes|
+        subclause = ''
+        if (default_code = codes.find { |code| code.catalog_id.blank? }) && (default_code.include_in_oec || import_all)
+          #All catalog IDs are included by default; note explicit exclusions
+          excluded_catalog_ids = codes.reject(&:include_in_oec).map { |code| "'#{code.catalog_id}'" }
+          subclause << "c.dept_name = '#{dept_name}'"
+          if !import_all && excluded_catalog_ids.any?
+            subclause << " and c.catalog_id NOT IN (#{excluded_catalog_ids.join(',')})"
+          end
+        else
+          #No catalog IDs are included by default; note explicit inclusions
+          included_catalog_ids = codes.select(&:include_in_oec).map { |code| "'#{code.catalog_id}'" }
+          if included_catalog_ids.any?
+            subclause << "c.dept_name = '#{dept_name}' and c.catalog_id IN (#{included_catalog_ids.join(',')})"
+          end
+        end
+        subclause
+      end
+      subclauses.reject! &:blank?
+      case subclauses.count
+        when 0
+          nil
+        when 1
+          "(#{subclauses.first})"
+        else
+          "(#{subclauses.map { |subclause| "(#{subclause})" }.join(' or ')})"
+      end
+    end
+
+    def self.course_and_ldap_uid_clause
+      <<-SQL
+      select distinct r.term_yr || '-' || r.term_cd || '-' || lpad(r.course_cntl_num, 5, '0') AS course_id,
+        r.student_ldap_uid AS ldap_uid
+      from calcentral_class_roster_vw r
+      SQL
+    end
+
+    def self.student_info_clause
+      <<-SQL
+      select distinct person.first_name, person.last_name,
+        person.email_address, person.ldap_uid,
+        CASE WHEN person.student_id IS NULL
+               THEN 'UID:' || person.ldap_uid
+               ELSE '' || person.student_id
+        END AS sis_id
+      from calcentral_class_roster_vw r
+      left outer join calcentral_person_info_vw person ON (person.ldap_uid = r.student_ldap_uid)
+      SQL
+    end
+
+    def self.course_ccn_column
+      'c.course_cntl_num'
+    end
+
+    def self.enrollment_ccn_column
+      'c.course_cntl_num'
+    end
+
+    def self.columns_are_equal(table1, table2, *columns)
+      columns.map { |column| "#{table1}.#{column} = #{table2}.#{column}" }.join(' and ')
+    end
+
+    def self.not_null(table, *columns)
+      columns.map { |column| "#{table}.#{column} IS NOT NULL" }.join(' and ')
+    end
+
+  end
+end

--- a/app/models/canvas_lti/sis_adapter.rb
+++ b/app/models/canvas_lti/sis_adapter.rb
@@ -1,13 +1,14 @@
 module CanvasLti
   module SisAdapter
+    extend EdoOracle::Adapters::Common
     extend self
 
     def get_enrolled_students(section_id, term_year, term_code)
       if Berkeley::Terms.legacy?(term_year, term_code)
         CampusOracle::Queries.get_enrolled_students(section_id, term_year, term_code)
       else
-        EdoOracle::Queries.get_enrolled_students(section_id, term_id(term_year, term_code)).tap do |enrollments|
-          add_legacy_pnp_flag enrollments
+        EdoOracle::Queries.get_enrolled_students(section_id, term_id(term_year, term_code)).each do |enrollment|
+          adapt_pnp_flag enrollment
         end
       end
     end
@@ -16,8 +17,9 @@ module CanvasLti
       if Berkeley::Terms.legacy?(term_year, term_code)
         CampusOracle::Queries.get_section_instructors(term_year, term_code, section_id)
       else
-        instructors = EdoOracle::Queries.get_section_instructors(term_id(term_year, term_code), section_id)
-        add_legacy_instructor_func(instructors)
+        EdoOracle::Queries.get_section_instructors(term_id(term_year, term_code), section_id).each do |instructor|
+          adapt_instructor_func instructor
+        end
       end
     end
 
@@ -25,62 +27,13 @@ module CanvasLti
       if Berkeley::Terms.legacy?(term_year, term_code)
         CampusOracle::Queries.get_sections_from_ccns(term_year, term_code, section_ids)
       else
-        EdoOracle::Queries.get_sections_by_ids(term_id(term_year, term_code), section_ids).tap do |sections|
-          add_legacy_ccns sections
-          add_legacy_term_fields sections
-          add_legacy_primary_secondary_cd sections
-          normalize_course_codes sections
+        user_courses = EdoOracle::UserCourses::Base.new
+        EdoOracle::Queries.get_sections_by_ids(term_id(term_year, term_code), section_ids).each do |section|
+          adapt_course_cntl_num section
+          adapt_dept_name_and_catalog_id(section, user_courses)
+          adapt_primary_secondary_cd section
+          adapt_term section
         end
-      end
-    end
-
-    def term_id(term_year, term_code)
-      Berkeley::TermCodes.to_edo_id(term_year, term_code)
-    end
-
-    def add_legacy_instructor_func(instructors)
-      instructors.collect {|instr| instr.merge({'instructor_func' => convert_role_code_to_instructor_func(instr['role_code'])})}
-    end
-
-    def convert_role_code_to_instructor_func(role_code)
-      case role_code.to_s
-        when 'PI' then '1'    # Teaching and In Charge, equivalent of Teaching and Instructor of Record (1)
-        when 'TNIC' then '2'  # Teaching but Not in Charge, equivalent of Teaching but not Instructor of Record (2)
-        when 'ICNT' then '3'  # In Charge but Not Teaching, equivalent of Not teaching but Instructor of Record (3). Instructors coded as 3 must be accompanied by another "teaching" instructor coded as 2.
-        when 'INVT' then '4'  # Teaching with Invalid Title, equivalent of No Valid Teaching Title Code (4)
-        else raise ArgumentError, "Unable to convert to 'instructor_func'. No such role code: '#{role_code}'"
-      end
-    end
-
-    def add_legacy_ccns(sections)
-      sections.each {|sec| sec['course_cntl_num'] = sec['section_id']}
-    end
-
-    def add_legacy_pnp_flag(enrollments)
-      enrollments.each do |enr|
-        grade_option = Berkeley::GradeOptions.grade_option_from_basis enr['grading_basis']
-        enr['pnp_flag'] = case grade_option
-                            when 'P/NP', 'S/U' then 'Y'
-                            else 'N'
-                          end
-      end
-    end
-
-    def add_legacy_term_fields(sections)
-      sections.each do |sec|
-        legacy_term = Berkeley::TermCodes.from_edo_id(sec['term_id'])
-        sec.merge!({'term_yr' => legacy_term[:term_yr], 'term_cd' => legacy_term[:term_cd]})
-      end
-    end
-
-    def add_legacy_primary_secondary_cd(sections)
-      sections.each {|sec| sec['primary_secondary_cd'] = sec['primary'] == 'true' ? 'P' : 'S'}
-    end
-
-    def normalize_course_codes(sections)
-      sections.each do |sec|
-        dept_name, catalog_id = EdoOracle::UserCourses::Base.parse_course_code sec
-        sec.merge!({'dept_name' => dept_name, 'catalog_id' => catalog_id})
       end
     end
 

--- a/app/models/edo_oracle/adapters/common.rb
+++ b/app/models/edo_oracle/adapters/common.rb
@@ -1,0 +1,51 @@
+module EdoOracle
+  module Adapters
+    module Common
+
+      def adapt_course_cntl_num(row)
+        row['course_cntl_num'] = row['section_id'].to_s
+      end
+
+      def adapt_dept_name_and_catalog_id(row, user_courses)
+        dept_name, catalog_id = user_courses.parse_course_code row
+        row.merge!({'dept_name' => dept_name, 'catalog_id' => catalog_id})
+      end
+
+      def adapt_instructor_func(row)
+        return unless (code = row.delete 'role_code')
+        row['instructor_func'] = case code
+          when 'PI' then '1'    # Teaching and In Charge, equivalent of Teaching and Instructor of Record (1)
+          when 'TNIC' then '2'  # Teaching but Not in Charge, equivalent of Teaching but not Instructor of Record (2)
+          when 'ICNT' then '3'  # In Charge but Not Teaching, equivalent of Not teaching but Instructor of Record (3). Instructors coded as 3 must be accompanied by another "teaching" instructor coded as 2.
+          when 'INVT' then '4'  # Teaching with Invalid Title, equivalent of No Valid Teaching Title Code (4)
+          else raise ArgumentError, "Unable to convert to 'instructor_func'. No such role code: '#{role_code}'"
+        end
+      end
+
+      def adapt_pnp_flag(row)
+        grade_option = Berkeley::GradeOptions.grade_option_from_basis row['grading_basis']
+        row['pnp_flag'] = case grade_option
+                            when 'P/NP', 'S/U' then 'Y'
+                            else 'N'
+                          end
+      end
+
+      def adapt_primary_secondary_cd(row)
+        row['primary_secondary_cd'] = row['primary'] == 'true' ? 'P' : 'S'
+      end
+
+      def adapt_term(row)
+        legacy_term = Berkeley::TermCodes.from_edo_id(row['term_id'])
+        row.merge!({'term_yr' => legacy_term[:term_yr], 'term_cd' => legacy_term[:term_cd]})
+      end
+
+      def term_id(term_year, term_code=nil)
+        unless term_code
+          term_year, term_code = term_year.split('-')
+        end
+        Berkeley::TermCodes.to_edo_id(term_year, term_code)
+      end
+
+    end
+  end
+end

--- a/app/models/edo_oracle/adapters/oec.rb
+++ b/app/models/edo_oracle/adapters/oec.rb
@@ -1,0 +1,94 @@
+module EdoOracle
+  module Adapters
+    class Oec < EdoOracle::Oec
+      extend EdoOracle::Adapters::Common
+
+      def self.get_courses(term_code, filter)
+        default_dates = default_edo_dates term_code
+        user_courses = EdoOracle::UserCourses::Base.new
+        super(term_id(term_code), filter).each do |row|
+          uniq_ccn_lists row
+
+          adapt_dept_name_and_catalog_id(row, user_courses)
+          adapt_course_name row
+
+          adapt_course_cntl_num row
+          adapt_course_id(row, term_code)
+          adapt_cross_listed_flag row
+          adapt_dates(row, default_dates)
+          adapt_evaluation_type row
+          adapt_instructor_func row
+          adapt_primary_secondary_cd row
+
+          row['blue_role'] = '23'
+        end
+      end
+
+      def self.get_enrollments(term_code, select_clause, filter)
+        super(term_id(term_code), select_clause, filter).each do |row|
+          adapt_course_id(row, term_code)
+        end
+      end
+
+      # TODO This temporary logic, appropriate for Fall 2016 only, bridges a gap between legacy term data and EDO
+      # section data on what counts as default course dates.
+      def self.default_edo_dates(term_code)
+        slug = Berkeley::TermCodes.to_slug *term_code.split('-')
+        term = Berkeley::Terms.fetch.campus[slug]
+        {
+          start: term.classes_start.to_date.advance(days: 7).next_week(:wednesday),  # 2016-08-24 for Fall 2016
+          end: term.classes_end.to_date.advance(days: -21).next_week(:friday)        # 2016-12-09 for Fall 2016
+        }
+      end
+
+      def self.adapt_course_id(row, term_code)
+        if row['section_id']
+          row['course_id'] = "#{term_code}-#{row.delete 'section_id'}"
+        end
+      end
+
+      def self.adapt_course_name(row)
+        if row['dept_name']
+          row['course_name'] = row.values_at('dept_name', 'catalog_id', 'instruction_format', 'section_num', 'course_title_short').join ' '
+        end
+      end
+
+      def self.adapt_cross_listed_flag(row)
+        row['cross_listed_flag'] = 'Y' if row['cross_listed_ccns'].present?
+      end
+
+      def self.adapt_dates(row, default_dates)
+        if (row['start_date'] && row['end_date'])
+          if (row['start_date'].to_date == default_dates[:start] && row['end_date'].to_date == default_dates[:end])
+            row.delete 'start_date'
+            row.delete 'end_date'
+          else
+            row['modular_course'] = 'Y'
+            row['start_date'] = row['start_date'].strftime ::Oec::Worksheet::WORKSHEET_DATE_FORMAT
+            row['end_date'] = row['end_date'].strftime ::Oec::Worksheet::WORKSHEET_DATE_FORMAT
+          end
+        end
+      end
+
+      def self.adapt_evaluation_type(row)
+        row['evaluation_type'] = case row['affiliations']
+                                   when /STUDENT/ then 'G'
+                                   when /INSTRUCTOR/ then 'F'
+                                 end
+      end
+
+      def self.uniq_ccn_lists(row)
+        %w(co_scheduled_ccns cross_listed_ccns).each do |key|
+          next unless row[key].present?
+          ccns = row[key].split(',').uniq
+          if ccns.count > 1
+            row[key] = ccns.join(',')
+          else
+            row.delete key
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/app/models/edo_oracle/calendar.rb
+++ b/app/models/edo_oracle/calendar.rb
@@ -48,7 +48,7 @@ module EdoOracle
           enroll."CLASS_SECTION_ID" = '#{course_id}'
           AND enroll."TERM_ID" = '#{term_id}'
           AND enroll."STDNT_ENRL_STATUS_CODE" != 'D'
-          #{users_clause}
+          AND #{users_clause}
       SQL
     end
 

--- a/app/models/edo_oracle/oec.rb
+++ b/app/models/edo_oracle/oec.rb
@@ -1,0 +1,167 @@
+module EdoOracle
+  class Oec < Connection
+    include ActiveRecordHelper
+    extend ::Oec::Queries
+
+    def self.get_courses(term_id, filter_clause)
+      safe_query <<-SQL
+      SELECT DISTINCT
+        sec."id" AS section_id,
+        sec."primary" AS primary,
+        sec."component-code" AS instruction_format,
+        sec."sectionNumber" AS section_num,
+        sec."displayName" AS course_display_name,
+        instr."campus-uid" AS ldap_uid,
+        instr."instructor-id" AS sis_id,
+        TRIM(instr."givenName") AS first_name,
+        TRIM(instr."familyName") AS last_name,
+        instr."role-code" AS role_code,
+        instr."emailAddress" AS email_address,
+        mtg."startDate" AS start_date,
+        mtg."endDate" AS end_date,
+        TRIM(crs."transcriptTitle") AS course_title_short,
+        sec."enrolledCount" AS enrollment_count,
+        (
+          SELECT listagg("AFFILIATION_TYPE_CODE", ',') WITHIN GROUP (ORDER BY "AFFILIATION_TYPE_CODE")
+          FROM SISEDO.PERSON_AFFILIATIONV00_VW aff
+          WHERE
+            aff."PERSON_KEY" = instr."instructor-id" AND
+            aff."AFFILIATION_STATUS_CODE" = 'ACT' AND
+            aff."AFFILIATION_TYPE_CODE" IN ('INSTRUCTOR', 'STUDENT')
+        ) AS affiliations,
+        (
+          SELECT LISTAGG("id", ',') WITHIN GROUP (ORDER BY "id")
+          FROM SISEDO.CLASSSECTIONV00_VW sec2
+          WHERE
+            sec."cs-course-id" = sec2."cs-course-id" AND
+            sec."term-id" = sec2."term-id" AND
+            sec."session-id" = sec2."session-id" AND
+            sec."sectionNumber" = sec2."sectionNumber"
+        ) AS cross_listed_ccns,
+        (
+          SELECT listagg("id", ',') WITHIN GROUP (ORDER BY "id")
+          FROM SISEDO.MEETINGV00_VW mtg2 JOIN SISEDO.CLASSSECTIONV00_VW sec3 ON (
+            mtg2."location-code" = mtg."location-code" AND
+            mtg2."meetsDays" = mtg."meetsDays" AND
+            mtg2."startTime" = mtg."startTime" AND
+            mtg2."endTime" = mtg."endTime" AND
+            mtg2."startDate" = mtg."startDate" AND
+            mtg2."endDate" = mtg."endDate" AND
+            mtg2."cs-course-id" = sec3."cs-course-id" AND
+            mtg2."term-id" = sec3."term-id" AND
+            mtg2."session-id" = sec3."session-id" AND
+            mtg2."offeringNumber" = sec3."offeringNumber" AND
+            mtg2."sectionNumber" = sec3."sectionNumber")
+        ) AS co_scheduled_ccns
+      FROM
+        SISEDO.CLASSSECTIONV00_VW sec
+        LEFT OUTER JOIN SISEDO.MEETINGV00_VW mtg ON (
+          mtg."cs-course-id" = sec."cs-course-id" AND
+          mtg."term-id" = sec."term-id" AND
+          mtg."session-id" = sec."session-id" AND
+          mtg."offeringNumber" = sec."offeringNumber" AND
+          mtg."sectionNumber" = sec."sectionNumber")
+        LEFT OUTER JOIN SISEDO.ASSIGNEDINSTRUCTORV00_VW instr ON (
+          instr."cs-course-id" = sec."cs-course-id" AND
+          instr."term-id" = sec."term-id" AND
+          instr."session-id" = sec."session-id" AND
+          instr."offeringNumber" = sec."offeringNumber" AND
+          instr."number" = sec."sectionNumber")
+        LEFT OUTER JOIN SISEDO.DISPLAYNAMEXLAT_MVW xlat ON (
+          xlat."classDisplayName" = sec."displayName")
+        LEFT OUTER JOIN SISEDO.API_COURSEV00_VW crs ON (
+          xlat."courseDisplayName" = crs."displayName")
+        WHERE
+          sec."term-id" = '#{term_id}'
+          AND #{filter_clause}
+          AND sec."status-code" = 'A'
+          AND (crs."status-code" = 'ACTIVE' OR crs."status-code" IS NULL)
+      SQL
+    end
+
+    def self.get_enrollments(term_id, select_clause, ccns_clause)
+      safe_query <<-SQL
+        #{select_clause}
+        WHERE
+          enroll."TERM_ID" = '#{term_id}'
+          AND #{ccns_clause}
+          AND (enroll."STDNT_ENRL_STATUS_CODE" = 'E')
+        ORDER BY ldap_uid
+      SQL
+    end
+
+    # Awkward substring matches on sec."displayName" are necessary because the better-parsed dept_name and catalog_id
+    # fields are derived from a join and not guaranteed to be present.
+    def self.depts_clause(course_codes, import_all)
+      return if course_codes.blank?
+      subclauses = course_codes.group_by(&:dept_name).map do |dept_name, codes|
+        subclause = ''
+        if (default_code = codes.find { |code| code.catalog_id.blank? }) && (default_code.include_in_oec || import_all)
+          #All catalog IDs are included by default; note explicit exclusions
+          excluded_catalog_ids = codes.reject(&:include_in_oec).map(&:catalog_id)
+          subclause << "sec.\"displayName\" LIKE '#{SubjectAreas.compress dept_name}%'"
+          if !import_all && excluded_catalog_ids.any?
+            excluded_catalog_ids.each do |id|
+              subclause << " and sec.\"displayName\" NOT LIKE '%#{id}')"
+            end
+          end
+        else
+          #No catalog IDs are included by default; note explicit inclusions
+          included_catalog_ids = codes.select(&:include_in_oec).map(&:catalog_id)
+          if included_catalog_ids.any?
+            subclause << "sec.\"displayName\" LIKE '#{SubjectAreas.compress dept_name}%' and ("
+            subclause << included_catalog_ids.map { |id| "sec.\"displayName\" LIKE '%#{id}'" }.join(' or ')
+            subclause << ')'
+          end
+        end
+        subclause
+      end
+      subclauses.reject! &:blank?
+      case subclauses.count
+        when 0
+          nil
+        when 1
+          "(#{subclauses.first})"
+        else
+          "(#{subclauses.map { |subclause| "(#{subclause})" }.join(' or ')})"
+      end
+    end
+
+    def self.course_and_ldap_uid_clause
+      <<-SQL
+        SELECT DISTINCT
+          enroll."CLASS_SECTION_ID" as section_id,
+          enroll."CAMPUS_UID" as ldap_uid
+        FROM SISEDO.ENROLLMENTV00_VW enroll
+      SQL
+    end
+
+    def self.student_info_clause
+      <<-SQL
+        SELECT DISTINCT
+          enroll."CAMPUS_UID" AS ldap_uid,
+          enroll."STUDENT_ID" AS sis_id,
+          TRIM(name."NAME_GIVENNAME" || ' ' || name."NAME_MIDDLENAME") AS first_name,
+          name."NAME_FAMILYNAME" AS last_name,
+          email."EMAIL_EMAILADDRESS" AS email_address
+        FROM SISEDO.ENROLLMENTV00_VW enroll
+        LEFT OUTER JOIN SISEDO.PERSON_EMAILV00_VW email ON (
+          email."PERSON_KEY" = enroll."STUDENT_ID" AND
+          email."EMAIL_TYPE_CODE" = 'CAMP')
+        LEFT OUTER JOIN SISEDO.PERSON_NAMEV00_VW name ON (
+          name."PERSON_KEY" = enroll."STUDENT_ID" AND
+          name."NAME_TYPE_CODE" = 'PRI')
+      SQL
+    end
+
+    def self.course_ccn_column
+      'sec."id"'
+    end
+
+    def self.enrollment_ccn_column
+      'enroll."CLASS_SECTION_ID"'
+    end
+
+  end
+end
+

--- a/app/models/edo_oracle/subject_areas.rb
+++ b/app/models/edo_oracle/subject_areas.rb
@@ -9,7 +9,7 @@ module EdoOracle
     def initialize
       # Build a map to restore subject-area formatting lost in Campus Solutions stripping of non-alphanumeric characters.
       @decompression_map = EdoOracle::Queries.get_subject_areas.inject({}) do |map, row|
-        compressed = compress row['subjectarea']
+        compressed = self.class.compress row['subjectarea']
         # If multiple decompressions are available, prefer the longest.
         if !map[compressed] || (map[compressed].length < row['subjectarea'].length)
           map[compressed] = row['subjectarea']
@@ -18,12 +18,12 @@ module EdoOracle
       end
     end
 
-    def compress(subject_area)
+    def self.compress(subject_area)
       subject_area.gsub(/\W+/, '') if subject_area
     end
 
     def decompress(subject_area)
-      compressed = compress subject_area
+      compressed = self.class.compress subject_area
       @decompression_map[compressed] || subject_area
     end
 

--- a/app/models/oec/queries.rb
+++ b/app/models/oec/queries.rb
@@ -1,171 +1,37 @@
 module Oec
-  class Queries < CampusOracle::Connection
-    include ActiveRecordHelper
+  module Queries
 
-    def self.courses_for_codes(term_code, course_codes, import_all = false)
-      return [] unless (filter = depts_clause('c', course_codes, import_all))
+    def courses_for_codes(term_code, course_codes, import_all = false)
+      return [] unless (filter = depts_clause(course_codes, import_all))
       get_courses(term_code, filter)
     end
 
-    def self.courses_for_cntl_nums(term_code, course_cntl_nums)
-      return [] unless (filter = ccns_clause('c', course_cntl_nums))
+    def courses_for_cntl_nums(term_code, ccns)
+      return [] unless ccns.present? && (filter = chunked_whitelist(course_ccn_column, ccns))
       get_courses(term_code, filter)
     end
 
-    def self.students_for_cntl_nums(term_code, course_cntl_nums)
-      return [] unless (filter = ccns_clause('c', course_cntl_nums))
+    def students_for_cntl_nums(term_code, ccns)
+      return [] unless ccns.present? && (filter = chunked_whitelist(enrollment_ccn_column, ccns))
       get_enrollments(term_code, student_info_clause, filter)
     end
 
-    def self.enrollments_for_cntl_nums(term_code, course_cntl_nums)
-      return [] unless (filter = ccns_clause('c', course_cntl_nums))
+    def enrollments_for_cntl_nums(term_code, ccns)
+      return [] unless ccns.present? && (filter = chunked_whitelist(enrollment_ccn_column, ccns))
       get_enrollments(term_code, course_and_ldap_uid_clause, filter)
     end
 
-    def self.get_courses(term_code, filter_clause)
-      term_yr, term_cd = term_code.split('-')
-      result = []
-      use_pooled_connection {
-        sql = <<-SQL
-      select distinct c.term_yr, c.term_cd, c.course_cntl_num, p.ldap_uid,
-        c.term_yr || '-' || c.term_cd || '-' || lpad(c.course_cntl_num, 5, '0') AS course_id,
-        c.dept_name || ' ' || c.catalog_id || ' ' || c.instruction_format || ' ' || c.section_num || ' ' || c.course_title_short AS course_name,
-        c.cross_listed_flag,
-        c.dept_name,
-        c.catalog_id,
-        c.instruction_format,
-        c.section_num,
-        c.primary_secondary_cd,
-        c.course_title_short,
-        CASE WHEN p.student_id IS NULL THEN 'UID:' || p.ldap_uid ELSE '' || p.student_id END AS sis_id,
-        p.first_name,
-        p.last_name,
-        p.email_address,
-        p.affiliations,
-        i.instructor_func,
-        (
-          select count(*)
-          from calcentral_class_roster_vw r
-          where r.enroll_status != 'D'
-            and #{columns_are_equal('r', 'c', 'term_yr', 'term_cd', 'course_cntl_num')}
-            and rownum < 2
-        ) as enrollment_count,
-        '23' AS blue_role,
-        (
-          select listagg(lpad(course_cntl_num, 5, '0'), ',') within group (order by course_cntl_num)
-          from calcentral_cross_listing_vw
-          where term_yr = c.term_yr and term_cd = c.term_cd and crosslist_hash = x.crosslist_hash
-        ) AS cross_listed_ccns,
-        (
-          select listagg(lpad(course_cntl_num, 5, '0'), ',') within group (order by course_cntl_num)
-          from calcentral_class_schedule_vw l
-          where #{not_null('s', 'building_name', 'room_number', 'meeting_days', 'meeting_start_time')}
-            and #{columns_are_equal('l', 'c', 'term_yr', 'term_cd')}
-            and #{columns_are_equal('l', 's', 'building_name', 'room_number', 'meeting_days', 'meeting_start_time', 'meeting_start_time_ampm_flag', 'meeting_end_time', 'meeting_end_time_ampm_flag')}
-            having count(*) > 1
-        ) AS co_scheduled_ccns
-      from calcentral_course_info_vw c
-      left outer join calcentral_cross_listing_vw x ON (#{columns_are_equal('c', 'x', 'term_yr', 'term_cd', 'course_cntl_num')})
-      left outer join calcentral_class_schedule_vw s ON (
-        #{columns_are_equal('c', 's', 'term_yr', 'term_cd', 'course_cntl_num')}
-        and #{not_null('s', 'building_name', 'room_number', 'meeting_days', 'meeting_start_time')})
-      left outer join calcentral_course_instr_vw i ON (#{columns_are_equal('c', 'i', 'term_yr', 'term_cd', 'course_cntl_num')})
-      left outer join calcentral_person_info_vw p ON (p.ldap_uid = i.instructor_ldap_uid)
-      where c.term_yr = '#{term_yr}' and c.term_cd = '#{term_cd}'
-        and c.section_cancel_flag is null
-        and #{filter_clause}
-      order by c.catalog_id, c.course_cntl_num, p.ldap_uid
-        SQL
-        result = connection.select_all(sql)
-      }
-      stringify_ints! result
-    end
-
-    def self.get_enrollments(term_code, select_clause, ccns_clause)
-      term_yr, term_cd = term_code.split('-')
-      result = []
-      use_pooled_connection {
-        sql = <<-SQL
-          #{select_clause}
-          left outer join calcentral_course_info_vw c ON (c.course_cntl_num = r.course_cntl_num)
-          where
-              c.term_yr = '#{term_yr}' and c.term_cd = '#{term_cd}'
-              and c.section_cancel_flag is null
-              and #{ccns_clause}
-              and (r.enroll_status = 'E' OR r.enroll_status = 'C')
-              and #{columns_are_equal('c', 'r', 'term_yr', 'term_cd')}
-          order by ldap_uid
-        SQL
-        result = connection.select_all(sql)
-      }
-      stringify_ints! result
-    end
-
-    def self.depts_clause(table, course_codes, import_all)
-      return if course_codes.blank?
-      subclauses = course_codes.group_by(&:dept_name).map do |dept_name, codes|
-        subclause = ''
-        if (default_code = codes.find { |code| code.catalog_id.blank? }) && (default_code.include_in_oec || import_all)
-          #All catalog IDs are included by default; note explicit exclusions
-          excluded_catalog_ids = codes.reject(&:include_in_oec).map { |code| "'#{code.catalog_id}'" }
-          subclause << "#{table}.dept_name = '#{dept_name}'"
-          if !import_all && excluded_catalog_ids.any?
-            subclause << " and #{table}.catalog_id NOT IN (#{excluded_catalog_ids.join(',')})"
-          end
+    # When a method is called on the module, forward to the appropriate extender class depending on term code.
+    self.instance_methods.each do |method_name|
+      define_singleton_method(method_name) do |*args|
+        term_yr, term_cd = args.first.split '-'
+        if Berkeley::Terms.legacy?(term_yr, term_cd)
+          CampusOracle::Oec.send(method_name, *args)
         else
-          #No catalog IDs are included by default; note explicit inclusions
-          included_catalog_ids = codes.select(&:include_in_oec).map { |code| "'#{code.catalog_id}'" }
-          if included_catalog_ids.any?
-            subclause << "#{table}.dept_name = '#{dept_name}' and #{table}.catalog_id IN (#{included_catalog_ids.join(',')})"
-          end
+          EdoOracle::Adapters::Oec.send(method_name, *args)
         end
-        subclause
-      end
-      subclauses.reject! &:blank?
-      case subclauses.count
-        when 0
-          nil
-        when 1
-          "(#{subclauses.first})"
-        else
-          "(#{subclauses.map { |subclause| "(#{subclause})" }.join(' or ')})"
       end
     end
 
-    def self.course_and_ldap_uid_clause
-      <<-SQL
-        select distinct r.term_yr || '-' || r.term_cd || '-' || lpad(r.course_cntl_num, 5, '0') AS course_id,
-          r.student_ldap_uid AS ldap_uid
-        from calcentral_class_roster_vw r
-      SQL
-    end
-
-    def self.student_info_clause
-      <<-SQL
-        select distinct person.first_name, person.last_name,
-          person.email_address, person.ldap_uid,
-          CASE WHEN person.student_id IS NULL
-                 THEN 'UID:' || person.ldap_uid
-                 ELSE '' || person.student_id
-          END AS sis_id
-        from calcentral_class_roster_vw r
-        left outer join calcentral_person_info_vw person ON (person.ldap_uid = r.student_ldap_uid)
-      SQL
-    end
-
-    # Oracle has limit of 1000 terms per expression so we filter using a series of OR statements, when necessary.
-    def self.ccns_clause(table, ccns)
-      return if ccns.blank?
-      subclauses = ccns.each_slice(1000).map { |chunk| "#{table}.course_cntl_num IN (#{chunk.join(',')})" }
-      "(#{subclauses.join(' or ')})"
-    end
-
-    def self.columns_are_equal(table1, table2, *columns)
-      columns.map { |column| "#{table1}.#{column} = #{table2}.#{column}" }.join(' and ')
-    end
-
-    def self.not_null(table, *columns)
-      columns.map { |column| "#{table}.#{column} IS NOT NULL" }.join(' and ')
-    end
   end
 end

--- a/lib/oracle_base.rb
+++ b/lib/oracle_base.rb
@@ -49,6 +49,6 @@ class OracleBase < ActiveRecord::Base
     predicates = terms.each_slice(1000).map do |slice|
       "#{column_name} IN (#{slice.join ','})"
     end
-    "AND (#{predicates.join ' OR '})"
+    "(#{predicates.join ' OR '})"
   end
 end

--- a/spec/models/campus_oracle/oec_spec.rb
+++ b/spec/models/campus_oracle/oec_spec.rb
@@ -1,9 +1,9 @@
-describe Oec::Queries do
+describe CampusOracle::Oec do
 
   let(:term_year) { '2015'}
-  let(:semester_code) { Oec::Queries.test_data? ? 'B' : 'D' }
+  let(:semester_code) { CampusOracle::Oec.test_data? ? 'B' : 'D' }
   let(:term_code) { "#{term_year}-#{semester_code}" }
-  let(:test_ccn) { Oec::Queries.test_data? ? '7309' : '7253' }
+  let(:test_ccn) { CampusOracle::Oec.test_data? ? '7309' : '7253' }
 
   before do
     term = OpenStruct.new({ :year => 2015, :code => term_code })
@@ -11,7 +11,7 @@ describe Oec::Queries do
   end
 
   context 'department-specific queries' do
-    subject { Oec::Queries.depts_clause('c', course_codes, import_all) }
+    subject { CampusOracle::Oec.depts_clause(course_codes, import_all) }
     let(:import_all) { false }
 
     context 'limiting query by department code' do
@@ -84,7 +84,7 @@ describe Oec::Queries do
 
   context 'course lookup by code', testext: true do
     subject do
-      Oec::Queries.courses_for_codes(
+      CampusOracle::Oec.courses_for_codes(
         term_code,
         [Oec::CourseCode.new(dept_name: 'MATH', catalog_id: nil, dept_code: 'PMATH', include_in_oec: true)]
       )
@@ -94,7 +94,7 @@ describe Oec::Queries do
 
   context 'a department not participating in OEC', testext: true do
     subject do
-      Oec::Queries.courses_for_codes(
+      CampusOracle::Oec.courses_for_codes(
         term_code,
         [Oec::CourseCode.new(dept_name: 'FRENCH', catalog_id: nil, dept_code: 'HFREN', include_in_oec: false)],
         import_all
@@ -114,7 +114,7 @@ describe Oec::Queries do
 
   context 'course lookup by ccn', testext: true do
     let(:ccns) { %w(53507 53513) }
-    subject { Oec::Queries.courses_for_cntl_nums(term_code, ccns) }
+    subject { CampusOracle::Oec.courses_for_cntl_nums(term_code, ccns) }
     include_examples 'expected result structure'
     it 'returns the right courses' do
       expect(subject).to have(2).items
@@ -125,14 +125,14 @@ describe Oec::Queries do
   context 'crosslisting and room share lookup', testext: true do
     let(:ccns) { %w(7677 7682) }
     let(:ccn_aggregates) { [ '07677,20542', '07682,21120' ] }
-    subject { Oec::Queries.courses_for_cntl_nums(term_code, ccns) }
+    subject { CampusOracle::Oec.courses_for_cntl_nums(term_code, ccns) }
     it 'returns correct aggregated ccns' do
       expect(subject.map { |row| row['cross_listed_ccns'] }).to match_array ccn_aggregates
       expect(subject.map { |row| row['co_scheduled_ccns'] }).to match_array ccn_aggregates
     end
   end
 
-  let(:students_query) { Oec::Queries.students_for_cntl_nums(term_code, [test_ccn]) }
+  let(:students_query) { CampusOracle::Oec.students_for_cntl_nums(term_code, [test_ccn]) }
 
   context 'looking up students' do
     it 'contains expected result structure' do
@@ -147,7 +147,7 @@ describe Oec::Queries do
     end
   end
 
-  let(:enrollments_query) { Oec::Queries.enrollments_for_cntl_nums(term_code, [test_ccn]) }
+  let(:enrollments_query) { CampusOracle::Oec.enrollments_for_cntl_nums(term_code, [test_ccn]) }
 
   context 'looking up enrollments' do
     it 'contains expected result structure' do

--- a/spec/models/oec/sis_import_task_spec.rb
+++ b/spec/models/oec/sis_import_task_spec.rb
@@ -380,6 +380,38 @@ describe Oec::SisImportTask do
       end
       it { should eq 'MATH/STAT C51, MATH C151 LEC 001, STAT C151 VOL 001' }
     end
+
+    context 'cross-listed course missing title from database join' do
+      let(:course_codes) do
+        {
+          random_id => {
+            'dept_name' => 'MATH',
+            'catalog_id' => 'C51',
+            'instruction_format' => 'LEC',
+            'section_num' => '001',
+            'course_title_short' => nil
+          },
+          random_id => {
+            'dept_name' => 'STAT',
+            'catalog_id' => 'C51',
+            'instruction_format' => 'LEC',
+            'section_num' => '001',
+            'course_title_short' => 'TWO HANDED REGRESSION'
+          }
+        }
+      end
+      let(:course) do
+        {
+          'COURSE_NAME' => 'MATH C51 LEC 001 ',
+          'CROSS_LISTED_CCNS' => course_codes.keys.join(',')
+        }
+      end
+      it 'should fill in missing title from cross-listing' do
+        subject
+        expect(course['COURSE_NAME']).to eq 'MATH C51 LEC 001 TWO HANDED REGRESSION'
+      end
+    end
+
   end
 
   context 'department-specific filters' do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6361

- Most of the former Oec::Queries is moved to CampusOracle::Oec.
- A parallel EdoOracle::Oec class is created.
- A subclass EdoOracle::Adapters::Oec adapts the new query results to nearly the exact format of the old. This class piggybacks on work originally done in CanvasLti::SisAdapter, and some common code is extracted from that class into a new EdoOracle::Adapters::Common.
- What remains of Oec::Queries is the interface of four methods directly called by OEC tasks. These methods are now extended by CampusOracle::Oec and EdoOracle::Oec. The Oec::Queries module forwards method calls to one class or the other, depending on term code.
- Oec::SisImportTask changes very slightly to handle the adapted data. (Evaluation type may be already set in the adapter, and some cross-listed courses may need titles filled in.)
- Existing specs for Oec::Queries (now known as CampusOracle::Oec) provide some reassurance against regressions. Specs for the new EdoOracle classes to follow.