### PR TITLE
SISRP-25750 - 7.1 - Retrofit Advising Resources links to the link API

### DIFF
--- a/spec/controllers/campus_solutions/advising_resources_controller_spec.rb
+++ b/spec/controllers/campus_solutions/advising_resources_controller_spec.rb
@@ -22,29 +22,65 @@ describe CampusSolutions::AdvisingResourcesController do
       let(:feed_key) { 'ucAdvisingResources' }
 
       shared_examples 'a feed with advising resources' do
-        it 'contains advising links' do
+        it 'contains advising links and csLinks' do
           get feed
           json = JSON.parse response.body
-          expect(links = json['feed']['links']).to_not be_nil
+          expect(json['feed']['links']).to_not be_nil
+          expect(json['feed']['csLinks']).to_not be_nil
+        end
+      end
+
+      context 'links from the CS advising resources API' do
+        let(:key) { 'webNowDocuments' }
+        let(:expected_name) { 'WebNow Documents' }
+
+        it_behaves_like 'a feed with advising resources'
+
+        it 'returns feed with links' do
+          get feed
+          json = JSON.parse response.body
+          links = json['feed']['links']
+
           expect(link = links[key]).to_not be_nil
           expect(link['isCsLink']).to be true
           expect(link['name']).to eq expected_name
         end
       end
 
-      context 'links from the CS API' do
-        let(:key) { 'ucAdviseeStudentCenter' }
-        let(:expected_name) { 'Advisee Student Center' }
-
-        it_behaves_like 'a feed with advising resources'
-      end
-
       context 'links from YAML settings' do
-        let(:key) { 'multiYearAcademicPlannerStudentSpecific' }
-        let(:expected_name) { 'Multi-Year Planner' }
+        let(:key) { 'schedulePlannerStudentSpecific' }
+        let(:expected_name) { 'Schedule Planner' }
 
         it_behaves_like 'a feed with advising resources'
+
+        it 'returns feed with CS links' do
+          get feed
+          json = JSON.parse response.body
+          links = json['feed']['links']
+
+          expect(link = links[key]).to_not be_nil
+          expect(link['isCsLink']).to be true
+          expect(link['name']).to eq expected_name
+        end
       end
+
+      context 'links from CS link API' do
+        let(:key) { 'ucClassSearch' }
+        let(:expected_name) { 'Class Search' }
+
+        it_behaves_like 'a feed with advising resources'
+
+        it 'returns feed with CS links' do
+          get feed
+          json = JSON.parse response.body
+          cs_links = json['feed']['csLinks']
+
+          expect(link = cs_links[key]).to_not be_nil
+          expect(link['isCsLink']).to be true
+          expect(link['name']).to eq expected_name
+        end
+      end
+
     end
   end
 

--- a/spec/models/campus_solutions/advising_resources_spec.rb
+++ b/spec/models/campus_solutions/advising_resources_spec.rb
@@ -6,6 +6,8 @@ describe CampusSolutions::AdvisingResources do
     it_behaves_like 'a proxy that got data successfully'
     it 'returns data with the expected structure' do
       expect(subject[:feed][:links]).to be
+      # cs_links come from models/campus_solutions/link.rb
+      expect(subject[:feed][:csLinks]).to be
     end
   end
 

--- a/src/assets/templates/widgets/advisor/advising_links.html
+++ b/src/assets/templates/widgets/advisor/advising_links.html
@@ -1,19 +1,20 @@
 <ul class="cc-list-links">
-  <li data-ng-if="links.ucServiceIndicator.url">
+  <li data-ng-if="csLinks.ucServiceIndicators.url">
     <div
       data-cc-campus-solutions-link-item-directive
-      data-link="links.ucServiceIndicator"
+      data-link="csLinks.ucServiceIndicators"
     ></div>
   </li>
