### PR TITLE
NOJIRA Tests which hit real server endpoints should be confined to textext

### DIFF
--- a/spec/controllers/service_alerts_controller_spec.rb
+++ b/spec/controllers/service_alerts_controller_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceAlertsController do
+describe ServiceAlertsController, :testext => true do
 
   before do
     allow(ServiceAlerts::Alert).to receive(:get_latest).and_return(fake_alert)

--- a/spec/models/service_alerts/merged_spec.rb
+++ b/spec/models/service_alerts/merged_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceAlerts::Merged do
+describe ServiceAlerts::Merged, :testext => true do
   let(:feed) { ServiceAlerts::Merged.new.get_feed_internal }
 
   shared_examples 'a feed with a release note' do


### PR DESCRIPTION
Currently these are breaking Travis CI due to CLC-6386. That SSLError issue needs to be fixed, but even so a RAILS_ENV=test rspec run should not rely on reaching live servers.