### PR TITLE
SISRP-25716 CalCentral landing page throws TypeError: Cannot set prop…

### DIFF
--- a/src/assets/templates/widgets/gear_popover.html
+++ b/src/assets/templates/widgets/gear_popover.html
@@ -4,7 +4,7 @@
   data-ng-class="{true:'cc-header-icon-selected'}[api.popover.status('cc-popover-menu')]"
   title="Settings">
     <div class="cc-flex cc-flex-align-center">
-      <span data-ng-if="!photo.loadError" class="cc-popover-gear-round-profile cc-popover-gear-round-profile-has-photo">
+      <span data-ng-if="!photo.loadError && api.user.events.isAuthenticated" class="cc-popover-gear-round-profile cc-popover-gear-round-profile-has-photo">
         <img data-cc-load-error-directive="photo" class="cc-visuallyhidden" data-ng-src="/api/my/photo">
       </span>
       <span data-ng-if="photo.loadError" class="cc-popover-gear-round-profile cc-popover-gear-round-profile-bear-photo"></span>


### PR DESCRIPTION
…erty 'loadError' of undefined
Even though the header HTML is visually hidden on the login page, the image tags still try to request and load images. This was the case for the gear_popover.html widget. This created an error on the page. Simply added condition not to display if user is not authenticated yet, this is the same condition to display the entire widget. 