### PR TITLE
CLC-6444 OEC: Reduce memory overhead of enrollments query and worksheet processing

### DIFF
--- a/app/models/edo_oracle/connection.rb
+++ b/app/models/edo_oracle/connection.rb
@@ -5,13 +5,13 @@ module EdoOracle
       Settings.edodb
     end
 
-    def self.safe_query(sql)
+    def self.safe_query(sql, opts={})
       result = []
       return result if fake?
       use_pooled_connection do
         result = connection.select_all sql
       end
-      stringify_ints! result
+      opts[:do_not_stringify] ? result : stringify_ints!(result)
     rescue => e
       logger.error "Query failed: #{e.class}: #{e.message}\n #{e.backtrace.join("\n ")}"
       []

--- a/app/models/oec/queries.rb
+++ b/app/models/oec/queries.rb
@@ -12,26 +12,48 @@ module Oec
       get_courses(term_code, filter)
     end
 
-    def students_for_cntl_nums(term_code, ccns)
-      return [] unless ccns.present? && (filter = EdoOracle::Oec.chunked_whitelist(EdoOracle::Oec.enrollment_ccn_column, ccns))
-      get_enrollments(term_code, EdoOracle::Oec.student_info_clause, filter)
-    end
-
-    def enrollments_for_cntl_nums(term_code, ccns)
-      return [] unless ccns.present? && (filter = EdoOracle::Oec.chunked_whitelist(EdoOracle::Oec.enrollment_ccn_column, ccns))
-      get_enrollments(term_code, EdoOracle::Oec.course_and_ldap_uid_clause, filter)
-    end
-
     def get_courses(term_code, filter)
       term_id = EdoOracle::Adapters::Oec.term_id term_code
       rows = EdoOracle::Oec.get_courses(term_id, filter)
       EdoOracle::Adapters::Oec.adapt_courses(rows, term_code)
     end
 
-    def get_enrollments(term_code, select_clause, filter)
+    # The number of section IDs under evaluation tends to be large enough that it's more efficient to query for all
+    # enrollments in the term and then filter results in code. Owing to the size of the result set, we execute the
+    # query in batches and return result rows as arrays, not hashes.
+    def get_enrollments(term_code, section_ids)
       term_id = EdoOracle::Adapters::Oec.term_id term_code
-      rows = EdoOracle::Oec.get_enrollments(term_id, select_clause, filter)
-      EdoOracle::Adapters::Oec.adapt_enrollments(rows, term_code)
+      columns = nil
+      rows = []
+      batch = 0
+
+      loop do
+        enrollments = EdoOracle::Oec.get_batch_enrollments(term_id, batch, Settings.oec.enrollments_batch_size)
+        raise StandardError, 'Enrollments query failed' unless enrollments.respond_to?(:columns) && enrollments.respond_to?(:rows)
+
+        columns ||= enrollments.columns.map &:upcase
+        section_id_idx = columns.index 'SECTION_ID'
+
+        enrollments.rows.each do |enrollment_row|
+          string_section_id = enrollment_row[section_id_idx].to_i.to_s
+          if section_ids.include? string_section_id
+            # Since we skipped OracleBase.stringify_ints! in the upstream query, stringify section IDs now.
+            enrollment_row[section_id_idx] = string_section_id
+            rows << enrollment_row
+          end
+        end
+
+        # If we receive fewer rows than the batch size, we've read all available rows and are done.
+        break if enrollments.rows.count < Settings.oec.enrollments_batch_size
+        batch += 1
+      end
+
+      EdoOracle::Adapters::Oec.supplement_email_addresses(rows, columns)
+
+      {
+        rows: rows,
+        columns: columns
+      }
     end
 
   end

--- a/app/models/oec/sis_import_sheet.rb
+++ b/app/models/oec/sis_import_sheet.rb
@@ -37,6 +37,14 @@ module Oec
       )
     end
 
+    def transient_headers
+      %w(
+        CROSS_LISTED_CCNS
+        CO_SCHEDULED_CCNS
+        COURSE_TITLE_SHORT
+      )
+    end
+
     def sorted_rows
       rows_by_cross_listing = @rows.values.group_by { |row| row['CROSS_LISTED_NAME'] }
       non_cross_listed_rows = rows_by_cross_listing.delete(nil) || []

--- a/app/models/oec/worksheet.rb
+++ b/app/models/oec/worksheet.rb
@@ -70,7 +70,11 @@ module Oec
     end
 
     def []=(key, value)
