### PR TITLE
SISRP-25648 Fixes to class Enrollment Section Overview capacity, counts

### DIFF
--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -101,7 +101,9 @@ module EdoOracle
       safe_query <<-SQL
         SELECT
           #{SECTION_COLUMNS},
-          sec."cs-course-id" AS cs_course_id
+          sec."cs-course-id" AS cs_course_id,
+          sec."maxEnroll" AS enroll_limit,
+          sec."maxWaitlist" AS waitlist_limit
         FROM SISEDO.CLASSSECTIONV00_VW sec
         #{JOIN_SECTION_TO_COURSE}
         WHERE sec."status-code" IN ('A','S')

--- a/app/models/rosters/campus.rb
+++ b/app/models/rosters/campus.rb
@@ -52,7 +52,7 @@ module Rosters
 
           section_enrolled_count, section_waitlisted_count = 0, 0
           if (section_enrollments = enrollments[section[:ccn]])
-            section_enrollments_grouped = section_enrollments.group_by { |e| !!e['waitlist_position'] ? :waitlisted : :enrolled }
+            section_enrollments_grouped = section_enrollments.group_by { |e| e[:enroll_status] != 'E' ? :waitlisted : :enrolled }
             section_waitlisted_count = section_enrollments_grouped[:waitlisted].try(:length).to_i
             section_enrolled_count = section_enrollments_grouped[:enrolled].try(:length).to_i
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-25648

* Added maxEnroll, maxWaitlist columns to secondary sections DB query to fix bogus 0 amounts.
* Fixed string-vs.-symbol mix-up in logic which derives enrolled and waitlisted enrollment counts. This PR switches to the front-end's classification logic.