### PR TITLE
CLC-6460, add -J-Xmx1024m to avoid OOM error in export-cached-csv-enrollments-set.sh

### DIFF
--- a/script/export-cached-csv-enrollments-set.sh
+++ b/script/export-cached-csv-enrollments-set.sh
@@ -17,7 +17,7 @@ source .rvmrc
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcompile.invokedynamic=false -Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled"
+export JRUBY_OPTS="-Xcompile.invokedynamic=false -Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled -J-Xmx1024m"
 
 echo | $LOGIT
 echo "------------------------------------------" | $LOGIT


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6460

Give `export-cached-csv-enrollments-set.sh` same JVM args used by other Canvas scripts.