-      @rows[key] = value
+      @rows[key] = WorksheetRow.new(value, self)
+    end
+
+    def count
+      @rows.count
     end
 
     def csv_export_path
@@ -93,8 +97,12 @@ module Oec
       @opts[:export_name] || self.class.export_name
     end
 
-    def headers
-      # subclasses override
+    # Column names that may be assigned to rows and will be included in CSV export. Subclasses must override.
+    def headers; end
+
+    # Column names that may be assigned to rows but will not be included in CSV export. Subclasses may override.
+    def transient_headers
+      []
     end
 
     def parse_row(row)
@@ -109,7 +117,7 @@ module Oec
           end
         end
       end
-      parsed_row
+      WorksheetRow.new(parsed_row, self)
     end
 
     def sorted_rows
@@ -138,7 +146,7 @@ module Oec
     def write_csv
       if @rows.any?
         output = CSV.open(csv_export_path, 'wb', headers: headers, write_headers: true)
-        sorted_rows.each { |row| output << row }
+        sorted_rows.each { |row| output << row.to_hash }
       else
         output = CSV.open(csv_export_path, 'wb')
         output << headers

--- a/app/models/oec/worksheet_row.rb
+++ b/app/models/oec/worksheet_row.rb
@@ -1,0 +1,60 @@
+# Representation of an individual row within Oec::Worksheet. It exposes an interface broadly similar to Hash, but
+# constrains keys to worksheet headers and stores values in an array for a smaller memory footprint. If a worksheet
+# has defined transient headers, these values may be written and read in memory but will not be included in CSV export.
+
+module Oec
+  class WorksheetRow
+    include Enumerable
+
+    def initialize(hash, worksheet)
+      @worksheet = worksheet
+      @values = all_headers.map { |header| hash[header] }
+    end
+
+    def [](key)
+      @values[get_index(key)]
+    end
+
+    def []=(key, value)
+      @values[get_index(key)] = value
+    end
+
+    def all_headers
+      @worksheet.headers + @worksheet.transient_headers
+    end
+
+    def each
+      self.to_hash_transient.each { |k, v| yield k, v }
+    end
+
+    def empty?
+      !@values.any?
+    end
+
+    def get_index(key)
+      all_headers.index(key) || (raise ArgumentError, "Key '#{key}' not found in WorksheetRow")
+    end
+
+    def merge(other_row)
+      self.to_hash.merge other_row.to_hash
+    end
+
+    def slice(*args)
+      self.to_hash_transient.slice *args
+    end
+
+    # Do not include transient values.
+    def to_hash
+      Hash[@worksheet.headers.zip @values]
+    end
+
+    # Include transient values.
+    def to_hash_transient
+      Hash[all_headers.zip @values]
+    end
+
+    def update(other_row)
+      other_row.each { |k, v| self[k] = v }
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -353,6 +353,7 @@ youtube_splash_id: '3Iz1NT9QKjI'
 
 oec:
   administrator_uid: ''
+  enrollments_batch_size: 120000
   local_write_directory: 'tmp/oec'
   explorance:
     sftp_server: ''

--- a/spec/models/edo_oracle/oec_spec.rb
+++ b/spec/models/edo_oracle/oec_spec.rb
@@ -131,34 +131,4 @@ describe EdoOracle::Oec do
       end
     end
   end
-
-  context 'student and enrollment lookup', testext: true do
-    let(:test_course_id) { '31702' }
-    let(:course_id_list) { EdoOracle::Oec.chunked_whitelist(EdoOracle::Oec.enrollment_ccn_column, [test_course_id]) }
-    let(:students_query) { EdoOracle::Oec.get_enrollments(term_id, EdoOracle::Oec.student_info_clause, course_id_list) }
-    let(:enrollments_query) { EdoOracle::Oec.get_enrollments(term_id, EdoOracle::Oec.course_and_ldap_uid_clause, course_id_list) }
-
-    it 'returns expected student data' do
-      expect(students_query).not_to be_empty
-      students_query.each do |row|
-        expect(row['first_name']).to be_present
-        expect(row['last_name']).to be_present
-        expect(row['email_address']).to be_present
-        expect(row['ldap_uid']).to be_present
-        expect(row['sis_id']).to be_present
-      end
-    end
-
-    it 'returns expected enrollment data' do
-      expect(enrollments_query).not_to be_empty
-      enrollments_query.each do |row|
-        expect(row['ldap_uid']).to be_present
-        expect(row['section_id']).to eq test_course_id
-      end
-    end
-
-    it 'returns matching student and enrollment data' do
-      expect(enrollments_query.map { |row| row['ldap_uid'] }).to match_array(students_query.map { |row| row['ldap_uid'] })
-    end
-  end
 end

