### PR TITLE
SISRP-23275 - 6.0d - Add Clearinghouse link to Enrollment Verification page

### DIFF
--- a/app/controllers/my_clearing_house_url_controller.rb
+++ b/app/controllers/my_clearing_house_url_controller.rb
@@ -1,0 +1,23 @@
+class MyClearingHouseUrlController < ApplicationController
+  include ClassLogger
+
+  rescue_from Errors::ProxyError, with: :proxy_error
+
+  def redirect
+    response = model_from_session.get_feed_internal
+    render html: response.html_safe
+  end
+
+  private
+
+  def model_from_session
+    options = {}
+    ClearingHouse::MyClearingHouseUrl.from_session(session, options)
+  end
+
+  def proxy_error(exception)
+    logger.debug "Proxy error when attempting to connect with National Student ClearingHouse: #{exception}"
+    redirect_to url_for_path '/404'
+  end
+
+end

--- a/app/models/clearing_house/my_clearing_house_url.rb
+++ b/app/models/clearing_house/my_clearing_house_url.rb
@@ -1,0 +1,43 @@
+module ClearingHouse
+  class MyClearingHouseUrl < UserSpecificModel
+    include CampusSolutions::CampusSolutionsIdRequired
+    include Proxies::HttpClient
+    include ClassLogger
+
+    def initialize(uid, options={})
+      super(uid, options)
+      @settings = Settings.clearing_house_proxy
+      @fake = (options[:fake] != nil) ? options[:fake] : @settings.fake
+    end
+
+    def lookup_student_id
+      calnet_crosswalk = CalnetCrosswalk::ByUid.new(user_id: @uid)
+      if @uid
+        @student_id = calnet_crosswalk.lookup_campus_solutions_id || calnet_crosswalk.lookup_legacy_student_id
+      end
+    end
+
+    def get_feed_internal
+      return {} if @fake
+      get_html_response
+    end
+
+    def get_html_response
+      lookup_student_id
+      url = "#{@settings.base_url}"
+      options = {
+        method: :post,
+        headers: {
+          "Referer" => 'https://calcentral.berkeley.edu/academics/enrollment_verification',
+          "User-Agent" => " "
+        },
+        body: "user_id=#{@settings.app_id}&password=#{@settings.app_key}&id=#{@student_id}"
+      }
+      logger.info "get_parsed_response: Fake = #{@fake}; Making request to #{url} on behalf of user #{@uid}"
+      response = get_response(url, options)
+      logger.debug "National Student ClearingHouse remote response: #{response.inspect}"
+      response
+    end
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,6 +225,9 @@ Calcentral::Application.routes.draw do
   # Redirect to HigherOne
   get '/higher_one/higher_one_url' => 'campus_solutions/higher_one_url#redirect'
 
+  # Redirect to National Student ClearingHouse
+  get '/clearing_house/clearing_house_url' => 'my_clearing_house_url#redirect'
+
   # EDOs from integration hub
   get '/api/edos/academic_status' => 'hub_edo#academic_status', :via => :get, :defaults => { :format => 'json' }
   get '/api/edos/student' => 'hub_edo#student', :via => :get, :defaults => { :format => 'json' }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -154,6 +154,12 @@ calmail_proxy:
   owner_address: 'owner@example.com'
   owner_uid: '211159'
 
+clearing_house_proxy:
+  fake: false
+  base_url: 'https://secure.studentclearinghouse.org/sssportalui/authenticate'
+  app_id: ''
+  app_key: ''
+
 eft_proxy:
   fake: true
   # QA Environment

--- a/config/settings/testext.yml
+++ b/config/settings/testext.yml
@@ -81,6 +81,7 @@ features:
   cs_profile_languages: true
   cs_profile_work_experience: true
   cs_transfer_credit: true
+  enrollment_verification: true
   financials: true
   legacy_advising: true
   textbooks: true