-  <li data-ng-if="links.ucStudentAdvisor.url">
-    <a
-      data-ng-href="{{links.ucStudentAdvisor.url}}"
-    >Advising Assignments</a>
-  </li>
-  <li data-ng-if="links.ucReportingCenter.url">
+  <li data-ng-if="csLinks.ucStudentAdvisor.url">
     <div
       data-cc-campus-solutions-link-item-directive
-      data-link="links.ucReportingCenter"
+      data-link="csLinks.ucStudentAdvisor"
+    ></div>
+  </li>
+  <li data-ng-if="csLinks.ucReportingCenter.url">
+    <div
+      data-cc-campus-solutions-link-item-directive
+      data-link="csLinks.ucReportingCenter"
     ></div>
   </li>
   <li data-ng-if="api.user.profile.features.csAcademicProgressReport && links.ucAcademicProgressReport.url">
@@ -22,16 +23,16 @@
       data-link="links.ucAcademicProgressReport"
     ></div>
   </li>
-  <li data-ng-if="links.ucEformsCenter.url">
+  <li data-ng-if="csLinks.ucEformsCenter.url">
     <a
-      data-ng-href="{{links.ucEformsCenter.url}}"
-      data-ng-bind="links.ucEformsCenter.name"
+      data-ng-href="{{csLinks.ucEformsCenter.url}}"
+      data-ng-bind="csLinks.ucEformsCenter.name"
     ></a>
   </li>
-  <li data-ng-if="links.ucEformsWorkList.url">
+  <li data-ng-if="csLinks.ucEformsWorkList.url">
     <a
-      data-ng-href="{{links.ucEformsWorkList.url}}"
-      data-ng-bind="links.ucEformsWorkList.name"
+      data-ng-href="{{csLinks.ucEformsWorkList.url}}"
+      data-ng-bind="csLinks.ucEformsWorkList.name"
     ></a>
   </li>
   <li data-ng-if="links.webNowDocuments.url">
@@ -40,18 +41,19 @@
       data-ng-bind="links.webNowDocuments.name"
     ></a>
   </li>
-  <li data-ng-if="links.ucMultiYearAcademicPlannerGeneric.url">
+  <li data-ng-if="csLinks.ucMultiYearAcademicPlannerGeneric.url">
     <a
-      data-ng-href="{{links.ucMultiYearAcademicPlannerGeneric.url}}"
-      data-ng-bind="links.ucMultiYearAcademicPlannerGeneric.name"
+      data-ng-href="{{csLinks.ucMultiYearAcademicPlannerGeneric.url}}"
+      data-ng-bind="csLinks.ucMultiYearAcademicPlannerGeneric.name"
     ></a>
   </li>
-  <li data-ng-if="links.ucAppointmentSystem.url">
+  <li data-ng-if="csLinks.ucAppointmentSystem.url">
     <div
       data-cc-campus-solutions-link-item-directive
-      data-link="links.ucAppointmentSystem"
+      data-link="csLinks.ucAppointmentSystem"
     ></div>
   </li>
+
   <!-- This URL is mislabelled in the API, it's in fact the scheduler view link -->
   <li data-ng-if="api.user.profile.features.csAdvisingSchedulerView && links.classSearch.url">
     <div
@@ -60,12 +62,11 @@
       data-text="Schedule of Classes - Scheduler View"
     ></div>
   </li>
-  <!-- This URL is mislabelled in the API, it's in fact the class search link -->
-  <li data-ng-if="links.scheduleClasses.url">
+
+  <li data-ng-if="csLinks.ucClassSearch.url">
     <div
       data-cc-campus-solutions-link-item-directive
-      data-link="links.scheduleClasses"
-      data-text="Schedule of Classes - Class Search"
+      data-link="csLinks.ucClassSearch"
     ></div>
   </li>
 </ul>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-25750

+ Should display links listed in design at https://jira.berkeley.edu/browse/SISRP-25611
+ `Schedule of Classes` and `WebNow Documents` links come from advisor resources api, the rest come from the link api.
+ Should suppress the `Academic Progress Reports` link until 7.2.

