### PR TITLE
SISRP-21164 - Delegate having Multiple students higherone navigates to wrong student profile

### DIFF
--- a/app/models/campus_solutions/higher_one_url.rb
+++ b/app/models/campus_solutions/higher_one_url.rb
@@ -25,7 +25,7 @@ module CampusSolutions
     end
 
     def url
-      query_args = @delegate_uid ? "DELEGATE_UID=#{@delegate_uid}" : "EMPLID=#{@campus_solutions_id}"
+      query_args = @delegate_uid ? "DELEGATE_UID=#{@delegate_uid}&EMPLID=#{@campus_solutions_id}" : "EMPLID=#{@campus_solutions_id}"
       "#{@settings.base_url}/UC_OB_HIGHER_ONE_URL_GET.v1/get?#{query_args}"
     end
 

--- a/spec/models/campus_solutions/higher_one_url_spec.rb
+++ b/spec/models/campus_solutions/higher_one_url_spec.rb
@@ -29,14 +29,15 @@ describe CampusSolutions::HigherOneUrl do
         expect(proxy.url).to end_with '/UC_OB_HIGHER_ONE_URL_GET.v1/get?EMPLID=26662066'
       end
     end
-    context 'pass DELEGATE_UID arg to Campus Solutions' do
+    context 'pass both DELEGATE_UID and EMPLID args to Campus Solutions' do
       let(:delegate_uid) { '12350' }
       let(:options) { { fake: true, user_id: user_id, delegate_uid: delegate_uid } }
 
       it_should_behave_like 'a proxy that gets data'
 
       it 'should construct proper URL' do
-        expect(proxy.url).to end_with '/UC_OB_HIGHER_ONE_URL_GET.v1/get?DELEGATE_UID=12350'
+        expect(proxy.url).to include("DELEGATE_UID=")
+        expect(proxy.url).to include("EMPLID=")
       end
     end
   end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-21164
Also:  https://jira.berkeley.edu/browse/SISRP-21729

* API is now expecting both DELEGATE_UID and CSID of the student that the delegate wants to navigate to
* Has not been smoke tested yet due to upstream dependencies