### PR TITLE
[QA] SISRP-23217 Enable GRADUATE, UNDERGRAD CS Affiliations

### DIFF
--- a/app/models/berkeley/user_roles.rb
+++ b/app/models/berkeley/user_roles.rb
@@ -104,8 +104,9 @@ module Berkeley
           when 'GRADUATE'
             result[:student] = true
             result[:graduate] = true
-          when 'INSTRUCTOR'
-            result[:faculty] = true
+          # TODO CalCentral does not yet source the instructional-staff role from CS.
+          # when 'INSTRUCTOR'
+          #   result[:faculty] = true
           when 'ADVISOR'
             result[:advisor] = true
           when 'STUDENT'

--- a/app/models/user/aggregated_attributes.rb
+++ b/app/models/user/aggregated_attributes.rb
@@ -2,9 +2,6 @@ module User
   class AggregatedAttributes < UserSpecificModel
     include CampusSolutions::ProfileFeatureFlagged
 
-    # Conservative merge of roles from EDO
-    WHITELISTED_EDO_ROLES = [:student, :applicant, :advisor, :law]
-
     def initialize(uid, options={})
       super(uid, options)
     end
@@ -43,10 +40,9 @@ module User
       campus_roles = oracle_roles.merge ldap_roles
       if @sis_profile_visible
         edo_roles = (@edo_attributes && @edo_attributes[:roles]) || {}
-        edo_roles_to_merge = edo_roles.slice *WHITELISTED_EDO_ROLES
         # While we're in the split-brain stage, LDAP and Oracle are more trusted on ex-student status.
-        edo_roles_to_merge.delete(:student) if campus_roles[:exStudent]
-        campus_roles.merge edo_roles_to_merge
+        edo_roles.delete(:student) if campus_roles[:exStudent]
+        campus_roles.merge edo_roles
       else
         campus_roles
       end

--- a/spec/models/berkeley/user_roles_spec.rb
+++ b/spec/models/berkeley/user_roles_spec.rb
@@ -269,25 +269,6 @@ describe Berkeley::UserRoles do
       it_behaves_like 'a parser for roles', []
     end
 
-    context 'active instructor' do
-      let(:affiliations) do
-        [
-          {
-            :type => {
-              :code => 'INSTRUCTOR',
-              :description => 'Instructor'
-            },
-            :status => {
-              :code =>'ACT',
-              :description => 'Active'
-            },
-            :fromDate => '2014-05-15'
-          }
-        ]
-      end
-      it_behaves_like 'a parser for roles', [:faculty]
-    end
-
     context 'advisor affiliation' do
       let(:affiliations) do
         [
@@ -314,25 +295,6 @@ describe Berkeley::UserRoles do
         let(:status_description) { 'Inactive' }
         it_behaves_like 'a parser for roles', []
       end
-    end
-
-    context 'inactive instructor' do
-      let(:affiliations) do
-        [
-          {
-            :type => {
-              :code => 'INSTRUCTOR',
-              :description => 'Instructor'
-            },
-            :status => {
-              :code =>'INA',
-              :description => 'Inactive'
-            },
-            :fromDate => '2014-05-15'
-          }
-        ]
-      end
-      it_behaves_like 'a parser for roles', []
     end
 
     context 'no affiliations' do

--- a/spec/models/user/aggregated_attributes_spec.rb
+++ b/spec/models/user/aggregated_attributes_spec.rb
@@ -98,6 +98,27 @@ describe User::AggregatedAttributes do
         expect(subject[:roles][:recentStudent]).to be true
       end
     end
+    context 'graduate' do
+      let(:edo_attributes) do
+        {
+          person_name: preferred_name,
+          student_id: student_id,
+          campus_solutions_id: campus_solutions_id,
+          official_bmail_address: bmail_from_edo,
+          roles: {
+            student: false,
+            exStudent: false,
+            faculty: false,
+            staff: true,
+            graduate: true
+          }
+        }
+      end
+      let(:is_active_student) { true }
+      it 'picks up EDO role' do
+        expect(subject[:roles][:graduate]).to be true
+      end
+    end
     context 'broken Hub API' do
       let(:is_active_student) { true }
       let(:edo_attributes) do

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -550,10 +550,7 @@ describe User::Api do
     context 'role lookup errors' do
       let(:edo_attributes) do
         {
-          roles: {
-            body: 'An unknown server error occurred',
-            statusCode: 503
-          }
+          roles: {}
         }
       end
       include_examples 'handling bad behavior'


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-23217

QA-FIRST PR!

This bug was caused by a disconnect between two levels of CalCentral code. One class added the CS Affiliations as User Roles, then a class farther up carefully filtered them out again.

The motivation behind this split-brain behavior is far in the past, and we can instead now use the UserRoles class as a single trusted source.