### PR TITLE
SISRP-22752 - Add CNP to Status and Holds, Update Popover

### DIFF
--- a/app/controllers/advising_student_controller.rb
+++ b/app/controllers/advising_student_controller.rb
@@ -51,6 +51,10 @@ class AdvisingStudentController < ApplicationController
     render json: json
   end
 
+  def student_attributes
+    render json: HubEdos::StudentAttributes.new(user_id: student_uid_param).get
+  end
+
   private
 
   def filtered_academics

--- a/app/controllers/hub_edo_controller.rb
+++ b/app/controllers/hub_edo_controller.rb
@@ -19,7 +19,8 @@ class HubEdoController < ApplicationController
   end
 
   def student_attributes
-    json_passthrough HubEdos::MyStudentAttributes
+    model = HubEdos::MyStudentAttributes.from_session session
+    render json: model.get_feed_internal
   end
 
   def work_experience

--- a/app/controllers/hub_edo_controller.rb
+++ b/app/controllers/hub_edo_controller.rb
@@ -18,6 +18,10 @@ class HubEdoController < ApplicationController
     json_passthrough HubEdos::MyStudent, options
   end
 
+  def student_attributes
+    json_passthrough HubEdos::MyStudentAttributes
+  end
+
   def work_experience
     # Delegates get an empty feed.
     return {

--- a/app/models/berkeley/term.rb
+++ b/app/models/berkeley/term.rb
@@ -19,6 +19,8 @@ module Berkeley
     attr_reader :classes_end
     # The end of instruction is one week after classes end. The week between is RRR week. The week after is for final exams.
     attr_reader :instruction_end
+    # The end of the drop/add period, used for Cancellation for Non-Payment for Grad and Law students.
+    attr_reader :end_drop_add
     # BearFacts and related systems set "CT"/"Current Term" to Fall (and "FT"/"Future Term" to
     # the next year's Spring) as soon as the Spring term is over. Summer terms are special-cased as
     # "CS" or "FS", and lack some SIS support. This quirk becomes important when configuring
@@ -60,12 +62,18 @@ module Berkeley
         @classes_start = @start
         @classes_end = @end
         @instruction_end = @end
+        @end_drop_add = false
       else
         @is_summer = false
         session = term_feed['sessions'].first
         @classes_start = session['beginDate'].to_date.in_time_zone.to_datetime
         @instruction_end = session['endDate'].to_date.in_time_zone.to_datetime.end_of_day
         @classes_end = @instruction_end.advance(days: -7)
+        session['timePeriods'].each do |timePeriod|
+          if timePeriod['period']['code'] == '140'
+            @end_drop_add = timePeriod['endDate']
+          end
+        end
       end
       self
     end

--- a/app/models/berkeley/term.rb
+++ b/app/models/berkeley/term.rb
@@ -15,11 +15,13 @@ module Berkeley
     attr_reader :start
     # The Fall/Spring semesters end two weeks after the end of formal classes.
     attr_reader :end
+    # The first day of instruction.  This date is used for Cancellation for Non-Payment logic to trigger the change from a
+    # CNP notification to a CNP warning, as well as the drop date for undergraduates.
     attr_reader :classes_start
     attr_reader :classes_end
     # The end of instruction is one week after classes end. The week between is RRR week. The week after is for final exams.
     attr_reader :instruction_end
-    # The end of the drop/add period, used for Cancellation for Non-Payment for Grad and Law students.
+    # The end of the drop/add period, used for Cancellation for Non-Payment as the drop date for Grad and Law students.
     attr_reader :end_drop_add
     # BearFacts and related systems set "CT"/"Current Term" to Fall (and "FT"/"Future Term" to
     # the next year's Spring) as soon as the Spring term is over. Summer terms are special-cased as
@@ -41,6 +43,8 @@ module Berkeley
     end
 
     def from_cs_api(api_feed)
+      # The code used to identify end date of drop/add period in the Terms API.
+      end_drop_add_code = '140'
       @raw_source = api_feed
       # The HubTerm API returns an array of matching terms, one for each applicable academic career. For general
       # campus-wide reference, we pick the Undergraduate entry.
@@ -70,7 +74,7 @@ module Berkeley
         @instruction_end = session['endDate'].to_date.in_time_zone.to_datetime.end_of_day
         @classes_end = @instruction_end.advance(days: -7)
         session['timePeriods'].each do |timePeriod|
-          if timePeriod['period']['code'] == '140'
+          if timePeriod['period']['code'] == end_drop_add_code
             @end_drop_add = timePeriod['endDate']
           end
         end

--- a/app/models/hub_edos/my_student_attributes.rb
+++ b/app/models/hub_edos/my_student_attributes.rb
@@ -1,11 +1,6 @@
 module HubEdos
   class MyStudentAttributes < UserSpecificModel
 
-    include ClassLogger
-    include Cache::CachedFeed
-    include Cache::JsonifiedFeed
-    include Cache::UserCacheExpiry
-
     def get_feed_internal
       HubEdos::StudentAttributes.new({user_id: @uid}).get
     end

--- a/app/models/hub_edos/my_student_attributes.rb
+++ b/app/models/hub_edos/my_student_attributes.rb
@@ -1,0 +1,14 @@
+module HubEdos
+  class MyStudentAttributes < UserSpecificModel
+
+    include ClassLogger
+    include Cache::CachedFeed
+    include Cache::JsonifiedFeed
+    include Cache::UserCacheExpiry
+
+    def get_feed_internal
+      HubEdos::StudentAttributes.new({user_id: @uid}).get
+    end
+
+  end
+end

--- a/app/models/hub_edos/student_attributes.rb
+++ b/app/models/hub_edos/student_attributes.rb
@@ -1,0 +1,31 @@
+module HubEdos
+  class StudentAttributes < Student
+
+    include Cache::UserCacheExpiry
+
+    def initialize(options = {})
+      super(options)
+    end
+
+    def url
+      "#{@settings.base_url}/#{@campus_solutions_id}/student-attributes"
+    end
+
+    def json_filename
+      'hub_student_attributes.json'
+    end
+
+    def include_fields
+      %w(studentAttributes)
+    end
+
+    def get
+      return {} unless is_feature_enabled
+      response = self.class.smart_fetch_from_cache(id: instance_key) do
+        get_internal
+      end
+      decorate_internal_response response
+    end
+
+  end
+end

--- a/app/models/my_registrations/my_registrations.rb
+++ b/app/models/my_registrations/my_registrations.rb
@@ -22,6 +22,7 @@ module MyRegistrations
     end
 
     def get_terms
+      berkeley_term = Berkeley::Term.new
       berkeley_terms = Berkeley::Terms.fetch
       terms = {}
       # ':previous' and ':grading_in_progress' methods are not included here because Campus::Oracle does not keep information prior to the current term.
@@ -36,9 +37,9 @@ module MyRegistrations
             cs_feed = HubTerm::Proxy.new(temporal_position: temporal_position).get_term
             terms[term_method] = terms[term_method].merge(
               {
-                classesStart: term_start(cs_feed),
-                end: term_end(cs_feed),
-                endDropAdd: term_end_drop_add(cs_feed)
+                classesStart: berkeley_term.from_cs_api(cs_feed).classes_start,
+                end: berkeley_term.from_cs_api(cs_feed).end,
+                endDropAdd: berkeley_term.from_cs_api(cs_feed).end_drop_add
               }
             )
             terms[term_method] = set_term_flags(terms[term_method])
@@ -123,18 +124,6 @@ module MyRegistrations
       end
 
       HashConverter.camelize response
-    end
-
-    def term_start(cs_feed)
-      Berkeley::Term.new.from_cs_api(cs_feed).classes_start
-    end
-
-    def term_end(cs_feed)
-      Berkeley::Term.new.from_cs_api(cs_feed).end
-    end
-
-    def term_end_drop_add(cs_feed)
-      Berkeley::Term.new.from_cs_api(cs_feed).end_drop_add
     end
 
     def term_transition?

--- a/app/models/my_registrations/my_registrations.rb
+++ b/app/models/my_registrations/my_registrations.rb
@@ -30,12 +30,40 @@ module MyRegistrations
         term = berkeley_terms.send term_method
         if term
           terms[term_method] = {id: term.campus_solutions_id, name: term.to_english}
+          # For 'current' and 'next' terms, we need the date of start and end of instruction to determine CNP status
+          if (term_method == :current || term_method == :next)
+            temporal_position = term_method == :current ? HubTerm::Proxy::CURRENT_TERM : HubTerm::Proxy::NEXT_TERM
+            cs_feed = HubTerm::Proxy.new(temporal_position: temporal_position).get_term
+            terms[term_method] = terms[term_method].merge(
+              {
+                classesStart: term_start(cs_feed),
+                end: term_end(cs_feed),
+                endDropAdd: term_end_drop_add(cs_feed)
+              }
+            )
+            terms[term_method] = set_term_flags(terms[term_method])
+          end
         # Often ':future' will be nil, but during Spring terms, it should send back data for the upcoming Fall semester.
         else
           terms[term_method] = nil
         end
       end
       terms
+    end
+
+    def set_term_flags(term)
+      current_date = Settings.terms.fake_now || DateTime.now
+      term.merge({
+        # CNP logic dictates that grad/law students are dropped one day AFTER the add/drop deadline.
+        pastAddDrop: term[:endDropAdd] ? current_date > term[:endDropAdd] : nil,
+        # Undergrad students are dropped on the first day of instruction.
+        pastClassesStart: current_date >= term[:classesStart],
+        # All term registration statuses are hidden the day after the term ends.
+        pastEndOfInstruction: current_date > term[:end],
+        # Financial Aid disbursement is used in CNP notification.  This will be 8 days before start of instruction in Fall 2016,
+        # but this should be changed to 9 days before start of instruction post-Fall 2016.
+        pastFinancialDisbursement: current_date >= (term[:classesStart] - 8)
+        })
     end
 
     private
@@ -95,6 +123,18 @@ module MyRegistrations
       end
 
       HashConverter.camelize response
+    end
+
+    def term_start(cs_feed)
+      Berkeley::Term.new.from_cs_api(cs_feed).classes_start
+    end
+
+    def term_end(cs_feed)
+      Berkeley::Term.new.from_cs_api(cs_feed).end
+    end
+
+    def term_end_drop_add(cs_feed)
+      Berkeley::Term.new.from_cs_api(cs_feed).end_drop_add
     end
 
     def term_transition?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -224,6 +224,7 @@ Calcentral::Application.routes.draw do
   # EDOs from integration hub
   get '/api/edos/academic_status' => 'hub_edo#academic_status', :via => :get, :defaults => { :format => 'json' }
   get '/api/edos/student' => 'hub_edo#student', :via => :get, :defaults => { :format => 'json' }
+  get '/api/edos/student_attributes' => 'hub_edo#student_attributes', :via => :get, :defaults => { :format => 'json' }
   get '/api/edos/work_experience' => 'hub_edo#work_experience', :via => :get, :defaults => { :format => 'json' }
 
   # All the other paths should use the bootstrap page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,6 +151,7 @@ Calcentral::Application.routes.draw do
   get '/api/advising/registrations/:student_uid' => 'advising_student#registrations', :defaults => { :format => 'json' }
   get '/api/advising/resources/:student_uid' => 'advising_student#resources', :defaults => { :format => 'json' }
   get '/api/advising/student/:student_uid' => 'advising_student#profile', :defaults => { :format => 'json' }
+  get '/api/advising/student_attributes/:student_uid' => 'advising_student#student_attributes', :defaults => { :format => 'json' }
   post '/advisor_act_as' => 'advisor_act_as#start'
   post '/stop_advisor_act_as' => 'advisor_act_as#stop'
 

--- a/fixtures/json/hub_student_attributes.json
+++ b/fixtures/json/hub_student_attributes.json
@@ -1,0 +1,141 @@
+{
+   "apiResponse":{
+      "source":"UCB-SIS-STUDENT",
+      "correlationId":"efec2be8-0198-495c-93f8-922a76dc2193",
+      "responseType":"http://bmeta.berkeley.edu/student/studentV0.xsd/students",
+      "response":{
+         "any":{
+            "students":[
+               {
+                  "identifiers":[
+                     {
+                        "type":"student-id",
+                        "id":"11667051",
+                        "disclose":false
+                     },
+                     {
+                        "type":"campus-uid",
+                        "id":"61889",
+                        "disclose":true
+                     },
+                     {
+                        "type":"Social Security Number",
+                        "id":"***-**-****",
+                        "disclose":false
+                     },
+                     {
+                        "type":"DB2",
+                        "id":"11667051",
+                        "disclose":false,
+                        "fromDate":"1902-02-01"
+                     }
+                  ],
+                  "affiliations":[
+                     {
+                        "type":{
+                           "code":"STUDENT",
+                           "description":""
+                        },
+                        "detail":"",
+                        "status":{
+                           "code":"ACT",
+                           "description":"Active"
+                        },
+                        "fromDate":"2016-03-19"
+                     },
+                     {
+                        "type":{
+                           "code":"UNDERGRAD",
+                           "description":"Undergraduate Student"
+                        },
+                        "detail":"Active",
+                        "status":{
+                           "code":"ACT",
+                           "description":"Active"
+                        },
+                        "fromDate":"2016-03-19"
+                     }
+                  ],
+                  "confidential":false,
+                  "studentAttributes":{
+                     "studentAttributes":[
+                        {
+                           "type":{
+                              "code":"AHI",
+                              "description":"American Hist & Inst Waiver"
+                           },
+                           "fromDate":"2001-01-01",
+                           "comments":""
+                        },
+                        {
+                           "type":{
+                              "code":"R5TA",
+                              "description":"5 Terms in Attendance"
+                           },
+                           "fromDate":"2016-03-21",
+                           "comments":""
+                        },
+                        {
+                           "type":{
+                              "code":"RL4",
+                              "description":"EOP Recalc based on FASFA"
+                           },
+                           "fromDate":"2016-03-21",
+                           "comments":""
+                        },
+                        {
+                           "type":{
+                              "code":"RL5",
+                              "description":"EOP Pool for GB"
+                           },
+                           "fromDate":"2016-03-21",
+                           "comments":""
+                        },
+                        {
+                           "type":{
+                              "code":"RPRI",
+                              "description":"Priority Enrollment"
+                           },
+                           "fromDate":"2016-03-21",
+                           "comments":""
+                        },
+                        {
+                           "type":{
+                              "code":"RVT",
+                              "description":"Veteran - Priority Enrollment"
+                           },
+                           "fromDate":"2016-03-21",
+                           "comments":""
+                        },
+                        {
+                           "type":{
+                              "code":"RZA",
+                              "description":"Active Athlete"
+                           },
+                           "fromDate":"2016-05-25",
+                           "comments":""
+                        },
+                        {
+                           "type":{
+                              "code":"VAC",
+                              "description":"American Cultures"
+                           },
+                           "fromDate":"2001-01-01",
+                           "comments":""
+                        },
+                        {
+                           "type":{
+                              "code":"VELW",
+                              "description":"Entry Level Writing"
+                           },
+                           "fromDate":"2001-01-01",
+                           "comments":""
+                        }
+                     ]
+                  }
+               }
+            ]
+         }
+      }
+   }
+}

--- a/public/dummy/json/hub_student_attributes.json
+++ b/public/dummy/json/hub_student_attributes.json
@@ -1,0 +1,138 @@
+{
+   "statusCode":200,
+   "feed":{
+      "student":{
+         "studentAttributes":{
+            "studentAttributes":[
+               {
+                  "type":{
+                     "code":"AHI",
+                     "description":"American Hist & Inst Waiver"
+                  },
+                  "fromDate":"2001-01-01",
+                  "comments":""
+               },
+               {
+                  "type":{
+                     "code":"R5TA",
+                     "description":"5 Terms in Attendance"
+                  },
+                  "fromDate":"2016-03-21",
+                  "comments":""
+               },
+               {
+                  "type":{
+                     "code":"RL4",
+                     "description":"EOP Recalc based on FASFA"
+                  },
+                  "fromDate":"2016-03-21",
+                  "comments":""
+               },
+               {
+                  "type":{
+                     "code":"RL5",
+                     "description":"EOP Pool for GB"
+                  },
+                  "fromDate":"2016-03-21",
+                  "comments":""
+               },
+               {
+                  "type":{
+                     "code":"RPRI",
+                     "description":"Priority Enrollment"
+                  },
+                  "fromDate":"2016-03-21",
+                  "comments":""
+               },
+               {
+                  "type":{
+                     "code":"RVT",
+                     "description":"Veteran - Priority Enrollment"
+                  },
+                  "fromDate":"2016-03-21",
+                  "comments":""
+               },
+               {
+                  "type":{
+                     "code":"RZA",
+                     "description":"Active Athlete"
+                  },
+                  "fromDate":"2016-05-25",
+                  "comments":""
+               },
+               {
+                  "type":{
+                     "code":"VAC",
+                     "description":"American Cultures"
+                  },
+                  "fromDate":"2001-01-01",
+                  "comments":""
+               },
+               {
+                  "type":{
+                     "code":"VELW",
+                     "description":"Entry Level Writing"
+                  },
+                  "fromDate":"2001-01-01",
+                  "comments":""
+               },
+               {
+                 "type": {
+                   "code": "+REG",
+                   "description": "Officially Registered"
+                 },
+                 "fromDate": "2016-08-17",
+                 "fromTerm":{
+                    "id":"2168",
+                    "name":"2016 Fall",
+                    "category":{
+                       "code":"R",
+                       "description":"Regular Term"
+                    },
+                    "academicYear":"2017",
+                    "beginDate":"2018-01-09",
+                    "endDate":"2018-05-11"
+                 }
+               },
+               {
+                 "type": {
+                   "code": "+S09",
+                   "description": "Tuition Calculated"
+                 },
+                 "fromDate": "2016-08-17",
+                 "fromTerm":{
+                    "id":"2168",
+                    "name":"2016 Fall",
+                    "category":{
+                       "code":"R",
+                       "description":"Regular Term"
+                    },
+                    "academicYear":"2017",
+                    "beginDate":"2018-01-09",
+                    "endDate":"2018-05-11"
+                 }
+               },
+               {
+                 "type": {
+                   "code": "+R99",
+                   "description": "You are protected from CNP."
+                 },
+                 "fromDate": "2016-08-17",
+                 "fromTerm":{
+                    "id":"2168",
+                    "name":"2016 Fall",
+                    "category":{
+                       "code":"R",
+                       "description":"Regular Term"
+                    },
+                    "academicYear":"2017",
+                    "beginDate":"2018-01-09",
+                    "endDate":"2018-05-11"
+                 }
+               }
+            ]
+         }
+      }
+   },
+   "studentNotFound":null
+}

--- a/public/dummy/json/my_registrations.json
+++ b/public/dummy/json/my_registrations.json
@@ -1,158 +1,168 @@
 {
-  "affiliations": [
-    {
-      "type": {
-        "code": "STUDENT",
-        "description": ""
-      },
-      "detail": "",
-      "status": {
-        "code": "ACT",
-        "description": "Active"
-      },
-      "fromDate": "2015-12-14"
-    },
-    {
-      "type": {
-        "code": "UNDERGRAD",
-        "description": "Undergraduate Student"
-      },
-      "detail": "Active",
-      "status": {
-        "code": "ACT",
-        "description": "Active"
-      },
-      "fromDate": "2015-12-14"
-    }
-  ],
-  "terms": {
-    "current": {
-      "id": "2165",
-      "name": "Summer 2016"
-    },
-    "running": {
-      "id": "2165",
-      "name": "Summer 2016"
-    },
-    "sis_current_term": {
-      "id": "2168",
-      "name": "Fall 2016"
-    },
-    "next": {
-      "id": "2168",
-      "name": "Fall 2016"
-    },
-    "future": null,
-    "grading_in_progress": null
-  },
-  "registrations": {
-    "2165": [
+   "affiliations":[
       {
-        "is_legacy": true,
-        "reg_status": {
-          "code": "S",
-          "summary": "Registered",
-          "explanation": "You are officially registered for this term and are entitled to access campus services.",
-          "needsAction": false,
-          "education_level": "Senior ",
-          "transitionTerm": true
-        },
-        "roles": {
-          "student": true,
-          "registered": true,
-          "exStudent": false,
-          "faculty": false,
-          "staff": true,
-          "guest": false,
-          "concurrentEnrollmentStudent": false,
-          "undergrad": true,
-          "expiredAccount": false
-        }
-      }
-    ],
-    "2168": [
+         "type":{
+            "code":"STUDENT",
+            "description":""
+         },
+         "detail":"",
+         "status":{
+            "code":"ACT",
+            "description":"Active"
+         },
+         "fromDate":"2016-03-19"
+      },
       {
-        "term": {
-          "id": "2168",
-          "name": "2016 Fall",
-          "academicYear": "2017"
-        },
-        "academicCareer": {
-          "code": "UGRD",
-          "description": "Undergraduate"
-        },
-        "eligibleToRegister": true,
-        "registered": true,
-        "disabled": false,
-        "athlete": false,
-        "intendsToGraduate": false,
-        "academicLevel": {
-          "level": {
-            "code": "30",
-            "description": "Junior"
-          }
-        },
-        "termUnits": [
-          {
-            "type": {
-              "code": "Total",
-              "description": "Total"
-            },
-            "unitsMin": 0,
-            "unitsMax": 0,
-            "unitsEnrolled": 0,
-            "unitsWaitlisted": 0,
-            "unitsTaken": 0,
-            "unitsPassed": 0,
-            "unitsIncomplete": 0,
-            "unitsTransferEarned": 0,
-            "unitsTransferAccepted": 0,
-            "unitsTest": 0,
-            "unitsOther": 0
-          },
-          {
-            "type": {
-              "code": "For GPA",
-              "description": "For GPA"
-            },
-            "unitsMin": 0,
-            "unitsMax": 0,
-            "unitsEnrolled": 4,
-            "unitsWaitlisted": 0,
-            "unitsTaken": 0,
-            "unitsPassed": 0,
-            "unitsIncomplete": 0,
-            "unitsTransferEarned": 0
-          },
-          {
-            "type": {
-              "code": "Not For GPA",
-              "description": "Not For GPA"
-            },
-            "unitsMin": 0,
-            "unitsMax": 0,
-            "unitsEnrolled": 0,
-            "unitsWaitlisted": 0,
-            "unitsTaken": 0,
-            "unitsPassed": 0,
-            "unitsIncomplete": 0,
-            "unitsTransferEarned": 0
-          }
-        ],
-        "termGPA": {
-          "type": {
-            "description": "Term GPA"
-          },
-          "average": 0,
-          "source": "UCB"
-        },
-        "specialStudyPrograms": [],
-        "withdrawalCancel": {
-          "type": {},
-          "reason": {}
-        },
-        "new": false
+         "type":{
+            "code":"UNDERGRAD",
+            "description":"Undergraduate Student"
+         },
+         "detail":"Active",
+         "status":{
+            "code":"ACT",
+            "description":"Active"
+         },
+         "fromDate":"2016-03-19"
       }
-    ]
-  }
+   ],
+   "terms":{
+      "current":{
+         "id":"2165",
+         "name":"Summer 2016",
+         "classesStart":"2016-05-23T00:00:00.000-07:00",
+         "end":"2016-08-12T23:59:59.000-07:00",
+         "endDropAdd":"2016-08-12T23:59:59.000-07:00",
+         "pastEndOfInstruction":false,
+         "pastClassesStart":true,
+         "pastAddDrop":false
+      },
+      "running":{
+         "id":"2165",
+         "name":"Summer 2016"
+      },
+      "sis_current_term":{
+         "id":"2168",
+         "name":"Fall 2016"
+      },
+      "next":{
+         "id":"2168",
+         "name":"Fall 2016",
+         "classesStart":"2016-08-24T00:00:00.000-07:00",
+         "end":"2016-12-16T23:59:59.000-08:00",
+         "endDropAdd":"2016-09-23",
+         "pastEndOfInstruction":false,
+         "pastClassesStart":false,
+         "pastAddDrop":false
+      },
+      "future":{
+         "id":"2172",
+         "name":"Spring 2017"
+      }
+   },
+   "registrations":{
+      "2165":[
+         {
+            "isLegacy":true,
+            "regStatus":{
+               "code":" ",
+               "summary":"Not registered for Summer 2016",
+               "explanation":null,
+               "needsAction":false
+            },
+            "roles":{
+               "student":true,
+               "registered":true,
+               "exStudent":false,
+               "faculty":false,
+               "staff":false,
+               "guest":false,
+               "concurrentEnrollmentStudent":false,
+               "undergrad":true,
+               "expiredAccount":false
+            }
+         }
+      ],
+      "2168":[
+         {
+            "term":{
+               "id":"2168",
+               "name":"2016 Fall",
+               "academicYear":"2017"
+            },
+            "academicCareer":{
+               "code":"UGRD",
+               "description":"Undergraduate"
+            },
+            "eligibleToRegister":true,
+            "registered":true,
+            "disabled":false,
+            "athlete":false,
+            "intendsToGraduate":false,
+            "academicLevel":{
+               "level":{
+                  "code":"10",
+                  "description":"Freshman"
+               }
+            },
+            "termUnits":[
+               {
+                  "type":{
+                     "code":"Total",
+                     "description":"Total"
+                  },
+                  "unitsMin":13,
+                  "unitsMax":25,
+                  "unitsEnrolled":9,
+                  "unitsWaitlisted":0,
+                  "unitsTaken":0,
+                  "unitsPassed":0,
+                  "unitsIncomplete":0,
+                  "unitsTransferEarned":0,
+                  "unitsTransferAccepted":0,
+                  "unitsTest":0,
+                  "unitsOther":0
+               },
+               {
+                  "type":{
+                     "code":"For GPA",
+                     "description":"For GPA"
+                  },
+                  "unitsMin":13,
+                  "unitsMax":4.5,
+                  "unitsEnrolled":8,
+                  "unitsWaitlisted":0,
+                  "unitsTaken":0,
+                  "unitsPassed":0,
+                  "unitsIncomplete":0,
+                  "unitsTransferEarned":0
+               },
+               {
+                  "type":{
+                     "code":"Not For GPA",
+                     "description":"Not For GPA"
+                  },
+                  "unitsMin":13,
+                  "unitsMax":20.5,
+                  "unitsEnrolled":1,
+                  "unitsWaitlisted":0,
+                  "unitsTaken":0,
+                  "unitsPassed":0,
+                  "unitsIncomplete":0,
+                  "unitsTransferEarned":0
+               }
+            ],
+            "termGPA":{
+               "type":{
+                  "description":"Term GPA"
+               },
+               "average":0,
+               "source":"UCB"
+            },
+            "specialStudyPrograms":[
+
+            ],
+            "new":true
+         }
+      ]
+   }
 }

