### PR TITLE
CLC-6361 OEC: tweak EDO DB query

### DIFF
--- a/app/models/edo_oracle/oec.rb
+++ b/app/models/edo_oracle/oec.rb
@@ -70,12 +70,12 @@ module EdoOracle
         LEFT OUTER JOIN SISEDO.DISPLAYNAMEXLAT_MVW xlat ON (
           xlat."classDisplayName" = sec."displayName")
         LEFT OUTER JOIN SISEDO.API_COURSEV00_VW crs ON (
-          xlat."courseDisplayName" = crs."displayName")
+          xlat."courseDisplayName" = crs."displayName"
+          AND crs."status-code" = 'ACTIVE')
         WHERE
           sec."term-id" = '#{term_id}'
           AND #{filter_clause}
           AND sec."status-code" = 'A'
-          AND (crs."status-code" = 'ACTIVE' OR crs."status-code" IS NULL)
       SQL
     end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6361

Follow-up to #5587, moving the status-code condition from WHERE to JOIN so as not to screen out courses which have 1) a deprecated status code in the EDO course view, but 2) an active status code in the EDO cross-listing view.