### PR TITLE
SISRP-26403 - Remove showing of exam conflicts if a student has more …

### DIFF
--- a/public/dummy/json/academics_interim_two_sets_conflicts.json
+++ b/public/dummy/json/academics_interim_two_sets_conflicts.json
@@ -869,41 +869,9 @@
       "curr": false,
       "time_bucket": "future",
       "exams": {
-        "5": [
+        "2017-05-05": [
           {
-            "name": "INTEGBI 35AC",
-            "number": 35,
-            "time": "TuTh 2:00P-3:29P",
-            "waitlisted": null,
-            "exam_location": "",
-            "exam_time": "8-11A",
-            "exam_slot": 5,
-            "exam_date": "Tue 12/13"
-          },
-          {
-            "name": "POLI SCI 112B",
-            "number": 112,
-            "time": "TuTh 5:00P-6:29P",
-            "waitlisted": true,
-            "exam_location": "",
-            "exam_time": "11:30-2:30P",
-            "exam_slot": 14,
-            "exam_date": "Thu 12/15"
-          }
-        ],
-        "13": [
-          {
-            "name": "MATH 53",
-            "number": 53,
-            "time": "MWF 4:00P-4:59P",
-            "waitlisted": null,
-            "exam_location": "",
-            "exam_time": "8-11A",
-            "exam_slot": 13,
-            "exam_date": "Thu 12/15"
-          },
-          {
-            "name": "MATH 54",
+            "name": "INTEGBI 54",
             "number": 54,
             "time": "MWF 4:00P-4:59P",
             "waitlisted": null,
@@ -911,6 +879,36 @@
             "exam_time": "8-11A",
             "exam_slot": 13,
             "exam_date": "Thu 12/15"
+          }
+        ],
+        "none": [
+          {
+            "name": "INTEGBI 35AC",
+            "number": 35,
+            "time": "TuTh 2:00P-3:29P",
+            "waitlisted": null,
+            "exam_location": "Final exam information not available. Please consult instructors.",
+            "exam_time": null,
+            "exam_slot": 5,
+            "exam_date": null
+          },
+          {
+            "name": "POLI SCI 112B",
+            "number": 112,
+            "time": "TuTh 5:00P-6:29P",
+            "waitlisted": true,
+            "exam_location": "No exam.",
+            "exam_slot": 14
+          },
+          {
+            "name": "INTEGBI 35AC",
+            "number": 35,
+            "time": "TuTh 2:00P-3:29P",
+            "waitlisted": null,
+            "exam_location": "Final exam information not available. Please consult instructors.",
+            "exam_time": null,
+            "exam_slot": 5,
+            "exam_date": null
           }
         ]
       }

--- a/src/assets/templates/widgets/final_exam_schedule.html
+++ b/src/assets/templates/widgets/final_exam_schedule.html
@@ -10,8 +10,8 @@
       <div class="cc-widget-exam-schedule-text" data-ng-if="!semester.cs_data_available && semester.exams">Dates and times are subject to change. Please check your syllabus for the official exam day and time for each class.</div>
       <div class="cc-widget-exam-schedule-text" data-ng-if="!semester.exams && isUndergraduate">No exam schedules listed.</div>
       <div data-ng-repeat="(exam_slot, exam) in semester.exams">
-        <div ng-class="{'cc-widget-exam-schedule-conflicts': exam.length > 1, 'cc-widget-exam-schedule-time-conflicts-left': exam.length > 1}">
-          <div class="cc-widget-exam-schedule-conflicts-text" data-ng-if="exam.length > 1">
+        <div ng-class="{'cc-widget-exam-schedule-conflicts': exam.length > 1 && exam_slot != 'none', 'cc-widget-exam-schedule-time-conflicts-left': exam.length > 1 && exam_slot != 'none'}">
+          <div class="cc-widget-exam-schedule-conflicts-text" data-ng-if="exam.length > 1 && exam_slot != 'none'">
             <i class="fa fa-exclamation-triangle cc-icon-gold"></i>
             <strong>Exam Conflict: </strong>Consult with instructors.
           </div>


### PR DESCRIPTION
…than one no exam
https://jira.berkeley.edu/browse/SISRP-26403
QA PR after this is merged.

- Adds "no exam" if a class' section doesn't have any final exams
- Removed the Time.new(9999999) vs. Time.new(999998) thing and just consolidated it to Time.new(9999)
- Show "location TBD" if a class has an exam, but not sure where the exam is
- Change messaging around whether a class is alternate
- Remove conflict messaging / visuals if there are multiple "no exams" or alternate final exams (this is hacky, if it's not good, any other suggestions?"