### PR TITLE
SISRP-25121 Reduce caching load of MyAcademics

### DIFF
--- a/app/controllers/advising_student_controller.rb
+++ b/app/controllers/advising_student_controller.rb
@@ -20,7 +20,7 @@ class AdvisingStudentController < ApplicationController
   end
 
   def academics
-    render json: filtered_academics.to_json
+    render json: MyAcademics::FilteredForAdvisor.from_session('user_id' => student_uid_param).get_feed_as_json
   end
 
   def academic_status
@@ -57,27 +57,6 @@ class AdvisingStudentController < ApplicationController
   end
 
   private
-
-  def filtered_academics
-    feed = MyAcademics::Merged.from_session('user_id' => student_uid_param).get_feed
-    if (semesters = feed[:semesters])
-      semesters.each do |s|
-        s.delete :slug
-        (classes = s[:classes]) && classes.each do |c|
-          c.delete :slug
-          c.delete :url
-          (sections = c[:sections]) && sections.each do |section|
-            section.delete :url
-          end
-        end
-      end
-    end
-    (memberships = feed[:otherSiteMemberships]) && memberships.each do |membership|
-      membership.delete :slug
-      membership[:sites].each { |site| site.delete :site_url } if membership[:sites]
-    end
-    feed
-  end
 
   def authorize_for_student
     raise NotAuthorizedError.new('The student lookup feature is disabled') unless is_feature_enabled

--- a/app/controllers/my_academics_controller.rb
+++ b/app/controllers/my_academics_controller.rb
@@ -6,6 +6,8 @@ class MyAcademicsController < ApplicationController
   def get_feed
     if current_user.authenticated_as_delegate?
       render json: MyAcademics::FilteredForDelegate.from_session(session).get_feed_as_json
+    elsif current_user.authenticated_as_advisor?
+      render json: MyAcademics::FilteredForAdvisor.from_session(session).get_feed_as_json
     else
       render json: MyAcademics::Merged.from_session(session).get_feed_as_json
     end

--- a/app/models/canvas_csv/provide_course_site.rb
+++ b/app/models/canvas_csv/provide_course_site.rb
@@ -253,11 +253,10 @@ module CanvasCsv
         # Get all sections for which this user is an instructor, sorted in a useful fashion.
         # Since this mostly matches what's shown by MyAcademics::Teaching for a given semester,
         # we can simply re-use the academics feed (so long as course site provisioning is restricted to
-        # semesters supported by My Academics). Ideally, MyAcademics::Teaching would be efficiently cached
-        # by user_id + term_yr + term_cd. But since we currently only cache at the level of the full
-        # merged model, we're probably better off selecting the desired teaching-semester from that bigger feed.
+        # semesters supported by My Academics).
         semesters = []
-        academics_feed = MyAcademics::Merged.new(@uid).get_feed
+        academics_feed = {}
+        MyAcademics::Teaching.new(@uid).merge academics_feed
         if (teaching_semesters = academics_feed[:teachingSemesters])
           current_terms.each do |term|
             if (teaching_semester = teaching_semesters.find {|semester| semester[:slug] == term[:slug]})

--- a/app/models/my_academics/filtered_for_advisor.rb
+++ b/app/models/my_academics/filtered_for_advisor.rb
@@ -1,23 +1,18 @@
 module MyAcademics
-  class Merged < UserSpecificModel
+  class FilteredForAdvisor < UserSpecificModel
     include Cache::CachedFeed
-    include Cache::UserCacheExpiry
     include Cache::JsonifiedFeed
     include MergedModel
 
+    # Advisors do not see Teaching or Course Website (aka CanvasSites) data.
     def self.providers
-      # Provider ordering is significant! Semesters/Teaching must be merged before course sites.
-      # CollegeAndLevel must be merged before TransitionTerm.
-      # All current providers draw from separately cached sources.
       [
         CollegeAndLevel,
         TransitionTerm,
         GpaUnits,
         Requirements,
         Semesters,
-        Teaching,
-        Exams,
-        CanvasSites
+        Exams
       ]
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -240,7 +240,7 @@ cache:
     Cache::FeedUpdateWhiteboard: <%= 5.minutes %>
     LiveUpdatesWarmer: <%= 4.minutes %>
     BackgroundJobsCheck: <%= 29.days %>