--- a/spec/models/oec/create_confirmation_sheets_task_spec.rb
+++ b/spec/models/oec/create_confirmation_sheets_task_spec.rb
@@ -46,7 +46,7 @@ describe Oec::CreateConfirmationSheetsTask do
     let(:template) { double(id: 'template_id', title: 'TEMPLATE', mime_type: 'application/vnd.google-apps.spreadsheet') }
     let(:spreadsheet) { double(worksheets: [courses_worksheet, report_viewers_worksheet]) }
     let(:courses_worksheet) { double(title: 'Courses', rows: [Oec::CourseConfirmation.new.headers]) }
-    let(:report_viewers_worksheet) { double(title: 'Report Viewers', rows: [Oec::Supervisors.new.headers]) }
+    let(:report_viewers_worksheet) { double(title: 'Report Viewers', rows: [Oec::SupervisorConfirmation.new.headers]) }
 
     it 'should copy template, update cells and upload log' do
       expect(fake_remote_drive).to receive(:find_first_matching_item).with('TEMPLATE', anything).and_return template

--- a/spec/models/oec/merge_confirmation_sheets_task_spec.rb
+++ b/spec/models/oec/merge_confirmation_sheets_task_spec.rb
@@ -136,7 +136,7 @@ describe Oec::MergeConfirmationSheetsTask do
         confirmation.each do |confirmation_row|
           merged_confirmation_row = merged_supervisor_confirmation.find { |row| row['LDAP_UID'] == confirmation_row['LDAP_UID'] }
           supervisors_row = supervisors_worksheet.find { |row| row['LDAP_UID'] == confirmation_row['LDAP_UID'] }
-          merged_course_confirmation.headers.each do |header|
+          merged_supervisor_confirmation.headers.each do |header|
             if confirmation.headers.include? header
               expect(merged_confirmation_row[header]).to eq confirmation_row[header]
             else

--- a/spec/models/oec/publish_task_spec.rb
+++ b/spec/models/oec/publish_task_spec.rb
@@ -148,12 +148,12 @@ describe Oec::PublishTask do
       end
 
       it 'should merge instructor data from previous terms when current-term data absent' do
-        expect(instructors.find { |i| i['LDAP_UID'] == '66666'}).to include({'FIRST_NAME' => 'Ysidro', 'LAST_NAME' => 'Yyyy', 'EMAIL_ADDRESS' => 'yyyy@berkeley.edu'})
-        expect(instructors.find { |i| i['LDAP_UID'] == '77777'}).to include({'FIRST_NAME' => 'Zaphod', 'LAST_NAME' => 'Zzzz', 'EMAIL_ADDRESS' => 'zzzz@berkeley.edu'})
+        expect(instructors.find { |i| i['LDAP_UID'] == '66666'}.to_hash).to include({'FIRST_NAME' => 'Ysidro', 'LAST_NAME' => 'Yyyy', 'EMAIL_ADDRESS' => 'yyyy@berkeley.edu'})
+        expect(instructors.find { |i| i['LDAP_UID'] == '77777'}.to_hash).to include({'FIRST_NAME' => 'Zaphod', 'LAST_NAME' => 'Zzzz', 'EMAIL_ADDRESS' => 'zzzz@berkeley.edu'})
       end
 
       it 'should not overwrite current-term instructor data with previous-term data' do