--- a/src/assets/javascripts/angular/controllers/pages/academicsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicsController.js
@@ -7,7 +7,7 @@ var angular = require('angular');
 /**
  * Academics controller
  */
-angular.module('calcentral.controllers').controller('AcademicsController', function(academicsFactory, academicsService, academicStatusFactory, apiService, badgesFactory, $q, $routeParams, $scope) {
+angular.module('calcentral.controllers').controller('AcademicsController', function(academicsFactory, academicsService, academicStatusFactory, apiService, badgesFactory, registrationsFactory, $q, $routeParams, $scope) {
   var title = 'My Academics';
   apiService.util.setTitle(title);
   $scope.backToText = title;
@@ -157,6 +157,11 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
     $scope.numberOfHolds = _.get(data, 'feed.student.holds.length');
   };
 
+  var loadRegistrations = function(data) {
+    var registrations = _.get(data, 'registrations');
+    $scope.hasRegstatus = _.isEmpty(registrations);
+  };
+
   var parseAcademics = function(data) {
     angular.extend($scope, data);
 
@@ -188,7 +193,6 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
   };
 
   var filterWidgets = function() {
-    $scope.hasRegStatus = !!($scope.studentInfo && $scope.studentInfo.regStatus && $scope.studentInfo.regStatus.code !== null);
     $scope.isAcademicInfoAvailable = !!($scope.hasRegstatus ||
                                        ($scope.semesters && $scope.semesters.length) ||
                                        ($scope.requirements && $scope.requirements.length));
@@ -216,8 +220,9 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
     if (isAuthenticated) {
       $scope.canViewAcademics = $scope.api.user.profile.hasAcademicsTab;
       var getAcademics = academicsFactory.getAcademics().success(parseAcademics);
+      var getRegistrations = registrationsFactory.getRegistrations().success(loadRegistrations);
       var getBadges = badgesFactory.getBadges().success(loadBadges);
-      var requests = [getAcademics, getBadges];
+      var requests = [getAcademics, getBadges, getRegistrations];
       if ($scope.api.user.profile.features.csHolds &&
         ($scope.api.user.profile.roles.student || $scope.api.user.profile.roles.applicant)) {
         var getNumberOfHolds = academicStatusFactory.getAcademicStatus().success(loadNumberOfHolds);

--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -160,7 +160,7 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
     studentAttributesFactory.getStudentAttributes({
       uid: $routeParams.uid
     }).success(function(data) {
-      var studentAttributes = _.get(data, 'data.feed.student.studentAttributes.studentAttributes');
+      var studentAttributes = _.get(data, 'feed.student.studentAttributes.studentAttributes');
       // Strip all positive student indicators from student attributes feed.
       _.forEach(studentAttributes, function(attribute) {
         if (_.startsWith(attribute.type.code, '+')) {

--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -6,7 +6,7 @@ var _ = require('lodash');
 /**
  * Preview of user profile prior to viewing-as
  */
-angular.module('calcentral.controllers').controller('UserOverviewController', function(adminService, advisingFactory, academicStatusFactory, residencyMessageFactory, apiService, statusHoldsService, $route, $routeParams, $scope) {
+angular.module('calcentral.controllers').controller('UserOverviewController', function(adminService, advisingFactory, academicStatusFactory, residencyMessageFactory, apiService, statusHoldsService, studentAttributesFactory, $route, $routeParams, $scope) {
   $scope.academics = {
     isLoading: true,
     excludeLinksToRegistrar: true
@@ -21,6 +21,7 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
   $scope.regStatus = {
     terms: [],
     registrations: [],
+    positiveIndicators: [],
     isLoading: true
   };
   $scope.residency = {
@@ -134,11 +135,7 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
       _.forOwn(data.terms, function(value, key) {
         if (key === 'current' || key === 'next') {
           if (value) {
-            $scope.regStatus.terms.push({
-              temporalPosition: key,
-              id: value.id,
-              name: value.name
-            });
+            $scope.regStatus.terms.push(value);
           }
         }
       });
@@ -146,8 +143,7 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
         var regStatus = data.registrations[term.id];
 
         if (regStatus && regStatus[0]) {
-          _.set(regStatus[0], 'termName', term.name);
-          _.set(regStatus[0], 'termId', parseInt(term.id));
+          _.merge(regStatus[0], term);
           regStatus[0].isSummer = _.startsWith(term.name, 'Summer');
 
           if (regStatus[0].isLegacy) {
@@ -157,6 +153,22 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
           }
         }
       });
+    });
+  };
+
+  var loadStudentAttributes = function() {
+    studentAttributesFactory.getStudentAttributes({
+      uid: $routeParams.uid
+    }).success(function(data) {
+      var studentAttributes = _.get(data, 'data.feed.student.studentAttributes.studentAttributes');
+      // Strip all positive student indicators from student attributes feed.
+      _.forEach(studentAttributes, function(attribute) {
+        if (_.startsWith(attribute.type.code, '+')) {
+          $scope.regStatus.positiveIndicators.push(attribute);
+        }
+      });
+
+      statusHoldsService.matchTermIndicators($scope.regStatus.positiveIndicators, $scope.regStatus.registrations);
     }).finally(function() {
       $scope.regStatus.isLoading = false;
     });
@@ -196,7 +208,8 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
       .then(loadAcademics)
       .then(loadHolds)
       .then(loadBlocks)
-      .then(loadRegistrations);
+      .then(loadRegistrations)
+      .then(loadStudentAttributes);
     }
   });
 });

--- a/src/assets/javascripts/angular/factories/studentAttributesFactory.js
+++ b/src/assets/javascripts/angular/factories/studentAttributesFactory.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var angular = require('angular');
+
+/**
+ * Student Attributes Factory
+ */
+angular.module('calcentral.factories').factory('studentAttributesFactory', function(apiService) {
+  var urlStudentAttributes = '/dummy/json/hub_student_attributes.json';
+  // var urlStudentAttributes = '/api/edos/student_attributes';
+
+  var getStudentAttributes = function(options) {
+    return apiService.http.request(options, urlStudentAttributes);
+  };
+
+  return {
+    getStudentAttributes: getStudentAttributes
+  };
+});

--- a/src/assets/javascripts/angular/factories/studentAttributesFactory.js
+++ b/src/assets/javascripts/angular/factories/studentAttributesFactory.js
@@ -5,12 +5,14 @@ var angular = require('angular');
 /**
  * Student Attributes Factory
  */
-angular.module('calcentral.factories').factory('studentAttributesFactory', function(apiService) {
-  var urlStudentAttributes = '/dummy/json/hub_student_attributes.json';
-  // var urlStudentAttributes = '/api/edos/student_attributes';
+angular.module('calcentral.factories').factory('studentAttributesFactory', function(apiService, $route, $routeParams) {
+  // var urlStudentAttributes = '/dummy/json/hub_student_attributes.json';
+  var urlAdvisingStudentAttributes = '/api/advising/student_attributes/';
+  var urlStudentAttributes = '/api/edos/student_attributes';
 
   var getStudentAttributes = function(options) {
-    return apiService.http.request(options, urlStudentAttributes);
+    var url = $route.current.isAdvisingStudentLookup ? urlAdvisingStudentAttributes + $routeParams.uid : urlStudentAttributes;
+    return apiService.http.request(options, url);
   };
 
   return {

--- a/src/assets/javascripts/angular/services/statusHoldsService.js
+++ b/src/assets/javascripts/angular/services/statusHoldsService.js
@@ -1,61 +1,110 @@
 'use strict';
 
 var angular = require('angular');
+var _ = require('lodash');
 
-angular.module('calcentral.services').service('statusHoldsService', function() {
+angular.module('calcentral.services').service('statusHoldsService', function(userService) {
   /**
    * Parses any terms past the legacy cutoff.  Mirrors current functionality for now, but this will be changed in redesigns slated
    * for GL6.
    */
   var parseCsTerm = function(term) {
-    var termReg = {
-      isSummer: term.isSummer,
-      termName: term.termName,
-      termId: term.termId,
+    _.merge(term, {
       summary: null,
-      explanation: null
-    };
+      explanation: null,
+      positiveIndicators: {}
+    });
     if (term.registered === true) {
-      termReg.summary = 'Officially Registered';
-      termReg.explanation = term.isSummer ? 'You are officially registered for this term.' : 'You are officially registered and are entitled to access campus services.';
+      term.summary = 'Officially Registered';
+      term.explanation = term.isSummer ? 'You are officially registered for this term.' : 'You are officially registered and are entitled to access campus services.';
     }
     if (term.registered === false) {
-      termReg.summary = 'Not Officially Registered';
-      termReg.explanation = term.isSummer ? 'You are not officially registered for this term.' : 'You are not entitled to access campus services until you are officially registered.  In order to be officially registered, you must pay your Tuition and Fees, and have no outstanding holds.';
+      term.summary = 'Not Officially Registered';
+      term.explanation = term.isSummer ? 'You are not officially registered for this term.' : 'You are not entitled to access campus services until you are officially registered.  In order to be officially registered, you must pay your Tuition and Fees, and have no outstanding holds.';
     }
-
-    return termReg;
+    if (term.registered === false && userService.profile.roles.undergrad && term.pastClassesStart) {
+      term.summary = 'Not Enrolled';
+      term.explanation = term.isSummer ? 'You are not officially registered for this term.' : 'You are not enrolled in any classes for this term.';
+    }
+    if (term.registered === false && (userService.profile.roles.graduate || userService.profile.roles.law) && term.pastAddDrop) {
+      term.summary = 'Not Enrolled';
+      term.explanation = term.isSummer ? 'You are not officially registered for this term.' : 'You are not enrolled in any classes for this term. Fees will not be assessed, and any expected fee remissions or fee payment credits cannot be applied until you are enrolled in classes.  For more information, please contact your departmental graduate advisor.';
+    }
+    return term;
   };
 
   /**
    * Parses any terms on or before the legacy cutoff.  Mirrors current functionality, this should be able to be removed in Fall 2016.
    */
   var parseLegacyTerm = function(term) {
-    var termReg = {
-      isSummer: term.isSummer,
-      termName: term.termName,
-      termId: term.termId,
+    _.merge(term, {
       summary: null,
-      explanation: null
-    };
-    termReg.summary = term.regStatus.summary;
-    termReg.explanation = term.regStatus.explanation;
+      explanation: null,
+      positiveIndicators: {}
+    });
+    term.summary = term.regStatus.summary;
+    term.explanation = term.regStatus.explanation;
 
     // Special summer parsing for the last legacy term (Summer 2016)
     if (term.isSummer) {
       if (term.regStatus.summary !== 'Registered') {
-        termReg.summary = 'Not Officially Registered';
-        termReg.explanation = 'You are not officially registered for this term.';
+        term.summary = 'Not Officially Registered';
+        term.explanation = 'You are not officially registered for this term.';
       } else {
-        termReg.summary = 'Officially Registered';
-        termReg.explanation = 'You are officially registered for this term.';
+        term.summary = 'Officially Registered';
+        term.explanation = 'You are officially registered for this term.';
       }
     }
 
-    return termReg;
+    return term;
+  };
+
+  /**
+   * Matches positive indicator to registration status object by term.
+   */
+  var matchTermIndicators = function(positiveIndicators, registrations) {
+    _.forEach(registrations, function(registration) {
+      _.forEach(positiveIndicators, function(indicator) {
+        if (indicator.fromTerm.id === registration.id) {
+          var indicatorCode = _.trimStart(indicator.type.code, '+');
+          _.set(registration.positiveIndicators, indicatorCode, true);
+          if (indicator.type.description) {
+            _.set(registration.positiveIndicators, indicatorCode + 'descr', indicator.type.description);
+          }
+        }
+      });
+    });
+  };
+
+  var getRegStatusMessages = function(messages) {
+    var returnedMessages = {};
+    returnedMessages.notRegistered = _.find(messages, {
+      'messageNbr': '100'
+    });
+    returnedMessages.cnpNotificationUndergrad = _.find(messages, {
+      'messageNbr': '101'
+    });
+    returnedMessages.cnpNotificationGrad = _.find(messages, {
+      'messageNbr': '102'
+    });
+    returnedMessages.cnpWarningUndergrad = _.find(messages, {
+      'messageNbr': '103'
+    });
+    returnedMessages.cnpWarningGrad = _.find(messages, {
+      'messageNbr': '104'
+    });
+    returnedMessages.notEnrolledUndergrad = _.find(messages, {
+      'messageNbr': '105'
+    });
+    returnedMessages.notEnrolledGrad = _.find(messages, {
+      'messageNbr': '106'
+    });
+    return returnedMessages;
   };
 
   return {
+    getRegStatusMessages: getRegStatusMessages,
+    matchTermIndicators: matchTermIndicators,
     parseCsTerm: parseCsTerm,
     parseLegacyTerm: parseLegacyTerm
   };

--- a/src/assets/templates/widgets/status_and_holds.html
+++ b/src/assets/templates/widgets/status_and_holds.html
@@ -30,17 +30,19 @@
                       <span data-ng-bind="registration.explanation"></span>
                     </div>
                     <div data-ng-if="registration.summary !== 'Officially Registered' && !registration.isSummer">
-                      <span data-ng-if="registration.summary === 'Not Officially Registered'" data-ng-bind-html="$parent.regStatus.messages.notRegistered.descrLong"></span>
-                      <span data-ng-if="registration.summary === 'Not Enrolled' && api.user.profile.roles.undergrad" data-ng-bind-html="$parent.regStatus.messages.notEnrolledUndergrad.descrLong"></span>
-                      <span data-ng-if="registration.summary === 'Not Enrolled' && (api.user.profile.roles.grad || api.user.profile.roles.law)" data-ng-bind-html="$parent.regStatus.messages.notEnrolledGrad.descrLong"></span>
-                      <span data-ng-if="!$parent.regStatus.messages" data-ng-bind="registration.explanation"></span>
+                      <div data-ng-if="$parent.regStatus.messages">
+                        <span data-ng-if="registration.summary === 'Not Officially Registered'" data-ng-bind-html="$parent.regStatus.messages.notRegistered.descrLong"></span>
+                        <span data-ng-if="registration.summary === 'Not Enrolled' && api.user.profile.roles.undergrad" data-ng-bind-html="$parent.regStatus.messages.notEnrolledUndergrad.descrLong"></span>
+                        <span data-ng-if="registration.summary === 'Not Enrolled' && (api.user.profile.roles.grad || api.user.profile.roles.law)" data-ng-bind-html="$parent.regStatus.messages.notEnrolledGrad.descrLong"></span>
+                      </div>
+                      <span data-ng-if="!$parent.regStatus.messages || api.user.profile.roles.advisor" data-ng-bind="registration.explanation"></span>
                     </div>
                   </div>
                 </div>
               </li>
               <li class="cc-widget-list-hover"
                   data-ng-if="(api.user.profile.roles.undergrad && !registration.pastClassesStart) ||
-                  ((api.user.profile.roles.graduate || api.user.profile.roles.law) && !registration.pastAddDrop) &&
+                  ((api.user.profile.roles.graduate || api.user.profile.roles.law || api.user.profile.roles.advisor) && !registration.pastAddDrop) &&
                   !registration.isLegacy && !registration.isSummer"
                   data-ng-class="{'cc-widget-list-hover-opened':(registration.positiveIndicators.show)}"
                   data-cc-accessible-focus-directive
@@ -62,11 +64,13 @@
                   <div class="cc-status-holds-expanded-text" data-ng-show="registration.positiveIndicators.show">
                     <span data-ng-if="registration.positiveIndicators.R99 && registration.positiveIndicators.R99descr" data-ng-bind="registration.positiveIndicators.R99descr"></span>
                     <div data-ng-if="!registration.positveIndicators.R99">
-                      <span data-ng-if="!registration.pastFinancialDisbursement && api.user.profile.roles.undergrad" data-ng-bind-html="$parent.regStatus.messages.cnpNotificationUndergrad.descrLong"></span>
-                      <span data-ng-if="!registration.pastFinancialDisbursement && (api.user.profile.roles.grad || api.user.profile.roles.law)" data-ng-bind-html="$parent.regStatus.messages.cnpNotificationGrad.descrLong"></span>
-                      <span data-ng-if="registration.pastFinancialDisbursement && api.user.profile.roles.undergrad" data-ng-bind-html="$parent.regStatus.messages.cnpWarningUndergrad.descrLong"></span>
-                      <span data-ng-if="registration.pastFinancialDisbursement && (api.user.profile.roles.grad || api.user.profile.roles.law)" data-ng-bind-html="$parent.regStatus.messages.cnpWarningGrad.descrLong"></span>
-                      <span data-ng-if="!$parent.regStatus.messages">You may be subject to <a href="http://registrar.berkeley.edu/cnp">Cancel for Non-Payment.</a></span>
+                      <div data-ng-if="$parent.regStatus.messages">
+                        <span data-ng-if="!registration.pastFinancialDisbursement && api.user.profile.roles.undergrad" data-ng-bind-html="$parent.regStatus.messages.cnpNotificationUndergrad.descrLong"></span>
+                        <span data-ng-if="!registration.pastFinancialDisbursement && (api.user.profile.roles.grad || api.user.profile.roles.law)" data-ng-bind-html="$parent.regStatus.messages.cnpNotificationGrad.descrLong"></span>
+                        <span data-ng-if="registration.pastFinancialDisbursement && api.user.profile.roles.undergrad" data-ng-bind-html="$parent.regStatus.messages.cnpWarningUndergrad.descrLong"></span>
+                        <span data-ng-if="registration.pastFinancialDisbursement && (api.user.profile.roles.grad || api.user.profile.roles.law)" data-ng-bind-html="$parent.regStatus.messages.cnpWarningGrad.descrLong"></span>
+                      </div>
+                      <span data-ng-if="!$parent.regStatus.messages || api.user.profile.roles.advisor">You may be subject to <a href="http://registrar.berkeley.edu/cnp">Cancel for Non-Payment.</a></span>
                     </div>
                   </div>
                 </div>

--- a/src/assets/templates/widgets/status_and_holds.html
+++ b/src/assets/templates/widgets/status_and_holds.html
@@ -31,9 +31,9 @@
                     </div>
                     <div data-ng-if="registration.summary !== 'Officially Registered' && !registration.isSummer">
                       <div data-ng-if="$parent.regStatus.messages">
-                        <span data-ng-if="registration.summary === 'Not Officially Registered'" data-ng-bind-html="$parent.regStatus.messages.notRegistered.descrLong"></span>
-                        <span data-ng-if="registration.summary === 'Not Enrolled' && api.user.profile.roles.undergrad" data-ng-bind-html="$parent.regStatus.messages.notEnrolledUndergrad.descrLong"></span>
-                        <span data-ng-if="registration.summary === 'Not Enrolled' && (api.user.profile.roles.grad || api.user.profile.roles.law)" data-ng-bind-html="$parent.regStatus.messages.notEnrolledGrad.descrLong"></span>
+                        <span data-ng-if="registration.summary === 'Not Officially Registered'" data-ng-bind-html="$parent.regStatus.messages.notRegistered.descrlong"></span>
+                        <span data-ng-if="registration.summary === 'Not Enrolled' && api.user.profile.roles.undergrad" data-ng-bind-html="$parent.regStatus.messages.notEnrolledUndergrad.descrlong"></span>
+                        <span data-ng-if="registration.summary === 'Not Enrolled' && (api.user.profile.roles.grad || api.user.profile.roles.law)" data-ng-bind-html="$parent.regStatus.messages.notEnrolledGrad.descrlong"></span>
                       </div>
                       <span data-ng-if="!$parent.regStatus.messages || api.user.profile.roles.advisor" data-ng-bind="registration.explanation"></span>
                     </div>
@@ -64,12 +64,12 @@
                   <div class="cc-status-holds-expanded-text" data-ng-show="registration.positiveIndicators.show">
                     <span data-ng-if="registration.positiveIndicators.R99 && registration.positiveIndicators.R99descr" data-ng-bind="registration.positiveIndicators.R99descr"></span>
                     <div data-ng-if="!registration.positveIndicators.R99">
-                      <div data-ng-if="$parent.regStatus.messages">
-                        <span data-ng-if="!registration.pastFinancialDisbursement && api.user.profile.roles.undergrad" data-ng-bind-html="$parent.regStatus.messages.cnpNotificationUndergrad.descrLong"></span>
-                        <span data-ng-if="!registration.pastFinancialDisbursement && (api.user.profile.roles.grad || api.user.profile.roles.law)" data-ng-bind-html="$parent.regStatus.messages.cnpNotificationGrad.descrLong"></span>
-                        <span data-ng-if="registration.pastFinancialDisbursement && api.user.profile.roles.undergrad" data-ng-bind-html="$parent.regStatus.messages.cnpWarningUndergrad.descrLong"></span>
-                        <span data-ng-if="registration.pastFinancialDisbursement && (api.user.profile.roles.grad || api.user.profile.roles.law)" data-ng-bind-html="$parent.regStatus.messages.cnpWarningGrad.descrLong"></span>
-                      </div>
+                      <span data-ng-if="$parent.regStatus.messages">
+                        <span data-ng-if="!registration.pastFinancialDisbursement && api.user.profile.roles.undergrad" data-ng-bind-html="$parent.regStatus.messages.cnpNotificationUndergrad.descrlong"></span>
+                        <span data-ng-if="!registration.pastFinancialDisbursement && (api.user.profile.roles.grad || api.user.profile.roles.law)" data-ng-bind-html="$parent.regStatus.messages.cnpNotificationGrad.descrlong"></span>
+                        <span data-ng-if="registration.pastFinancialDisbursement && api.user.profile.roles.undergrad" data-ng-bind-html="$parent.regStatus.messages.cnpWarningUndergrad.descrlong"></span>
+                        <span data-ng-if="registration.pastFinancialDisbursement && (api.user.profile.roles.grad || api.user.profile.roles.law)" data-ng-bind-html="$parent.regStatus.messages.cnpWarningGrad.descrlong"></span>
+                      </span>
                       <span data-ng-if="!$parent.regStatus.messages || api.user.profile.roles.advisor">You may be subject to <a href="http://registrar.berkeley.edu/cnp">Cancel for Non-Payment.</a></span>
                     </div>
                   </div>

--- a/src/assets/templates/widgets/status_and_holds.html
+++ b/src/assets/templates/widgets/status_and_holds.html
@@ -7,27 +7,72 @@
     <h3 class="cc-status-holds-status-header">Status</h3>
 
     <div data-cc-spinner-directive="regStatus.isLoading">
-      <div data-ng-if="statusHoldsBlocks.enabledSections.indexOf('Status') !== -1">
-        <div class="cc-status-holds-section" data-ng-repeat="registration in regStatus.registrations | orderBy:'-termId'">
-          <h4 data-ng-bind="registration.termName"></h4>
-          <ul class="cc-widget-list cc-status-holds-list" data-ng-if="api.user.profile.features.regstatus">
-            <li class="cc-widget-list-hover"
-                data-ng-class="{'cc-widget-list-hover-opened':(registration.show)}"
-                data-cc-accessible-focus-directive
-                data-ng-click="api.widget.toggleShow($event, null, registration, 'My Academics - Status and Holds')">
-              <div class="cc-status-holds-list-section">
-                <div class="cc-status-holds-list-item">
-                  <span data-ng-hide="registration.isSummer && registration.summary === 'Not Officially Registered'">
-                    <i class="cc-icon fa"
-                       data-ng-class="{true:'fa-check-circle cc-icon-green',false:'fa-exclamation-circle cc-icon-red'}[registration.summary=='Officially Registered']">
-                    </i>
-                  </span>
-                  <span data-ng-bind="registration.summary"></span>
+      <div data-ng-if="(statusHoldsBlocks.enabledSections.indexOf('Status') !== -1) && !api.user.profile.roles.concurrentEnrollmentStudent">
+        <div class="cc-status-holds-section" data-ng-repeat="registration in regStatus.registrations | orderBy:'-id'">
+          <div data-ng-if="registration.isLegacy || (registration.positiveIndicators.S09 && !registration.pastEndOfInstruction)">
+            <h4 data-ng-bind="registration.name"></h4>
+            <ul class="cc-widget-list cc-status-holds-list" data-ng-if="api.user.profile.features.regstatus">
+              <li class="cc-widget-list-hover"
+                  data-ng-class="{'cc-widget-list-hover-opened':(registration.show)}"
+                  data-cc-accessible-focus-directive
+                  data-ng-click="api.widget.toggleShow($event, null, registration, 'My Academics - Status and Holds')">
+                <div class="cc-status-holds-list-section">
+                  <div class="cc-status-holds-list-item">
+                    <span data-ng-hide="registration.isSummer && registration.summary === 'Not Officially Registered'">
+                      <i class="cc-icon fa"
+                         data-ng-class="{true:'fa-check-circle cc-icon-green',false:'fa-exclamation-circle cc-icon-red'}[registration.summary=='Officially Registered']">
+                      </i>
+                    </span>
+                    <span data-ng-bind="registration.summary"></span>
+                  </div>
+                  <div class="cc-status-holds-expanded-text" data-ng-show="registration.show">
+                    <div data-ng-if="registration.summary === 'Officially Registered' || registration.isSummer">
+                      <span data-ng-bind="registration.explanation"></span>
+                    </div>
+                    <div data-ng-if="registration.summary !== 'Officially Registered' && !registration.isSummer">
+                      <span data-ng-if="registration.summary === 'Not Officially Registered'" data-ng-bind-html="$parent.regStatus.messages.notRegistered.descrLong"></span>
+                      <span data-ng-if="registration.summary === 'Not Enrolled' && api.user.profile.roles.undergrad" data-ng-bind-html="$parent.regStatus.messages.notEnrolledUndergrad.descrLong"></span>
+                      <span data-ng-if="registration.summary === 'Not Enrolled' && (api.user.profile.roles.grad || api.user.profile.roles.law)" data-ng-bind-html="$parent.regStatus.messages.notEnrolledGrad.descrLong"></span>
+                      <span data-ng-if="!$parent.regStatus.messages" data-ng-bind="registration.explanation"></span>
+                    </div>
+                  </div>
                 </div>
-                <div class="cc-status-holds-expanded-text" data-ng-show="registration.show" data-ng-bind="registration.explanation"></div>
-              </div>
-            </li>
-          </ul>
+              </li>
+              <li class="cc-widget-list-hover"
+                  data-ng-if="(api.user.profile.roles.undergrad && !registration.pastClassesStart) ||
+                  ((api.user.profile.roles.graduate || api.user.profile.roles.law) && !registration.pastAddDrop) &&
+                  !registration.isLegacy && !registration.isSummer"
+                  data-ng-class="{'cc-widget-list-hover-opened':(registration.positiveIndicators.show)}"
+                  data-cc-accessible-focus-directive
+                  data-ng-click="api.widget.toggleShow($event, null, registration.positiveIndicators, 'My Academics - Status and Holds')">
+                <div class="cc-status-holds-list-section">
+                  <div class="cc-status-holds-list-item">
+                      <i class="cc-icon fa fa-check-circle cc-icon-green"
+                         data-ng-if="registration.positiveIndicators.R99">
+                      </i>
+                      <i class="cc-icon fa"
+                         data-ng-if="!registration.positiveIndicators.R99"
+                         data-ng-class="{true:'fa-exclamation-circle cc-icon-red',false:'fa-exclamation-triangle cc-icon-yellow'}[registration.pastFinancialDisbursement]">
+                      </i>
+                    </span>
+                    <span data-ng-if="registration.positiveIndicators.R99">Exception from Cancel for Non-Payment</span>
+                    <span data-ng-if="!registration.positiveIndicators.R99 && !registration.pastFinancialDisbursement">Cancel for Non-Payment Notification</span>
+                    <span data-ng-if="!registration.positiveIndicators.R99 && registration.pastFinancialDisbursement">Cancel for Non-Payment Warning</span>
+                  </div>
+                  <div class="cc-status-holds-expanded-text" data-ng-show="registration.positiveIndicators.show">
+                    <span data-ng-if="registration.positiveIndicators.R99 && registration.positiveIndicators.R99descr" data-ng-bind="registration.positiveIndicators.R99descr"></span>
+                    <div data-ng-if="!registration.positveIndicators.R99">
+                      <span data-ng-if="!registration.pastFinancialDisbursement && api.user.profile.roles.undergrad" data-ng-bind-html="$parent.regStatus.messages.cnpNotificationUndergrad.descrLong"></span>
+                      <span data-ng-if="!registration.pastFinancialDisbursement && (api.user.profile.roles.grad || api.user.profile.roles.law)" data-ng-bind-html="$parent.regStatus.messages.cnpNotificationGrad.descrLong"></span>
+                      <span data-ng-if="registration.pastFinancialDisbursement && api.user.profile.roles.undergrad" data-ng-bind-html="$parent.regStatus.messages.cnpWarningUndergrad.descrLong"></span>
+                      <span data-ng-if="registration.pastFinancialDisbursement && (api.user.profile.roles.grad || api.user.profile.roles.law)" data-ng-bind-html="$parent.regStatus.messages.cnpWarningGrad.descrLong"></span>
+                      <span data-ng-if="!$parent.regStatus.messages">You may be subject to <a href="http://registrar.berkeley.edu/cnp">Cancel for Non-Payment.</a></span>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>

--- a/src/assets/templates/widgets/status_popover.html
+++ b/src/assets/templates/widgets/status_popover.html
@@ -6,12 +6,22 @@
       data-cc-loading-process="Loading...">
     </div>
   </li>
-  <li class="cc-popover-item" data-ng-if="api.user.profile.roles.student && studentInfo.regStatus.needsAction && api.user.profile.features.regstatus">
+  <li class="cc-popover-item"
+    data-ng-repeat="registration in regStatus.registrations | orderBy:'-id'"
+    data-ng-if="api.user.profile.roles.student && api.user.profile.features.regstatus && !registration.isSummer &&
+      registration.summary !== 'Officially Registered' && registration.positiveIndicators.S09 && !registration.pastEndOfInstruction">
     <a href="/academics">
       <div class="cc-launcher-status-description">
         <i class="fa fa-exclamation-circle cc-icon-red"></i>
-        <strong>Registration Status:</strong> <span data-ng-bind="studentInfo.regStatus.summary"></span><br>
-        <span data-ng-bind-html="studentInfo.regStatus.explanation"></span>
+        <strong><span data-ng-bind="registration.name"></span>: </strong> <span data-ng-bind="registration.summary"></span><br>
+      </div>
+      <div class="cc-launcher-status-description" data-ng-if="!registration.positiveIndicators.R99">
+        <i class="cc-icon fa"
+           data-ng-class="{true:'fa-exclamation-circle cc-icon-red',false:'fa-exclamation-triangle cc-icon-yellow'}[registration.pastFinancialDisbursement]">
+        </i>
+        <span data-ng-if="!registration.pastFinancialDisbursement">Cancel for Non-Payment Notification</span>
+        <span data-ng-if="registration.pastFinancialDisbursement">Cancel for Non-Payment Warning</span>
+        <br>
       </div>
     </a>
   </li>


### PR DESCRIPTION
Also includes:
* SISRP-23069 - Update Status and Holds on User Overview (Advisors)
* SISRP-23070 - Refactor My Academics for Status and Holds Card
* NOJIRA - Misc Status & Hold Unit Test Fixes

Stuff:
* Apologies for the huge PR.  
* I realize that we're using undergraduate Add/Drop date to drive CNP action for Grad/Law students.  This logic is due to the lack of a "Grad CNP" date from the Terms API, but it was a functional decision to have Grad/Law CNP action taken 5 weeks into the term, which fits perfectly with undergraduate add/drop date.
* The logic for what we show and when can get pretty complex.  The [Design JIRA](https://jira.berkeley.edu/browse/SISRP-13817) lays out things pretty well, which also links to a [Google Spreadsheet](https://docs.google.com/spreadsheets/d/1Pl_eS5uxKT-hjcaVFWknslqhrDlm8Tlj7iH22_DbW4k/edit#gid=0) that really maps out the logic really well.
* Once this gets in I'll open up a QA PR as well.