-    MyAcademics::Merged: NEXT_08_00
+    MyAcademics::Merged: <%= 15.minutes %>
     MyActivities::Merged: <%= 10.minutes %>
     MyBadges::Merged: <%= 2.hours %>
     MyCampusLinksController: NEXT_08_00
@@ -270,6 +270,9 @@ cache:
 
     CampusOracle::CourseSections: NEXT_08_00
     CampusOracle::UserAttributes: NEXT_08_00
+    CampusOracle::UserCourses::All: NEXT_08_00
+
+    EdoOracle::UserCourses::All: <%= 8.hours %>
 
     Canvas::MergedUserSites: <%= 30.minutes %>
     Canvas::UserCourses: <%= 30.minutes %>

--- a/spec/controllers/my_academics_controller_spec.rb
+++ b/spec/controllers/my_academics_controller_spec.rb
@@ -22,7 +22,6 @@ describe MyAcademicsController do
     end
     context 'normal user session' do
       it 'should get a feed full of content' do
-        expect(subject['feedName']).to eq 'MyAcademics::Merged'
         expect(subject['gpaUnits']).to include 'cumulativeGpa'
         expect(subject['otherSiteMemberships']).to be_present
         expect(subject['requirements']).to be_present
@@ -36,7 +35,6 @@ describe MyAcademicsController do
       include_context 'advisor view-as'
       it 'filters bCourses sites' do
         expect(subject['otherSiteMemberships']).to be_blank
-        expect(subject['feedName']).to eq 'MyAcademics::Merged'
         expect(subject['gpaUnits']).to include 'cumulativeGpa'
         expect(subject['requirements']).to be_present
         expect(subject['semesters']).to have(24).items

--- a/spec/models/canvas_csv/provide_course_site_spec.rb
+++ b/spec/models/canvas_csv/provide_course_site_spec.rb
@@ -624,7 +624,9 @@ describe CanvasCsv::ProvideCourseSite do
         ]
       }
       allow(subject).to receive(:current_terms).and_return(current_terms)
-      allow_any_instance_of(MyAcademics::Merged).to receive(:get_feed).and_return(fake_feed)
+      allow_any_instance_of(MyAcademics::Teaching).to receive(:merge) do |data|
+        data.merge! fake_feed
+      end
       result = subject.candidate_courses_list
       expect(result).to be_a Array
       expect(result.count).to eq 2

--- a/spec/models/my_academics/filtered_for_advisor_spec.rb
+++ b/spec/models/my_academics/filtered_for_advisor_spec.rb
@@ -1,0 +1,24 @@
+describe MyAcademics::FilteredForAdvisor do
+  before do
+    MyAcademics::Merged.providers.each do |provider_class|
+      provider = double
+      allow(provider).to receive(:merge) do |feed|
+        feed[provider_class.to_s] = true
+      end
+      allow(provider_class).to receive(:new).and_return provider
+    end
+  end
+  it 'only includes a subset of providers' do
+    unfiltered_provider_classes = MyAcademics::Merged.providers
+    filtered_provider_classes = MyAcademics::FilteredForAdvisor.providers
+    expect(filtered_provider_classes.length).to be < unfiltered_provider_classes.length
+    verboten_provider_classes = unfiltered_provider_classes - filtered_provider_classes
+    feed = JSON.parse described_class.new(random_id).get_feed_as_json
+    filtered_provider_classes.map do |provider_class|
+      expect(feed[provider_class.to_s]).to eq true
+    end
+    verboten_provider_classes.map do |provider_class|
+      expect(feed[provider_class.to_s]).to be_nil
+    end
+  end
+end

