### PR TITLE
SISRP-25362 - adds handling for CS API error responses with status=200

### DIFF
--- a/app/models/campus_solutions/proxy.rb
+++ b/app/models/campus_solutions/proxy.rb
@@ -92,7 +92,7 @@ module CampusSolutions
     end
 
     def is_errored?(feed)
-      feed.is_a?(Hash) && feed[:errmsgtext].present?
+      !feed.is_a?(Hash) || feed[:errmsgtext].present?
     end
 
     def request_options

--- a/spec/models/campus_solutions/proxy_spec.rb
+++ b/spec/models/campus_solutions/proxy_spec.rb
@@ -9,13 +9,22 @@ describe CampusSolutions::Proxy do
       allow(response).to receive(:body).and_return double force_encoding: nil
       allow(response).to receive(:parsed_response).and_return feed
     }
-    context 'errmsgtext in response' do
-      let(:feed) { { 'ERRMSGTEXT' => 'Wicked problems' } }
+    shared_examples 'a proxy that handles errors' do
       it 'should flag error condition' do
         processed_feed = HashConverter.downcase_and_camelize feed
         expect(subject.is_errored? processed_feed).to be true
         expect(subject.get).to eq ({ statusCode: 400, errored: true, feed: processed_feed })
       end
+    end
+
+    context 'errmsgtext in response' do
+      let(:feed) { { 'ERRMSGTEXT' => 'Wicked problems' } }
+      it_behaves_like 'a proxy that handles errors'
+    end
+
+    context 'invalid response' do
+      let(:feed) { '<HTML><HEAD><TITLE>RESTListeningConnector</TITLE></HEAD><BODY>Unable to find a Routing corresponding to the incoming request message.</BODY></HTML>' }
+      it_behaves_like 'a proxy that handles errors'
     end
   end
 end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-25362 (ticket not related; I ran into this issue working on the degree progress API but it was a preexisting issue)

If we try to hit a CS endpoint that doesn't exist, we'll get a string response but a successful status code.  This fix will flag it as an error so we can properly deal with it and avoid `TypeError`s down the line.