### PR TITLE
CLC-6374 OEC: Pull email addresses from User::BasicAttributes when missing from DB

### DIFF
--- a/app/models/edo_oracle/adapters/oec.rb
+++ b/app/models/edo_oracle/adapters/oec.rb
@@ -16,6 +16,8 @@ module EdoOracle
       def self.adapt_courses(rows, term_code)
         default_dates = get_default_dates term_code
         user_courses = EdoOracle::UserCourses::Base.new
+        supplement_email_addresses rows
+
         rows.each do |row|
           uniq_ccn_lists row
 
@@ -35,8 +37,25 @@ module EdoOracle
       end
 
       def self.adapt_enrollments(rows, term_code)
+        supplement_email_addresses rows
         rows.each do |row|
           adapt_course_id(row, term_code)
+        end
+      end
+
+      def self.supplement_email_addresses(rows)
+        rows_without_email = rows.inject({}) do |hash, row|
+          # Check for the presence of the email_address key because not all queries are expected to return email addresses.
+          if row['ldap_uid'].present? && row.has_key?('email_address') && row['email_address'].blank?
+            hash[row['ldap_uid']] ||= []
+            hash[row['ldap_uid']] << row
+          end
+          hash
+        end
+        User::BasicAttributes.attributes_for_uids(rows_without_email.keys).each do |attrs|
+          rows_without_email[attrs[:ldap_uid]].each do |row|
+            row['email_address'] = attrs[:email_address]
+          end
         end
       end
 

--- a/spec/models/edo_oracle/adapters/oec_spec.rb
+++ b/spec/models/edo_oracle/adapters/oec_spec.rb
@@ -108,6 +108,17 @@ describe EdoOracle::Adapters::Oec do
       end
     end
 
+    context 'missing email address' do
+      before { row['email_address'] = nil }
+      it 'fills in email address from attributes query' do
+        expect(User::BasicAttributes).to receive(:attributes_for_uids).with(['12345']).and_return([{
+          ldap_uid: '12345',
+          email_address: 'kaymcnulty@arl.army.mil'
+        }])
+        expect(course['email_address']).to eq 'kaymcnulty@arl.army.mil'
+      end
+    end
+
     it 'leaves other values unchanged' do
       %w(instruction_format section_num ldap_uid sis_id first_name last_name email_address enrollment_count).each do |key|
         expect(course[key]).to eq row[key]


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6374