### PR TITLE
SISRP-23011 - My Academics Feed - College and Level - Remove FPF Role Logic

### DIFF
--- a/app/models/my_academics/college_and_level.rb
+++ b/app/models/my_academics/college_and_level.rb
@@ -108,10 +108,7 @@ module MyAcademics
       {
         majors: majors,
         minors: minors,
-        plans: plans,
-        roles: {
-          fpf: plans.any? { |plan| plan[:code] == '25000FPFU' }
-        }
+        plans: plans
       }
     end
 

--- a/spec/models/my_academics/college_and_level_spec.rb
+++ b/spec/models/my_academics/college_and_level_spec.rb
@@ -86,20 +86,6 @@ describe 'MyAcademics::CollegeAndLevel' do
       )
     end
 
-    it 'specifies cpp roles' do
-      expect(feed[:collegeAndLevel][:roles]).to eq({
-        fpf: false
-      })
-    end
-
-    context 'fpf plan is present' do
-      it 'includes fpf role' do
-        expect(feed[:collegeAndLevel][:roles]).to eq({
-          fpf: false
-        })
-      end
-    end
-
     it 'specifies term name' do
       expect(feed[:collegeAndLevel][:termName]).to eq 'Spring 2017'
     end


### PR DESCRIPTION
The Roles added to the MyAcademics::CollegeAndLevel feed are no longer necessary after the refactor done in [SISRP-22857](https://jira.berkeley.edu/browse/SISRP-22857). This is a follow up to remove this data which is no longer needed.

https://jira.berkeley.edu/browse/SISRP-23011