### PR TITLE
SISRP-24452 - Students with no reg, 0 units should see 'Not Enrolled' status alone but there is no registration section at all

### DIFF
--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -6,7 +6,7 @@ var _ = require('lodash');
 /**
  * Preview of user profile prior to viewing-as
  */
-angular.module('calcentral.controllers').controller('UserOverviewController', function(academicsService, adminService, advisingFactory, academicStatusFactory, residencyMessageFactory, apiService, statusHoldsService, studentAttributesFactory, $route, $routeParams, $scope) {
+angular.module('calcentral.controllers').controller('UserOverviewController', function(academicsService, adminService, advisingFactory, academicStatusFactory, residencyMessageFactory, apiService, enrollmentVerificationFactory, statusHoldsService, studentAttributesFactory, $route, $routeParams, $scope) {
   $scope.expectedGradTerm = academicsService.expectedGradTerm;
   $scope.academics = {
     isLoading: true,
@@ -202,6 +202,17 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
     }
   };
 
+  var getRegMessages = function() {
+    enrollmentVerificationFactory.getEnrollmentVerificationMessages()
+      .then(function(data) {
+        var messages = _.get(data, 'data.feed.root.getMessageCatDefn');
+        if (messages) {
+          $scope.regStatus.messages = {};
+          _.merge($scope.regStatus.messages, statusHoldsService.getRegStatusMessages(messages));
+        }
+      });
+  };
+
   $scope.targetUser.actAs = function() {
     adminService.actAs($scope.targetUser);
   };
@@ -214,7 +225,8 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
       .then(loadAcademics)
       .then(loadHolds)
       .then(loadBlocks)
-      .then(loadRegistrations);
+      .then(loadRegistrations)
+      .then(getRegMessages);
     }
   });
 });

--- a/src/assets/javascripts/angular/services/statusHoldsService.js
+++ b/src/assets/javascripts/angular/services/statusHoldsService.js
@@ -3,7 +3,7 @@
 var angular = require('angular');
 var _ = require('lodash');
 
-angular.module('calcentral.services').service('statusHoldsService', function(userService) {
+angular.module('calcentral.services').service('statusHoldsService', function() {
   /**
    * Parses any terms past the legacy cutoff.  Mirrors current functionality for now, but this will be changed in redesigns slated
    * for GL6.
@@ -28,11 +28,11 @@ angular.module('calcentral.services').service('statusHoldsService', function(use
       term.summary = 'Not Officially Registered';
       term.explanation = term.isSummer ? 'You are not officially registered for this term.' : 'You are not entitled to access campus services until you are officially registered.  In order to be officially registered, you must pay your Tuition and Fees, and have no outstanding holds.';
     }
-    if (termUnitsTotal.unitsEnrolled === 0 && userService.profile.roles.undergrad && term.pastClassesStart) {
+    if (termUnitsTotal.unitsEnrolled === 0 && (term.academicCareer && term.academicCareer.code === 'UGRD')) {
       term.summary = 'Not Enrolled';
       term.explanation = term.isSummer ? 'You are not officially registered for this term.' : 'You are not enrolled in any classes for this term.';
     }
-    if (termUnitsTotal.unitsEnrolled === 0 && (userService.profile.roles.graduate || userService.profile.roles.law) && term.pastAddDrop) {
+    if (termUnitsTotal.unitsEnrolled === 0 && (term.academicCareer && term.academicCareer.code !== 'UGRD')) {
       term.summary = 'Not Enrolled';
       term.explanation = term.isSummer ? 'You are not officially registered for this term.' : 'You are not enrolled in any classes for this term. Fees will not be assessed, and any expected fee remissions or fee payment credits cannot be applied until you are enrolled in classes.  For more information, please contact your departmental graduate advisor.';
     }

--- a/src/assets/templates/widgets/status_and_holds.html
+++ b/src/assets/templates/widgets/status_and_holds.html
@@ -32,10 +32,10 @@
                     <div data-ng-if="registration.summary !== 'Officially Registered' && !registration.isSummer">
                       <div data-ng-if="$parent.regStatus.messages">
                         <span data-ng-if="registration.summary === 'Not Officially Registered'" data-ng-bind-html="$parent.regStatus.messages.notRegistered.descrlong"></span>
-                        <span data-ng-if="registration.summary === 'Not Enrolled' && api.user.profile.roles.undergrad" data-ng-bind-html="$parent.regStatus.messages.notEnrolledUndergrad.descrlong"></span>
-                        <span data-ng-if="registration.summary === 'Not Enrolled' && (api.user.profile.roles.graduate || api.user.profile.roles.law)" data-ng-bind-html="$parent.regStatus.messages.notEnrolledGrad.descrlong"></span>
+                        <span data-ng-if="registration.summary === 'Not Enrolled' && (registration.academicCareer.code === 'UGRD')" data-ng-bind-html="$parent.regStatus.messages.notEnrolledUndergrad.descrlong"></span>
+                        <span data-ng-if="registration.summary === 'Not Enrolled' && (registration.academicCareer.code !== 'UGRD')" data-ng-bind-html="$parent.regStatus.messages.notEnrolledGrad.descrlong"></span>
                       </div>
-                      <span data-ng-if="!$parent.regStatus.messages || api.user.profile.roles.advisor" data-ng-bind="registration.explanation"></span>
+                      <span data-ng-if="!$parent.regStatus.messages" data-ng-bind="registration.explanation"></span>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-24452

This PR does a couple things:
* Expands "Not Enrolled" status - previously students would only see "Not enrolled" if they were at 0 units + it was past CNP action.  This makes it so that students will be "Not Enrolled" if they are at 0 enrolled units, regardless of current date.
* Switches academic career checks from `/api/my/status` to term-specific `registration.academicCareer.code`.  This will minimize any potential `roles` conflicts (e.g. for a student going from undergrad to grad), as well as enable advisors to view whatever the student is viewing.
* Since advisor user overview is no long reliant on `/api/my/status`, we can start surfacing intended message catalog messages for academicCareer-specific student messaging.