### PR TITLE
SISRP-26595 - Advisor Resources link hover text isn't always included in the markup

### DIFF
--- a/src/assets/templates/widgets/advisor/advising_links.html
+++ b/src/assets/templates/widgets/advisor/advising_links.html
@@ -24,28 +24,28 @@
     ></div>
   </li>
   <li data-ng-if="csLinks.ucEformsCenter.url">
-    <a
-      data-ng-href="{{csLinks.ucEformsCenter.url}}"
-      data-ng-bind="csLinks.ucEformsCenter.name"
-    ></a>
+    <div
+      data-cc-campus-solutions-link-item-directive
+      data-link="csLinks.ucEformsCenter"
+    ></div>
   </li>
   <li data-ng-if="csLinks.ucEformsWorkList.url">
-    <a
-      data-ng-href="{{csLinks.ucEformsWorkList.url}}"
-      data-ng-bind="csLinks.ucEformsWorkList.name"
-    ></a>
+    <div
+      data-cc-campus-solutions-link-item-directive
+      data-link="csLinks.ucEformsWorkList"
+    ></div>
   </li>
   <li data-ng-if="links.webNowDocuments.url">
-    <a
-      data-ng-href="{{links.webNowDocuments.url}}"
-      data-ng-bind="links.webNowDocuments.name"
-    ></a>
+    <div
+      data-cc-campus-solutions-link-item-directive
+      data-link="links.webNowDocuments"
+    ></div>
   </li>
   <li data-ng-if="csLinks.ucMultiYearAcademicPlannerGeneric.url">
-    <a
-      data-ng-href="{{csLinks.ucMultiYearAcademicPlannerGeneric.url}}"
-      data-ng-bind="csLinks.ucMultiYearAcademicPlannerGeneric.name"
-    ></a>
+    <div
+      data-cc-campus-solutions-link-item-directive
+      data-link="csLinks.ucMultiYearAcademicPlannerGeneric"
+    ></div>
   </li>
   <li data-ng-if="csLinks.ucAppointmentSystem.url">
     <div


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26595

+ Problem caused by not using the cc-campus-solutions-link-item-directive for items from the Link API.
+ The change here will fix the 2 eForms links, and the Multi-Year Planner link.
+ The WebNow and Schedule of Classes links come from another API that does not provide hover text.
+ The Academic Progress Report should not be visible in 7.1