### PR TITLE
SISRP-26305 - MyAcademics::Exams for UID 1064465: NoMethodError: undefined method gsub for nil:NilClass

### DIFF
--- a/app/models/my_academics/exams.rb
+++ b/app/models/my_academics/exams.rb
@@ -39,20 +39,20 @@ module MyAcademics
     def parse_courses(semester, courses, cs_data_available)
       semester[:classes].each do |course|
         course[:sections].select{|x| course[:role] == 'Student' && x[:is_primary_section]}.each do |section|
-          course = {
+          parsed_course = {
             name: course[:course_code],
-            number: course[:course_code].gsub(/[^0-9]/, '').to_i,
+            number: course[:courseCatalog].to_i,
             time: section[:schedules][:recurring].to_a.first.try(:[], :schedule),
             waitlisted: section[:waitlisted]
           }
           if cs_data_available && section[:final_exams].any?
             exam = section[:final_exams].first
-            course[:exam_location] = choose_cs_exam_location(exam)
-            course[:exam_date] = parse_cs_exam_date(exam)
-            course[:exam_time] = parse_cs_exam_time(exam)
-            course[:exam_slot] = parse_cs_exam_slot(exam)
+            parsed_course[:exam_location] = choose_cs_exam_location(exam)
+            parsed_course[:exam_date] = parse_cs_exam_date(exam)
+            parsed_course[:exam_time] = parse_cs_exam_time(exam)
+            parsed_course[:exam_slot] = parse_cs_exam_slot(exam)
           end
-          courses << course
+          courses << parsed_course
         end
       end
     end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26305

* `course` variable name was overwriting the original `|course|` input parameter, this became a problem for students taking two of the same classes, as the 2nd `course` would try to parse the first, already-parsed `course`.