### PR TITLE
CLC-6386 Use TLS1.2 SSL for RSS feeds

### DIFF
--- a/app/models/ets_blog/rss_proxy.rb
+++ b/app/models/ets_blog/rss_proxy.rb
@@ -3,6 +3,7 @@ module EtsBlog
     include DatedFeed
     include Proxies::HttpClient
     include Proxies::MockableXml
+    include Proxies::Tls12
 
     # Tell HTTParty that the 'application/rss+xml' content type used by Drupal should be parsed as XML.
     class RssParser < HTTParty::Parser
@@ -17,7 +18,7 @@ module EtsBlog
 
     def get_feed_internal(path)
       logger.info "Fetching #{path}; fake=#{@fake}; cache expiration #{self.class.expires_in}"
-      response = get_response(path, {parser: RssParser})
+      response = get_response(path, request_options)
       entries = Array.wrap(response['rss']['channel']['item'])
       if entries.present?
         entry = entries.first
@@ -32,6 +33,10 @@ module EtsBlog
       else
         nil
       end
+    end
+
+    def request_options(opts = {})
+      {parser: RssParser}.deep_merge super(opts)
     end
 
     def mock_response

--- a/lib/proxies/authenticated_api.rb
+++ b/lib/proxies/authenticated_api.rb
@@ -1,6 +1,7 @@
 module Proxies
   module AuthenticatedApi
     def request_options(opts = {})
+      opts = super(opts)
       if @settings.app_id.present? && @settings.app_key.present?
         opts = {headers: {
           'app_id' => @settings.app_id,

--- a/lib/proxies/http_client.rb
+++ b/lib/proxies/http_client.rb
@@ -17,5 +17,10 @@ module Proxies
       end
     end
 
+    # For support of chained mix-ins.
+    def request_options(opts = {})
+      opts
+    end
+
   end
 end

--- a/lib/proxies/tls12.rb
+++ b/lib/proxies/tls12.rb
@@ -1,0 +1,9 @@
+module Proxies
+  module Tls12
+    def request_options(opts = {})
+      {
+        ssl_version: 'TLSv1_2'
+      }.deep_merge super(opts)
+    end
+  end
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6386

(The new ``request_options`` mix-ins can also be applied to some existing proxy classes -- I just haven't gotten around to it yet...)