### PR TITLE
CLC-6425 Add pagination to Canvas Course Sections API call

### DIFF
--- a/app/models/canvas/course_sections.rb
+++ b/app/models/canvas/course_sections.rb
@@ -1,5 +1,6 @@
 module Canvas
   class CourseSections < Proxy
+    include PagedProxy
 
     def initialize(options = {})
       super(options)
@@ -7,7 +8,7 @@ module Canvas
     end
 
     def sections_list(force_write = false)
-      self.class.fetch_from_cache(@course_id, force_write) { wrapped_get request_path }
+      self.class.fetch_from_cache(@course_id, force_write) { paged_get request_path }
     end
 
     def official_section_identifiers(force_write = false)

--- a/spec/models/canvas/course_sections_spec.rb
+++ b/spec/models/canvas/course_sections_spec.rb
@@ -41,7 +41,7 @@ describe Canvas::CourseSections do
     context 'on request failure' do
       let(:failing_request) { {method: :get} }
       let(:response) { subject.sections_list }
-      it_should_behave_like 'an unpaged Canvas proxy handling request failure'
+      it_should_behave_like 'a paged Canvas proxy handling request failure'
     end
   end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6425

As usual when Instructure adds pagination, we found out by our payloads suddenly being restricted to 10 items.