### PR TITLE
SISRP-25001 - Test Fixtures Still Rely on Bearfacts / Legacy Data

### DIFF
--- a/app/controllers/my_academics_controller.rb
+++ b/app/controllers/my_academics_controller.rb
@@ -14,9 +14,11 @@ class MyAcademicsController < ApplicationController
   end
 
   def residency
-    # Delegates get an empty feed.
-    return {} if current_user.authenticated_as_delegate?
-    render json: MyAcademics::Residency.from_session(session).get_feed_as_json
+    if current_user.authenticated_as_delegate?
+      render json: {}
+    else
+      render json: MyAcademics::Residency.from_session(session).get_feed_as_json
+    end
   end
 
 end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-25001

- Breaks unit test dependency on BearFacts; replaces detailed low-level unit tests with higher-level tests for delegate and advisor access
- Fixes MyAcademicsController.residency so it always returns JSON