### PR TITLE
NOJIRA Additional logging to help production support & bug investigation

### DIFF
--- a/app/models/calnet_ldap/client.rb
+++ b/app/models/calnet_ldap/client.rb
@@ -88,9 +88,10 @@ module CalnetLdap
       ActiveSupport::Notifications.instrument('proxy', {class: self.class, search: args}) do
         response = @ldap.search args
         if response.nil?
-          logger.error "LDAP error returned: #{@ldap.get_operation_result}"
+          logger.error "LDAP search with args #{args} returned: #{@ldap.get_operation_result}"
           []
         else
+          logger.debug "LDAP search with args #{args} returned: #{response}"
           response
         end
       end

--- a/app/models/user/api.rb
+++ b/app/models/user/api.rb
@@ -146,6 +146,7 @@ module User
       has_student_history = User::HasStudentHistory.new(@uid).has_student_history?
       has_instructor_history = User::HasInstructorHistory.new(@uid).has_instructor_history?
       roles = @user_attributes[:roles]
+      logger.warn "UID #{@uid} has active student role but no CS ID" if @user_attributes[:campusSolutionsId].blank? && roles[:student] && !Berkeley::Terms.fetch.current.legacy?
       can_view_academics = has_academics_tab?(roles, has_instructor_history, has_student_history)
       directly_authenticated = authentication_state.directly_authenticated?
       # This tangled logic is a historical artifact of divergent approaches to View-As and LTI-based authentication.


### PR DESCRIPTION
* @redconfetti suggested it was time to start noticing when supposedly active students don't have a Campus Solutions ID, & I agree with him.
* DEBUG-level logging of raw responses from most upstream APIs is invaluable when investigating issues or generating tests, but our CalNet LDAP client missed that step.