-        expect(instructors.find { |i| i['LDAP_UID'] == '128533'}).to include({
+        expect(instructors.find { |i| i['LDAP_UID'] == '128533'}.to_hash).to include({
           'FIRST_NAME' => 'Alan',
           'LAST_NAME' => 'Aaaa',
           'EMAIL_ADDRESS' => 'aaaa@berkeley.edu',

--- a/spec/models/oec/publish_task_spec.rb
+++ b/spec/models/oec/publish_task_spec.rb
@@ -30,8 +30,7 @@ describe Oec::PublishTask do
       previous_course_supervisors_csv)
     allow(Settings.terms).to receive(:fake_now).and_return DateTime.parse('2015-03-09 12:00:00')
 
-    allow(Oec::Queries).to receive(:students_for_cntl_nums).and_return student_data_rows
-    allow(Oec::Queries).to receive(:enrollments_for_cntl_nums).and_return(enrollment_data_rows, suffixed_enrollment_data_rows)
+    allow(Oec::Queries).to receive(:get_enrollments).and_return enrollment_data
     allow_any_instance_of(Oec::Task).to receive(:default_term_dates).and_return({'START_DATE' => '01-26-2015', 'END_DATE' => '05-11-2015'})
   end
 
@@ -181,26 +180,12 @@ describe Oec::PublishTask do
     end
 
     context 'data with suffixed course IDs' do
+      let(:student_uids_for_ccn) { %w(1000 2000 3000) }
       before do
         merged_course_confirmations_csv.concat(
           "2015-B-#{ccn}_GSI,2015-B-#{ccn}_GSI,LGBT C146A LEC 001 REP SEXUALITY/LIT,,,LGBT,C146A,LEC,001,P,562283,10945601,Clarice,Cccc,cccc@berkeley.edu,23,Y,LGBT,G,,01-26-2015,05-11-2015")
-        expect(Oec::Queries).to receive(:enrollments_for_cntl_nums)
-          .with(term_code, [ccn])
-          .and_return student_ids_for_ccn.map { |id| {'course_id' => "2015-B-#{ccn}", 'ldap_uid' => id} }
-        expect(Oec::Queries).to receive(:students_for_cntl_nums)
-          .with(term_code, array_including(ccn))
-          .and_return(student_data_rows + student_data_rows_for_ccn)
-      end
-      let(:student_ids_for_ccn) { %w(1000 2000 3000) }
-      let(:student_data_rows_for_ccn) do
-        student_ids_for_ccn.map do |id|
-          {
-            'ldap_uid' => id,
-            'first_name' => 'Val',
-            'last_name' => 'Valid',
-            'email_address' => 'valid@berkeley.edu',
-            'sis_id' => random_id
-          }
+        student_uids_for_ccn.each do |uid|
+          enrollment_data[:rows] << fake_enrollment_data_row(ccn, uid)
         end
       end
 
@@ -208,7 +193,7 @@ describe Oec::PublishTask do
         it 'should match appropriate data to suffixed CCN' do
           task.run
           expect(courses.find { |course| course['COURSE_ID'] == "2015-B-#{ccn}_GSI"}).to be_present
-          student_ids_for_ccn.each do |id|
+          student_uids_for_ccn.each do |id|
             expect(course_students.find { |course_student| course_student['COURSE_ID'] == "2015-B-#{ccn}_GSI" && course_student['LDAP_UID'] == id }).to be_present
           end
           expect(course_instructors.find { |course_instructor| course_instructor['COURSE_ID'] == "2015-B-#{ccn}_GSI" && course_instructor['LDAP_UID'] == '562283'}).to be_present
@@ -228,10 +213,20 @@ describe Oec::PublishTask do
 
   describe 'integrity validation' do
     let(:local_write) { 'Y' }
-    before { allow(Rails.logger).to receive(:warn) }
-    context 'mismatched enrollment data' do
+    before do
+      allow(Rails.logger).to receive(:warn)
+      enrollment_data[:rows] << fake_enrollment_data_row('34821', '99999999')
+    end
+
+    context 'missing students row' do
       before do
-        enrollment_data_rows << {'course_id' => '2016-B-99999', 'ldap_uid' => '99999999'}
+        # Intercept the students row for UID 99999999 only.
+        original_validate_and_add = task.method(:validate_and_add)
+        allow(task).to receive(:validate_and_add) do |sheet, row, key|
+          unless sheet.instance_of?(Oec::Students) && row['LDAP_UID'] == '99999999'
+            original_validate_and_add.call(sheet, row, key)
+          end
+        end
       end
       it 'should report error' do
         expect(Rails.logger).to receive(:warn).with /Validation failed!/
@@ -239,15 +234,16 @@ describe Oec::PublishTask do
         task.run
       end
     end
-    context 'mismatched student data' do
+
+    context 'missing course_students row' do
       before do
-        student_data_rows << {
-          'ldap_uid' => 99999999,
-          'first_name' => 'Inter',
-          'last_name' => 'Loper',
-          'email_address' => 'interloper@berkeley.edu',
-          'sis_id' => random_id
-        }
+        # Intercept the course_students row for UID 99999999 only.
+        original_validate_and_add = task.method(:validate_and_add)
+        allow(task).to receive(:validate_and_add) do |sheet, row, key|
+          unless sheet.instance_of?(Oec::CourseStudents) && row['LDAP_UID'] == '99999999'
+            original_validate_and_add.call(sheet, row, key)
+          end
+        end
       end
       it 'should report error' do
         expect(Rails.logger).to receive(:warn).with /Validation failed!/

--- a/spec/models/oec/queries_spec.rb
+++ b/spec/models/oec/queries_spec.rb
@@ -1,0 +1,51 @@
+describe Oec::Queries do
+  let(:term_code) { '2016-D' }
+
+  context 'enrollments query' do
+    subject { described_class.get_enrollments(term_code, requested_section_ids) }
+
+    let(:requested_section_ids) { %w(65536 65537 65538) }
+    let(:edo_oracle_columns) do
+      %w(section_id ldap_uid sis_id first_name last_name email_address)
+    end
+    let(:edo_oracle_rows) do
+      [
+        %w(65536 1234567 87654321 Malachi Mulligan buck@tcd.ie),
+        %w(65536 1234568 87654322 Vincent Lynch lynch@tcd.ie),
+        %w(65537 1234567 87654321 Malachi Mulligan buck@tcd.ie),
+        %w(65537 1234568 87654322 Vincent Lynch lynch@tcd.ie),
+        %w(65538 1234567 87654321 Malachi Mulligan buck@tcd.ie),
+        %w(65539 1234567 87654321 Malachi Mulligan buck@tcd.ie),
+        %w(65540 1234568 87654322 Vincent Lynch lynch@tcd.ie),
+        %w(65541 1234568 87654322 Vincent Lynch lynch@tcd.ie)
+      ]
+    end
+    before do
+      allow(EdoOracle::Oec).to receive(:get_batch_enrollments).with('2168', 0, Settings.oec.enrollments_batch_size).and_return double(
+        columns: edo_oracle_columns,
+        rows: edo_oracle_rows
+      )
+    end
+
+    it 'upcases column names' do
+      expect(subject[:columns]).to eq %w(SECTION_ID LDAP_UID SIS_ID FIRST_NAME LAST_NAME EMAIL_ADDRESS)
+    end
+
+    it 'filters results to requested section IDs only' do
+      expect(subject[:rows]).to have(5).items
+      returned_section_ids = subject[:rows].map(&:first).uniq
+      expect(returned_section_ids).to match_array requested_section_ids
+    end
+
+    context 'missing email address' do
+      before { edo_oracle_rows[0][5] = nil }
+      it 'fills in email address from attributes query' do
+        expect(User::BasicAttributes).to receive(:attributes_for_uids).with(['1234567']).and_return([{
+          ldap_uid: '1234567',
+          email_address: 'buck@tcd.ie'
+        }])
+        expect(subject[:rows][0][5]).to eq 'buck@tcd.ie'
+      end
+    end
+  end
+end

--- a/spec/models/oec/term_setup_task_spec.rb
+++ b/spec/models/oec/term_setup_task_spec.rb
@@ -124,7 +124,7 @@ describe Oec::TermSetupTask do
     it 'sets default term dates as overrides' do
       subject.run
       courses = Oec::Courses.from_csv File.read(Rails.root.join 'tmp', 'oec', 'courses.csv')
-      expect(courses.first).to include({
+      expect(courses.first.to_hash).to include({
         'START_DATE' => '01-22-2013',
         'END_DATE' => '05-12-2013'
       })


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6444
Bamboo: https://bamboo.ets.berkeley.edu/bamboo/browse/CPB-CPT384-13/

This PR does two things, split into two commits.

Part one reworks the enrollments query. Used to be, when gathering student and enrollment data for OEC, we would query Oracle only for sections we cared about, and would run two separate queries on those sections: a get_enrollments query that returned section-ID/UID associations, and a get_students query that used SELECT DISTINCT to return unique rows of student data.

Now that we have more than 4000 evaluated sections in production, our giant list is hobbling the database. We ditch the list, run a single query to get all student and enrollment data for the term, and post-process in code.

Our standard DB-facing code does not perform well on a result set of 200,000-plus rows. We save memory by handling rows and columns as separate arrays, and merge them into the more convenient hash format only when validation requires.

Part two reduces memory footprint by changing the internal representation of worksheet rows from hashes to arrays. This is fairly easily done because every worksheet comes with a known sequence of headers and can map between string keys and integer indexes on the fly.