### PR TITLE
SISRP-23223 - CS Link API - suppress `properties` hash in front-end JSON

### DIFF
--- a/app/models/campus_solutions/link.rb
+++ b/app/models/campus_solutions/link.rb
@@ -46,11 +46,13 @@ module CampusSolutions
             end
           end
 
+          # promote properties we're interested in, delete the rest
           link[:properties].each do |property|
             if property[:name] == 'NEW_WINDOW' && property[:value] == 'Y'
               link[:showNewWindow] = true
             end
           end
+          link.delete(:properties)
         end
       end
 

--- a/spec/controllers/campus_solutions/link_controller_spec.rb
+++ b/spec/controllers/campus_solutions/link_controller_spec.rb
@@ -38,7 +38,7 @@ describe CampusSolutions::LinkController do
 
         json_response = JSON.parse(response.body)
         expect(json_response["feed"]["link"]["urlId"]).to eq url_id
-        expect(json_response["feed"]["link"]["properties"].count).to eq 3
+        expect(json_response["feed"]["link"]["properties"]).not_to be
         # Verify placeholder is replaced by placeholders param entry.
         expect(json_response["feed"]["link"]["url"]).to include("PLACEHOLDER=#{placeholder_text}")
       end

--- a/spec/models/campus_solutions/link_spec.rb
+++ b/spec/models/campus_solutions/link_spec.rb
@@ -59,7 +59,7 @@ describe CampusSolutions::Link do
       it_should_behave_like 'a proxy that gets data'
       it 'returns data with the expected structure' do
         expect(link_get_url_response[:feed][:link][:urlId]).to eq url_id
-        expect(link_get_url_response[:feed][:link][:properties].count).to eq 3
+        expect(link_get_url_response[:feed][:link][:properties]).not_to be
         expect(link_get_url_response[:feed][:link][:showNewWindow]).to eq true
 
         # Verify that {placeholder} text is present


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-23223