### PR TITLE
CLC-6387, YouTube playlist ID added to API used by Course Capture card

### DIFF
--- a/app/models/webcast/course_media.rb
+++ b/app/models/webcast/course_media.rb
@@ -38,6 +38,7 @@ module Webcast
           audio = get_audio_as_json data
           itunes = get_itunes_as_json data
           media_per_ccn[ccn] = videos.merge(audio).merge(itunes)
+          media_per_ccn[ccn][:youTubePlaylist] = data[:youtube_playlist]
         end
       end
       media_per_ccn
@@ -57,7 +58,7 @@ module Webcast
     end
 
     def get_itunes_url(id)
-      !id.blank? ? 'https://itunes.apple.com/us/itunes-u/id' + id : nil
+      id && "https://itunes.apple.com/us/itunes-u/id#{id}"
     end
 
     def get_itunes_as_json(playlist)

--- a/app/models/webcast/merged.rb
+++ b/app/models/webcast/merged.rb
@@ -103,13 +103,13 @@ module Webcast
               next_class[:sections].each do |section|
                 ccn = section[:ccn]
                 section_metadata = {
-                  :termYr => @term_yr,
-                  :termCd => @term_cd,
-                  :ccn => ccn,
-                  :deptName => next_class[:dept],
-                  :catalogId => next_class[:courseCatalog],
-                  :instructionFormat => section[:instruction_format],
-                  :sectionNumber => section[:section_number]
+                  termYr: @term_yr,
+                  termCd: @term_cd,
+                  ccn: ccn,
+                  deptName: next_class[:dept],
+                  catalogId: next_class[:courseCatalog],
+                  instructionFormat: section[:instruction_format],
+                  sectionNumber: section[:section_number]
                 }
                 media = media_per_ccn[ccn.to_i]
                 feed << media.merge(section_metadata) if media

--- a/app/models/webcast/recordings.rb
+++ b/app/models/webcast/recordings.rb
@@ -19,10 +19,11 @@ module Webcast
           key = Webcast::CourseMedia.id_per_ccn(year, semester, course['ccn'])
           recordings[:courses][key] = {
             audio_only: course['audioOnly'],
-            audio_rss: course['audioRSS'].to_s,
+            audio_rss: course['audioRSS'],
             recordings: course['recordings'],
-            itunes_audio: course['iTunesAudio'].to_s,
-            itunes_video: course['iTunesVideo'].to_s
+            itunes_audio: course['iTunesAudio'],
+            itunes_video: course['iTunesVideo'],
+            youtube_playlist: course['youTubePlaylist']
           }
         end
       end

--- a/fixtures/webcast/warehouse/webcast.json
+++ b/fixtures/webcast/warehouse/webcast.json
@@ -2090,6 +2090,23 @@
         }
       ],
       "audioOnly": false
+    },
+    {
+      "year": 2016,
+      "semester": "Fall",
+      "ccn": 15954,
+      "deptName": "IAS",
+      "catalogId": "45",
+      "public": false,
+      "youTubePlaylist": "PL-XXv-cvA_iAn6Qt6B7D-phRT0Ld1GOUV",
+      "recordings": [
+        {
+          "lecture": "2016-08-25: IAS 45 lecture 1",
+          "youTubeId": "yDqMvV0Hj5g",
+          "recordingStartUTC": "2016-08-25T15:10:00-11:00"
+        }
+      ],
+      "audioOnly": false
     }
   ]
 }

--- a/spec/models/webcast/merged_spec.rb
+++ b/spec/models/webcast/merged_spec.rb
@@ -1,8 +1,8 @@
 describe Webcast::Merged do
 
   context 'authorized user and a fake proxy' do
-    let(:user_id) { rand(99999).to_s }
-    let(:options) { {:fake => true} }
+    let(:user_id) { random_id }
+    let(:options) { { fake: true } }
     let(:policy) do
       AuthenticationStatePolicy.new(AuthenticationState.new('user_id' => user_id), nil)
     end
