### PR TITLE
SISRP-25196 Avoid duplicate element IDs in academics-class-info-enrollment-directive

### DIFF
--- a/src/assets/templates/directives/academics_class_info_enrollment.html
+++ b/src/assets/templates/directives/academics_class_info_enrollment.html
@@ -133,14 +133,14 @@
                  data-ng-if="students.length">
             <tr class="cc-academics-class-enrollment-table-row">
               <td>
-                <input id="cc-academics-class-enrollment-student-{{$index}}"
+                <input id="cc-academics-class-enrollment-{{studentRole}}-{{$index}}"
                   type="checkbox" name="student_id" data-ng-model="student.selected">
               </td>
               <td data-ng-if="showPosition">
                 <strong data-ng-bind="student.waitlist_position"></strong>
               </td>
               <td>
-                <label for="cc-academics-class-enrollment-student-{{$index}}">
+                <label for="cc-academics-class-enrollment-{{studentRole}}-{{$index}}">
                   <span data-ng-bind="student.last_name"></span>,
                   <span data-ng-bind="student.first_name"></span>
                 </label>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-25196

[academics_classinfo.html](https://github.com/ets-berkeley-edu/calcentral/blob/v82/src/assets/templates/academics_classinfo.html#L264) includes this directive twice on one page, leading to screen reader problems.

The directive JS sets "studentRole" to either "waitlisted" or "enrolled".