--- a/spec/models/my_academics/merged_spec.rb
+++ b/spec/models/my_academics/merged_spec.rb
@@ -38,7 +38,7 @@ describe MyAcademics::Merged do
     before { set_mock_merge oski_providers }
 
     it 'should merge all providers into hash' do
-      feed = described_class.new(uid).get_feed
+      feed = described_class.new(uid).get_feed_internal
       provider_classes.each { |provider_class| expect(feed[provider_class.to_s]).to eq true }
       expect(feed[:errors]).to be_blank
     end
@@ -53,26 +53,11 @@ describe MyAcademics::Merged do
 
     it 'should merge other providers and report error' do
       expect(Rails.logger).to receive(:error).with /Failed to merge MyAcademics::Exams for UID #{uid}: NoMethodError/
-      feed = described_class.new(uid).get_feed
+      feed = described_class.new(uid).get_feed_internal
       well_behaved_classes = provider_classes - [MyAcademics::Exams]
       well_behaved_classes.each { |well_behaved_class| expect(feed[well_behaved_class.to_s]).to eq true }
       expect(feed).not_to include 'MyAcademics::Exams'
       expect(feed[:errors]).to eq ['MyAcademics::Exams']
-    end
-  end
-
-  describe '#filter_course_sites' do
-    let(:full_feed) {HashConverter.symbolize JSON.parse(File.read(Rails.root.join('public/dummy/json/academics.json')))}
-    it 'includes bCourses sites in a full feed' do
-      expect(full_feed[:semesters][1][:classes][2][:class_sites].index {|c| c[:emitter] == 'bCourses'}).to_not be_nil
-      expect(full_feed[:teachingSemesters][0][:classes][0][:class_sites].index {|c| c[:emitter] == 'bCourses'}).to_not be_nil
-      expect(full_feed[:otherSiteMemberships][0][:sites].index {|c| c[:emitter] == 'bCourses'}).to_not be_nil
-    end
-    it 'removes course sites from the full feed' do
-      feed = described_class.new(uid).filter_course_sites full_feed
-      expect(feed[:semesters][1][:classes][2][:class_sites]).to be_blank
-      expect(feed[:teachingSemesters][0][:classes][0][:class_sites]).to be_blank
-      expect(feed[:otherSiteMemberships]).to be_blank
     end
   end
 end

--- a/src/assets/templates/academics_semesters.html
+++ b/src/assets/templates/academics_semesters.html
@@ -21,10 +21,10 @@
   <div class="cc-widget-padding cc-flex-space-between-vertical-15">
     <div class="cc-table cc-academics-semester cc-academics-semester-{{semester.timeBucket}}" data-ng-repeat="semester in semesters | limitTo:pastSemestersLimit">
       <div>
-        <h3 data-ng-if="semester.hasEnrollmentData && semester.slug"><a class="cc-left" data-ng-href="/academics/semester/{{semester.slug}}" data-ng-bind="semester.name"></a></h3>
-        <h3 data-ng-if="!semester.hasEnrollmentData || !semester.slug" data-ng-bind="semester.name"></h3>
+        <h3 data-ng-if="semester.hasEnrollmentData && semester.slug && !isAdvisingStudentLookup"><a class="cc-left" data-ng-href="/academics/semester/{{semester.slug}}" data-ng-bind="semester.name"></a></h3>
+        <h3 data-ng-if="!semester.hasEnrollmentData || !semester.slug || isAdvisingStudentLookup" data-ng-bind="semester.name"></h3>
         <h4 data-ng-if="semester.notation" data-ng-bind="semester.notation"></h4>
-        <a class="cc-right cc-academics-semester-title-link" data-ng-href="/academics/booklist/{{semester.slug}}" data-ng-if="semester.hasEnrollmentData && semester.slug && semester.timeBucket !== 'past'">Book List</a>
+        <a class="cc-right cc-academics-semester-title-link" data-ng-href="/academics/booklist/{{semester.slug}}" data-ng-if="semester.hasEnrollmentData && semester.slug && semester.timeBucket !== 'past'  && !isAdvisingStudentLookup">Book List</a>
         <table>
           <thead>
             <tr>
