### PR TITLE
SISRP-25993 - Final Exam Schedule Incorporate Course Exceptions

### DIFF
--- a/app/models/edo_oracle/course_sections.rb
+++ b/app/models/edo_oracle/course_sections.rb
@@ -40,7 +40,7 @@ module EdoOracle
     def get_section_final_exam
       final_exams = EdoOracle::Queries.get_section_final_exam(@term_id, @course_id).map do |exam|
         {
-          type: exam['type'],
+          exam_type: exam['exam_type'],
           location: exam['location'],
           exam_date: exam['exam_date'],
           exam_start_time: exam['exam_start_time'],

--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -171,25 +171,28 @@ module EdoOracle
     def self.get_section_final_exam(term_id, section_id)
       safe_query <<-SQL
         SELECT DISTINCT
-          exam."term-id" AS term_id,
-          exam."session-id" AS session_id,
+          sec."term-id" AS term_id,
+          sec."session-id" AS session_id,
+          sec."id" AS section_id,
+          sec."finalExam" AS exam_type,
           exam."date" AS exam_date,
           exam."startTime" AS exam_start_time,
           exam."endTime" AS exam_end_time,
           exam."location-descr" AS location
         FROM
           SISEDO.EXAMV00_VW exam
-        JOIN SISEDO.CLASSSECTIONV00_VW sec ON (
+        RIGHT JOIN SISEDO.CLASSSECTIONV00_VW sec ON (
           exam."cs-course-id" = sec."cs-course-id" AND
           exam."term-id" = sec."term-id" AND
           exam."session-id" = sec."session-id" AND
           exam."offeringNumber" = sec."offeringNumber" AND
-          exam."sectionNumber" = sec."sectionNumber"
+          exam."sectionNumber" = sec."sectionNumber" AND
+          exam."type-code" = 'FIN'
         )
         WHERE
           sec."term-id" = '#{term_id}' AND
           sec."id" = '#{section_id}' AND
-          exam."type-code" = 'FIN'
+          sec."finalExam" IN ('A', 'Y')
         ORDER BY exam_date
       SQL
     end

--- a/app/models/my_academics/exams.rb
+++ b/app/models/my_academics/exams.rb
@@ -47,7 +47,7 @@ module MyAcademics
           }
           if cs_data_available && section[:final_exams].any?
             exam = section[:final_exams].first
-            course[:exam_location] = exam[:location] || 'Location TBD'
+            course[:exam_location] = choose_cs_exam_location(exam)
             course[:exam_date] = parse_cs_exam_date(exam)
             course[:exam_time] = parse_cs_exam_time(exam)
             course[:exam_slot] = parse_cs_exam_slot(exam)
@@ -125,6 +125,20 @@ module MyAcademics
         return Time.parse(date.strftime('%y-%m-%d') + ' ' + time.strftime('%H:%M'))
       elsif date
         return Time.parse(date.strftime('%y-%m-%d'))
+      elsif exam[:exam_type] == 'A' # alternate exams that aren't included
+        return Time.new(99999998)
+      else # no exams should be at the end
+        return Time.new(99999999)
+      end
+    end
+
+    def choose_cs_exam_location(exam)
+      if exam[:location]
+        return exam[:location]
+      elsif exam[:exam_type] == 'A'
+        return 'Final exam time not yet provided.'
+      else
+        return 'Location TBD'
       end
     end
 

--- a/spec/models/edo_oracle/course_sections_spec.rb
+++ b/spec/models/edo_oracle/course_sections_spec.rb
@@ -141,6 +141,7 @@ describe EdoOracle::CourseSections do
           {
             'term_id'=>'2168',
             'session_id'=>'1',
+            'exam_type' => 'Y',
             'exam_date'=>Time.parse('2016-12-15 00:00:00 UTC'),
             'exam_start_time'=>Time.parse('1900-01-01 19:00:00 UTC'),
             'exam_end_time'=>Time.parse('1900-01-01 22:00:00 UTC'),
@@ -149,6 +150,7 @@ describe EdoOracle::CourseSections do
           {
             'term_id'=>'2168',
             'session_id'=>'1',
+            'exam_type' => 'A',
             'exam_date'=>nil,
             'exam_start_time'=>nil,
             'exam_end_time'=>nil,

--- a/spec/models/edo_oracle/queries_spec.rb
+++ b/spec/models/edo_oracle/queries_spec.rb
@@ -157,7 +157,7 @@ describe EdoOracle::Queries, :ignore => true do
     it 'returns exams for section id specified' do
       results = EdoOracle::Queries.get_section_final_exam(fall_term_id, section_ids[0])
       expect(results.count).to eq 1
-      expected_keys = %w(term_id session_id exam_date exam_start_time exam_end_time location)
+      expected_keys = %w(term_id session_id section_id exam_type exam_date exam_start_time exam_end_time location)
       results.each do |result|
         expect(result['term_id']).to eq '2168'
         expect(result['exam_date']).to eq Time.parse('2016-12-12 00:00:00 UTC')

--- a/spec/models/my_academics/exams_spec.rb
+++ b/spec/models/my_academics/exams_spec.rb
@@ -165,9 +165,21 @@ describe MyAcademics::Exams do
   let(:all_exam) do
     {
       :location => 'Kroeber 221',
+      :exam_type => 'Y',
       :exam_date => Time.parse('2016-12-12 00:00:00 UTC'),
       :exam_start_time=>Time.parse('1900-01-01 19:00:00 UTC'),
       :exam_end_time=>Time.parse('1900-01-01 22:00:00 UTC'),
+    }
+  end
+
+  # example exam with an alternate method
+  let(:alternate_exam) do
+    {
+      :location => nil,
+      :exam_type => 'A',
+      :exam_date => nil,
+      :exam_start_time=> nil,
+      :exam_end_time=>nil,
     }
   end
 
@@ -175,6 +187,7 @@ describe MyAcademics::Exams do
   let(:no_exam) do
     {
       :location => nil,
+      :exam_type => 'Y',
       :exam_date => nil,
       :exam_start_time=> nil,
       :exam_end_time=> nil,
@@ -265,7 +278,8 @@ describe MyAcademics::Exams do
         waitlisted_class,
         ug_class_no_time,
         grad_class_no_time
-      ]
+      ],
+      :exams => fall_2016_exams_after_parsed
     }
   end
 
@@ -278,7 +292,8 @@ describe MyAcademics::Exams do
         # the following exams aren't directly a result of parse_academic_data
         ug_class_time,
         grad_class_no_time
-      ]
+      ],
+      :exams => spring_2016_exams_after_parsed
     }
   end
 
