### PR TITLE
CLC-6448 CLC-6449 OEC: special handling for Law and Spanish/Portuguese depts

### DIFF
--- a/app/models/edo_oracle/adapters/oec.rb
+++ b/app/models/edo_oracle/adapters/oec.rb
@@ -18,7 +18,6 @@ module EdoOracle
           adapt_course_id(row, term_code)
           adapt_cross_listed_flag row
           adapt_dates(row, default_dates)
-          adapt_evaluation_type row
           adapt_instructor_func row
           adapt_primary_secondary_cd row
           adapt_sis_id row
@@ -90,13 +89,6 @@ module EdoOracle
             row['end_date'] = row['end_date'].strftime ::Oec::Worksheet::WORKSHEET_DATE_FORMAT
           end
         end
-      end
-
-      def self.adapt_evaluation_type(row)
-        row['evaluation_type'] = case row['affiliations']
-                                   when /STUDENT/ then 'G'
-                                   when /INSTRUCTOR/ then 'F'
-                                 end
       end
 
       def self.adapt_sis_id(row)

--- a/fixtures/oec/courses_for_dept_SPANISH.json
+++ b/fixtures/oec/courses_for_dept_SPANISH.json
@@ -1,0 +1,33 @@
+[
+  {
+    "term_cd": "B",
+    "course_id": "2015-B-70000",
+    "course_name": "PORTUG 120 LEC 001 ATTRACTIONS OF DECADENCE",
+    "cross_listed_flag": null,
+    "course_title_short": null,
+    "dept_name": "PORTUG",
+    "catalog_id": "120",
+    "instruction_format": "LEC",
+    "section_num": "001",
+    "primary_secondary_cd": "P",
+    "sis_id": "UID:87654",
+    "affiliations": "EMPLOYEE-TYPE-ACADEMIC,STUDENT-STATUS-EXPIRED",
+    "first_name": "José Maria",
+    "last_name": "Eça de Queirós",
+    "email_address": "queiros@berkeley.edu",
+    "blue_role": "23",
+    "evaluate": null,
+    "dept_form": null,
+    "evaluation_type": null,
+    "modular_course": null,
+    "start_date": "1/20/2015",
+    "end_date": "5/8/2015",
+    "term_yr": "2015",
+    "course_cntl_num": "70000",
+    "ldap_uid": "87654",
+    "instructor_func": "1",
+    "enrollment_count": "20",
+    "cross_listed_ccns": null,
+    "co_scheduled_ccns": null
+  }
+]


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6448
https://jira.ets.berkeley.edu/jira/browse/CLC-6449

Note that because of this special handling, we no longer get to set evaluation type ahead of time in EdoOracle::Adapters::Oec.