### PR TITLE
SISRP-23528 - Cal Central Suppress zero amounts in billing details

### DIFF
--- a/src/assets/javascripts/angular/controllers/widgets/billingController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/billingController.js
@@ -127,6 +127,12 @@ angular.module('calcentral.controllers').controller('BillingController', functio
 
     billing.summary = setAmountStrings(billing.summary);
 
+    // Suppress all billing items with itemLineAmount: 0 and itemLineBalance: 0.
+    billing.activity = _.reject(billing.activity, {
+      itemLineAmount: 0,
+      itemBalance: 0
+    });
+
     billing.activity = _.map(billing.activity, function(object) {
       var billingItem = _.mapValues(object, function(value) {
         value = parseIncomingDates(value);


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-23528

* Lots of good conversation in the JIRA comments
* Bottom line, CS has a peculiar method of assessing financial line items which cause "obsolete" line items with `amount === 0 && balance === 0` to come through.
* The functional team would really like to get this fix in for 6.0d, would it be possible to put in a QA PR for this as well?