@@ -34,17 +34,17 @@ describe Webcast::Merged do
       before do
         courses_list = [
           {
-            :classes=>[
+            classes: [
               {
-                :dept => 'PLANTBI',
-                :courseCatalog => '150',
-                :sections => [
-                  { :ccn=>'87435', :section_number=>'101', :instruction_format=>'LAB' },
-                  { :ccn=>'87438', :section_number=>'102', :instruction_format=>'LAB' },
-                  { :ccn=>'87444', :section_number=>'201', :instruction_format=>'LAB' },
-                  { :ccn=>'87447', :section_number=>'202', :instruction_format=>'LAB' },
-                  { :ccn=>'87432', :section_number=>'001', :instruction_format=>'LEC' },
-                  { :ccn=>'87441', :section_number=>'002', :instruction_format=>'LEC' }
+                dept: 'PLANTBI',
+                courseCatalog: '150',
+                sections: [
+                  { ccn: '87435', section_number: '101', instruction_format: 'LAB' },
+                  { ccn: '87438', section_number: '102', instruction_format: 'LAB' },
+                  { ccn: '87444', section_number: '201', instruction_format: 'LAB' },
+                  { ccn: '87447', section_number: '202', instruction_format: 'LAB' },
+                  { ccn: '87432', section_number: '001', instruction_format: 'LEC' },
+                  { ccn: '87441', section_number: '002', instruction_format: 'LEC' }
                 ]
               }
             ]
@@ -53,20 +53,17 @@ describe Webcast::Merged do
         expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).once.and_return courses_list
       end
       it 'returns one match media' do
-        stat_131A = feed[:media][0]
-        expect(stat_131A[:termYr]).to eq 2014
-        expect(stat_131A[:termCd]).to eq 'B'
-        expect(stat_131A[:ccn]).to eq '87432'
-        expect(stat_131A[:deptName]).to eq 'PLANTBI'
-        expect(stat_131A[:catalogId]).to eq '150'
-        videos = stat_131A[:videos]
-        itunes_audio_id = '819827828'
-        expect(stat_131A[:iTunes][:audio]).to include itunes_audio_id
+        stat_131 = feed[:media][0]
+        expect(stat_131[:termYr]).to eq 2014
+        expect(stat_131[:termCd]).to eq 'B'
+        expect(stat_131[:ccn]).to eq '87432'
+        expect(stat_131[:deptName]).to eq 'PLANTBI'
+        expect(stat_131[:catalogId]).to eq '150'
+        videos = stat_131[:videos]
+        expect(stat_131[:iTunes][:audio]).to end_with '819827828'
         expect(videos).to have(31).items
         # Verify backwards compatibility
         expect(feed[:videos]).to eq videos
-        expect(feed[:videoErrorMessage]).to be_nil
-        expect(feed[:iTunes][:audio]).to include itunes_audio_id
       end
     end
 
@@ -75,8 +72,13 @@ describe Webcast::Merged do
         Webcast::Merged.new(user_id, policy, 2008, 'D', [9688], options).get_feed
       end
       before do
-        courses_list = [{
-            :classes=>[{ :sections => [{ :ccn=>'09688', :section_number=>'101', :instruction_format=>'LEC' }] }]
+        courses_list = [
+          {
+            classes: [
+              {
+                sections: [{ ccn: '09688', section_number: '101', instruction_format: 'LEC' }]
+              }
+            ]
           }
         ]
         expect_any_instance_of(MyAcademics::Teaching).to receive(:courses_list_from_ccns).once.and_return courses_list
@@ -100,18 +102,18 @@ describe Webcast::Merged do
       before do
         sections_with_recordings = [
           {
-            :classes=>[
+            classes: [
               {
-                :sections=>[
+                sections: [
                   {
-                    :ccn=>'76207',
-                    :instruction_format=>'LEC',
-                    :section_number=>'101'
+                    ccn: '76207',
+                    instruction_format: 'LEC',
+                    section_number: '101'
                   },
                   {
-                    :ccn=>'87432',
-                    :instruction_format=>'LEC',
-                    :section_number=>'101'
+                    ccn: '87432',
+                    instruction_format: 'LEC',
+                    section_number: '101'
                   }
                 ]
               }
@@ -120,30 +122,30 @@ describe Webcast::Merged do
         ]
         webcast_eligible = [
           {
-            :classes=>[
+            classes: [
               {
-                :dept => 'BIO',
-                :courseCatalog => '1B',
-                :sections=>[
+                dept: 'BIO',
+                courseCatalog: '1B',
+                sections: [
                   {
-                    :ccn=>'07620',
-                    :section_number=>'312',
-                    :instruction_format => 'LAB',
-                    :instructors=>[
+                    ccn: '07620',
+                    section_number: '312',
+                    instruction_format: 'LAB',
+                    instructors: [
                       {
-                        :name=>'Paul Duguid',
-                        :uid=>'18938',
-                        :instructor_func=>'1'
+                        name: 'Paul Duguid',
+                        uid: '18938',
+                        instructor_func: '1'
                       },
                       {
-                        :name=>'Geoffrey Nunberg',
-                        :uid=>ldap_uid,
-                        :instructor_func=>'3'
+                        name: 'Geoffrey Nunberg',
+                        uid: ldap_uid,
+                        instructor_func: '3'
                       },
                       {
-                        :name=>'Nikolai Smith',
-                        :uid=>'1016717',
-                        :instructor_func=>'2'
+                        name: 'Nikolai Smith',
+                        uid: '1016717',
+                        instructor_func: '2'
                       }
                     ]
                   }
@@ -160,20 +162,21 @@ describe Webcast::Merged do
         expect(feed[:videoErrorMessage]).to be_nil
         media = feed[:media]
         expect(media).to have(2).items
-        pb_hlth_241 = media[0]
-        stat_131A = media[1]
-        expect(stat_131A[:ccn]).to eq '87432'
-        expect(stat_131A[:videos]).to have(31).items
-        expect(stat_131A[:instructionFormat]).to eq 'LEC'
-        expect(stat_131A[:sectionNumber]).to eq '101'
-        expect(stat_131A[:eligibleForSignUp]).to be_nil
-        expect(pb_hlth_241[:ccn]).to eq '76207'
-        expect(pb_hlth_241[:videos]).to have(35).items
-        expect(pb_hlth_241[:iTunes][:audio]).to include('805328862')
-        expect(pb_hlth_241[:iTunes][:video]).to be_nil
-        expect(feed[:videos]).to match_array(pb_hlth_241[:videos] + stat_131A[:videos])
+        pb_health_241 = media[0]
+        stat_131 = media[1]
+        expect(stat_131[:ccn]).to eq '87432'
+        expect(stat_131[:videos]).to have(31).items
+        expect(stat_131[:instructionFormat]).to eq 'LEC'
+        expect(stat_131[:sectionNumber]).to eq '101'
+        expect(stat_131[:eligibleForSignUp]).to be_nil
+        expect(pb_health_241[:ccn]).to eq '76207'
+        expect(pb_health_241[:youTubePlaylist]).to eq '-XXv-cvA_iBacs-uhTVhDhip4sGWoq2C'
+        expect(pb_health_241[:videos]).to have(35).items
+        expect(pb_health_241[:iTunes][:audio]).to end_with '805328862'
+        expect(pb_health_241[:iTunes][:video]).to be_nil
+        expect(feed[:videos]).to match_array(pb_health_241[:videos] + stat_131[:videos])
         expect(feed[:audio]).to be_empty
-        expect(feed[:iTunes][:audio]).to include('805328862')
+        expect(feed[:iTunes][:audio]).to end_with '805328862'
         expect(feed[:iTunes][:video]).to be_nil
 
         # Instructors that can sign up for Webcast
@@ -204,11 +207,11 @@ describe Webcast::Merged do
       before do
         sections_with_recordings = [
           {
-            :classes=>[
+            classes: [
               {
-                :sections=>[
-                  { :ccn=>'05915', :section_number=>'101', :instruction_format=>'LEC' },
-                  { :ccn=>'51990', :section_number=>'201', :instruction_format=>'LEC' }
+                sections: [
+                  { ccn: '05915', section_number: '101', instruction_format: 'LEC' },
+                  { ccn: '51990', section_number: '201', instruction_format: 'LEC' }
                 ]
               }
             ]
@@ -230,7 +233,7 @@ describe Webcast::Merged do
     end
   end
 
-  context 'a real, non-fake proxy with user in view-as mode', :testext => true do
+  context 'a real, non-fake proxy with user in view-as mode', testext: true do
     context 'course with zero recordings is different than course not scheduled for recordings' do
       before do
         allow(Berkeley::Terms).to receive(:legacy?).with(2015, 'B').and_return true

--- a/spec/models/webcast/recordings_spec.rb
+++ b/spec/models/webcast/recordings_spec.rb
@@ -1,20 +1,19 @@
 describe Webcast::Recordings do
 
-  let (:webcast_uri) { URI.parse "#{Settings.webcast_proxy.base_url}/warehouse/webcast.json" }
-
   context 'a fake proxy' do
-    context 'data organized by ccn' do
-      let(:recordings) { Webcast::Recordings.new({:fake => true}).get }
-      it 'should return a lot of playlists' do
-        expect(recordings[:courses].keys.length).to eq 23
-        law_2723 = recordings[:courses]['2008-D-49688']
-        expect(law_2723).to_not be_nil
-        expect(law_2723[:recordings]).to have(12).items
-      end
+    let(:recordings) { Webcast::Recordings.new({:fake => true}).get }
+    it 'should return many playlists' do
+      expect(recordings[:courses]).to have(24).items
+      law_2723 = recordings[:courses]['2008-D-49688']
+      expect(law_2723).to_not be_nil
+      expect(law_2723[:youtube_playlist]).to eq 'EC8DA9DAD111EAAD28'
+      expect(law_2723[:recordings]).to have(12).items
     end
   end
 
-  context 'a real, non-fake proxy', :testext => true do
+  context 'a real, non-fake proxy', testext: true do
+    let (:webcast_uri) { URI.parse "#{Settings.webcast_proxy.base_url}/warehouse/webcast.json" }
+
     subject { Webcast::Recordings.new }
 
     context 'normal return of real data' do
@@ -52,8 +51,7 @@ describe Webcast::Recordings do
     end
 
     context 'when videos are disabled' do
-      before { Settings.features.videos = false }
-      after { Settings.features.videos = true }
+      before { allow(Settings.features).to receive(:videos).and_return false }
       it 'should return an empty hash' do
         result = subject.get
         expect(result).to be_an_instance_of Hash

--- a/src/assets/templates/widgets/webcast.html
+++ b/src/assets/templates/widgets/webcast.html
@@ -74,12 +74,32 @@
         </ul>
         <div data-ng-if="currentSelection === 'Video'">
           <div data-ng-if="videos.length">
-            <div class="cc-select cc-widget-webcast-select">
-              <label for="cc-widget-webcast-video-selection" class="cc-visuallyhidden">Select Video</label>
-              <select id="cc-widget-webcast-video-selection" class="bc-canvas-embedded-form-select" data-ng-model="selectedVideo" data-ng-change="announceVideoSelect()" data-ng-options="video.lecture for video in videos"></select>
-            </div>
-            <div class="cc-youtube-video">
-              <div data-cc-youtube-directive="selectedVideo.youTubeId" data-cc-youtube-directive-title="{{selectedVideo.lecture}}"></div>
+            <div class="cc-table" data-ng-repeat="medium in media">
+              <h3 data-ng-bind-template="{{medium.deptName + ' ' + medium.catalogId + ' ' + medium.instructionFormat + ' ' + medium.sectionNumber}}" data-ng-if="media.length > 1"></h3>
+              <table>
+                <thead>
+                  <tr>
+                    <th width="60%" scope="col">
+                      Recording (YouTube)
+                    </th>
+                    <th width="40%" scope="col">
+                      Date
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr data-ng-repeat="video in medium.videos | limitTo: futureLimit">
+                    <td class="cc-table-top-border">
+                      <a data-ng-href="https://www.youtube.com/watch?v={{video.youTubeId}}"
+                         title="{{video.lecture}}"
+                         data-ng-bind="video.lecture">
+                      </a>
+                    </td>
+                    <td class="cc-table-top-border" data-ng-bind="video.recordingStartUTC | date:'MMM d'"></td>
+                  </tr>
+                </tbody>
+              </table>
+              <div data-cc-show-more-directive data-cc-show-more-list="medium.videos" data-cc-show-more-limit="futureLimit"></div>
             </div>
           </div>
           <ul class="cc-widget-webcast-links" data-ng-if="iTunes.video">


### PR DESCRIPTION
Back-end: https://jira.ets.berkeley.edu/jira/browse/CLC-6387
Front-end: https://jira.ets.berkeley.edu/jira/browse/CLC-6389

Includes:
* new playlist property in `/api/media` feed 
* better syntax in specs
* replace YouTube-embed in Course Capture card with a nicely formatted list of links