### PR TITLE
CLC-5956, upgrade scss_lint to 0.49.0; disable linters: PseudoElement, ColorVariable

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -5,6 +5,10 @@ exclude:
   - 'node_modules/**'
 
 linters:
+  PseudoElement:
+    enabled: false
+  ColorVariable:
+    enabled: false
   DuplicateProperty:
     enabled: false
   EmptyLineBetweenBlocks:

--- a/script/front-end-test.sh
+++ b/script/front-end-test.sh
@@ -1,14 +1,23 @@
+#!/bin/bash
+
 # Install the correct node version (specified in package.json) on Travis
-if [ -d "$HOME/.nvm" ] && [ "$TRAVIS" = "true" ]; then
-  . $HOME/.nvm/nvm.sh
+if [ -d "${HOME}/.nvm" ] && [ "${TRAVIS}" = "true" ]; then
+  source ${HOME}/.nvm/nvm.sh
   nvm install $(node -e 'console.log(require("./package.json").engines.node.replace(/[^\d\.]+/g, ""))')
 fi
 
-node_version=`node --version`
-echo "Node version: $node_version"
+echo "Node version: $(node --version)"
 npm config set strict-ssl false
 npm install
 npm run build-production
-gem install scss_lint --version 0.38.0
-scss-lint src/assets/stylesheets/
-[[ $? -ne 0 ]] && echo 'scss-lint failed' && exit 1 || echo 'scss-lint was succesful'
+
+echo "Verify clean and consistent SCSS with scss_lint"
+gem cleanup scss_lint
+gem install scss_lint --version 0.49.0
+
+scss-lint src/assets/stylesheets
+
+lint_exit_status=$?
+[[ ${lint_exit_status} -ne 0 ]] && echo "[ERROR] scss-lint returned non-zero status: ${lint_exit_status}" && exit 1 || echo '[INFO] scss-lint reported no problems'
+
+exit 0


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-5956

* scss_lint upgrade: 0.38.0 --> 0.49.0
* Per CLC-5956, I hope to resolve "scss_lint conflicts with installed executable from scss-lint" with `gem cleanup scss_lint` prior to `gem install scss_lint ...`
* I created https://jira.ets.berkeley.edu/jira/browse/CLC-6433 to "Enable PseudoElement, ColorVariable linters (scss_lint) and fix corresponding issues"
