### PR TITLE
CLC-6397 OEC: Enforce matching header rows when parsing from CSV

### DIFF
--- a/app/models/oec/worksheet.rb
+++ b/app/models/oec/worksheet.rb
@@ -38,7 +38,11 @@ module Oec
       return unless csv && (parsed_csv = CSV.parse csv)
       instance = self.new opts
       (header_row = parsed_csv.shift) until (header_row == instance.headers || parsed_csv.empty?)
-      raise ArgumentError, "Header mismatch: cannot create instance of #{self.name} from CSV" unless header_row
+      unless header_row == instance.headers
+        csv_snippet = csv[0..499]
+        csv_snippet << '...' if csv.length > 500
+        raise ArgumentError, "Header mismatch: cannot create instance of #{self.name} from CSV: '#{csv_snippet}'"
+      end
       parsed_csv.each_with_index { |row, index| instance[index] = instance.parse_row row  }
       instance
     end

--- a/spec/models/oec/publish_task_spec.rb
+++ b/spec/models/oec/publish_task_spec.rb
@@ -24,8 +24,10 @@ describe Oec::PublishTask do
   before(:each) do
     allow(Oec::RemoteDrive).to receive(:new).and_return fake_remote_drive
     allow(fake_remote_drive).to receive(:find_nested).and_return mock_google_drive_item
-    allow(fake_remote_drive).to receive(:export_csv)
-                                  .and_return(merged_course_confirmations_csv, merged_supervisor_confirmations_csv)
+    allow(fake_remote_drive).to receive(:export_csv).and_return(
+      merged_course_confirmations_csv,
+      merged_supervisor_confirmations_csv,
+      previous_course_supervisors_csv)
     allow(Settings.terms).to receive(:fake_now).and_return DateTime.parse('2015-03-09 12:00:00')
 
     allow(Oec::Queries).to receive(:students_for_cntl_nums).and_return student_data_rows

--- a/spec/models/oec/worksheet_spec.rb
+++ b/spec/models/oec/worksheet_spec.rb
@@ -1,0 +1,47 @@
+describe Oec::Worksheet do
+
+  describe 'parsing from CSV' do
+    let(:csv) { File.read Rails.root.join('fixtures', 'oec', filename) }
+    subject { klass.from_csv csv }
+
+    context 'CSV headers matching class definition' do
+      let(:klass) { Oec::Supervisors }
+      let(:filename) { 'supervisors.csv' }
+      let(:rows) { subject.to_a }
+
+      it 'parses headers and rows' do
+        expect(subject).to be_a klass
+        expect(rows).to be_present
+      end
+
+      context 'header-only csv' do
+        let(:csv_headers) { csv.sub(/\n.*\Z/m, '') }
+        subject { klass.from_csv csv_headers }
+
+        it 'parses headers and no rows' do
+          expect(subject).to be_a klass
+          expect(rows).to be_empty
+        end
+      end
+    end
+
+    context 'CSV headers not matching class definition' do
+      let(:klass) { Oec::Supervisors }
+      let(:filename) { 'courses.csv' }
+
+      it 'errors out' do
+        expect {subject}.to raise_error /Header mismatch/
+      end
+    end
+
+    context 'empty CSV' do
+      let(:klass) { Oec::Supervisors }
+      let(:csv) { '' }
+
+      it 'errors out' do
+        expect {subject}.to raise_error /Header mismatch/
+      end
+    end
+  end
+
+end

--- a/spec/support/oec_shared_examples.rb
+++ b/spec/support/oec_shared_examples.rb
@@ -3,6 +3,7 @@ shared_context 'OEC enrollment data merge' do
   let(:fake_remote_drive) { double() }
   let(:merged_course_confirmations_csv) { File.read Rails.root.join('fixtures', 'oec', 'merged_course_confirmations.csv') }
   let(:merged_supervisor_confirmations_csv) { File.read Rails.root.join('fixtures', 'oec', 'supervisors.csv') }
+  let(:previous_course_supervisors_csv) { Oec::CourseSupervisors.new.headers.join(',') }
   let(:merged_course_confirmations) { Oec::SisImportSheet.from_csv merged_course_confirmations_csv }
 
   let(:course_ids) { merged_course_confirmations_csv.scan(/2015-B-\d+/).uniq.flatten }
@@ -35,8 +36,11 @@ shared_context 'OEC enrollment data merge' do
   before(:each) do
     allow(Oec::RemoteDrive).to receive(:new).and_return fake_remote_drive
     allow(fake_remote_drive).to receive(:find_nested).and_return mock_google_drive_item
-    allow(fake_remote_drive).to receive(:export_csv)
-                                  .and_return(merged_course_confirmations_csv, merged_supervisor_confirmations_csv)
+    allow(fake_remote_drive).to receive(:export_csv).and_return(
+      merged_course_confirmations_csv,
+      merged_supervisor_confirmations_csv,
+      previous_course_supervisors_csv)
+
     allow(Settings.terms).to receive(:fake_now).and_return DateTime.parse('2015-03-09 12:00:00')
 
     allow(Oec::CourseCode).to receive(:participating_dept_names).and_return %w(GWS LGBT)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6397

The code wanted to error out on mismatch, but didn't quite know how. Spec for reassurance.