--- a/fixtures/html/my_clearing_house_url.html
+++ b/fixtures/html/my_clearing_house_url.html
@@ -1,0 +1,21 @@
+<HTML>
+  <HEAD>
+    <TITLE>Clearinghouse</TITLE>
+  </HEAD>
+  <BODY>
+    <FORM name="frm_nsc" method="POST"  action="https://secure.studentclearinghouse.org/sssportalui/sssportal" >
+      <INPUT type="hidden" name="token_name" value="SOME VALUE">
+    </FORM>
+    <div ID=redir_msg style='display:block'>
+      You will now access the
+      <A HREF="https://secure.studentclearinghouse.org/sssportalui/sssportal" onclick="javascript:document.frm_nsc.submit(); return false;">
+      National Student Clearinghouse Student Self-Service Site</A>.
+      <BR>
+      <BR>
+      If you are not redirected within a few seconds, click on the above link.
+    </div>
+    <SCRIPT Language="JavaScript">
+      document.frm_nsc.submit();
+    </SCRIPT>
+  </BODY>
+</HTML>

--- a/spec/controllers/my_clearing_house_url_controller_spec.rb
+++ b/spec/controllers/my_clearing_house_url_controller_spec.rb
@@ -1,0 +1,14 @@
+describe MyClearingHouseUrlController do
+  let(:session_user_id) { '61889' }
+  let (:clearing_house_uri) { URI.parse(Settings.clearing_house_proxy.base_url) }
+  before do
+    stub_request(:any, /.*#{clearing_house_uri.hostname}.*/).to_return(status: 404)
+  end
+
+  context 'handling proxy errors' do
+    subject {get :redirect, user_id: session_user_id}
+    it 'should rescue' do
+      expect(subject).to redirect_to('/404')
+    end
+  end
+end

--- a/spec/models/clearing_house/my_clearing_house_url_spec.rb
+++ b/spec/models/clearing_house/my_clearing_house_url_spec.rb
@@ -1,0 +1,22 @@
+describe ClearingHouse::MyClearingHouseUrl do
+  let (:uid) {'61889'}
+  let (:real_model) {ClearingHouse::MyClearingHouseUrl.new(uid, fake: false)}
+  let (:fake_model) {ClearingHouse::MyClearingHouseUrl.new(uid, fake: true)}
+  let (:clearing_house_uri) { URI.parse(Settings.clearing_house_proxy.base_url) }
+
+  context 'fake model' do
+    subject { fake_model }
+    it 'returns an empty feed' do
+      response = subject.get_feed_internal
+      expect(response).to eq ({})
+    end
+  end
+
+  context 'real model', testext: true do
+    subject { real_model }
+    it 'should make a connection' do
+      response = subject.get_feed_internal
+      expect(response.code).to eq 200
+    end
+  end
+end

--- a/src/assets/templates/widgets/academics/enrollment_verification.html
+++ b/src/assets/templates/widgets/academics/enrollment_verification.html
@@ -20,6 +20,16 @@
           <div class="cc-enrollment-verification-message">
             <span data-ng-bind-html="enrollmentMessages.messages.viewOnline.descrlong"></span>
           </div>
+          <div class="cc-enrollment-verification-link">
+            <div data-ng-if="api.user.profile.isDirectlyAuthenticated">
+              <strong><a data-cc-outbound-enabled="true" href="/clearing_house/clearing_house_url">View or Print Enrollment via Self Service</a></strong>
+            </div>
+            <div data-ng-if="!api.user.profile.isDirectlyAuthenticated">
+              <p class="cc-enrollment-verification-link-disabled">
+                <strong>View or Print Enrollment via Self Service</strong><i> (Functionality is not available in view-as mode.)</i>
+              </p>
+            </div>
+          </div>
         </li>
         <li>
           <div class="cc-enrollment-verification-subtitle">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-23275

* @raydavis, I had attempted to figure out how to get Mockable to render the HTML given back to us by NSC, unfortunately I couldn't figure it out and due to time constraints had to instead return an empty object in fake mode =\.  Let me know if this is acceptable.
* This is also my first time attempting handling raised errors, so I'd appreciate a review on if I had correctly implemented that aspect.
* For more information on why I had to set "Referer" and "User-Agent" headers in the API call, see the attached guides at parent JIRA [SISRP-23271](https://jira.berkeley.edu/browse/SISRP-23271)