### PR TITLE
[QA] CLC-6440 When LDAP 'mail' attribute is missing, fall back to berkeleyEduOfficialEmail

### DIFF
--- a/app/models/user/parser.rb
+++ b/app/models/user/parser.rb
@@ -11,7 +11,7 @@ module User
       group_roles = Berkeley::UserRoles.roles_from_ldap_groups(ldap_record[:berkeleyeduismemberof], !!affiliation_roles[:exStudent])
       roles = group_roles.merge affiliation_roles
       {
-        email_address: string_attribute(ldap_record, :mail),
+        email_address: string_attribute(ldap_record, :mail) || string_attribute(ldap_record, :berkeleyeduofficialemail),
         first_name: string_attribute(ldap_record, :berkeleyEduFirstName) || string_attribute(ldap_record, :givenname),
         last_name: string_attribute(ldap_record, :berkeleyEduLastName) || string_attribute(ldap_record, :sn),
         ldap_uid: string_attribute(ldap_record, :uid),

--- a/spec/models/calnet_ldap/user_attributes_spec.rb
+++ b/spec/models/calnet_ldap/user_attributes_spec.rb
@@ -103,6 +103,13 @@ describe CalnetLdap::UserAttributes do
         expect(feed[:roles][:staff]).to eq true
       end
     end
+
+    context 'when LDAP query returns no mail attribute' do
+      before { ldap_result.delete :mail }
+      it 'falls back to berkeleyeduofficialemail' do
+        expect(feed[:email_address]).to eq 'oski_bearable@berkeley.edu'
+      end
+    end
   end
 
   context 'test user from real LDAP connection', testext: true do


### PR DESCRIPTION
QA-first PR for https://jira.ets.berkeley.edu/jira/browse/CLC-6440.