@@ -527,7 +542,14 @@ describe MyAcademics::Exams do
 
     it 'should create cs exam slots properly' do
       expect(subject.parse_cs_exam_slot(all_exam)).to eq Time.parse('2016-12-12 19:00:00')
-      expect(subject.parse_cs_exam_slot(no_exam)).to eq nil
+      expect(subject.parse_cs_exam_slot(alternate_exam)).to eq Time.new(99999998)
+      expect(subject.parse_cs_exam_slot(no_exam)).to eq Time.new(99999999)
+    end
+
+    it 'should choose cs exam locations properly' do
+      expect(subject.choose_cs_exam_location(all_exam)).to eq 'Kroeber 221'
+      expect(subject.choose_cs_exam_location(alternate_exam)).to eq 'Final exam time not yet provided.'
+      expect(subject.choose_cs_exam_location(no_exam)).to eq 'Location TBD'
     end
 
   end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-25993
- Incorporate classes that have an alternate method of final exams or no exam at all.

Note: I did a hacky thing, in order to send a class that has no exam and an alternate method to the bottom, I set its Time field to something like the year 999999. If this isn't a good way to go, I'm open to other suggestions.

I apologize for this being late, not sure whether this should be cherry-picked into QA, but this should be the final piece to the final exam schedule feature.