### PR TITLE
SISRP-26567 - MyAcademics::Exams for UID 1507981: NoMethodError: undefined method final_exam_cs_data_available for nil:NilClass

### DIFF
--- a/app/models/my_academics/filtered_for_delegate.rb
+++ b/app/models/my_academics/filtered_for_delegate.rb
@@ -10,8 +10,7 @@ module MyAcademics
         CollegeAndLevel,
         TransitionTerm,
         GpaUnits,
-        Semesters,
-        Exams
+        Semesters
       ]
     end
 

--- a/src/assets/templates/academics.html
+++ b/src/assets/templates/academics.html
@@ -28,7 +28,7 @@
     <div class="medium-6 large-4 columns cc-column-3">
       <div data-ng-include="'widgets/enrollment_card.html'" data-ng-if="api.user.profile.features.csEnrollmentCard"></div>
 
-      <div data-ng-include="'widgets/final_exam_schedule.html'" data-ng-if="api.user.profile.roles.student && !api.user.profile.roles.law && api.user.profile.features.finalExamSchedule"></div>
+      <div data-ng-include="'widgets/final_exam_schedule.html'" data-ng-if="api.user.profile.roles.student && !api.user.profile.roles.law && !api.user.profile.delegateActingAsUid && api.user.profile.features.finalExamSchedule"></div>
 
       <div data-ng-include="'academics_ls_advising.html'" data-ng-if="showLegacyAdvising"></div>
 

--- a/src/assets/templates/academics_semesters.html
+++ b/src/assets/templates/academics_semesters.html
@@ -22,9 +22,9 @@
     <div class="cc-table cc-academics-semester cc-academics-semester-{{semester.timeBucket}}" data-ng-repeat="semester in semesters | limitTo:pastSemestersLimit">
       <div>
         <h3 data-ng-if="semester.hasEnrollmentData && semester.slug && !isAdvisingStudentLookup"><a class="cc-left" data-ng-href="/academics/semester/{{semester.slug}}" data-ng-bind="semester.name"></a></h3>
-        <h3 data-ng-if="!semester.hasEnrollmentData || !semester.slug || isAdvisingStudentLookup" data-ng-bind="semester.name"></h3>
+        <h3 class="cc-left" data-ng-if="!semester.hasEnrollmentData || !semester.slug || isAdvisingStudentLookup" data-ng-bind="semester.name"></h3>
         <h4 data-ng-if="semester.notation" data-ng-bind="semester.notation"></h4>
-        <a class="cc-right cc-academics-semester-title-link" data-ng-href="/academics/booklist/{{semester.slug}}" data-ng-if="semester.hasEnrollmentData && semester.slug && semester.timeBucket !== 'past'">Book List</a>
+        <a class="cc-right cc-academics-semester-title-link" data-ng-href="/academics/booklist/{{semester.slug}}" data-ng-if="semester.hasEnrollmentData && semester.slug && semester.timeBucket !== 'past' && !isAdvisingStudentLookup">Book List</a>
         <br>
         <div class="cc-widget-text" data-ng-if="!semester.hasEnrolledClasses && !semester.summaryFromTranscript">
           You are currently not enrolled in any classes for


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26567

* Good bug - led to the decision not to surface Final Exams to delegates, more info in the JIRA.
* Also included a CSS fix
* Also included an `!isAdvisingStudentLookup` conditional that was accidentally removed in #5905.  This makes it so that advisors don't see the "Book List" link on the User Overview page.  As it stands, if an advisor clicks on that link, they will be taken to a 404 page.
* QA PR to come upon merge.