### PR TITLE
SISRP-22665 - Displays profile image instead of default image on advisor Student Lookup

### DIFF
--- a/app/controllers/photo_controller.rb
+++ b/app/controllers/photo_controller.rb
@@ -1,10 +1,25 @@
 class PhotoController < ApplicationController
-
   before_filter :api_authenticate_401
 
   def my_photo
-    if (photo_feed = User::Photo.fetch session['user_id'], session)
-      data = photo_feed[:photo]
+    send_photo get_photo(session['user_id'])
+  end
+
+  def photo
+    if current_user.policy.can_view_other_user_photo?
+      send_photo get_photo(uid_param)
+    else
+      render :nothing => true, :status => 403
+    end
+  end
+
+  def get_photo(uid)
+    photo_feed = User::Photo.fetch uid, session
+    photo_feed.try(:[], :photo)
+  end
+
+  def send_photo(data)
+    if data
       send_data(
         data,
         type: 'image/jpeg',
@@ -13,6 +28,10 @@ class PhotoController < ApplicationController
     else
       render :nothing => true, :status => 200
     end
+  end
+
+  def uid_param
+    params.require 'uid'
   end
 
 end

--- a/app/policies/authentication_state_policy.rb
+++ b/app/policies/authentication_state_policy.rb
@@ -79,4 +79,12 @@ class AuthenticationStatePolicy
     feature_flag.present? && feature_flag && (can_administrate? || can_view_as? || can_add_current_official_sections?)
   end
 
+  def can_view_other_user_photo?
+    real_auth = @user.real_user_auth
+    return false unless real_auth.active?
+    attributes = User::AggregatedAttributes.new(@user.user_id).get_feed
+    has_advisor_role = attributes.try(:[], :roles).try(:[], :advisor)
+    real_auth.is_superuser? || has_advisor_role
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Calcentral::Application.routes.draw do
   get '/api/advising/my_advising' => 'my_advising#get_feed', :as => :advising, :defaults => {:format => 'json'}
   get '/api/my/classes' => 'my_classes#get_feed', :as => :my_classes, :defaults => { :format => 'json' }
   get '/api/my/photo' => 'photo#my_photo', :as => :my_photo, :defaults => {:format => 'jpeg' }
+  get '/api/photo/:uid' => 'photo#photo', :as => :photo, :defaults => {:format => 'jpeg' }
   get '/api/my/textbooks_details' => 'my_textbooks#get_feed', :as => :my_textbooks, :defaults => { :format => 'json' }
   get '/api/my/up_next' => 'my_up_next#get_feed', :as => :my_up_next, :defaults => { :format => 'json' }
   get '/api/my/tasks' => 'my_tasks#get_feed', :via => :get, :as => :my_tasks, :defaults => { :format => 'json' }

--- a/spec/controllers/photo_controller_spec.rb
+++ b/spec/controllers/photo_controller_spec.rb
@@ -1,47 +1,110 @@
 describe PhotoController do
-  let(:make_request) { get :my_photo }
-  it_should_behave_like 'an authenticated endpoint'
 
-  context 'when a user is authenticated' do
-    before do
-      session['user_id'] = random_id
-      allow_any_instance_of(Cal1card::Photo).to receive(:get_feed).and_return(test_photo_object)
+  let(:uid) { random_id }
+
+  shared_examples 'a controller with no photo' do
+    it 'returns an empty body' do
+      make_request
+      expect(response.status).to eq 200
+      expect(response.body).to eq ' '
     end
+  end
 
-    shared_examples 'a controller with no photo' do
-      it 'returns an empty body' do
-        make_request
-        expect(response.status).to eq 200
-        expect(response.body).to eq ' '
+  shared_examples 'a controller with a photo' do
+    it 'renders raw image' do
+      make_request
+      expect(response.status).to eq 200
+      expect(response.body).to eq 'photo_binary_content'
+    end
+  end
+
+  shared_examples 'a controller that prevents unauthorized access' do
+    it 'returns an empty body and an error status' do
+      make_request
+      expect(response.status).to eq 403
+      expect(response.body).to eq ' '
+    end
+  end
+
+  shared_examples 'an endpoint that returns a response' do
+    it_should_behave_like 'an authenticated endpoint'
+
+    context 'when a user is authenticated' do
+      before do
+        session['user_id'] = uid
+        allow_any_instance_of(Cal1card::Photo).to receive(:get_feed).and_return(test_photo_object)
       end
-    end
 
-    shared_examples 'a controller with a photo' do
-      it 'renders raw image' do
-        make_request
-        expect(response.status).to eq 200
-        expect(response.body).to eq 'photo_binary_content'
+      context 'when person has no photo' do
+        let(:test_photo_object) { {} }
+        it_should_behave_like 'a controller with no photo'
       end
-    end
 
-    context 'when user has no photo' do
-      let(:test_photo_object) { {} }
-      it_should_behave_like 'a controller with no photo'
-    end
+      context 'when person has photo' do
+        let(:test_photo_object) { {photo: 'photo_binary_content'} }
+        it_should_behave_like 'a controller with a photo'
 
-    context 'when user has photo' do
-      let(:test_photo_object) { {photo: 'photo_binary_content'} }
-      it_should_behave_like 'a controller with a photo'
-      context 'delegate view' do
-        before do
-          session[SessionKey.original_delegate_user_id] = random_id
-          allow(Settings.features).to receive(:cs_delegated_access).and_return true
-        end
-        it 'returns an empty body' do
-          make_request
-          expect(response.body).to eq ' '
+        context 'delegate view' do
+          before do
+            session[SessionKey.original_delegate_user_id] = uid
+            allow(Settings.features).to receive(:cs_delegated_access).and_return true
+          end
+          it_should_behave_like 'a controller that prevents unauthorized access'
         end
       end
     end
   end
+
+  describe '#my_photo' do
+    let(:make_request) { get :my_photo }
+    it_should_behave_like 'an endpoint that returns a response'
+  end
+
+  describe '#photo' do
+    let(:make_request) { get :photo, uid: random_id }
+    let(:user_attributes) {
+      {
+        roles: {
+          concurrentEnrollmentStudent: true,
+          exStudent: true,
+          expiredAccount: false,
+          faculty: true,
+          guest: false,
+          registered: true,
+          staff: true,
+          student: true,
+          undergrad: true,
+          advisor: is_advisor
+        }
+      }
+    }
+
+    before do
+      session['user_id'] = uid
+      allow(User::AggregatedAttributes).to receive(:new).and_return double get_feed: user_attributes
+      allow_any_instance_of(User::Auth).to receive(:active).and_return true
+      allow_any_instance_of(User::Auth).to receive(:is_superuser?).and_return is_super_user
+    end
+
+    context 'when user is an advisor' do
+      let(:is_advisor) { true }
+      let(:is_super_user) { false }
+      it_should_behave_like 'an endpoint that returns a response'
+    end
+
+    context 'when user is a superuser' do
+      let(:is_advisor) { false }
+      let(:is_super_user) { true }
+      it_should_behave_like 'an endpoint that returns a response'
+    end
+
+    context 'when user is not authorized to see another user\'s photo' do
+      let(:is_advisor) { false }
+      let(:is_super_user) { false }
+      let(:test_photo_object) { {photo: 'photo_binary_content'} }
+      it_should_behave_like 'a controller that prevents unauthorized access'
+    end
+
+  end
+
 end

--- a/src/assets/javascripts/angular/directives/profileImageDirective.js
+++ b/src/assets/javascripts/angular/directives/profileImageDirective.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var angular = require('angular');
+
+angular.module('calcentral.directives').directive('ccProfileImageDirective', function() {
+  return {
+    scope: {
+      name: '=',
+      uid: '='
+    },
+    templateUrl: 'widgets/profile_img.html'
+  };
+});

--- a/src/assets/stylesheets/_profile_image.scss
+++ b/src/assets/stylesheets/_profile_image.scss
@@ -1,5 +1,5 @@
-// _delegate_student.scss
-.cc-widget-delegate-student-img {
+// _profile_image.scss
+.cc-widget-profile-img {
   border: 1px solid $cc-color-lighter-medium-grey;
   height: 96px;
   width: 72px;

--- a/src/assets/stylesheets/calcentral.scss
+++ b/src/assets/stylesheets/calcentral.scss
@@ -114,13 +114,13 @@
 // Profile
 @import "profile_page";
 @import "profile_bconnected";
+@import "profile_image";
 
 // Advising User Overview
 @import "student_success";
 
 // Delegated Access
 @import "delegate_welcome";
-@import "delegate_student";
 
 // Toolbox
 @import "toolbox";

--- a/src/assets/templates/widgets/delegate_student_img.html
+++ b/src/assets/templates/widgets/delegate_student_img.html
@@ -1,1 +1,1 @@
-<img class="cc-widget-delegate-student-img" height="96" width="72" data-ng-attr-alt="{{student.fullName || api.user.profile.fullName}}'s photo" data-ng-src="/assets/images/svg/photo_unavailable_bear_72x96.svg">
+<img class="cc-widget-profile-img" height="96" width="72" data-ng-attr-alt="{{student.fullName || api.user.profile.fullName}}'s photo" data-ng-src="/assets/images/svg/photo_unavailable_bear_72x96.svg">

--- a/src/assets/templates/widgets/profile_img.html
+++ b/src/assets/templates/widgets/profile_img.html
@@ -1,0 +1,1 @@
+<img class="cc-widget-profile-img" height="96" width="72" data-ng-attr-alt="{{ name && name.trim ? name.trim() + '\'s photo' : 'profile photo' }}" data-ng-src="api/photo/{{ uid }}">

--- a/src/assets/templates/widgets/toolbox/user_preview.html
+++ b/src/assets/templates/widgets/toolbox/user_preview.html
@@ -13,7 +13,7 @@
           <tbody>
           <tr>
             <th>
-              <div data-ng-include="'widgets/delegate_student_img.html'"></div>
+              <div data-cc-profile-image-directive data-name="targetUser.fullName" data-uid="targetUser.ldapUid"></div>
             </th>
             <td>
               <div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-22665

- Adds a new endpoint to return a photo for a specified UID (only available to advisors and superusers)
- Adds a directive that calls that endpoint and displays the photo

I was hoping to move the authorization logic from the angular templates into the PhotoController for better security.  That way a single endpoint could return either the requested person's photo, or the generic bear photo if the requestor is not authorized (e.g., a delegate).  

HOWEVER, the generic bear photo is an SVG.  I tried having the endpoint send the SVG but it wouldn't render.  It works when that file is requested by delegate_student_img.html.  Didn't want to spend too much time figuring it out, but if anyone knows a quick solution I'd love to hear it!  That would allow me to replace lines 85-95 in academics_student_profile.html with the new directive and let the controller handle the authorization on the server side.