### PR TITLE
SISRP-26772, My Finances tab if student or has_student_history

### DIFF
--- a/app/models/user/api.rb
+++ b/app/models/user/api.rb
@@ -102,8 +102,8 @@ module User
       roles[:student] || roles[:faculty] || roles[:applicant] || has_instructor_history || has_student_history
     end
 
-    def has_financials_tab?(roles)
-      !!(roles[:student] || roles[:exStudent] || roles[:applicant])
+    def has_financials_tab?(roles, has_student_history)
+      roles[:student] || roles[:exStudent] || roles[:applicant] || has_student_history
     end
 
     def has_toolbox_tab?(policy, roles)
@@ -169,7 +169,7 @@ module User
         hasDashboardTab: true,
         hasAcademicsTab: can_view_academics,
         canViewGrades: can_view_academics || !!roles[:advisor],
-        hasFinancialsTab: has_financials_tab?(roles),
+        hasFinancialsTab: has_financials_tab?(roles, has_student_history),
         hasToolboxTab: has_toolbox_tab?(current_user_policy, roles),
         inEducationAbroadProgram: @user_attributes[:educationAbroad],
         googleEmail: google_mail,

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -343,7 +343,14 @@ describe User::Api do
 
   describe 'My Finances tab' do
     let(:delegate_students) { {} }
+    let(:has_student_history) { false }
+    before {
+      allow(User::HasStudentHistory).to receive(:new).and_return(model = double)
+      allow(model).to receive(:has_student_history?).and_return has_student_history
+    }
+
     subject { User::Api.new(uid).get_feed[:hasFinancialsTab] }
+
     context 'active student' do
       let(:ldap_attributes) { {roles: { :student => true, :exStudent => false, :faculty => false, :staff => false }} }
       let(:edo_attributes) { {roles: { student: true } } }
@@ -362,6 +369,12 @@ describe User::Api do
     context 'former student' do
       let(:ldap_attributes) { {roles: { :student => false, :exStudent => true, :faculty => false, :staff => false }} }
       let(:edo_attributes) { {roles: {}} }
+      it { should be true }
+    end
+    context 'has student history' do
+      let(:ldap_attributes) { {roles: { :student => false, :exStudent => false, :faculty => false, :staff => false }} }
+      let(:edo_attributes) { {roles: {}} }
+      let(:has_student_history) { true }
       it { should be true }
     end
   end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26772

We leverage the existing call to `User::HasStudentHistory.has_student_history?`. Note: relying on `CampusSolutions::Billing` to decide if `has_financials_tab?` is risky w.r.t performance.