### PR TITLE
SISRP-20755 Use fake Hub Term API in default developer.yml

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -67,6 +67,9 @@ advising_proxy:
 eft_proxy:
   fake: true
 
+hub_term_proxy:
+  fake: true
+
 features:
   advising: true
   audio: true


### PR DESCRIPTION
A little late following our convention on this one...