### PR TITLE
SISRP-22717 Merged model and controller for advising card

### DIFF
--- a/app/controllers/my_advising_controller.rb
+++ b/app/controllers/my_advising_controller.rb
@@ -3,6 +3,10 @@ class MyAdvisingController < ApplicationController
   before_filter :api_authenticate
 
   def get_feed
+    render json: Advising::MyAdvising.from_session(session).get_feed_as_json
+  end
+
+  def get_legacy_feed
     render json: Advising::LegacyMyAdvising.from_session(session).get_feed_as_json
   end
 

--- a/app/models/advising/my_advising.rb
+++ b/app/models/advising/my_advising.rb
@@ -1,0 +1,38 @@
+module Advising
+  class MyAdvising < UserSpecificModel
+
+    include Cache::CachedFeed
+    include Cache::FeedExceptionsHandled
+    include Cache::UserCacheExpiry
+    include User::Student
+
+    def get_feed_internal
+      advising_feed = {
+        feed: {},
+        statusCode: 200
+      }
+      merge advising_feed if Settings.features.advising
+      advising_feed
+    end
+
+    FEED_COMPONENTS = {
+      advisorRelationships: CampusSolutions::AdvisorStudentRelationship,
+      advisorActionItems: CampusSolutions::AdvisorStudentActionItems,
+      advisorAppointments: CampusSolutions::AdvisorStudentAppointmentCalendar
+    }
+
+    def merge(advising_feed)
+      FEED_COMPONENTS.each do |key, proxy_class|
+        response = proxy_class.new(user_id: @uid).get
+        if !response || !response[:feed] || response[:errored]
+          advising_feed[:statusCode] = 500
+          advising_feed[:errored] = true
+          logger.error("Got errors in merged MyAdvising feed on #{proxy_class} for uid #{@uid} with response #{response}")
+        else
+          advising_feed[:feed][key] = response[:feed]
+        end
+      end
+    end
+
+  end
+end

--- a/app/models/campus_solutions/advising_expiry.rb
+++ b/app/models/campus_solutions/advising_expiry.rb
@@ -1,0 +1,9 @@
+module CampusSolutions
+  module AdvisingExpiry
+    def self.expire(uid=nil)
+      [Advising::MyAdvising, CampusSolutions::AdvisingResources].each do |klass|
+        klass.expire uid
+      end
+    end
+  end
+end

