### PR TITLE
SISRP-22703 - Add Link to CS Enrollment Verification

### DIFF
--- a/app/controllers/campus_solutions/enrollment_verification_deeplink_controller.rb
+++ b/app/controllers/campus_solutions/enrollment_verification_deeplink_controller.rb
@@ -1,0 +1,9 @@
+module CampusSolutions
+  class EnrollmentVerificationDeeplinkController < CampusSolutionsController
+
+    def get
+      json_passthrough CampusSolutions::EnrollmentVerificationDeeplink
+    end
+
+  end
+end

--- a/app/models/campus_solutions/enrollment_verification_deeplink.rb
+++ b/app/models/campus_solutions/enrollment_verification_deeplink.rb
@@ -1,0 +1,28 @@
+module CampusSolutions
+  class EnrollmentVerificationDeeplink < CachedProxy
+
+    def initialize(options = {})
+      super options
+    end
+
+    def get_internal
+        build_feed
+    end
+
+    def build_feed()
+      return {} unless Settings.features.enrollment_verification_deeplink
+      {
+        feed: {
+          name: "Enrollment Verification",
+          url: Settings.campus_solutions_links.academics.enrollment_verification,
+          isCsLink: true
+        }
+      }
+    end
+
+    def json_filename
+      'enrollment_verification_deeplink.json'
+    end
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -187,6 +187,7 @@ Calcentral::Application.routes.draw do
   get '/api/campus_solutions/enrollment_verification_messages' => 'campus_solutions/enrollment_verification_messages#get', :via => :get, :defaults => {:format => 'json'}
   get '/api/campus_solutions/advising_resources' => 'campus_solutions/advising_resources#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/ferpa_deeplink' => 'campus_solutions/ferpa_deeplink#get', :via => :get, :defaults => { :format => 'json' }
+  get '/api/campus_solutions/enrollment_verification_deeplink' => 'campus_solutions/enrollment_verification_deeplink#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/billing' => 'campus_solutions/billing#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/slr_deeplink' => 'campus_solutions/slr_deeplink#get', :via => :get, :defaults => { :format => 'json' }
   get '/api/campus_solutions/fpp_enrollment' => 'campus_solutions/fpp_enrollment#get', :via => :get, :defaults => { :format => 'json' }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -437,6 +437,9 @@ campus_solutions_links:
     web_now_documents: ''
     eforms_center: ''
     eforms_work_list: ''
+  academics:
+    enrollment_verification_google: ''
+    enrollment_Verification: ''
 
 # A feature will be disabled if the corresponding feature-flag is false or nil.
 features:

--- a/fixtures/json/enrollment_verification_deeplink.json
+++ b/fixtures/json/enrollment_verification_deeplink.json
@@ -1,0 +1,7 @@
+{
+   "feed":{
+      "name":"Enrollment Verification",
+      "url":"https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SA_LEARNER_SERVICES.SS_ENRL_VER_REQ.GBL",
+      "isCsLink":true
+   }
+}

--- a/public/dummy/json/enrollment_verification_deeplink.json
+++ b/public/dummy/json/enrollment_verification_deeplink.json
@@ -1,0 +1,7 @@
+{
+   "feed":{
+      "name":"Enrollment Verification",
+      "url":"https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SA_LEARNER_SERVICES.SS_ENRL_VER_REQ.GBL",
+      "isCsLink":true
+   }
+}

