### PR TITLE
SISRP-21883 First fixes for View-As self issues

### DIFF
--- a/app/controllers/act_as_controller.rb
+++ b/app/controllers/act_as_controller.rb
@@ -67,6 +67,12 @@ class ActAsController < ApplicationController
       return false
     end
 
+    # Block acting as oneself, because that's way too confusing.
+    if act_as_uid.to_i == current_user.real_user_id.to_i
+      logger.warn "User #{current_user.user_id} FAILED to login to #{act_as_uid}, cannot view-as oneself"
+      raise Pundit::NotAuthorizedError.new "You cannot View As yourself."
+    end
+
     # Ensure uid is in our database
     if Settings.features.cs_profile
       ldap_uid = CalnetCrosswalk::ByUid.new(user_id: act_as_uid).lookup_ldap_uid

--- a/app/controllers/concerns/advisor_authorization.rb
+++ b/app/controllers/concerns/advisor_authorization.rb
@@ -1,13 +1,5 @@
 module AdvisorAuthorization
 
-  def render_403(error)
-    if error.respond_to? :message
-      render json: { :error => error.message }.to_json, :status => 403
-    else
-      render :nothing => true, :status => 403
-    end
-  end
-
   def authorize_advisor_view_as(uid, student_uid)
     require_advisor uid
     student = user_attributes student_uid

--- a/app/controllers/concerns/view_as_authorization.rb
+++ b/app/controllers/concerns/view_as_authorization.rb
@@ -1,6 +1,14 @@
 module ViewAsAuthorization
   include AdvisorAuthorization
 
+  def render_403(error)
+    if error.respond_to? :message
+      render json: { :error => error.message }.to_json, :status => 403
+    else
+      render :nothing => true, :status => 403
+    end
+  end
+
   def authorize_user_lookup(current_user, lookup_uid)
     return if can_view_as_for_all_uids? current_user
     authorize_advisor_view_as current_user.real_user_id, lookup_uid

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 class SessionsController < ApplicationController
   include ActiveRecordHelper, ClassLogger
+  include AllowDelegateViewAs
   include AllowLti
 
   skip_before_filter :check_reauthentication, :only => [:lookup, :destroy]

--- a/spec/controllers/act_as_controller_spec.rb
+++ b/spec/controllers/act_as_controller_spec.rb
@@ -67,6 +67,17 @@ describe ActAsController do
         it_fails
       end
     end
+    context 'acting as oneself' do
+      let(:real_superuser) {false}
+      let(:real_viewer) {true}
+      let(:target_uid) {real_user_id}
+      it 'refuses to budge' do
+        session['user_id'] = real_user_id
+        post :start, uid: target_uid
+        expect(response).to_not be_success
+        expect(session[SessionKey.original_user_id]).to be_nil
+      end
+    end
   end
 
 end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-21883

This first PR fixes the Delegate log-out issue and does basic server-side blocking of View-As-self requests. Front-end code needs to be changed to show error responses from ``/act_as``.