--- a/app/models/notifications/sis_expiry_processor.rb
+++ b/app/models/notifications/sis_expiry_processor.rb
@@ -32,7 +32,7 @@ module Notifications
 
     #TODO Mapping of event topics to expiry modules is incomplete.
     EXPIRY_BY_TOPIC = {
-      'sis:staff:advisor' => CampusSolutions::AdvisingResources,
+      'sis:staff:advisor' => CampusSolutions::AdvisingExpiry,
       'sis:student:affiliation' => CampusSolutions::UserApiExpiry,
       'sis:student:checklist' => CampusSolutions::ChecklistDataExpiry,
       'sis:student:delegate' => CampusSolutions::DelegateStudentsExpiry,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Calcentral::Application.routes.draw do
   post '/api/my/calendar/opt_out' => 'user_api#calendar_opt_out', :via => :post
 
   # Feeds of read-only content
+  get '/api/advising/my_advising' => 'my_advising#get_feed', :as => :advising, :defaults => {:format => 'json'}
   get '/api/my/classes' => 'my_classes#get_feed', :as => :my_classes, :defaults => { :format => 'json' }
   get '/api/my/photo' => 'photo#my_photo', :as => :my_photo, :defaults => {:format => 'jpeg' }
   get '/api/my/textbooks_details' => 'my_textbooks#get_feed', :as => :my_textbooks, :defaults => { :format => 'json' }
@@ -30,7 +31,8 @@ Calcentral::Application.routes.draw do
   get '/api/my/financials' => 'my_financials#get_feed', :as => :my_financials, :defaults => {:format => 'json'}
   get '/api/my/finaid' => 'my_finaid#get_feed', :as => :my_finaid, :defaults => {:format => 'json'}
   get '/api/my/cal1card' => 'my_cal1card#get_feed', :as => :my_cal1card, :defaults => {:format => 'json'}
-  get '/api/my/advising' => 'my_advising#get_feed', :as => :my_advising, :defaults => {:format => 'json'}
+  # TODO This legacy advising endpoint will not remain long.
+  get '/api/my/advising' => 'my_advising#get_legacy_feed', :as => :my_advising, :defaults => {:format => 'json'}
   get '/api/my/campuslinks' => 'my_campus_links#get_feed', :as => :my_campus_links, :defaults => { :format => 'json' }
   get '/api/my/campuslinks/expire' => 'my_campus_links#expire'
   get '/api/my/campuslinks/refresh' => 'my_campus_links#refresh', :defaults => { :format => 'json' }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -253,7 +253,9 @@ cache:
     CanvasBackgroundJobs: <%= 24.hours %>
     CanvasLti::Egrades: <%= 1.minute %>
     CanvasLti::Lti: <%= 5.minutes %>
+
     Advising::LegacyMyAdvising: <%= 2.hours %>
+    Advising::MyAdvising: <%= 2.hours %>
 
     MyAcademics::CollegeAndLevel: NEXT_08_00
     MyAcademics::GpaUnits: NEXT_08_00

--- a/spec/models/advising/my_advising_spec.rb
+++ b/spec/models/advising/my_advising_spec.rb
@@ -1,0 +1,78 @@
+describe Advising::MyAdvising do
+  let(:uid) { random_id }
+  subject { described_class.new(uid).get_feed_internal }
+
+  context 'fake proxies' do
+    let(:fake_proxies) do
+      proxies = {}
+      Advising::MyAdvising::FEED_COMPONENTS.each_value do |proxy_class|
+        fake_proxy = proxy_class.new(user_id: uid, fake: true)
+        proxies[proxy_class] = fake_proxy
+        allow(proxy_class).to receive(:new).and_return fake_proxy
+      end
+      proxies
+    end
+
+    context 'well-behaved proxies' do
+      it 'should return successful status code' do
+        expect(subject[:statusCode]).to eq 200
+      end
+      it 'should include expected action items' do
+        expect(subject[:feed][:advisorActionItems][:ucAaActionItems][:actionItems]).to have(12).items
+        expect(subject[:feed][:advisorActionItems][:ucAaActionItems][:actionItems].first).to include({
+          actionItemAssignedDate: '2016-07-22',
+          actionItemDescription: 'Testing 123',
+          actionItemDueDate: '2016-07-25',
+          actionItemStatus: 'Incomplete',
+          actionItemTitle: 'Action Item test',
+          actionItemView: 'Complete'
+        })
+      end
+      it 'should include expected advising appointments' do
+        expect(subject[:feed][:advisorAppointments][:ucAaAdvisingAppts][:advisingAppts]).to have(23).items
+        expect(subject[:feed][:advisorAppointments][:ucAaAdvisingAppts][:advisingAppts].first).to include({
+          apptAdvisorId: '3030312345',
+          apptAdvisorName: 'Jane Smith',
+          apptCategory: 'Academic Advising',
+          apptDate: '2016-07-25',
+          apptDuration: '30',
+          apptReason: 'Add',
+          apptScheduledTime: '08.00.00.000000',
+          apptStatus: 'CANCEL',
+          apptType: 'Drop-in'
+        })
+      end
+      it 'should include expected advisor relationships' do
+        expect(subject[:feed][:advisorRelationships][:ucAaStudentAdvisor][:studentAdvisor]).to have(1).items
+        expect(subject[:feed][:advisorRelationships][:ucAaStudentAdvisor][:studentAdvisor].first).to include({
+          assignedAdvisorEmail: 'janed@example.com',
+          assignedAdvisorName: 'Jane Doe',
+          assignedAdvisorProgram: 'Undergrad Chemistry',
+          assignedAdvisorType: 'College Advisor'
+        })
+      end
+    end
+
+    shared_examples 'a good and proper error report' do
+      it 'reports error' do
+        expect(Rails.logger).to receive(:error).with /Got errors in merged MyAdvising feed/
+        expect(subject[:statusCode]).to eq 500
+        expect(subject[:errored]).to eq true
+      end
+    end
+
+    context 'proxy returns an error' do
+      before do
+        allow(fake_proxies[CampusSolutions::AdvisorStudentAppointmentCalendar]).to receive(:get).and_return(errored: true)
+      end
+      it_should_behave_like 'a good and proper error report'
+    end
+
+    context 'proxy fails to look up student ID' do
+      before do
+        allow(fake_proxies[CampusSolutions::AdvisorStudentActionItems]).to receive(:get).and_return(noStudentId: true)
+      end
+      it_should_behave_like 'a good and proper error report'
+    end
+  end
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-22717

We've been advised that the sis:staff:advisor ENF topic, which currently expires advising resources, will be used to expire advising appointments as well.