### PR TITLE
SISRP-24125 - My Academics>[term name] - GPA Calculator (ID and add CS total-units-at-risk-in-letter-grade-attempts equivalent)

### DIFF
--- a/app/models/my_academics/college_and_level.rb
+++ b/app/models/my_academics/college_and_level.rb
@@ -27,30 +27,34 @@ module MyAcademics
 
     def bearfacts_college_and_level
       response = Bearfacts::Profile.new(user_id: @uid).get
-      feed = response.delete :feed
+      # response is a pointer to an obj in memory and should not be modified, other functions may need to use it later
+      result = response.clone
+      feed = result.delete :feed
       # The Bear Facts API can return empty profiles if the user is no longer (or not yet) considered an active student.
       # Partial profiles can be returned for incoming students around the start of the term.
       if (feed.nil? || feed['studentProfile']['studentGeneralProfile'].blank? || feed['studentProfile']['ugGradFlag'].blank?)
-        response[:empty] = true
+        result[:empty] = true
       else
-        response.merge! parse_bearfacts_feed(feed)
+        result.merge! parse_bearfacts_feed(feed)
       end
-      response
+      result
     end
 
     def hub_college_and_level
       response = HubEdos::AcademicStatus.new(user_id: @uid).get
-      if (status = parse_hub_academic_status response)
-        response[:careers] = parse_hub_careers status
-        response[:level] = parse_hub_level status
-        response[:termName] = parse_hub_term_name status
-        response[:termsInAttendance] = status['termsInAttendance'].to_s
-        response.merge! parse_hub_plans status
+      # response is a pointer to an obj in memory and should not be modified, other functions may need to use it later
+      result = response.clone
+      if (status = parse_hub_academic_status result)
+        result[:careers] = parse_hub_careers status
+        result[:level] = parse_hub_level status
+        result[:termName] = parse_hub_term_name status
+        result[:termsInAttendance] = status['termsInAttendance'].to_s
+        result.merge! parse_hub_plans status
       else
-        response[:empty] = true
+        result[:empty] = true
       end
-      response.delete(:feed)
-      response
+      result.delete(:feed)
+      result
     end
 
     def parse_hub_careers(status)

--- a/app/models/my_academics/gpa_units.rb
+++ b/app/models/my_academics/gpa_units.rb
@@ -18,9 +18,10 @@ module MyAcademics
 
     def hub_gpa_units
       response = HubEdos::AcademicStatus.new(user_id: @uid).get
-      # response is a pointer to an obj in memory and should not be modified, other functions may need to use it later
-      result = response.clone
-      if (status = parse_hub_academic_status result)
+      result = {}
+      #copy needed feilds from response obj
+      result[:errored] = response[:errored]
+      if (status = parse_hub_academic_status response)
         # GPA is passed as a string to force a decimal point for whole values.
         result[:cumulativeGpa] = (cumulativeGpa = parse_hub_cumulative_gpa status) && cumulativeGpa.to_s
         result[:totalUnits] = (totalUnits = parse_hub_total_units status) && totalUnits.to_f
@@ -28,7 +29,6 @@ module MyAcademics
       else
         result[:empty] = true
       end
-      result.delete(:feed)
       result
     end
 

--- a/app/models/my_academics/gpa_units.rb
+++ b/app/models/my_academics/gpa_units.rb
@@ -18,15 +18,18 @@ module MyAcademics
 
     def hub_gpa_units
       response = HubEdos::AcademicStatus.new(user_id: @uid).get
-      if (status = parse_hub_academic_status response)
+      # response is a pointer to an obj in memory and should not be modified, other functions may need to use it later
+      result = response.clone
+      if (status = parse_hub_academic_status result)
         # GPA is passed as a string to force a decimal point for whole values.
-        response[:cumulativeGpa] = (cumulativeGpa = parse_hub_cumulative_gpa status) && cumulativeGpa.to_s
-        response[:totalUnits] = (totalUnits = parse_hub_total_units status) && totalUnits.to_f
+        result[:cumulativeGpa] = (cumulativeGpa = parse_hub_cumulative_gpa status) && cumulativeGpa.to_s
+        result[:totalUnits] = (totalUnits = parse_hub_total_units status) && totalUnits.to_f
+        result[:totalUnitsAttempted] = (totalUnitsAttempted = parse_hub_total_units_attempted status) && totalUnitsAttempted.to_f
       else
-        response[:empty] = true
+        result[:empty] = true
       end
-      response.delete(:feed)
-      response
+      result.delete(:feed)
+      result
     end
 
     def parse_hub_cumulative_gpa(status)
@@ -36,6 +39,12 @@ module MyAcademics
     def parse_hub_total_units(status)
       if (units = status['cumulativeUnits']) && (total_units = units.find { |u| u['type'] && u['type']['code'] == 'Total'})
         total_units['unitsPassed']
+      end
+    end
+
+    def parse_hub_total_units_attempted(status)
+      if (units = status['cumulativeUnits']) && (total_units = units.find { |u| u['type'] && u['type']['code'] == 'For GPA'})
+        total_units['unitsTaken']
       end
     end
 

--- a/spec/models/my_academics/gpa_units_spec.rb
+++ b/spec/models/my_academics/gpa_units_spec.rb
@@ -50,6 +50,10 @@ describe 'MyAcademics::GpaUnits' do
       expect(feed[:gpaUnits][:totalUnits]).to eq 73
     end
 
+    it 'translates total units attempted' do
+      expect(feed[:gpaUnits][:totalUnitsAttempted]).to eq 8
+    end
+
     context 'empty status feed' do
       before { status_proxy.set_response(status: 200, body: '{}') }
       it 'reports empty' do


### PR DESCRIPTION
bug fix where I cloned the response obj to be changed in the college_and_level rather than the response obj being changed itself which led to a bug downstream when response was being referenced by the hub_gpa_units module.

followed API spec for pulling the equivalent of "totalUnitsAttempted" field from CS similar to what was provided by legacy 