@@ -37,25 +37,25 @@
           </thead>
           <tbody data-ng-if="!semester.summaryFromTranscript" data-ng-repeat="class in semester.classes">
             <tr data-ng-repeat="section in class.sections" data-ng-if="section.is_primary_section && !section.waitlisted">
-              <td data-ng-if="class.multiplePrimaries && section.url"><a data-ng-href="{{section.url}}" data-ng-bind-template="{{class.course_code}} {{section.section_label}}"></a></td>
-              <td data-ng-if="class.multiplePrimaries && !section.url" data-ng-bind-template="{{class.course_code}} {{section.section_label}}"></td>
-              <td data-ng-if="!class.multiplePrimaries && class.url"><a data-ng-href="{{class.url}}" data-ng-bind="class.course_code"></a></td>
-              <td data-ng-if="!class.multiplePrimaries && !class.url" data-ng-bind="class.course_code"></td>
+              <td data-ng-if="class.multiplePrimaries && section.url && !isAdvisingStudentLookup"><a data-ng-href="{{section.url}}" data-ng-bind-template="{{class.course_code}} {{section.section_label}}"></a></td>
+              <td data-ng-if="class.multiplePrimaries && (!section.url || isAdvisingStudentLookup)" data-ng-bind-template="{{class.course_code}} {{section.section_label}}"></td>
+              <td data-ng-if="!class.multiplePrimaries && class.url && !isAdvisingStudentLookup"><a data-ng-href="{{class.url}}" data-ng-bind="class.course_code"></a></td>
+              <td data-ng-if="!class.multiplePrimaries && (!class.url || isAdvisingStudentLookup)" data-ng-bind="class.course_code"></td>
               <td data-ng-bind="class.title"></td>
               <td data-ng-bind="section.units | number:1" class="cc-table-right"></td>
             </tr>
           </tbody>
           <tbody data-ng-if="semester.summaryFromTranscript" data-ng-repeat="class in semester.classes">
             <tr data-ng-if="class.transcript" data-ng-repeat="transcript in class.transcript">
-              <td data-ng-if="class.url"><a data-ng-href="{{class.url}}" data-ng-bind="class.course_code"></a>
-              <td data-ng-if="!class.url" data-ng-bind="class.course_code"></td>
+              <td data-ng-if="class.url && !isAdvisingStudentLookup"><a data-ng-href="{{class.url}}" data-ng-bind="class.course_code"></a>
+              <td data-ng-if="!class.url || isAdvisingStudentLookup" data-ng-bind="class.course_code"></td>
               <td data-ng-bind="class.title"></td>
               <td data-ng-bind="transcript.units | number:1" class="cc-table-right cc-table-right-spacing"></td>
               <td data-ng-bind="transcript.grade" data-ng-if="api.user.profile.canViewGrades"></td>
             </tr>
             <tr data-ng-if="!class.transcript && section.is_primary_section" data-ng-repeat="section in class.sections">
-              <td data-ng-if="class.url"><a data-ng-href="{{class.url}}" data-ng-bind="class.course_code"></a>
-              <td data-ng-if="!class.url" data-ng-bind="class.course_code"></td>
+              <td data-ng-if="class.url && !isAdvisingStudentLookup"><a data-ng-href="{{class.url}}" data-ng-bind="class.course_code"></a>
+              <td data-ng-if="!class.url || isAdvisingStudentLookup" data-ng-bind="class.course_code"></td>
               <td data-ng-bind="class.title"></td>
               <td data-ng-bind="section.units | number:1" class="cc-table-right cc-table-right-spacing"></td>
               <td data-ng-if="api.user.profile.canViewGrades">--</td>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-25121

Front-end code does not check My Academics for Live Updates & so the feed should not be repeatedly pinged by server-side warming.
MyAcademics::Merged can be cached in JSON form thanks to the addition of FilteredForAdvisor.
This also fixes an inconsistency between Advisor View-As & User Overview.