### PR TITLE
[QA] SISRP-26668 - Final exams conflicting messaging

### DIFF
--- a/public/dummy/json/academics_interim_two_sets_conflicts.json
+++ b/public/dummy/json/academics_interim_two_sets_conflicts.json
@@ -1,9 +1,9 @@
 {
   "collegeAndLevel": {
     "careers": [
-      "Undergraduate"
+      "Graduate"
     ],
-    "level": "Senior",
+    "level": "Graduate",
     "futureTelebearsLevel": "",
     "majors": [
       {
@@ -809,11 +809,63 @@
   "feedName": "MyAcademics::Merged",
   "examSchedule": [
     {
-      "cs_data_available": false,
+      "cs_data_available": true,
       "name": "Fall 2016",
       "term": "D",
       "term_year": "2016",
       "time_bucket": "current",
+      "exams": {
+        "2017-05-05": [
+          {
+            "name": "INTEGBI 54",
+            "number": 54,
+            "time": "MWF 4:00P-4:59P",
+            "waitlisted": null,
+            "exam_location": "",
+            "exam_time": "8-11A",
+            "exam_slot": 13,
+            "exam_date": "Thu 12/15"
+          }
+        ],
+        "none": [
+          {
+            "name": "INTEGBI 35AC",
+            "number": 35,
+            "time": "TuTh 2:00P-3:29P",
+            "waitlisted": null,
+            "exam_location": "Final exam information not available. Please consult instructors.",
+            "exam_time": null,
+            "exam_slot": 5,
+            "exam_date": null
+          },
+          {
+            "name": "POLI SCI 112B",
+            "number": 112,
+            "time": "TuTh 5:00P-6:29P",
+            "waitlisted": true,
+            "exam_location": "No exam.",
+            "exam_slot": 14
+          },
+          {
+            "name": "INTEGBI 35AC",
+            "number": 35,
+            "time": "TuTh 2:00P-3:29P",
+            "waitlisted": null,
+            "exam_location": "Final exam information not available. Please consult instructors.",
+            "exam_time": null,
+            "exam_slot": 5,
+            "exam_date": null
+          }
+        ]
+      }
+    },
+    {
+      "cs_data_available": false,
+      "name": "Spring 2017",
+      "term": "B",
+      "term_year": "2017",
+      "curr": false,
+      "time_bucket": "future",
       "exams": {
         "5": [
           {
@@ -857,58 +909,6 @@
             "exam_time": "8-11A",
             "exam_slot": 13,
             "exam_date": "Thu 12/15"
-          }
-        ]
-      }
-    },
-    {
-      "cs_data_available": false,
-      "name": "Spring 2017",
-      "term": "B",
-      "term_year": "2017",
-      "curr": false,
-      "time_bucket": "future",
-      "exams": {
-        "2017-05-05": [
-          {
-            "name": "INTEGBI 54",
-            "number": 54,
-            "time": "MWF 4:00P-4:59P",
-            "waitlisted": null,
-            "exam_location": "",
-            "exam_time": "8-11A",
-            "exam_slot": 13,
-            "exam_date": "Thu 12/15"
-          }
-        ],
-        "none": [
-          {
-            "name": "INTEGBI 35AC",
-            "number": 35,
-            "time": "TuTh 2:00P-3:29P",
-            "waitlisted": null,
-            "exam_location": "Final exam information not available. Please consult instructors.",
-            "exam_time": null,
-            "exam_slot": 5,
-            "exam_date": null
-          },
-          {
-            "name": "POLI SCI 112B",
-            "number": 112,
-            "time": "TuTh 5:00P-6:29P",
-            "waitlisted": true,
-            "exam_location": "No exam.",
-            "exam_slot": 14
-          },
-          {
-            "name": "INTEGBI 35AC",
-            "number": 35,
-            "time": "TuTh 2:00P-3:29P",
-            "waitlisted": null,
-            "exam_location": "Final exam information not available. Please consult instructors.",
-            "exam_time": null,
-            "exam_slot": 5,
-            "exam_date": null
           }
         ]
       }

--- a/src/assets/templates/academics.html
+++ b/src/assets/templates/academics.html
@@ -28,7 +28,7 @@
     <div class="medium-6 large-4 columns cc-column-3">
       <div data-ng-include="'widgets/enrollment_card.html'" data-ng-if="api.user.profile.features.csEnrollmentCard"></div>
 
-      <div data-ng-include="'widgets/final_exam_schedule.html'" data-ng-if="api.user.profile.roles.student && !api.user.profile.roles.law && !api.user.profile.delegateActingAsUid && api.user.profile.features.finalExamSchedule"></div>
+      <div data-ng-include="'widgets/final_exam_schedule.html'" data-ng-if="api.user.profile.roles.student && !api.user.profile.delegateActingAsUid && api.user.profile.features.finalExamSchedule"></div>
 
       <div data-ng-include="'academics_ls_advising.html'" data-ng-if="showLegacyAdvising"></div>
 

--- a/src/assets/templates/widgets/final_exam_schedule.html
+++ b/src/assets/templates/widgets/final_exam_schedule.html
@@ -6,7 +6,7 @@
     <div data-ng-repeat="semester in examSchedule">
       <hr data-ng-if="!$first">
       <h3 data-ng-bind="semester.name"></h3>
-      <div class="cc-widget-exam-schedule-text" data-ng-if="!isUndergraduate">Please check your syllabus for your final exams for your graduate classes.</div>
+      <div class="cc-widget-exam-schedule-text" data-ng-if="!semester.cs_data_available && !isUndergraduate">Please check your syllabus for your final exams for your graduate classes.</div>
       <div class="cc-widget-exam-schedule-text" data-ng-if="!semester.cs_data_available && semester.exams">Dates and times are subject to change. Please check your syllabus for the official exam day and time for each class.</div>
       <div class="cc-widget-exam-schedule-text" data-ng-if="!semester.exams && isUndergraduate">No exam schedules listed.</div>
       <div data-ng-repeat="(exam_slot, exam) in semester.exams">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26668
Master PR: https://github.com/ets-berkeley-edu/calcentral/pull/5988

Removed messaging for graduate students once cs data becomes available. Also showed the card back to law students, in which they will see the same messages as grad students.

The most important changes are located in academics.html and final_exam_schedule.html (both one line changes), the others in academics_interim_two_sets_conflicts.json was just to test those front-end changes.