### PR TITLE
SISRP-24500 - CalCentral prod is calling /api/eft_status?studentId= w…

### DIFF
--- a/app/models/bearfacts/proxy.rb
+++ b/app/models/bearfacts/proxy.rb
@@ -23,7 +23,7 @@ module Bearfacts
     end
 
     def get
-      return {} unless legacy_student?
+      return {} unless has_legacy_data?
       raw_response = self.class.smart_fetch_from_cache({id: instance_key, user_message_on_exception: 'Remote server unreachable'}) do
         request_internal(request_path, request_params)
       end

--- a/app/models/bearfacts/regblocks.rb
+++ b/app/models/bearfacts/regblocks.rb
@@ -3,7 +3,7 @@ module Bearfacts
     include DatedFeed
 
     def get
-      return {} unless legacy_student? && Settings.features.legacy_regblocks
+      return {} unless has_legacy_data? && Settings.features.legacy_regblocks
       response = super
       feed = response.delete :feed
       return response if feed.blank?

--- a/app/models/eft/my_eft_enrollment.rb
+++ b/app/models/eft/my_eft_enrollment.rb
@@ -27,7 +27,7 @@ module Eft
     end
 
     def get_feed_internal
-      return {} unless Settings.features.cs_billing
+      return {} if @campus_solutions_id.nil? || !Settings.features.cs_billing
       get_parsed_response
     end
 

--- a/app/models/hub_edos/user_attributes.rb
+++ b/app/models/hub_edos/user_attributes.rb
@@ -29,7 +29,7 @@ module HubEdos
       @campus_solutions_id = lookup_campus_solutions_id
       result[:campus_solutions_id] = @campus_solutions_id
 
-      result[:is_legacy_student] = legacy_student?(@campus_solutions_id) || result[:legacy_student_id]
+      result[:is_legacy_student] = has_legacy_data?(@campus_solutions_id) || result[:legacy_student_id]
     end
 
     def get_edo

--- a/app/models/my_academics/gpa_units.rb
+++ b/app/models/my_academics/gpa_units.rb
@@ -7,7 +7,7 @@ module MyAcademics
     def merge(data)
       gpa = hub_gpa_units
       prefer_legacy_data = Settings.features.cs_academic_profile_prefers_legacy
-      if (current_term.legacy? || prefer_legacy_data) && legacy_student?
+      if (current_term.legacy? || prefer_legacy_data) && has_legacy_data?
         legacy_gpa = oracle_gpa_units
         if gpa[:empty] || (prefer_legacy_data && !legacy_gpa[:empty])
           gpa = legacy_gpa

--- a/app/models/my_academics/regblocks.rb
+++ b/app/models/my_academics/regblocks.rb
@@ -7,7 +7,7 @@ module MyAcademics
 
     def merge(data)
       # TODO Remove by Fall 2016.
-      return unless legacy_student? && current_term.legacy?
+      return unless has_legacy_data? && current_term.legacy?
       data[:regblocks] = Bearfacts::Regblocks.new({user_id: @uid}).get
     end
   end

--- a/app/models/my_academics/requirements.rb
+++ b/app/models/my_academics/requirements.rb
@@ -6,7 +6,7 @@ module MyAcademics
 
     def merge(data)
       # TODO Replace or remove by Fall 2016.
-      return unless legacy_student? && current_term.legacy?
+      return unless has_legacy_data? && current_term.legacy?
       feed = Bearfacts::Profile.new({:user_id => @uid}).get[:feed]
       return if feed.nil?
 

--- a/app/models/my_academics/transition_term.rb
+++ b/app/models/my_academics/transition_term.rb
@@ -26,7 +26,7 @@ module MyAcademics
     # It is displayed in My Academics / Status, Holds, and Blocks and in the Status popover.
     def regstatus_feed
       # TODO LEGACY ONLY! Must be replaced before Settings.terms.legacy_cutoff.
-      if legacy_student?
+      if has_legacy_data?
         response = Regstatus::Proxy.new(user_id: @uid).get
         if response && response[:feed] && (reg_status = response[:feed]['regStatus'])
           {

--- a/app/models/user/student.rb
+++ b/app/models/user/student.rb
@@ -20,7 +20,7 @@ module User
       CalnetCrosswalk::ByUid.new(user_id: @uid).lookup_delegate_user_id
     end
 
-    def legacy_student?(id = nil)
+    def has_legacy_data?(id = nil)
       if (test_id = id || campus_solutions_id || lookup_student_id)
         test_id.to_s.length < 10
       else

--- a/spec/models/user/student_spec.rb
+++ b/spec/models/user/student_spec.rb
@@ -29,7 +29,7 @@ describe User::Student do
   end
 
   context 'legacy student check' do
-    subject { StudentTestClass.new(double(fake: true), user_id: uid).legacy_student? }
+    subject { StudentTestClass.new(double(fake: true), user_id: uid).has_legacy_data? }
     let(:legacy_id) { '12345678' }
     let(:cs_id) { '9876543210' }
     before do


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-24500

Just added a check not to call the eft_enrolment for legacy students. I am assuming that there is no alternative for this data from non-CS sources and thus returning empty data for legacy students is sufficient. 