### PR TITLE
SISRP-23303 Rename misleading "lookup_student_id" Crosswalk method

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,7 +17,7 @@ class SessionsController < ApplicationController
       cs_id = auth.extra['berkeleyEduCSID']
       if sid.present?
         logger.debug "Caching student ID #{sid} for UID #{auth_uid} based on SAML assertion"
-        crosswalk.cache_student_id sid
+        crosswalk.cache_legacy_student_id sid
       end
       if cs_id.present?
         # TODO reduce this log level once CAS reliably sends us the CS ID

--- a/app/models/calnet_crosswalk/proxy.rb
+++ b/app/models/calnet_crosswalk/proxy.rb
@@ -83,11 +83,11 @@ module CalnetCrosswalk
       cache_id('CAMPUS_SOLUTIONS_ID', value)
     end
 
-    def lookup_student_id
+    def lookup_legacy_student_id
       lookup_id 'LEGACY_SIS_STUDENT_ID'
     end
 
-    def cache_student_id(value)
+    def cache_legacy_student_id(value)
       cache_id('LEGACY_SIS_STUDENT_ID', value)
     end
 

--- a/app/models/hub_edos/user_attributes.rb
+++ b/app/models/hub_edos/user_attributes.rb
@@ -59,7 +59,7 @@ module HubEdos
       result[:ldap_uid] = @uid
       result[:campus_solutions_id] = campus_solutions_id
       result[:is_legacy_user] = legacy_user?
-      result[:student_id] = lookup_student_id_from_crosswalk
+      result[:student_id] = lookup_legacy_student_id_from_crosswalk
       result[:delegate_user_id] = lookup_delegate_user_id
     end
 

--- a/app/models/user/search_users.rb
+++ b/app/models/user/search_users.rb
@@ -12,7 +12,7 @@ module User
           results = Set.new
           [CalnetCrosswalk::ByUid, CalnetCrosswalk::BySid, CalnetCrosswalk::ByCsId].each do |proxy_class|
             proxy = proxy_class.new(user_id: @id)
-            sid = proxy.lookup_student_id
+            sid = proxy.lookup_legacy_student_id
             uid = proxy.lookup_ldap_uid
             if sid.present? || uid.present?
               results << {

--- a/app/models/user/student.rb
+++ b/app/models/user/student.rb
@@ -12,8 +12,8 @@ module User
       CalnetCrosswalk::ByUid.new(user_id: @uid).lookup_campus_solutions_id
     end
 
-    def lookup_student_id_from_crosswalk
-      CalnetCrosswalk::ByUid.new(user_id: @uid).lookup_student_id
+    def lookup_legacy_student_id_from_crosswalk
+      CalnetCrosswalk::ByUid.new(user_id: @uid).lookup_legacy_student_id
     end
 
     def lookup_delegate_user_id

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -80,7 +80,7 @@ describe SessionsController do
 
         crosswalk = CalnetCrosswalk::ByUid.new user_id: user_id
         expect(crosswalk.lookup_campus_solutions_id).to eq '13320459'
-        expect(crosswalk.lookup_student_id).to eq '24188910'
+        expect(crosswalk.lookup_legacy_student_id).to eq '24188910'
         expect(crosswalk.lookup_delegate_user_id).to eq '20394351'
       end
     end

--- a/spec/models/calnet_crosswalk/by_cs_id_spec.rb
+++ b/spec/models/calnet_crosswalk/by_cs_id_spec.rb
@@ -16,7 +16,7 @@ describe CalnetCrosswalk::ByCsId do
     end
 
     context 'looking up student id' do
-      subject { proxy.lookup_student_id }
+      subject { proxy.lookup_legacy_student_id }
       it 'should be nil' do
         # Always nil because feed does not give LEGACY_SIS_STUDENT_ID.
         expect(subject).to be_nil

--- a/spec/models/calnet_crosswalk/by_uid_spec.rb
+++ b/spec/models/calnet_crosswalk/by_uid_spec.rb
@@ -16,7 +16,7 @@ describe CalnetCrosswalk::ByUid do
     end
 
     context 'looking up student id' do
-      subject { proxy.lookup_student_id }
+      subject { proxy.lookup_legacy_student_id }
       it 'should return the Student ID' do
         expect(subject).to be
       end

--- a/spec/models/user/search_users_spec.rb
+++ b/spec/models/user/search_users_spec.rb
@@ -22,15 +22,15 @@ describe User::SearchUsers do
     allow(CalnetCrosswalk::ByCsId).to receive(:new).and_return fake_cs_id_proxy
 
     allow(fake_uid_proxy).to receive(:lookup_ldap_uid).and_return uid_proxy_ldap_uid
-    allow(fake_uid_proxy).to receive(:lookup_student_id).and_return uid_proxy_student_id
+    allow(fake_uid_proxy).to receive(:lookup_legacy_student_id).and_return uid_proxy_student_id
     allow(fake_uid_proxy).to receive(:lookup_campus_solutions_id).and_return uid_proxy_campus_solutions_id
 
     allow(fake_sid_proxy).to receive(:lookup_ldap_uid).and_return sid_proxy_ldap_uid
-    allow(fake_sid_proxy).to receive(:lookup_student_id).and_return sid_proxy_student_id
+    allow(fake_sid_proxy).to receive(:lookup_legacy_student_id).and_return sid_proxy_student_id
     allow(fake_sid_proxy).to receive(:lookup_campus_solutions_id).and_return sid_proxy_campus_solutions_id
 
     allow(fake_cs_id_proxy).to receive(:lookup_ldap_uid).and_return cs_id_proxy_ldap_uid
-    allow(fake_cs_id_proxy).to receive(:lookup_student_id).and_return cs_id_proxy_student_id
+    allow(fake_cs_id_proxy).to receive(:lookup_legacy_student_id).and_return cs_id_proxy_student_id
     allow(fake_cs_id_proxy).to receive(:lookup_campus_solutions_id).and_return cs_id_proxy_campus_solutions_id
   end
   context 'ByUid returns results' do


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-23303

A bit of clarification before our code learns about CS-provided identifiers. This method actually only looks for a _legacy_ (pre-CS) Student ID.