### PR TITLE
SISRP-22628: fix LinkController#get options param setting and spec

### DIFF
--- a/app/controllers/campus_solutions/link_controller.rb
+++ b/app/controllers/campus_solutions/link_controller.rb
@@ -2,7 +2,7 @@ module CampusSolutions
   class LinkController < CampusSolutionsController
 
     def get
-      render json: CampusSolutions::Link.new(params).get_url(params['urlId'])
+      render json: CampusSolutions::Link.new(params).get_url(params['urlId'], params['options'])
     end
 
   end

--- a/app/models/campus_solutions/link.rb
+++ b/app/models/campus_solutions/link.rb
@@ -31,7 +31,7 @@ module CampusSolutions
       link = links.find do |link|
         link[:urlId] == urlId
       end
-      if link && options.any?
+      if link && options.present?
         options.each do |k, v|
           link[:url] = link[:url].gsub("{#{k}}", v)
         end

--- a/spec/controllers/campus_solutions/link_controller_spec.rb
+++ b/spec/controllers/campus_solutions/link_controller_spec.rb
@@ -8,10 +8,39 @@ describe CampusSolutions::LinkController do
       let(:user_id) { '12345' }
       let(:feed_key) { 'link' }
       let(:urlId) { "UC_CX_TEST_LINK" }
+      let(:placeholder) { "Some placeholder text" }
 
-      it 'has some field mapping info' do
-        get feed, {:urlId => "UC_CX_TEST_LINK", :options => { PLACEHOLDER: "some text"}, :format => 'json'}
+      before { session['user_id'] = user_id }
+
+      it 'returns empty feed when urlId param not specified' do
+        get feed, {:format => 'json'}
+        expect(response.status).to eq 200
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["feed"]["link"]).to_not be
       end
+
+      it 'returns link feed with matching urlId' do
+        get feed, {:urlId => urlId, :format => 'json'}
+        expect(response.status).to eq 200
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["feed"]["link"]["urlId"]).to eq urlId
+        # Verify placeholder text is not replaced when options param omitted.
+        expect(json_response["feed"]["link"]["url"]).to include("PLACEHOLDER={PLACEHOLDER}")
+      end
+
+      it 'returns link feed with matching urlId and replaced options key-values' do
+        get feed, {:urlId => urlId, :options => { PLACEHOLDER: placeholder}, :format => 'json'}
+        expect(response.status).to eq 200
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["feed"]["link"]["urlId"]).to eq urlId
+        expect(json_response["feed"]["link"]["properties"].count).to eq 2
+        # Verify placeholder is replaced by options param entry.
+        expect(json_response["feed"]["link"]["url"]).to include("PLACEHOLDER=#{placeholder}")
+      end
+
     end
   end
 end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-22628

Fix to earlier PR https://github.com/ets-berkeley-edu/calcentral/pull/5641

This PR adds actual expectations to the Link Controller Spec for behavior when params are (or are not) specified.