### PR TITLE
SISRP-23757 - Ensure Summer 2016 Regstatus Expires after End of Instruction

### DIFF
--- a/src/assets/templates/widgets/status_and_holds.html
+++ b/src/assets/templates/widgets/status_and_holds.html
@@ -9,7 +9,7 @@
     <div data-cc-spinner-directive="regStatus.isLoading">
       <div data-ng-if="(statusHoldsBlocks.enabledSections.indexOf('Status') !== -1) && !api.user.profile.roles.concurrentEnrollmentStudent">
         <div class="cc-status-holds-section" data-ng-repeat="registration in regStatus.registrations | orderBy:'-id'">
-          <div data-ng-if="registration.isLegacy || (registration.positiveIndicators.S09 && !registration.pastEndOfInstruction)">
+          <div data-ng-if="(registration.isLegacy || registration.positiveIndicators.S09) && !registration.pastEndOfInstruction">
             <h4 data-ng-bind="registration.name"></h4>
             <ul class="cc-widget-list cc-status-holds-list" data-ng-if="api.user.profile.features.regstatus">
               <li class="cc-widget-list-hover"


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-23757

* Since the Terms API will start bumping Summer 2016 out of "Current" and replace it with Fall 2016, this problem of not expiring visibility for Summer regstatus should actually take care of itself - this is just a precaution.
* Let me know if I should make a QA PR for this as well, since Summer 2016 term ends on 8/12 according to the Terms API.  But as I had stated, this problem should take care of itself.