### PR TITLE
[ QA ] SISRP-24502 - CalCentral prod: FATAL TypeError (can't convert nil into String) at campus_solutions/link.rb:47: 'get_url'

### DIFF
--- a/app/models/campus_solutions/link.rb
+++ b/app/models/campus_solutions/link.rb
@@ -42,34 +42,40 @@ module CampusSolutions
         if entry
           link = entry.slice(:url, :urlId, :description, :comments)
 
-          if placeholders.present?
-            placeholders.each do |k, v|
+          placeholders.try(:each) do |k, v|
+            if v.blank?
+              logger.error "Could not set placeholder for #{k} on link with url_id #{link[:urlId]}"
+              link = nil
+              break
+            else
               link[:url] = link[:url].gsub("{#{k}}", v)
             end
           end
 
-          # promote properties we're interested in
-          entry[:properties].each do |property|
-            if property[:name] == 'NEW_WINDOW' && property[:value] == 'Y'
-              link[:showNewWindow] = true
+          if !link.blank?
+            # promote properties we're interested in
+            entry[:properties].each do |property|
+              if property[:name] == 'NEW_WINDOW' && property[:value] == 'Y'
+                link[:showNewWindow] = true
+              end
+              if property[:name] == 'UCFROM'
+                link[:ucFrom] = property[:value]
+              end
+              if property[:name] == 'UCFROMLINK'
+                link[:ucFromLink] = property[:value]
+              end
+              if property[:name] == 'UCFROMTEXT'
+                link[:ucFromText] = property[:value]
+              end
             end
-            if property[:name] == 'UCFROM'
-              link[:ucFrom] = property[:value]
-            end
-            if property[:name] == 'UCFROMLINK'
-              link[:ucFromLink] = property[:value]
-            end
-            if property[:name] == 'UCFROMTEXT'
-              link[:ucFromText] = property[:value]
-            end
-          end
 
-          # convert campus solutions property names to calcentral
-          link[:name] = link.delete(:description)
-          link[:title] = link.delete(:comments)
-          if !link[:showNewWindow]
-            link[:isCsLink] = true
-            link['IS_CS_LINK'] = true
+            # convert campus solutions property names to calcentral
+            link[:name] = link.delete(:description)
+            link[:title] = link.delete(:comments)
+            if !link[:showNewWindow]
+              link[:isCsLink] = true
+              link['IS_CS_LINK'] = true
+            end
           end
         end
       end

--- a/spec/models/campus_solutions/link_spec.rb
+++ b/spec/models/campus_solutions/link_spec.rb
@@ -17,6 +17,7 @@ describe CampusSolutions::Link do
 
     let(:link_set_response) { proxy.get }
     let(:link_get_url_response) { proxy.get_url(url_id) }
+    let(:link_get_url_with_bad_placeholder_response) { proxy.get_url(url_id, {:BAD_PLACEHOLDER => nil}) }
     let(:link_get_url_and_replace_placeholders_response) { proxy.get_url(url_id, placeholders) }
     let(:link_get_url_for_properties_response) { proxy.get_url(url_id_for_properties) }
 
@@ -66,7 +67,16 @@ describe CampusSolutions::Link do
       end
     end
 
-    context 'replaces any placeholders' do
+    context 'returns empty link when a placeholder value is blank' do
+      let(:filename) { 'link_api.xml' }
+
+      it_should_behave_like 'a proxy that gets data'
+      it 'returns data with the expected structure' do
+        expect(link_get_url_with_bad_placeholder_response[:feed][:link]).not_to be
+      end
+    end
+
+    context 'replaces matching placeholders' do
       let(:filename) { 'link_api_multiple.xml' }
 
       it_should_behave_like 'a proxy that gets data'

--- a/src/assets/javascripts/angular/controllers/widgets/studentResourcesController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/studentResourcesController.js
@@ -4,7 +4,6 @@ var angular = require('angular');
 var _ = require('lodash');
 
 angular.module('calcentral.controllers').controller('StudentResourcesController', function(studentResourcesFactory, userService, $scope) {
-  $scope.studentResources = {};
   $scope.isLoading = true;
 
   var loadStudentResources = function() {
@@ -13,7 +12,9 @@ angular.module('calcentral.controllers').controller('StudentResourcesController'
 
   var parseStudentResources = function(data) {
     var resources = _.get(data, 'data.feed.resources');
-    angular.extend($scope.studentResources, resources);
+    if (!_.isEmpty(resources)) {
+      $scope.studentResources = resources;
+    }
   };
 
   // Identify Law students to suppress withdrawal link

--- a/src/assets/templates/widgets/student_resources.html
+++ b/src/assets/templates/widgets/student_resources.html
@@ -3,7 +3,10 @@
     <h2>Student Resources</h2>
   </div>
   <div data-cc-spinner-directive="isLoading">
-    <div class="cc-widget-padding">
+    <div class="cc-widget-padding" data-ng-if="!studentResources">
+      Resource links unavailable.
+    </div>
+    <div class="cc-widget-padding" data-ng-if="studentResources">
       <h3>General Forms</h3>
       <ul class="cc-list-bullets">
         <li data-ng-if="studentResources.changeOfAcademicPlanAdd.url">


### PR DESCRIPTION
Master PR https://github.com/ets-berkeley-edu/calcentral/pull/5871

Main jira: https://jira.berkeley.edu/browse/SISRP-24502
Addresses the TypeError messages.

Realized too late I included the fix to this related jira: https://jira.berkeley.edu/browse/SISRP-24174
Addresses infinite spinner on student resources. 