### PR TITLE
SISRP-15935 Remove extra current field in exams

### DIFF
--- a/app/models/my_academics/exams.rb
+++ b/app/models/my_academics/exams.rb
@@ -28,7 +28,6 @@ module MyAcademics
           term: semester[:termCode],
           term_year: semester[:termYear],
           courses: courses,
-          curr: (semester[:timeBucket] == 'current'),
           timeBucket: semester[:timeBucket],
           slug: semester[:slug]
         }
@@ -69,7 +68,7 @@ module MyAcademics
         sort_exams(semester)
       end
       # sort by semester, current first
-      academics_data.sort_by{|semester| semester[:curr] ? 0 : 1 }
+      academics_data.sort_by{|semester| semester[:timeBucket] == 'current' ? 0 : 1 }
     end
 
     # Groups exams by exam_slot for conflicts, then sorts by exam_slot for each semester

--- a/public/dummy/json/academics_interim_two_sets_conflicts.json
+++ b/public/dummy/json/academics_interim_two_sets_conflicts.json
@@ -811,7 +811,6 @@
       "name": "Fall 2016",
       "term": "D",
       "term_year": "2016",
-      "curr": true,
       "time_bucket": "current",
       "exams": {
         "5": [

--- a/spec/models/my_academics/exams_spec.rb
+++ b/spec/models/my_academics/exams_spec.rb
@@ -245,7 +245,7 @@ describe MyAcademics::Exams do
   let(:fall_2016_semester_after_parsed) do
     {
       :cs_data_available => false,:name => 'Fall 2016',:term => 'D',
-      :term_year => '2016',:curr => false,:timeBucket => 'future',:slug=>'fall-2016',
+      :term_year => '2016',:timeBucket => 'future',:slug=>'fall-2016',
       :courses => [
         ug_class_time,
         ug_course_exception,
@@ -259,7 +259,7 @@ describe MyAcademics::Exams do
   let(:spring_2016_semester_after_parsed) do
     {
       :cs_data_available => true,:name => 'Spring 2016',:term => 'B',
-      :term_year => '2016',:curr => true,:timeBucket => 'current',:slug=>'spring-2016',
+      :term_year => '2016',:timeBucket => 'current',:slug=>'spring-2016',
       :courses => [
         cs_class,
         # the following exams aren't directly a result of parse_academic_data
@@ -396,7 +396,7 @@ describe MyAcademics::Exams do
     context 'with classes and no exams as cs data is populated' do
       let(:feed_after_parse_academic_data) do
         [{
-          :cs_data_available => true,:name => 'Fall 2016',:term => 'D',:term_year => '2016',:curr => false,:timeBucket => 'future',
+          :cs_data_available => true,:name => 'Fall 2016',:term => 'D',:term_year => '2016',:timeBucket => 'future',
           :courses => [ug_class_time,ug_course_exception,waitlisted_class]
         }]
       end


### PR DESCRIPTION
Follow up to https://jira.berkeley.edu/browse/SISRP-15935, remove the "curr" field to declutter the examSchedules field.

Previous PR: https://github.com/ets-berkeley-edu/calcentral/pull/5833