### PR TITLE
SISRP-25322 - My Academics - Profile Card - Expected Graduation - Displaying as "2016 Fall" instead of "Fall 2016"

### DIFF
--- a/app/models/my_academics/college_and_level.rb
+++ b/app/models/my_academics/college_and_level.rb
@@ -47,7 +47,7 @@ module MyAcademics
       if (status = parse_hub_academic_status result)
         result[:careers] = parse_hub_careers status
         result[:level] = parse_hub_level status
-        result[:termName] = parse_hub_term_name status
+        result[:termName] = parse_hub_term_name(status['currentRegistration'].try(:[], 'term')).try(:[], 'name')
         result[:termsInAttendance] = status['termsInAttendance'].to_s
         result.merge! parse_hub_plans status
       else
@@ -96,7 +96,7 @@ module MyAcademics
             plans << {
               code: plan_code,
               primary: plan_primary,
-              expectedGraduationTerm: student_plan['expectedGraduationTerm']
+              expectedGraduationTerm: parse_hub_term_name(student_plan['expectedGraduationTerm']),
             }
             grad_terms << student_plan['expectedGraduationTerm']
           end
@@ -107,12 +107,15 @@ module MyAcademics
         majors: majors,
         minors: minors,
         plans: plans,
-        lastExpectedGraduationTerm: last_grad_term.try(:[], 'name'),
+        lastExpectedGraduationTerm: parse_hub_term_name(last_grad_term).try(:[], 'name'),
       }
     end
 
-    def parse_hub_term_name(status)
-      Berkeley::TermCodes.normalized_english status['currentRegistration'].try(:[], 'term').try(:[], 'name')
+    def parse_hub_term_name(term)
+      if term
+        term['name'] = Berkeley::TermCodes.normalized_english term.try(:[], 'name')
+      end
+      term
     end
 
     def parse_bearfacts_feed(feed)

--- a/spec/models/my_academics/college_and_level_spec.rb
+++ b/spec/models/my_academics/college_and_level_spec.rb
@@ -110,7 +110,7 @@ describe MyAcademics::CollegeAndLevel do
             :primary => true,
             :expectedGraduationTerm => {
               "id" => "2202",
-              "name" => "2020 Spring"
+              "name" => "Spring 2020"
             }
           },
           {
@@ -128,7 +128,7 @@ describe MyAcademics::CollegeAndLevel do
     end
 
     it 'includes the farthest graduation term available from all plans' do
-      expect(feed[:collegeAndLevel][:lastExpectedGraduationTerm]).to eq '2020 Spring'
+      expect(feed[:collegeAndLevel][:lastExpectedGraduationTerm]).to eq 'Spring 2020'
     end
 
     it 'specifies term name' do


### PR DESCRIPTION
Code change addresses 2 jiras:

- https://jira.berkeley.edu/browse/SISRP-25322
- https://jira.berkeley.edu/browse/SISRP-25324   