### PR TITLE
CLC-6453, instructor role-code 'PROXY' assists instructor(s) with grading (e.g., Head GSI)

### DIFF
--- a/app/models/edo_oracle/adapters/common.rb
+++ b/app/models/edo_oracle/adapters/common.rb
@@ -8,18 +8,22 @@ module EdoOracle
 
       def adapt_dept_name_and_catalog_id(row, user_courses)
         dept_name, catalog_id = user_courses.parse_course_code row
-        row.merge!({'dept_name' => dept_name, 'catalog_id' => catalog_id})
+        row.merge!({
+          'dept_name' => dept_name,
+          'catalog_id' => catalog_id
+        })
       end
 
       def adapt_instructor_func(row)
         return unless (code = row.delete 'role_code')
         row['instructor_func'] = case code
-          when 'PI' then '1'    # Teaching and In Charge, equivalent of Teaching and Instructor of Record (1)
-          when 'TNIC' then '2'  # Teaching but Not in Charge, equivalent of Teaching but not Instructor of Record (2)
-          when 'ICNT' then '3'  # In Charge but Not Teaching, equivalent of Not teaching but Instructor of Record (3). Instructors coded as 3 must be accompanied by another "teaching" instructor coded as 2.
-          when 'INVT' then '4'  # Teaching with Invalid Title, equivalent of No Valid Teaching Title Code (4)
-          else raise ArgumentError, "Unable to convert to 'instructor_func'. No such role code: '#{role_code}'"
-        end
+                                   when 'PI'    then '1'  # Teaching and In Charge, equivalent of Teaching and Instructor of Record (1)
+                                   when 'TNIC'  then '2'  # Teaching but Not in Charge, equivalent of Teaching but not Instructor of Record (2)
+                                   when 'ICNT'  then '3'  # In Charge but Not Teaching, equivalent of Not teaching but Instructor of Record (3). Instructors coded as 3 must be accompanied by another "teaching" instructor coded as 2.
+                                   when 'INVT'  then '4'  # Teaching with Invalid Title, equivalent of No Valid Teaching Title Code (4)
+                                   when 'PROXY' then '5'  # Head GSI, or similar, who assists the instructor(s) in charge with grading (5)
+                                   else raise ArgumentError, "Unable to convert to 'instructor_func'. No such role code: '#{code}'"
+                                 end
       end
 
       def adapt_pnp_flag(row)
@@ -35,13 +39,16 @@ module EdoOracle
       end
 
       def adapt_term(row)
-        legacy_term = Berkeley::TermCodes.from_edo_id(row['term_id'])
-        row.merge!({'term_yr' => legacy_term[:term_yr], 'term_cd' => legacy_term[:term_cd]})
+        legacy_term = Berkeley::TermCodes.from_edo_id row['term_id']
+        row.merge!({
+          'term_yr' => legacy_term[:term_yr],
+          'term_cd' => legacy_term[:term_cd]
+        })
       end
 
       def term_id(term_year, term_code=nil)
         unless term_code
-          term_year, term_code = term_year.split('-')
+          term_year, term_code = term_year.split '-'
         end
         Berkeley::TermCodes.to_edo_id(term_year, term_code)
       end

--- a/spec/models/edo_oracle/adapters/oec_spec.rb
+++ b/spec/models/edo_oracle/adapters/oec_spec.rb
@@ -63,6 +63,10 @@ describe EdoOracle::Adapters::Oec do
       let(:instructor_func) { '4' }
     end
     include_examples 'role code to instructor func' do
+      let(:role_code) { 'PROXY' }
+      let(:instructor_func) { '5' }
+    end
+    include_examples 'role code to instructor func' do
       let(:role_code) { nil }
       let(:instructor_func) { nil }
     end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6453

cc: @paulkerschen 

The new 'PROXY' instructor role-code is coming soon. At the very least, we should not `raise ArgumentError` when the role-code lands. Future PRs will address specific business logic concerns. E.g., OEC.

Fyi, (personal) Bamboo build in-progress: https://bamboo.ets.berkeley.edu/bamboo/browse/CPB-CJT85-2