### PR TITLE
SISRP-21785 - Finances Billing - Balance filter showing paid transactions with zero balance

### DIFF
--- a/src/assets/javascripts/angular/controllers/widgets/billingController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/billingController.js
@@ -48,9 +48,9 @@ angular.module('calcentral.controllers').controller('BillingController', functio
       endDt: ''
     },
     searchTermId: {},
-    searchStatus: '0.00',
+    searchStatus: 0,
     statuses: {
-      balance: '0.00',
+      balance: 0,
       allTransactions: ['Unpaid', 'Paid']
     }
   };
@@ -94,17 +94,21 @@ angular.module('calcentral.controllers').controller('BillingController', functio
 
   var makeDollarAmountsSearchable = function(billingItem) {
     if (billingItem.itemLineAmount) {
-      var itemLineAmountSearch = '$' + billingItem.itemLineAmount;
+      var itemLineAmountSearch = '$' + billingItem.itemLineAmount.toFixed(2);
       _.set(billingItem, 'itemLineAmountSearch', itemLineAmountSearch);
     }
     if (billingItem.itemBalance) {
-      var itemBalanceSearch = '$' + billingItem.itemBalance;
+      var itemBalanceSearch = '$' + billingItem.itemBalance.toFixed(2);
       _.set(billingItem, 'itemBalanceSearch', itemBalanceSearch);
     }
   };
 
-  var parseAmounts = function(value) {
-    return _.isNumber(value) ? parseFloat(value.toFixed(2)) : value;
+  var setAmountStrings = function(billingItem) {
+    _.forOwn(billingItem, function(value, key) {
+      if (_.isNumber(value)) {
+        _.set(billingItem, key + 'String', value.toFixed(2));
+      }
+    });
   };
 
   var parseBillingInfo = function(data) {
@@ -120,14 +124,11 @@ angular.module('calcentral.controllers').controller('BillingController', functio
       $scope.billing.fallSubheader = 'Fall 2016';
     }
 
-    billing.summary = _.mapValues(billing.summary, function(value) {
-      value = parseAmounts(value);
-      return value;
-    });
+    setAmountStrings(billing.summary);
 
     billing.activity = _.map(billing.activity, function(object) {
       var billingItem = _.mapValues(object, function(value) {
-        value = parseIncomingDates(parseAmounts(value));
+        value = parseIncomingDates(value);
         return value;
       });
       return billingItem;
@@ -137,6 +138,7 @@ angular.module('calcentral.controllers').controller('BillingController', functio
       getTermOptions(billingItem);
       makeDatesSearchable(billingItem);
       makeDollarAmountsSearchable(billingItem);
+      setAmountStrings(billingItem);
     });
 
     $scope.billing.data = billing;

--- a/src/assets/templates/widgets/billing_activity.html
+++ b/src/assets/templates/widgets/billing_activity.html
@@ -115,8 +115,8 @@
               <td>
                 <div data-ng-bind="item.itemDescription" data-ng-class="{'cc-ellipsis':(!item.show)}"></div>
               </td>
-              <td class="cc-page-myfinances-amount cc-table-right cc-table-right-spacing" data-ng-if="filter.choice !== 'balance'" data-cc-amount-directive="item.itemLineAmount"></td>
-              <td class="cc-page-myfinances-amount cc-table-right cc-table-right-spacing" data-ng-if="filter.choice === 'balance'" data-cc-amount-directive="item.itemBalance"></td>
+              <td class="cc-page-myfinances-amount cc-table-right cc-table-right-spacing" data-ng-if="filter.choice !== 'balance'" data-cc-amount-directive="item.itemLineAmountString"></td>
+              <td class="cc-page-myfinances-amount cc-table-right cc-table-right-spacing" data-ng-if="filter.choice === 'balance'" data-cc-amount-directive="item.itemBalanceString"></td>
               <td class="cc-page-myfinances-type">
                 <span class="hide-for-small cc-print-show" data-ng-bind="item.itemType"></span>
                 <div class="hide-for-medium-up cc-print-hide">
@@ -145,9 +145,9 @@
                     </strong>
                     <span data-ng-bind="item.itemReferenceDescription"></span>
                   </div>
-                  <div data-ng-if="item.itemLineAmount && filter.choice === 'balance'">
+                  <div data-ng-if="item.itemLineAmount && item.itemLineAmountString && filter.choice === 'balance'">
                     <strong>Original Amount:</strong>
-                    <span class="cc-page-myfinances-amount" data-cc-amount-directive="item.itemLineAmount"></span>
+                    <span class="cc-page-myfinances-amount" data-cc-amount-directive="item.itemLineAmountString"></span>
                   </div>
                   <div data-ng-if="item.itemStatus && (item.itemType === 'Charge' || item.itemType === 'Refund') && filter.choice !== 'balance'">
                     <strong>Status:</strong>

--- a/src/assets/templates/widgets/billing_summary.html
+++ b/src/assets/templates/widgets/billing_summary.html
@@ -16,20 +16,20 @@
           <strong data-ng-if="billing.data.summary.amountDueNow >= 0">
             Amount Due Now
           </strong>
-          <div data-ng-if="billing.data.summary.pastDueAmount > 0" class="cc-page-myfinances-red cc-page-myfinances-account-summary-subtitle">Includes Past Due Amount of <span data-cc-amount-directive="billing.data.summary.pastDueAmount"></span>
+          <div data-ng-if="billing.data.summary.pastDueAmount > 0" class="cc-page-myfinances-red cc-page-myfinances-account-summary-subtitle">Includes Past Due Amount of <span data-cc-amount-directive="billing.data.summary.pastDueAmountString"></span>
           </div>
         </div>
         <div class="small-4 columns cc-print-width-auto cc-print-right">
           <div class="cc-page-myfinances-amount">
-            <strong data-cc-amount-directive="billing.data.summary.amountDueNow"></strong>
+            <strong data-cc-amount-directive="billing.data.summary.amountDueNowString"></strong>
           </div>
         </div>
-        <section class="cc-clearfix-container" data-ng-if="billing.data.summary.chargesNotYetDue !== '0.00'">
+        <section class="cc-clearfix-container" data-ng-if="billing.data.summary.chargesNotYetDue !== 0">
           <div class="small-8 columns cc-print-width-auto cc-print-clear">
             Charges Not Yet Due
           </div>
           <div class="small-4 columns cc-print-width-auto cc-print-right">
-            <div class="cc-page-myfinances-amount" data-cc-amount-directive="billing.data.summary.chargesNotYetDue"></div>
+            <div class="cc-page-myfinances-amount" data-cc-amount-directive="billing.data.summary.chargesNotYetDueString"></div>
           </div>
         </section>
       </li>
@@ -40,7 +40,7 @@
           <div class="cc-page-myfinances-account-summary-subtitle cc-page-myfinances-light">Includes charges not yet due</div>
         </div>
         <div class="small-4 columns cc-print-width-auto cc-print-right">
-          <div class="cc-page-myfinances-amount" data-cc-amount-directive="billing.data.summary.accountBalance"></div>
+          <div class="cc-page-myfinances-amount" data-cc-amount-directive="billing.data.summary.accountBalanceString"></div>
         </div>
       </li>
       <li data-ng-if="billing.data.summary.accountBalance > 0">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-21785

Also fixes:
https://jira.berkeley.edu/browse/SISRP-21704

* Verified with functional that CS will never send amounts with more than two decimal places
* Since JS is terrible at keeping trailing zeroes on `floats`, decided to just leave the `float` as is, and append a `string` version of that float to the object for presentation, while any controller/filter/sort logic is still based on the `float`.
* Still need to fix the "all transactions" sort, which is breaking because it still sorts on `itemBalance` but is showing `itemLineAmount`