### PR TITLE
SISRP-25121 Reduce caching load of MyGroups

### DIFF
--- a/app/models/my_groups/merged.rb
+++ b/app/models/my_groups/merged.rb
@@ -1,9 +1,7 @@
 module MyGroups
   class Merged < UserSpecificModel
-
-    include Cache::LiveUpdatesEnabled
-    include Cache::FreshenOnWarm
-    include Cache::JsonAddedCacher
+    include Cache::CachedFeed
+    include Cache::UserCacheExpiry
     include Cache::FilterJsonOutput
     include MergedModel
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -245,7 +245,6 @@ cache:
     MyBadges::Merged: NEXT_00_00
     MyCampusLinksController: NEXT_08_00
     MyClasses::Merged: NEXT_08_00
-    MyGroups::Merged: NEXT_08_00
     MyTasks::Merged: <%= 10.minutes %>
     UpNext::MyUpNext: NEXT_00_00
     User::Api: NEXT_08_00

--- a/public/dummy/json/groups.json
+++ b/public/dummy/json/groups.json
@@ -16,13 +16,5 @@
       "siteType": "course",
       "role": "teacher"
     }
-  ],
-  "lastModified": {
-    "hash": "af8f7132a5d2efdf8bd3d88c2d1fa5d37086c389",
-    "timestamp": {
-      "epoch": 1383947240,
-      "dateTime": "2013-11-08T13:47:20-08:00",
-      "dateString": "11/08"
-    }
-  }
+  ]
 }

--- a/src/assets/javascripts/angular/services/updatedFeedsService.js
+++ b/src/assets/javascripts/angular/services/updatedFeedsService.js
@@ -16,7 +16,6 @@ angular.module('calcentral.services').service('updatedFeedsService', function($h
     'MyActivities::Merged',
     'MyBadges::Merged',
     'MyClasses::Merged',
-    'MyGroups::Merged',
     'MyTasks::Merged',
     'UpNext::MyUpNext'
   ];


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-25121

First of about a half-dozen cache structure changes to reduce load.

Removed LiveUpdatesEnabled because the "My Groups" feed is not volatile or important enough to require an update every 2 minutes.

Removed JsonAddedCacher because the feed's not long and complex enough to benefit from cached JSON, and it's referred to from another class on the server side.