### PR TITLE
[QA] CLC-6425 Add pagination to Canvas Course Sections API call

### DIFF
--- a/app/models/canvas/course_sections.rb
+++ b/app/models/canvas/course_sections.rb
@@ -1,5 +1,6 @@
 module Canvas
   class CourseSections < Proxy
+    include PagedProxy
 
     def initialize(options = {})
       super(options)
@@ -7,7 +8,7 @@ module Canvas
     end
 
     def sections_list(force_write = false)
-      self.class.fetch_from_cache(@course_id, force_write) { wrapped_get request_path }
+      self.class.fetch_from_cache(@course_id, force_write) { paged_get request_path }
     end
 
     def official_section_identifiers(force_write = false)

--- a/spec/models/canvas/course_sections_spec.rb
+++ b/spec/models/canvas/course_sections_spec.rb
@@ -41,7 +41,7 @@ describe Canvas::CourseSections do
     context 'on request failure' do
       let(:failing_request) { {method: :get} }
       let(:response) { subject.sections_list }
-      it_should_behave_like 'an unpaged Canvas proxy handling request failure'
+      it_should_behave_like 'a paged Canvas proxy handling request failure'
     end
   end
 


### PR DESCRIPTION
QA version of https://github.com/ets-berkeley-edu/calcentral/pull/5780

@pfarestveit suggested and the bCourses service lead confirmed that this is a blocker for bCourses, and that the code change needs to be in place before Summer 2016 final grading finishes and Fall 2016 course site creation enters full frenzy.