### PR TITLE
SISRP-26288 - Show instructors their scheduled final exam

### DIFF
--- a/public/dummy/json/academics.json
+++ b/public/dummy/json/academics.json
@@ -568,6 +568,401 @@
       "slug": "fall-2016",
       "termCode": "D",
       "termYear": "2016",
+      "timeBucket": "current",
+      "campusSolutionsTerm": true,
+      "gradingInProgress": null,
+      "classes": [
+        {
+          "role": "Instructor",
+          "sections": [
+            {
+              "ccn": "10707",
+              "instruction_format": "LEC",
+              "is_primary_section": true,
+              "section_label": "LEC 003",
+              "section_number": "003",
+              "units": null,
+              "enroll_limit": 115,
+              "waitlist_limit": 0,
+              "instructors": [
+                {
+                  "name": "Tiffany Rasmussen",
+                  "role": "PI",
+                  "uid": "921283"
+                }
+              ],
+              "estimated_final_exam": [
+                {
+                  "time": "MWF 4:00P-4:59P",
+                  "exam_location": "Scheduled Final Exam",
+                  "exam_time": "8-11A",
+                  "exam_date": "Th 12/15"
+                }
+              ],
+              "schedules": {
+                "oneTime": [],
+                "recurring": [
+                  {
+                    "buildingName": "Cheit",
+                    "roomNumber": "C230",
+                    "schedule": "TuTh 9:30A-10:59A"
+                  }
+                ]
+              },
+              "slug": "lec-003",
+              "url": "/academics/teaching-semester/fall-2016/class/ugba-102a/lec-003",
+              "courseCode": "UGBA 102A",
+              "siteIds": [
+                "1452406"
+              ]
+            },
+            {
+              "ccn": "10708",
+              "instruction_format": "LEC",
+              "is_primary_section": true,
+              "section_label": "LEC 004",
+              "section_number": "004",
+              "units": null,
+              "enroll_limit": 0,
+              "waitlist_limit": 0,
+              "estimated_final_exam": [
+                {
+                  "time": "MWF 4:00P-4:59P",
+                  "exam_location": "Scheduled Final Exam",
+                  "exam_time": "8-11A",
+                  "exam_date": "Th 12/15"
+                }
+              ],
+              "instructors": [
+                {
+                  "name": "Tiffany Rasmussen",
+                  "role": "PI",
+                  "uid": "921283"
+                }
+              ],
+              "schedules": {
+                "oneTime": [],
+                "recurring": []
+              },
+              "slug": "lec-004",
+              "url": "/academics/teaching-semester/fall-2016/class/ugba-102a/lec-004",
+              "courseCode": "UGBA 102A",
+              "siteIds": [
+                "1452406"
+              ]
+            },
+            {
+              "ccn": "10685",
+              "instruction_format": "DIS",
+              "is_primary_section": false,
+              "section_label": "DIS 301",
+              "section_number": "301",
+              "associated_primary_id": "10707.0",
+              "enroll_limit": 0,
+              "waitlist_limit": 0,
+              "instructors": [],
+              "schedules": {
+                "oneTime": [],
+                "recurring": [
+                  {
+                    "buildingName": "Cheit",
+                    "roomNumber": "C220",
+                    "schedule": "F 8:00A-8:59A"
+                  }
+                ]
+              },
+              "associatedWithPrimary": null,
+              "courseCode": "UGBA 102A"
+            },
+            {
+              "ccn": "10666",
+              "instruction_format": "DIS",
+              "is_primary_section": false,
+              "section_label": "DIS 302",
+              "section_number": "302",
+              "associated_primary_id": "10707.0",
+              "enroll_limit": 0,
+              "waitlist_limit": 0,
+              "instructors": [],
+              "schedules": {
+                "oneTime": [],
+                "recurring": [
+                  {
+                    "buildingName": "Cheit",
+                    "roomNumber": "C220",
+                    "schedule": "F 9:00A-9:59A"
+                  }
+                ]
+              },
+              "associatedWithPrimary": null,
+              "courseCode": "UGBA 102A"
+            },
+            {
+              "ccn": "10667",
+              "instruction_format": "DIS",
+              "is_primary_section": false,
+              "section_label": "DIS 401",
+              "section_number": "401",
+              "associated_primary_id": "10708.0",
+              "enroll_limit": 0,
+              "waitlist_limit": 0,
+              "instructors": [],
+              "schedules": {
+                "oneTime": [],
+                "recurring": [
+                  {
+                    "buildingName": "Cheit",
+                    "roomNumber": "C220",
+                    "schedule": "F 12:00P-12:59P"
+                  }
+                ]
+              },
+              "associatedWithPrimary": null,
+              "courseCode": "UGBA 102A"
+            },
+            {
+              "ccn": "10668",
+              "instruction_format": "DIS",
+              "is_primary_section": false,
+              "section_label": "DIS 402",
+              "section_number": "402",
+              "associated_primary_id": "10708.0",
+              "enroll_limit": 0,
+              "waitlist_limit": 0,
+              "instructors": [],
+              "schedules": {
+                "oneTime": [],
+                "recurring": []
+              },
+              "associatedWithPrimary": null,
+              "courseCode": "UGBA 102A"
+            }
+          ],
+          "slug": "ugba-102a",
+          "listings": [
+            {
+              "course_code": "UGBA 102A",
+              "dept": "UGBA",
+              "courseCatalog": "102A",
+              "course_id": "ugba-102a-2016-D"
+            }
+          ],
+          "title": "Introduction to Financial Accounting",
+          "url": "/academics/teaching-semester/fall-2016/class/ugba-102a",
+          "enrollLimit": 115,
+          "waitlistLimit": 0,
+          "multiplePrimaries": true,
+          "scheduledSectionCount": 6,
+          "scheduledSections": [
+            {
+              "format": "lecture",
+              "count": 2
+            },
+            {
+              "format": "discussion",
+              "count": 4
+            }
+          ],
+          "course_code": "UGBA 102A",
+          "dept": "UGBA",
+          "courseCatalog": "102A",
+          "course_id": "ugba-102a-2016-D",
+          "class_sites": [
+            {
+              "emitter": "bCourses",
+              "id": "1452406",
+              "name": "UGBA 102A",
+              "shortDescription": "Introduction to Financial Accounting",
+              "site_url": "https://bcourses.berkeley.edu/courses/1452406",
+              "siteType": "course",
+              "sections": [
+                {
+                  "ccn": "10707"
+                },
+                {
+                  "ccn": "10708"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "role": "Instructor",
+          "sections": [
+            {
+              "ccn": "10702",
+              "instruction_format": "LEC",
+              "is_primary_section": true,
+              "section_label": "LEC 001",
+              "section_number": "001",
+              "units": null,
+              "enroll_limit": 12,
+              "waitlist_limit": 0,
+              "instructors": [
+                {
+                  "name": "Tiffany Rasmussen",
+                  "role": "PI",
+                  "uid": "921283"
+                }
+              ],
+              "schedules": {
+                "oneTime": [],
+                "recurring": [
+                  {
+                    "buildingName": "Cheit",
+                    "roomNumber": "C210",
+                    "schedule": "TuTh 12:30P-1:59P"
+                  }
+                ]
+              },
+              "courseCode": "UGBA 126"
+            },
+            {
+              "ccn": "10703",
+              "instruction_format": "DIS",
+              "is_primary_section": false,
+              "section_label": "DIS 101",
+              "section_number": "101",
+              "associated_primary_id": "10702.0",
+              "enroll_limit": 0,
+              "waitlist_limit": 0,
+              "instructors": [],
+              "schedules": {
+                "oneTime": [],
+                "recurring": [
+                  {
+                    "buildingName": "Cheit",
+                    "roomNumber": "C330",
+                    "schedule": "F 8:00A-9:59A"
+                  }
+                ]
+              },
+              "courseCode": "UGBA 126"
+            }
+          ],
+          "slug": "ugba-126",
+          "listings": [
+            {
+              "course_code": "UGBA 126",
+              "dept": "UGBA",
+              "courseCatalog": "126",
+              "course_id": "ugba-126-2016-D"
+            }
+          ],
+          "title": "Auditing",
+          "url": "/academics/teaching-semester/fall-2016/class/ugba-126",
+          "enrollLimit": 12,
+          "waitlistLimit": 0,
+          "scheduledSectionCount": 2,
+          "scheduledSections": [
+            {
+              "format": "lecture",
+              "count": 1
+            },
+            {
+              "format": "discussion",
+              "count": 1
+            }
+          ],
+          "course_code": "UGBA 126",
+          "dept": "UGBA",
+          "courseCatalog": "126",
+          "course_id": "ugba-126-2016-D",
+          "class_sites": [
+            {
+              "emitter": "bCourses",
+              "id": "1452407",
+              "name": "UGBA 126 - LEC 001",
+              "shortDescription": "Auditing",
+              "site_url": "https://bcourses.berkeley.edu/courses/1452407",
+              "siteType": "course",
+              "sections": [
+                {
+                  "ccn": "10702"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "role": "Instructor",
+          "sections": [
+            {
+              "ccn": "32961",
+              "instruction_format": "LEC",
+              "is_primary_section": true,
+              "section_label": "LEC 002",
+              "section_number": "002",
+              "units": null,
+              "enroll_limit": 21,
+              "waitlist_limit": 0,
+              "instructors": [
+                {
+                  "name": "Tiffany Rasmussen",
+                  "role": "PI",
+                  "uid": "921283"
+                }
+              ],
+              "schedules": {
+                "oneTime": [],
+                "recurring": [
+                  {
+                    "buildingName": "Cheit",
+                    "roomNumber": "C330",
+                    "schedule": "TuTh 2:00P-3:29P"
+                  }
+                ]
+              },
+              "courseCode": "UGBA 127"
+            }
+          ],
+          "slug": "ugba-127",
+          "listings": [
+            {
+              "course_code": "UGBA 127",
+              "dept": "UGBA",
+              "courseCatalog": "127",
+              "course_id": "ugba-127-2016-D"
+            }
+          ],
+          "title": "Special Topics in Accounting",
+          "url": "/academics/teaching-semester/fall-2016/class/ugba-127",
+          "enrollLimit": 21,
+          "waitlistLimit": 0,
+          "scheduledSectionCount": 1,
+          "scheduledSections": [
+            {
+              "format": "lecture",
+              "count": 1
+            }
+          ],
+          "course_code": "UGBA 127",
+          "dept": "UGBA",
+          "courseCatalog": "127",
+          "course_id": "ugba-127-2016-D",
+          "class_sites": [
+            {
+              "emitter": "bCourses",
+              "id": "1452408",
+              "name": "UGBA 127 - LEC 002",
+              "shortDescription": "Ethics in Accounting",
+              "site_url": "https://bcourses.berkeley.edu/courses/1452408",
+              "siteType": "course",
+              "sections": [
+                {
+                  "ccn": "32961"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Fall 2016",
+      "slug": "fall-2016",
+      "termCode": "D",
+      "termYear": "2016",
       "campusSolutionsTerm": true,
       "classes": [
         {

--- a/spec/models/my_academics/exams_spec.rb
+++ b/spec/models/my_academics/exams_spec.rb
@@ -30,7 +30,7 @@ describe MyAcademics::Exams do
           is_primary_section: false,
           final_exams: [],
           schedules: {
-            recurring:[
+            recurring: [
               {
                 buildingName: 'Etcheverry',
                 roomNumber: '1111',
@@ -53,15 +53,16 @@ describe MyAcademics::Exams do
         {
           is_primary_section: true,
           final_exams: [],
-          schedules: {
-            recurring:[
-              {
-                buildingName: 'Pimentel',
-                roomNumber: '1',
-                schedule: 'MWF 2:00P-2:59P'
-              }
-            ]
-          }
+          schedules:
+            {
+              recurring: [
+                {
+                  buildingName: 'Pimentel',
+                  roomNumber: '1',
+                  schedule: 'MWF 2:00P-2:59P'
+                }
+              ]
+            }
         }
       ]
     }
@@ -99,13 +100,13 @@ describe MyAcademics::Exams do
       role: 'Student',
       course_code: 'EWMBA 107',
       courseCatalog: '107',
-      sections:[
+      sections: [
         {
-          is_primary_section:true,
+          is_primary_section: true,
           final_exams: [],
           schedules:
             {
-              recurring:[]
+              recurring: []
             }
         }
       ]
@@ -118,13 +119,13 @@ describe MyAcademics::Exams do
       role: 'Student',
       course_code: 'EWMBA 299',
       courseCatalog: '299',
-      sections:[
+      sections: [
         {
-          is_primary_section:true,
+          is_primary_section: true,
           final_exams: [],
           schedules:
             {
-              recurring:[]
+              recurring: []
             }
         }
       ]
@@ -139,13 +140,112 @@ describe MyAcademics::Exams do
       courseCatalog: '201B',
       sections: [
         {
-          is_primary_section:true,
+          is_primary_section: true,
           final_exams: [],
           schedules:
             {
-              recurring:[
+              recurring: [
                 {
                   schedule: 'Sa 2:00P-6:00P'
+                }
+              ]
+            }
+        }
+      ]
+    }
+  end
+
+  let(:fall_teaching_recurring) do
+    {
+      role: 'Student',
+      courseCode: 'BIO ENG',
+      courseCatalog: '131',
+      sections: [
+        {
+          is_primary_section: true,
+          final_exams: [],
+          schedules:
+            {
+              recurring: [
+                {
+                  buildingName: 'Dwinelle',
+                  roomNumber: '155',
+                  schedule: 'MWF 2:00P-2:59P'
+                }
+              ]
+            }
+        },
+        {
+          is_primary_section: false,
+          final_exams: [],
+          schedules:
+            {
+              recurring: [
+                {
+                  buildingName: 'Etcheverry',
+                  roomNumber: '1111',
+                  schedule: 'W 4:00P-5:29P'
+                }
+              ]
+            }
+        }
+      ]
+    }
+  end
+
+  let(:spring_teaching_recurring) do
+    {
+      role: 'Student',
+      courseCode: 'BIO ENG',
+      courseCatalog: '131',
+      sections: [
+        {
+          is_primary_section: true,
+          final_exams: [],
+          schedules: {
+            recurring: [
+              {
+                buildingName: 'Dwinelle',
+                roomNumber: '155',
+                schedule: 'MWF 2:00P-2:59P'
+              }
+            ]
+          }
+        },
+        {
+          is_primary_section: false,
+          final_exams: [],
+          schedules: {
+            recurring: [
+              {
+                buildingName: 'Etcheverry',
+                roomNumber: '1111',
+                schedule: 'W 4:00P-5:29P'
+              }
+            ]
+          }
+        }
+      ]
+    }
+  end
+
+
+  let(:teaching_no_recurring) do
+    {
+      role: 'Student',
+      courseCode: 'BIO ENG',
+      courseCatalog: '131',
+      sections: [
+        {
+          is_primary_section: true,
+          final_exams: [],
+          schedules:
+            {
+              recurring: [
+                {
+                  buildingName: 'Dwinelle',
+                  roomNumber: '155',
+                  schedule: nil
                 }
               ]
             }
@@ -217,7 +317,10 @@ describe MyAcademics::Exams do
   # after parsed academic data, cs still has no exams
   let(:no_cs_exam_class) do
     {
-      name: 'CHEM 3B', number: 3, time: 'MWF 2:00P-2:59P', waitlisted: nil,
+      name: 'CHEM 3B',
+      number: 3,
+      time: 'MWF 2:00P-2:59P',
+      waitlisted: nil,
       exam_location: 'No exam.',
       exam_date: nil,
       exam_time: nil,
@@ -231,8 +334,8 @@ describe MyAcademics::Exams do
       location: 'Kroeber 221',
       exam_type: 'Y',
       exam_date: Time.parse('2016-12-12 00:00:00 UTC'),
-      exam_start_time:Time.parse('1900-01-01 19:00:00 UTC'),
-      exam_end_time:Time.parse('1900-01-01 22:00:00 UTC'),
+      exam_start_time: Time.parse('1900-01-01 19:00:00 UTC'),
+      exam_end_time: Time.parse('1900-01-01 22:00:00 UTC'),
     }
   end
 
@@ -243,7 +346,7 @@ describe MyAcademics::Exams do
       exam_type: 'A',
       exam_date: nil,
       exam_start_time: nil,
-      exam_end_time:nil,
+      exam_end_time: nil
     }
   end
 
@@ -272,7 +375,10 @@ describe MyAcademics::Exams do
 
   let(:fall_2016_semester) do
     {
-      name: 'Fall 2016', termCode: 'D', termYear: '2016', timeBucket: 'future', slug: 'fall-2016',
+      name: 'Fall 2016',
+      termCode: 'D',
+      timeBucket: 'future',
+      slug: 'fall-2016',
       classes: fall_2016_classes
     }
   end
@@ -297,7 +403,6 @@ describe MyAcademics::Exams do
     {
       name: 'Spring 2016',
       termCode: 'B',
-      termYear: '2016',
       timeBucket: 'current',
       slug: 'spring-2016',
       classes: [
@@ -312,20 +417,38 @@ describe MyAcademics::Exams do
     {
       3 => [
         {
-          name: 'CHEM 3B', number: 3, time: 'MWF 2:00P-2:59P', waitlisted: nil,
-          exam_location: '', exam_date: 'Mon 12/12', exam_time: '3-6P', exam_slot: 3
+          name: 'CHEM 3B',
+          number: 3,
+          time: 'MWF 2:00P-2:59P',
+          waitlisted: nil,
+          exam_location: '',
+          exam_date: 'Mon 12/12',
+          exam_time: '3-6P',
+          exam_slot: 3
         }
       ],
       8 => [
         {
-          name: 'COMPSCI 61B', number: 61, time: 'MWF 3:00P-3:59P', waitlisted: true,
-          exam_location: '', exam_date: 'Tue 12/13', exam_time: '7-10P', exam_slot: 8
+          name: 'COMPSCI 61B',
+          number: 61,
+          time: 'MWF 3:00P-3:59P',
+          waitlisted: true,
+          exam_location: '',
+          exam_date: 'Tue 12/13',
+          exam_time: '7-10P',
+          exam_slot: 8
         }
       ],
       15 => [
         {
-          name: 'BIO ENG 131', number: 131, time: 'MWF 2:00P-2:59P', waitlisted: nil,
-          exam_location: '', exam_date: 'Thu 12/15', exam_time: '3-6P', exam_slot: 15
+          name: 'BIO ENG 131',
+          number: 131,
+          time: 'MWF 2:00P-2:59P',
+          waitlisted: nil,
+          exam_location: '',
+          exam_date: 'Thu 12/15',
+          exam_time: '3-6P',
+          exam_slot: 15
         }
       ]
     }
@@ -367,8 +490,7 @@ describe MyAcademics::Exams do
     {
       cs_data_available: false,
       name: 'Fall 2016',
-      term: 'D',
-      term_year: '2016',
+      termCode: 'D',
       timeBucket: 'future',
       slug: 'fall-2016',
       courses: [
@@ -386,8 +508,7 @@ describe MyAcademics::Exams do
     {
       cs_data_available: true,
       name: 'Spring 2016',
-      term: 'B',
-      term_year: '2016',
+      termCode: 'B',
       timeBucket: 'current',
       slug: 'spring-2016',
       courses: [
@@ -407,19 +528,51 @@ describe MyAcademics::Exams do
     ]
   end
 
+  let(:teaching) do
+    [
+      {
+        name: 'Fall 2016',
+        termCode: 'D',
+        timeBucket: 'future',
+        slug: 'fall-2016',
+        classes: [
+          fall_teaching_recurring,
+          teaching_no_recurring
+        ]
+      },
+      {
+        name: 'Spring 2016',
+        termCode: 'B',
+        termYear: '2016',
+        timeBucket: 'current',
+        slug: 'spring-2016',
+        classes: [
+          spring_teaching_recurring,
+          teaching_no_recurring
+        ]
+      }
+
+    ]
+  end
+
   let(:feed) do
     {
       collegeAndLevel:
         {
-          careers:['Undergraduate'],
-          isCurrent:true
+          careers: ['Undergraduate'],
+          isCurrent: true
         },
-      semesters: semesters
+      semesters: semesters,
+      teachingSemesters: teaching
     }
   end
 
   subject do
     MyAcademics::Exams.new uid
+  end
+
+  let(:final_exam_conversion) do
+    Berkeley::FinalExamSchedule.fetch
   end
 
   let(:feed_after_parse_academic_data) do
@@ -475,7 +628,7 @@ describe MyAcademics::Exams do
       end
 
       it 'should assign exams correctly' do
-        result = subject.assign_exams feed_after_parse_academic_data
+        result = subject.assign_exams(feed_after_parse_academic_data, final_exam_conversion)
         expect(result.length).to eq 2
 
         # Note: These are not properly sorted because we've invoked assign_exams() directly, skipping logic in merge().
@@ -519,7 +672,9 @@ describe MyAcademics::Exams do
     context 'with semesters and classes and cs exams' do
       let(:ug_class_recurring) do
         {
-          role: 'Student', course_code: 'BIO ENG 131', courseCatalog: '131',
+          role: 'Student',
+          course_code: 'BIO ENG 131',
+          courseCatalog: '131',
           sections: [
             {
               is_primary_section: true,
@@ -540,7 +695,9 @@ describe MyAcademics::Exams do
 
       let(:no_recurring_ug_class) do
         {
-          role: 'Student', course_code: 'EWMBA 107', courseCatalog: '107',
+          role: 'Student',
+          course_code: 'EWMBA 107',
+          courseCatalog: '107',
           sections:[
             {
               is_primary_section:true,
@@ -556,7 +713,9 @@ describe MyAcademics::Exams do
 
       let(:recurring_grad_class) do
         {
-          role: 'Student', course_code: 'EWMBA 201B', courseCatalog: '201B',
+          role: 'Student',
+          course_code: 'EWMBA 201B',
+          courseCatalog: '201B',
           sections: [
             {
               is_primary_section:true,
@@ -614,8 +773,7 @@ describe MyAcademics::Exams do
           {
             cs_data_available: true,
             name: 'Fall 2016',
-            term: 'D',
-            term_year: '2016',
+            termCode: 'D',
             timeBucket: 'future',
             courses: [ no_cs_exam_class ]
           }
@@ -623,7 +781,7 @@ describe MyAcademics::Exams do
       end
 
       it 'should assign exams correctly' do
-        result = subject.assign_exams(feed_after_parse_academic_data)
+        result = subject.assign_exams(feed_after_parse_academic_data, final_exam_conversion)
         expect(result[0][:exams].length).to eq 1
         result[0][:exams].each do |exam_slot, data|
           expect(exam_slot).to eq 'none'
@@ -644,11 +802,10 @@ describe MyAcademics::Exams do
     end
 
     it 'should determine the exam key correctly' do
-      final_exam_schedule = Berkeley::FinalExamSchedule.fetch
-      expect(subject.determine_exam_key(fall_2016_semester_after_parsed, ug_class_time, final_exam_schedule)).to eq 'D-M-2:00P'
-      expect(subject.determine_exam_key(fall_2016_semester_after_parsed, ug_course_exception, final_exam_schedule)).to eq 'D-CHEM 3B'
-      expect(subject.determine_exam_key(fall_2016_semester_after_parsed, ug_class_no_time, final_exam_schedule)).to eq nil
-      expect(subject.determine_exam_key(spring_2016_semester_after_parsed, cs_class, final_exam_schedule)).to eq 'B-CHEM 3B'
+      expect(subject.determine_exam_key(fall_2016_semester_after_parsed, ug_class_time, final_exam_conversion)).to eq 'D-M-2:00P'
+      expect(subject.determine_exam_key(fall_2016_semester_after_parsed, ug_course_exception, final_exam_conversion)).to eq 'D-CHEM 3B'
+      expect(subject.determine_exam_key(fall_2016_semester_after_parsed, ug_class_no_time, final_exam_conversion)).to eq nil
+      expect(subject.determine_exam_key(spring_2016_semester_after_parsed, cs_class, final_exam_conversion)).to eq 'B-CHEM 3B'
     end
 
     it 'should determine the cs exam date correctly' do
@@ -678,6 +835,148 @@ describe MyAcademics::Exams do
       expect(subject.choose_cs_exam_location(alternate_exam)).to eq 'Final exam information not available. Please consult instructors.'
       expect(subject.choose_cs_exam_location(no_exam)).to eq 'Location TBD'
     end
+  end
 
+  context 'as an instructor' do
+    context 'without cs exams in interim' do
+      it 'should show exams properly' do
+        fall_recurring_class_exam = feed_after_merge[:teachingSemesters][0][:classes][0][:sections][0][:estimated_final_exam][0]
+        recurring_class_not_primary_exam = feed_after_merge[:teachingSemesters][0][:classes][0][:sections][0][:estimated_final_exam][1]
+        spring_recurring_class_exam = feed_after_merge[:teachingSemesters][1][:classes][0][:sections][0][:estimated_final_exam][0]
+
+        expect(fall_recurring_class_exam).to be
+        expect(fall_recurring_class_exam[:exam_location]).to eq 'Scheduled Final Exam'
+        expect(fall_recurring_class_exam[:exam_date]).to eq 'Thu 12/15'
+        expect(fall_recurring_class_exam[:exam_time]).to eq '3-6P'
+        expect(recurring_class_not_primary_exam).to_not be
+        expect(spring_recurring_class_exam[:exam_location]).to eq 'Scheduled Final Exam'
+        expect(spring_recurring_class_exam[:exam_date]).to eq 'Tue 5/10'
+        expect(spring_recurring_class_exam[:exam_time]).to eq '11:30-2:30P'
+      end
+    end
+
+    context 'with cs exams' do
+      let(:fall_teaching_recurring) do
+        {
+          role: 'Student',
+          courseCode: 'BIO ENG 131',
+          courseCatalog: '131',
+          sections: [
+            {
+              is_primary_section: true,
+              final_exams: [all_exam],
+              schedules: {
+                recurring: [
+                  {
+                    buildingName:'LeConte',
+                    roomNumber: '251',
+                    schedule: 'MWF 2:00P-2:59P'
+                  }
+                ]
+              }
+            },
+            {
+              is_primary_section: false,
+              final_exams: [],
+              schedules: {
+                recurring: [
+                  {
+                    buildingName: 'Etcheverry',
+                    roomNumber: '1111',
+                    schedule: 'W 4:00P-5:29P'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      end
+
+      let(:spring_teaching_recurring) do
+        {
+          role: 'Student',
+          courseCode: 'BIO ENG 131',
+          courseCatalog: '131',
+          sections: [
+            {
+              is_primary_section: true,
+              final_exams: [all_exam],
+              schedules: {
+                recurring: [
+                  {
+                    buildingName: 'LeConte',
+                    roomNumber:'251',
+                    schedule:'MWF 2:00P-2:59P'
+                  }
+                ]
+              }
+            },
+            {
+              is_primary_section: false,
+              final_exams: [],
+              schedules: {
+                recurring: [
+                  {
+                    buildingName: 'Etcheverry',
+                    roomNumber: '1111',
+                    schedule: 'W 4:00P-5:29P'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      end
+
+      let(:teaching_no_recurring) do
+        {
+          role: 'Student',
+          courseCode: 'BIO ENG 131',
+          courseCatalog: '131',
+          sections: [
+            {
+              is_primary_section: true,
+              final_exams: [no_exam],
+              schedules: {
+                recurring: [
+                  {
+                    buildingName:'LeConte',
+                    roomNumber:'251',
+                    schedule: nil
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      end
+      it 'should show exams properly' do
+        fall_recurring_class_exam = feed_after_merge[:teachingSemesters][0][:classes][0][:sections][0][:estimated_final_exam][0]
+        recurring_class_not_primary_exam = feed_after_merge[:teachingSemesters][0][:classes][0][:sections][0][:estimated_final_exam][1]
+        fall_not_recurring_class_exam = feed_after_merge[:teachingSemesters][0][:classes][1][:sections][0][:estimated_final_exam][0]
+        spring_recurring_class_exam = feed_after_merge[:teachingSemesters][1][:classes][0][:sections][0][:estimated_final_exam][0]
+        spring_not_recurring_class_exam = feed_after_merge[:teachingSemesters][1][:classes][1][:sections][0][:estimated_final_exam][0]
+
+        expect(fall_recurring_class_exam).to be
+        expect(fall_recurring_class_exam[:exam_location]).to eq 'Scheduled Final Exam'
+        expect(fall_recurring_class_exam[:exam_date]).to eq 'Thu 12/15'
+        expect(fall_recurring_class_exam[:exam_time]).to eq '3-6P'
+        expect(recurring_class_not_primary_exam).to_not be
+        expect(fall_not_recurring_class_exam).to be
+        expect(fall_not_recurring_class_exam[:exam_location]).to eq 'Location TBD'
+        expect(fall_not_recurring_class_exam[:exam_date]).to eq nil
+        expect(fall_not_recurring_class_exam[:exam_time]).to eq nil
+
+        expect(spring_recurring_class_exam).to be
+        expect(spring_recurring_class_exam[:exam_location]).to eq 'Kroeber 221'
+        expect(spring_recurring_class_exam[:exam_date]).to eq 'Mon 12/12'
+        expect(spring_recurring_class_exam[:exam_time]).to eq '07:00PM-10:00PM'
+
+        expect(spring_not_recurring_class_exam).to be
+        expect(spring_not_recurring_class_exam[:exam_location]).to eq 'Location TBD'
+        expect(spring_not_recurring_class_exam[:exam_date]).to eq nil
+        expect(spring_not_recurring_class_exam[:exam_time]).to eq nil
+      end
+    end
   end
 end

--- a/src/assets/templates/academics_classinfo.html
+++ b/src/assets/templates/academics_classinfo.html
@@ -103,15 +103,20 @@
             </div>
           </div>
 
-          <div class="cc-academics-schedules" data-ng-if="classScheduleCount.oneTime">
+          <div class="cc-academics-schedules">
             <div class="cc-academics-column-labels cc-academics-schedule-label">Individual Sessions</div>
             <div class="row collapse" data-ng-repeat="section in selectedCourse.sections" data-ng-if="!section.scheduledWithCcn">
-              <div class="small-3 columns" data-ng-if="section.schedules.oneTime.length" data-ng-bind="section.section_label"></div>
+              <div class="small-3 columns" data-ng-if="section.estimated_final_exam.length || section.schedules.oneTime.length" data-ng-bind="section.section_label"></div>
               <div class="small-9 columns">
                 <div data-ng-repeat="schedule in section.schedules.oneTime" data-ng-if="section.schedules.oneTime" class="cc-academics-schedule-room">
                   <span data-ng-bind="schedule.date"></span> |
                   <span data-ng-bind="schedule.time"></span> |
                   <span data-ng-bind="schedule.roomNumber"></span> <span data-ng-bind="schedule.buildingName"></span> <br>
+                </div>
+                <div ng-repeat="exam in section.estimated_final_exam" data-ng-if="section.estimated_final_exam.length" class="cc-academics-schedule-room">
+                  <span data-ng-bind="exam.exam_date"></span> |
+                  <span data-ng-bind="exam.exam_time"></span> |
+                  <span data-ng-bind="exam.exam_location"></span> <br>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26288
Design: https://jira.berkeley.edu/browse/SISRP-22748

Pull request to get some feelers out to devs. Essentially the purpose is to show instructors their scheduled final exam slot on the class page so they know whether to cancel or hold their final exam at that time. Most of this is in the `assign_exam_to_instructor` method, which copies and utilizes many of the already existing methods in `exams.rb` (which is both good and bad...). Any comments will be appreciated!

More information and what it's supposed to look like on the JIRA!