### PR TITLE
SISRP-26676 - Student Success Card needs to suppress current term GPA

### DIFF
--- a/app/models/campus_solutions/student_term_gpa.rb
+++ b/app/models/campus_solutions/student_term_gpa.rb
@@ -8,6 +8,17 @@ module CampusSolutions
       "#{@settings.base_url}/UC_AA_STDNT_GPA_TERMS.v1/get?EMPLID=#{@campus_solutions_id}"
     end
 
+    def build_feed(response)
+      # Since CS will always return a zero value for the current term, we want to suppress it
+      current_term = Berkeley::Terms.fetch.current
+      response.try(:[], 'UC_AA_TERM_DATA').try(:[], 'UC_AA_TERM_GPA').each do |term_gpa|
+        if term_gpa.try(:[], 'TERM_ID') == current_term.try(:[], :campus_solutions_id)
+          term_gpa['TERM_CUM_GPA'] = nil
+        end
+      end
+      response.parsed_response
+    end
+
     def xml_filename
       'student_term_gpa.xml'
     end

--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -197,7 +197,9 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
   var parseTermGpa = function() {
     var termGpa = [];
     _.forEach($scope.studentSuccess.termGpa, function(term) {
-      termGpa.push(term.termCumGpa);
+      if (term.termCumGpa) {
+        termGpa.push(term.termCumGpa);
+      }
     });
     if (termGpa.length < 2) {
       return;

--- a/src/assets/templates/widgets/student_success/gpa_trends.html
+++ b/src/assets/templates/widgets/student_success/gpa_trends.html
@@ -20,8 +20,9 @@
       <tr>
         <td data-ng-bind="term.termName"></td>
         <td class="cc-table-right" colspan="2">
-          <i data-ng-if="term.termCumGpa < 2" class="fa fa-exclamation-circle cc-icon-red"></i>
-          <span data-ng-class="{'cc-student-success-sub-gpa': (term.termCumGpa < 2)}" data-ng-bind="term.termCumGpa | number:1"></span>
+          <i data-ng-if="term.termCumGpa && term.termCumGpa < 2" class="fa fa-exclamation-circle cc-icon-red"></i>
+          <span data-ng-if="!term.termCumGpa">&mdash;</span>
+          <span data-ng-if="term.termCumGpa" data-ng-class="{'cc-student-success-sub-gpa': (term.termCumGpa < 2)}" data-ng-bind="term.termCumGpa | number:1"></span>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26676

* The JIRA title is a bit misleading - bottom line, we want to suppress the current term GPA because CS will always return 0.0, as grades have not been entered yet.
* We still want to show the term though
* QA PR to come upon merge.