### PR TITLE
SISRP-26590 - Profile > Emergency Contact > Phone Field >When there is a warning in the phone field Due to white space the warning messages are not clearing

### DIFF
--- a/src/assets/javascripts/angular/directives/telPhoneInputDirective.js
+++ b/src/assets/javascripts/angular/directives/telPhoneInputDirective.js
@@ -20,13 +20,13 @@ angular.module('calcentral.directives').directive('ccTelPhoneInputDirective', fu
    *  + `valid` boolean property set to true if a pattern was matched, false if
    *   no pattern is matched.
    */
-  var reIntlPhone = /^(\+?((?:\d ?){6,14}\d))?\s?$/;
-  var reUsPhone = /^([\d][\W])?(\d{3})\W?[\W]?(\d{3})[\W]?(\d{4})?\s?$/;
+  var reIntlPhone = /^(\+?((?:\d ?){6,14}\d))?$/;
+  var reUsPhone = /^([\d][\W])?(\d{3})\W?[\W]?(\d{3})[\W]?(\d{4})?$/;
   var space = ' ';
   var blank = '';
 
   var validPhone = function(phone) {
-    var value = (phone || blank).replace(/[\W]{1,}/gm, space);
+    var value = (phone || blank).replace(/[\W]{1,}/gm, space).trim();
     var valid = reUsPhone.test(value) || reIntlPhone.test(value);
 
     return {
@@ -47,8 +47,7 @@ angular.module('calcentral.directives').directive('ccTelPhoneInputDirective', fu
 
         if (valid || (!valid && showMessage)) {
           ctrl.$setValidity('invalidPhoneNumber', valid);
-          var viewValue = valid ? phone.value.trim() : phone.value;
-          ctrl.$setViewValue(viewValue);
+          ctrl.$setViewValue(phone.value);
           ctrl.$render();
         }
       };

--- a/src/assets/templates/widgets/profile/emergency_contact.html
+++ b/src/assets/templates/widgets/profile/emergency_contact.html
@@ -29,8 +29,8 @@
       </button>
     </div>
   </div>
-  <div class="cc-page-widget-profile-section-add" data-ng-if="!items.editorEnabled && api.user.profile.actAsOptions.canPost">
-    <button class="cc-button-link" data-ng-click="showAdd()">
+  <div class="cc-page-widget-profile-section-add" data-ng-if="!items.editorEnabled">
+    <button class="cc-button-link" data-ng-click="showAdd()" data-ng-disabled="!api.user.profile.isDirectlyAuthenticated">
       <i class="fa fa-plus"></i> Add <span class="cc-visuallyhidden">Emergency Contact</span>
     </button>
   </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26590

Two fixes:
+ remove whitespace allowance in phone validation regex
+ show but disable the `+Add` link when user is viewing-as another student
