### PR TITLE
SISRP-22490 - Add Both Current and Next RegStatus to Status & Holds

### DIFF
--- a/src/assets/javascripts/angular/services/statusHoldsService.js
+++ b/src/assets/javascripts/angular/services/statusHoldsService.js
@@ -1,0 +1,62 @@
+'use strict';
+
+var angular = require('angular');
+
+angular.module('calcentral.services').service('statusHoldsService', function() {
+  /**
+   * Parses any terms past the legacy cutoff.  Mirrors current functionality for now, but this will be changed in redesigns slated
+   * for GL6.
+   */
+  var parseCsTerm = function(term) {
+    var termReg = {
+      isSummer: term.isSummer,
+      termName: term.termName,
+      termId: term.termId,
+      summary: null,
+      explanation: null
+    };
+    if (term.registered === true) {
+      termReg.summary = 'Officially Registered';
+      termReg.explanation = term.isSummer ? 'You are officially registered for this term.' : 'You are officially registered and are entitled to access campus services.';
+    }
+    if (term.registered === false) {
+      termReg.summary = 'Not Officially Registered';
+      termReg.explanation = term.isSummer ? 'You are not officially registered for this term.' : 'You are not entitled to access campus services until you are officially registered.  In order to be officially registered, you must pay your Tuition and Fees, and have no outstanding holds.';
+    }
+
+    return termReg;
+  };
+
+  /**
+   * Parses any terms on or before the legacy cutoff.  Mirrors current functionality, this should be able to be removed in Fall 2016.
+   */
+  var parseLegacyTerm = function(term) {
+    var termReg = {
+      isSummer: term.isSummer,
+      termName: term.termName,
+      termId: term.termId,
+      summary: null,
+      explanation: null
+    };
+    termReg.summary = term.regStatus.summary;
+    termReg.explanation = term.regStatus.explanation;
+
+    // Special summer parsing for the last legacy term (Summer 2016)
+    if (term.isSummer) {
+      if (term.regStatus.summary !== 'Registered') {
+        termReg.summary = 'Not Officially Registered';
+        termReg.explanation = 'You are not officially registered for this term.';
+      } else {
+        termReg.summary = 'Officially Registered';
+        termReg.explanation = 'You are officially registered for this term.';
+      }
+    }
+
+    return termReg;
+  };
+
+  return {
+    parseCsTerm: parseCsTerm,
+    parseLegacyTerm: parseLegacyTerm
+  };
+});

--- a/src/assets/templates/widgets/status_and_holds.html
+++ b/src/assets/templates/widgets/status_and_holds.html
@@ -8,23 +8,23 @@
 
     <div data-cc-spinner-directive="regStatus.isLoading">
       <div data-ng-if="statusHoldsBlocks.enabledSections.indexOf('Status') !== -1">
-        <div class="cc-status-holds-section">
-          <h4 data-ng-bind="regStatus.term"></h4>
+        <div class="cc-status-holds-section" data-ng-repeat="registration in regStatus.registrations | orderBy:'-termId'">
+          <h4 data-ng-bind="registration.termName"></h4>
           <ul class="cc-widget-list cc-status-holds-list" data-ng-if="api.user.profile.features.regstatus">
             <li class="cc-widget-list-hover"
-                data-ng-class="{'cc-widget-list-hover-opened':(regStatus.show)}"
+                data-ng-class="{'cc-widget-list-hover-opened':(registration.show)}"
                 data-cc-accessible-focus-directive
-                data-ng-click="api.widget.toggleShow($event, null, regStatus, 'My Academics - Status and Holds')">
+                data-ng-click="api.widget.toggleShow($event, null, registration, 'My Academics - Status and Holds')">
               <div class="cc-status-holds-list-section">
                 <div class="cc-status-holds-list-item">
-                  <span data-ng-if="!regStatus.isSummer && regStatus.summary !== 'Not Officially Registered'">
+                  <span data-ng-hide="registration.isSummer && registration.summary === 'Not Officially Registered'">
                     <i class="cc-icon fa"
-                       data-ng-class="{true:'fa-check-circle cc-icon-green',false:'fa-exclamation-circle cc-icon-red'}[regStatus.summary=='Officially Registered']">
+                       data-ng-class="{true:'fa-check-circle cc-icon-green',false:'fa-exclamation-circle cc-icon-red'}[registration.summary=='Officially Registered']">
                     </i>
                   </span>
-                  <span data-ng-bind="regStatus.summary"></span>
+                  <span data-ng-bind="registration.summary"></span>
                 </div>
-                <div class="cc-status-holds-expanded-text" data-ng-show="regStatus.show" data-ng-bind="regStatus.explanation"></div>
+                <div class="cc-status-holds-expanded-text" data-ng-show="registration.show" data-ng-bind="registration.explanation"></div>
               </div>
             </li>
           </ul>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-22490

* If either `current` or `next` are `null`, then hide that regstatus
* This does **not** change any logic on `academicsController.js` that conditionally shows/hide the "Status and Holds" card - that will come in a future refactoring PR
* Includes "My Academics" and "User Overview" versions of this card
* Moves shared code into a service
* Keeps legacy messaging, but that will likely turn into message catalog stuff in a future PR