### PR TITLE
SISRP-23165 - Header Popover alert has alert, but no hold/bock details

### DIFF
--- a/src/assets/javascripts/angular/controllers/widgets/statusController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/statusController.js
@@ -135,11 +135,14 @@ angular.module('calcentral.controllers').controller('StatusController', function
 
   var parseRegistrationCounts = function() {
     _.forEach($scope.regStatus.registrations, function(registration) {
-      if (!registration.isSummer && registration.summary !== 'Officially Registered') {
+      if (registration.isSummer || !registration.positiveIndicators.S09) {
+        return;
+      }
+      if (registration.summary !== 'Officially Registered') {
         $scope.count++;
         $scope.hasAlerts = true;
       }
-      if (!registration.isSummer && !registration.positiveIndicators.R99 && registration.pastFinancialDisbursement) {
+      if (!registration.positiveIndicators.R99 && registration.pastFinancialDisbursement) {
         $scope.count++;
         $scope.hasAlerts = true;
       }


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-23165

* There is an extra count in the popover because we are counting "Not Officially Registered" terms without the S09 service indicator attached to it.  We want to make non-S09 terms invisible to students until S09 has been attached to the specific term.
* JIRA also outlines a Holds bug for the Enrollment Card that is already fixed on Master, due to @redconfetti's refactoring.
* I do think this should be a QA PR as well, as students will be receiving an alert when they shouldn't be.  Let me know if you agree & I'll open a QA PR.