### PR TITLE
SISRP-26727 - Final exams graduate courses should not show up in interim

### DIFF
--- a/app/models/my_academics/exams.rb
+++ b/app/models/my_academics/exams.rb
@@ -41,7 +41,7 @@ module MyAcademics
         course[:sections].select{|x| course[:role] == 'Student' && x[:is_primary_section]}.each do |section|
           parsed_course = {
             name: course[:course_code],
-            number: course[:courseCatalog].to_i,
+            number: course[:courseCatalog].gsub(/[^0-9]/, '').to_i,
             time: section[:schedules][:recurring].to_a.first.try(:[], :schedule),
             waitlisted: section[:waitlisted]
           }

--- a/spec/models/my_academics/exams_spec.rb
+++ b/spec/models/my_academics/exams_spec.rb
@@ -10,7 +10,7 @@ describe MyAcademics::Exams do
   # a class with recurring times
   let(:ug_class_recurring) do
     {
-      :role => 'Student',:course_code => 'BIO ENG 131',:courseCatalog => '131',
+      :role => 'Student',:course_code => 'BIO ENG C131',:courseCatalog => '131',
       :sections => [
         {
           :is_primary_section => true,
@@ -389,7 +389,7 @@ describe MyAcademics::Exams do
         expect(fall_courses.length).to eq 5
         fall_courses.each do |course|
           expect(course[:name]).to be
-          expect(course[:number]).to be
+          expect(course[:number]).to_not eq 0
           expect(course[:exam_location]).to_not be
         end
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26727

Replaced method to completely remove letters from the course code. Things like 'C242C' would become '0' instead of '242', so it was replaced.