--- a/src/assets/javascripts/angular/controllers/pages/enrollmentVerificationController.js
+++ b/src/assets/javascripts/angular/controllers/pages/enrollmentVerificationController.js
@@ -10,6 +10,14 @@ angular.module('calcentral.controllers').controller('EnrollmentVerificationContr
   var title = 'My Enrollment Verification';
   apiService.util.setTitle(title);
 
+  $scope.enrollmentCsDeeplink = {
+    title: 'Request Other Verifications',
+    backToText: 'My Academics'
+  };
+  $scope.enrollmentGoogleLink = {
+    url: 'http://goo.gl/forms/xcYYehIBFDbDE92y1',
+    title: 'Request Other Verifications'
+  };
   $scope.enrollmentMessages = {
     isLoading: true,
     hasMessages: false,
@@ -18,6 +26,10 @@ angular.module('calcentral.controllers').controller('EnrollmentVerificationContr
       requestOfficial: {},
       viewOnline: {}
     }
+  };
+  $scope.enrollmentVerificationServices = {
+    url: 'http://registrar.berkeley.edu/academic-records/verification-enrollment-degrees',
+    title: 'Learn more about enrollment verification services'
   };
 
   var parseMessages = function(data) {
@@ -37,9 +49,18 @@ angular.module('calcentral.controllers').controller('EnrollmentVerificationContr
     }
   };
 
+  var getDeeplink = function() {
+    enrollmentVerificationFactory.getEnrollmentVerificationDeeplink()
+      .then(function(data) {
+        var enrollmentCsDeeplink = _.get(data, 'data.feed');
+        _.merge($scope.enrollmentCsDeeplink, enrollmentCsDeeplink);
+      });
+  };
+
   var getMessages = function() {
     enrollmentVerificationFactory.getEnrollmentVerificationMessages()
       .then(parseMessages)
+      .then(getDeeplink)
       .finally(function() {
         $scope.enrollmentMessages.isLoading = false;
       });

--- a/src/assets/javascripts/angular/factories/enrollmentVerificationFactory.js
+++ b/src/assets/javascripts/angular/factories/enrollmentVerificationFactory.js
@@ -6,14 +6,21 @@ var angular = require('angular');
  * Factory for the enrollment verification messages.
  */
 angular.module('calcentral.factories').factory('enrollmentVerificationFactory', function(apiService) {
-  // var url = '/dummy/json/enrollment_verification_messages.json'
-  var url = '/api/campus_solutions/enrollment_verification_messages';
+  // var urlMessages = '/dummy/json/enrollment_verification_messages.json';
+  var urlMessages = '/api/campus_solutions/enrollment_verification_messages';
+  // var urlLink = '/dummy/json/enrollment_verification_deeplink.json';
+  var urlLink = '/api/campus_solutions/enrollment_verification_deeplink';
 
   var getEnrollmentVerificationMessages = function(options) {
-    return apiService.http.request(options, url);
+    return apiService.http.request(options, urlMessages);
+  };
+
+  var getEnrollmentVerificationDeeplink = function(options) {
+    return apiService.http.request(options, urlLink);
   };
 
   return {
-    getEnrollmentVerificationMessages: getEnrollmentVerificationMessages
+    getEnrollmentVerificationMessages: getEnrollmentVerificationMessages,
+    getEnrollmentVerificationDeeplink: getEnrollmentVerificationDeeplink
   };
 });

--- a/src/assets/stylesheets/_enrollment_verification.scss
+++ b/src/assets/stylesheets/_enrollment_verification.scss
@@ -1,4 +1,10 @@
 .cc-enrollment-verification {
+  .cc-enrollment-verification-link {
+    margin-bottom: 12px;
+  }
+  .cc-enrollment-verification-footer {
+    margin-top: 12px;
+  }
   .cc-enrollment-verification-subtitle {
     font-size: 11px;
     line-height: 8px;

--- a/src/assets/templates/widgets/academics/enrollment_verification.html
+++ b/src/assets/templates/widgets/academics/enrollment_verification.html
@@ -19,6 +19,8 @@
           </div>
           <div class="cc-enrollment-verification-message">
             <span data-ng-bind-html="enrollmentMessages.messages.viewOnline.descrlong"></span>
+            <span>NOTE: NSC link will not be available until August 19, 2016 for Fall 2016 enrollment.
+              Summer students please visit BearFacts to access self-service enrollment verifications.</span>
           </div>
         </li>
         <li>
@@ -27,6 +29,30 @@
           </div>
           <div class="cc-enrollment-verification-message">
             <span data-ng-bind-html="enrollmentMessages.messages.requestOfficial.descrlong"></span>
+            <span><strong>IMPORTANT NOTE!</strong> The Office of the Registrar does not certify third-party froms seeking information provided on the two
+              options listed above.  Many of our partner institutions have already been notified of this new service and associated policies, but feel free
+              to <a href="http://registrar.berkeley.edu/Registrar/DisplayMedia.aspx?ID=Service%20Providers%20re%20Verifications.pdf">print this letter</a>
+              from the University Registrar and submit it with your verification certificate.
+            </span>
+          </div>
+          <div class="cc-enrollment-verification-link">
+            <div data-ng-if="!api.user.profile.features.enrollmentVerificationDeeplink">
+              <strong><a data-ng-href="{{enrollmentGoogleLink.url}}" data-ng-attr-title="{{enrollmentGoogleLink.title}}">Request Official Verification</a></strong>
+            </div>
+            <div data-ng-if="api.user.profile.features.enrollmentVerificationDeeplink">
+              <strong>
+                <a data-cc-campus-solutions-link-directive="enrollmentCsDeeplink.url"
+                data-cc-campus-solutions-link-directive-enabled="{{enrollmentCsDeeplink.isCsLink}}"
+                data-cc-campus-solutions-link-directive-text="enrollmentCsDeeplink.backToText"
+                data-cc-campus-solutions-link-directive-cache="'academics'"
+                data-cc-outbound-enabled="false">Request Official Verification</a>
+              </strong>
+            </div>
+          </div>
+        </li>
+        <li>
+          <div class="cc-enrollment-verification-message cc-enrollment-verification-footer">
+            <p>Learn more about <a data-ng-href="{{enrollmentVerificationServices.url}}" data-ng-attr-title="{{enrollmentVerificationServices.title}}">enrollment verification services.</a></p>
           </div>
         </li>
       </ul>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-22703

* Design JIRA:  https://jira.berkeley.edu/browse/SISRP-15681
* The feature flag for `enrollment_verification_deeplink` will be flipped once the CS mod is done.  This has been approved for the no-fly zone, if necessary.
* Deeplink is hardcoded since we are transitioning to the Links API, but to my understanding the API won't be ready to be used until post GL6.
* In the meantime, we'll be showing the link to the Google doc.
* For testing, we are able to use the same Google Doc, with the request that we prepend "test-" in front of the test ID used.