### PR TITLE
SISRP-24774 - Concurrent Enrollment Student (Sep 24th) - shouldn't display any REG status.

### DIFF
--- a/src/assets/javascripts/angular/controllers/widgets/academicsStatusHoldsBlocksController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/academicsStatusHoldsBlocksController.js
@@ -19,18 +19,21 @@ angular.module('calcentral.controllers').controller('AcademicsStatusHoldsBlocksC
     isLoading: true
   };
 
-  $scope.$watchGroup(['regStatus.registrations[0].summary', 'api.user.profile.features.csHolds', 'api.user.profile.features.legacyRegblocks'], function(newValues) {
+  $scope.$watchGroup(['(regStatus.registrations[0].summary && regStatus.registrations[0].academicCareer.code !== "UCBX")',
+                      '(regStatus.registrations[1].summary && regStatus.registrations[1].academicCareer.code !== "UCBX")',
+                      'api.user.profile.features.csHolds',
+                      'api.user.profile.features.legacyRegblocks'], function(newValues) {
     var enabledSections = [];
 
-    if (newValues[0] !== null && newValues[0] !== undefined) {
+    if (newValues[0] || newValues[1]) {
       enabledSections.push('Status');
     }
 
-    if (newValues[1]) {
+    if (newValues[2]) {
       enabledSections.push('Holds');
     }
 
-    if (newValues[2]) {
+    if (newValues[3]) {
       enabledSections.push('Blocks');
     }
 

--- a/src/assets/javascripts/angular/controllers/widgets/statusController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/statusController.js
@@ -135,7 +135,7 @@ angular.module('calcentral.controllers').controller('StatusController', function
 
   var parseRegistrationCounts = function() {
     _.forEach($scope.regStatus.registrations, function(registration) {
-      if (registration.isSummer || !registration.positiveIndicators.S09) {
+      if (registration.isSummer || !registration.positiveIndicators.S09 || registration.academicCareer.code === 'UCBX') {
         return;
       }
       if (registration.summary !== 'Officially Registered') {

--- a/src/assets/templates/widgets/status_and_holds.html
+++ b/src/assets/templates/widgets/status_and_holds.html
@@ -4,12 +4,11 @@
   </div>
 
   <div class="cc-widget-padding">
-    <h3 class="cc-status-holds-status-header">Status</h3>
-
     <div data-cc-spinner-directive="regStatus.isLoading">
-      <div data-ng-if="(statusHoldsBlocks.enabledSections.indexOf('Status') !== -1) && !api.user.profile.roles.concurrentEnrollmentStudent">
+      <div data-ng-if="(statusHoldsBlocks.enabledSections.indexOf('Status') !== -1)">
+        <h3 class="cc-status-holds-status-header">Status</h3>
         <div class="cc-status-holds-section" data-ng-repeat="registration in regStatus.registrations | orderBy:'-id'">
-          <div data-ng-if="(registration.isLegacy || registration.positiveIndicators.S09) && !registration.pastEndOfInstruction">
+          <div data-ng-if="(registration.isLegacy || registration.positiveIndicators.S09) && !registration.pastEndOfInstruction && (registration.academicCareer.code !== 'UCBX')">
             <h4 data-ng-bind="registration.name"></h4>
             <ul class="cc-widget-list cc-status-holds-list" data-ng-if="api.user.profile.features.regstatus">
               <li class="cc-widget-list-hover"

--- a/src/assets/templates/widgets/status_popover.html
+++ b/src/assets/templates/widgets/status_popover.html
@@ -9,7 +9,7 @@
   <li class="cc-popover-item"
     data-ng-repeat="registration in regStatus.registrations | orderBy:'-id'"
     data-ng-if="api.user.profile.roles.student && api.user.profile.features.regstatus && !registration.isSummer &&
-      registration.summary !== 'Officially Registered' && registration.positiveIndicators.S09 && !registration.pastEndOfInstruction">
+      registration.summary !== 'Officially Registered' && registration.positiveIndicators.S09 && !registration.pastEndOfInstruction && registration.academicCareer.code !== 'UCBX'">
     <a href="/academics">
       <div class="cc-launcher-status-description">
         <i class="fa fa-exclamation-circle cc-icon-red"></i>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-24774

Notes for this PR:
* Since we are showing up to two terms (current and next), we need to enable the "Status" section to show if either of these terms are applicable to show registration status.  The changes in `$scope.$watchGroup` reflects this need.
* Uses term-specific career code "UCBX" to determine whether or not we should show that term's regstatus, which is more reliable due to possible conflicting `roles`.