### PR TITLE
SISRP-21252 - Financials - how will ‘amount due’ alerts in CalCentral appear for CS financials?

### DIFF
--- a/src/assets/javascripts/angular/controllers/widgets/statusController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/statusController.js
@@ -89,7 +89,9 @@ angular.module('calcentral.controllers').controller('StatusController', function
       $scope.hasWarnings = true;
     }
 
-    $scope.hasBillingData = ($scope.minimumAmountDue !== null);
+    if ($scope.minimumAmountDue) {
+      $scope.hasBillingData = true;
+    }
   };
 
   var loadActivity = function(data) {


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-21252

* "Status" was showing for staff/faculty in the popover because JS was parsing `$scope.minimumAmountDue` to `NaN`, and `NaN !== null` is parsed to `true`, giving these users `$scope.hasBillingData = true`.
* This will evaluate `null`, `NaN`, and `0` cases to false - see [this thread for some good information](http://stackoverflow.com/questions/5515310/is-there-a-standard-function-to-check-for-null-undefined-or-blank-variables-in)