### PR TITLE
SISRP-26666 - Advising Resources - should not include 'Schedule of Classes - Scheduler View' link

### DIFF
--- a/app/models/campus_solutions/advising_resources.rb
+++ b/app/models/campus_solutions/advising_resources.rb
@@ -37,8 +37,8 @@ module CampusSolutions
 
       # The following links are hard-coded, for now. Ideally they would be served by CS API but there is an urgent need
       # thus we manage the content via CalCentral settings.
-      add_cs_link links, :web_now_documents, 'WEB_NOW_DOCUMENTS', 'WebNow Documents'
-      add_cs_link links, :schedule_planner, 'SCHEDULE_PLANNER_STUDENT_SPECIFIC', 'Schedule Planner', "?EMPLID=#{student_empl_id}"
+      add_cs_link links, :web_now_documents, 'WEB_NOW_DOCUMENTS', 'WebNow Documents', '', 'View uploaded student documents in the Image Now dashboard.'
+      add_cs_link links, :schedule_planner, 'SCHEDULE_PLANNER_STUDENT_SPECIFIC', 'Schedule Planner', "?EMPLID=#{student_empl_id}", "View this student's planned schedule for this term."
 
       # LINK-API CALLS
       cs_links = {}
@@ -97,13 +97,14 @@ module CampusSolutions
 
     private
 
-    def add_cs_link(links, config_key, link_key, name, params_string = '')
+    def add_cs_link(links, config_key, link_key, name, params_string = '', title = '')
       value = Settings.campus_solutions_links.advising.send config_key
       if value
         links[link_key] = {
           'NAME' => name,
           'URL' => value + params_string,
-          'IS_CS_LINK' => true
+          'IS_CS_LINK' => true,
+          'TITLE' => title
         }
       end
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -464,7 +464,6 @@ features:
   cs_academic_profile_prefers_legacy: true
   cs_academic_progress_report: false
   cs_advising_links: false
-  cs_advising_scheduler_view: false
   cs_advisor_student_lookup: false
   cs_billing: false
   cs_delegated_access: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -79,7 +79,6 @@ features:
   course_manage_official_sections: true
   cs_academic_planner: true
   cs_academic_progress_report: true
-  cs_advising_scheduler_view: true
   cs_advisor_student_lookup: true
   cs_billing: true
   cs_delegated_access: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -92,7 +92,6 @@ features:
   class_info_enrollment_tab: true
   cs_academic_planner: true
   cs_academic_progress_report: true
-  cs_advising_scheduler_view: true
   cs_advisor_student_lookup: true
   cs_billing: true
   cs_delegated_access: true

--- a/config/settings/testext.yml
+++ b/config/settings/testext.yml
@@ -69,7 +69,6 @@ features:
   class_info_enrollment_tab: true
   cs_academic_planner: true
   cs_academic_progress_report: true
-  cs_advising_scheduler_view: true
   cs_advisor_student_lookup: true
   cs_billing: true
   cs_delegated_access: true

--- a/spec/models/campus_solutions/advising_resources_spec.rb
+++ b/spec/models/campus_solutions/advising_resources_spec.rb
@@ -5,9 +5,10 @@ describe CampusSolutions::AdvisingResources do
     it_should_behave_like 'a simple proxy that returns errors'
     it_behaves_like 'a proxy that got data successfully'
     it 'returns data with the expected structure' do
-      expect(subject[:feed][:links]).to be
+      # links come from AdvisingResources
+      expect(subject[:feed][:links].count).to eq 9
       # cs_links come from models/campus_solutions/link.rb
-      expect(subject[:feed][:csLinks]).to be
+      expect(subject[:feed][:csLinks].count).to be >= 5
     end
   end
 
@@ -22,8 +23,8 @@ describe CampusSolutions::AdvisingResources do
     context 'no student uid requested' do
       it_should_behave_like 'a proxy that gets data'
       it 'includes specific mock data' do
-        expect(proxy.get[:feed][:links][:ucAdviseeStudentCenter][:url]).to eq(
-          'https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SSR_ADVISEE_OVRD.SSS_STUDENT_CENTER.GBL?')
+        expect(proxy.get[:feed][:links][:ucServiceIndicator][:url]).to eq(
+          'https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/MAINTAIN_SERVICE_IND_STDNT.ACTIVE_SRVC_INDICA.GBL?EMPLID=17154428&ACAD_CAREER=')
       end
       it 'should query for advisor EMPLID only' do
         proxy.get

--- a/src/assets/templates/widgets/advisor/advising_links.html
+++ b/src/assets/templates/widgets/advisor/advising_links.html
@@ -53,16 +53,6 @@
       data-link="csLinks.ucAppointmentSystem"
     ></div>
   </li>
-
-  <!-- This URL is mislabelled in the API, it's in fact the scheduler view link -->
-  <li data-ng-if="api.user.profile.features.csAdvisingSchedulerView && links.classSearch.url">
-    <div
-      data-cc-campus-solutions-link-item-directive
-      data-link="links.classSearch"
-      data-text="Schedule of Classes - Scheduler View"
-    ></div>
-  </li>
-
   <li data-ng-if="csLinks.ucClassSearch.url">
     <div
       data-cc-campus-solutions-link-item-directive

--- a/src/assets/templates/widgets/toolbox/user_preview.html
+++ b/src/assets/templates/widgets/toolbox/user_preview.html
@@ -108,9 +108,10 @@
                   ></div>
                 </div>
                 <div data-ng-if="ucAdvisingResources.links.schedulePlannerStudentSpecific.url">
-                  <a
-                    data-ng-href="{{ucAdvisingResources.links.schedulePlannerStudentSpecific.url}}"
-                    data-ng-bind="ucAdvisingResources.links.schedulePlannerStudentSpecific.name"></a>
+                  <div
+                    data-cc-campus-solutions-link-item-directive
+                    data-link="ucAdvisingResources.links.schedulePlannerStudentSpecific"
+                  ></div>
                 </div>
                 <div data-ng-if="ucAdvisingResources.csLinks.studentAdvisorNotes.url">
                   <div


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26666

+ removes the Schedule of Classes link from Dashboard Advisor Resources
+ adds hover text to WebNow Documents link in Dashboard Advisor Resources
+ adds hover text to student-specific Schedule Planner link on Student Overview (Advisor Resources)

Release Notes for 7.1 updated - remove `cs_advising_scheduler_view` flag from all environments:
https://confluence.ets.berkeley.edu/confluence/pages/viewpage.action?spaceKey=MYB&title=Release-Specific+Instructions