### PR TITLE
SISRP-20510 - Hold icon on Enrollment card rendering poorly on iOS

### DIFF
--- a/src/assets/templates/widgets/enrollment/consult_advisor.html
+++ b/src/assets/templates/widgets/enrollment/consult_advisor.html
@@ -1,12 +1,12 @@
 <div class="cc-enrollment-card-advisors-consult">
 
-  <div data-ng-if="enrollmentInstruction.hasHolds" class="cc-flex">
-    <div>
+  <div data-ng-if="enrollmentInstruction.hasHolds">
+    <span>
       <i class="fa fa-exclamation-circle cc-icon-red cc-enrollment-card-icon"></i>
-    </div>
-    <div>
+    </span>
+    <span>
       You have a hold that may affect your ability to enroll in classes. Consult with an advisor.
-    </div>
+    </span>
   </div>
 
   <div data-ng-if="!enrollmentInstruction.hasHolds">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-20510

removed inconsistency in displaying notification icons. using <span> tags instead of <div> tags for enrollment card holds icon is consistent with other card using similar icons. This also removed the required cc-flex style which created an inconsistent look/spacing on safari based browsers. 