### PR TITLE
CLC-6464 CLC-6465 New tables and models for mailing lists; adapt sync logic

### DIFF
--- a/app/controllers/canvas_mailing_lists_controller.rb
+++ b/app/controllers/canvas_mailing_lists_controller.rb
@@ -23,10 +23,17 @@ class CanvasMailingListsController < ApplicationController
   end
 
   # POST /api/academics/canvas/mailing_lists/:canvas_course_id/create
+  # Unlike other CRUD actions, list creation must specify which type of list is being created.
 
   def create
-    list = MailingLists::SiteMailingList.create canvas_site_id: canvas_course_id.to_s, list_name: params['listName']
-    render json: list.to_json
+    list_type = params['listType'] || 'CalmailList'
+    list_class = MailingLists.const_get(list_type) rescue nil
+    if MailingLists::SiteMailingList.subclasses.include? list_class
+      list = list_class.create canvas_site_id: canvas_course_id.to_s, list_name: params['listName']
+      render json: list.to_json
+    else
+      raise Errors::BadRequestError, "Unrecognized list type '#{list_type}'"
+    end
   end
 
   # POST /api/academics/canvas/mailing_lists/:canvas_course_id/populate

--- a/app/models/mailing_lists/calmail_list.rb
+++ b/app/models/mailing_lists/calmail_list.rb
@@ -1,0 +1,109 @@
+module MailingLists
+  class CalmailList < SiteMailingList
+
+    # Lists with membership stored in Calmail enter a 'pending' state on first save, and are not
+    # considered 'created' until we've verified creation on the Calmail side.
+    before_create { self.state = 'pending' }
+    after_find { check_for_creation if self.state == 'pending' }
+
+    def self.domain
+      Settings.calmail_proxy.domain
+    end
+
+    private
+
+    def add_list_urls(feed)
+      feed[:mailingList][:creationUrl] = build_creation_url if self.state == 'pending'
+      feed[:mailingList][:administrationUrl] = build_administration_url if self.state == 'created'
+    end
+
+    def build_administration_url
+      Settings.calmail_proxy.base_url.sub(
+        /api1\Z/,
+        "list/listinfo/#{self.list_name}%40#{self.class.domain}"
+      )
+    end
+
+    def build_creation_url
+      params = {
+        domain_name: self.class.domain,
+        listname: self.list_name,
+        owner_address: Settings.calmail_proxy.owner_address,
+        advertised: 0,
+        subscribe_policy: 3,
+        moderate: 1,
+        generic_nonmember_action: 1
+      }
+      Settings.calmail_proxy.base_url.sub(/api1\Z/, "list/domain_create_list2?#{params.to_query}")
+    end
+
+    def check_for_creation
+      if name_available? == false
+        self.state = 'created'
+        save
+      end
+    end
+
+    def add_member(address, first_name, last_name, roles)
+      @add_member_proxy ||= Calmail::AddListMember.new
+      proxy_response = @add_member_proxy.add_member(self.list_name, address, "#{first_name} #{last_name}")
+      proxy_response[:response] && proxy_response[:response][:added]
+    end
+
+    def get_list_members
+      if (list_members = Calmail::ListMembers.new.list_members self.list_name)
+        addresses = list_members[:response] && list_members[:response][:addresses]
+        # Addresses are returned in a Hash for 1) quick lookup; 2) compatibility with non-Calmail implementations that
+        # return additional member data.
+        addresses.inject({}) { |hash, address| hash[address] = true; hash }
+      end
+    end
+
+    def log_population_results
+      # The Calmail API may successfully update memberships without returning a success response, so do
+      # a post-update check on any failures to see if they were real failures.
+      if any_population_failures? && (addresses_after_update = get_list_members)
+        population_results[:add][:failure].reject! { |address| addresses_after_update.has_key? address }
+        population_results[:remove][:failure].reject! { |address| !addresses_after_update.has_key? address }
+        population_results[:add][:success] = population_results[:add][:total] - population_results[:add][:failure].count
+        population_results[:remove][:success] = population_results[:remove][:total] - population_results[:remove][:failure].count
+        self.members_count = addresses_after_update.count
+      else
+        self.members_count = population_results[:initial_count] + population_results[:add][:success] - population_results[:remove][:success]
+      end
+
+      logger.info "Added #{population_results[:add][:success]} of #{population_results[:add][:total]} new site members."
+      if population_results[:add][:failure].any?
+        logger.error "Failed to add #{population_results[:add][:failure].count} addresses to #{self.list_name}: #{population_results[:add][:failure].join ', '}"
+      end
+
+      logger.info "Removed #{population_results[:remove][:success]} of #{population_results[:remove][:total]} former site members."
+      if population_results[:remove][:failure].any?
+        logger.error "Failed to remove #{population_results[:remove][:failure].count} addresses from #{self.list_name}: #{population_results[:remove][:failure].join ', '}"
+      end
+    end
+
+    def name_available?
+      return if list_name.blank?
+      if (check_namespace = Calmail::CheckNamespace.new.name_available? self.list_name) &&
+        (check_namespace[:response] == true || check_namespace[:response] == false)
+        check_namespace[:response]
+      else
+        self.request_failure = 'There was an error connecting to Calmail.'
+        nil
+      end
+    end
+
+    def remove_member(address)
+      @remove_member_proxy ||= Calmail::RemoveListMember.new
+      proxy_response = @remove_member_proxy.remove_member(self.list_name, address)
+      proxy_response[:response] && proxy_response[:response][:removed]
+    end
+
+    def update_required?(old_member_data, new_member_data)
+      # The Calmail implementation does not support member data updates.
+      false
+    end
+
+  end
+end

--- a/app/models/mailing_lists/mailgun_list.rb
+++ b/app/models/mailing_lists/mailgun_list.rb
@@ -1,0 +1,70 @@
+module MailingLists
+  class MailgunList < SiteMailingList
+
+    # Mailgun lists have membership stored locally and are considered 'created' as soon as they're saved.
+    has_many :members, class_name: 'MailingLists::Member', foreign_key: 'mailing_list_id'
+    before_create { self.state = 'created' }
+
+    def self.domain
+      Settings.mailgun_proxy.domain
+    end
+
+    def add_list_urls(feed)
+      # No-op; Mailgun lists have no external administration URLs.
+    end
+
+    def add_member(address, first_name, last_name, can_send)
+      MailingLists::Member.create!(
+        email_address: address,
+        first_name: first_name,
+        last_name: last_name,
+        can_send: can_send,
+        mailing_list_id: self.id
+      )
+    rescue => e
+      logger.error "Failed to add #{address} to mailing list #{self.list_name}: #{e.message}\n\t#{e.backtrace.join "\n\t"}"
+      false
+    end
+
+    def get_list_members
+      self.members.inject({}) { |members_by_email, member| members_by_email[member.email_address] = member; members_by_email }
+    end
+
+    def log_population_results
+      self.members_count = self.members.count
+
+      logger.info "Added #{population_results[:add][:success]} of #{population_results[:add][:total]} new site members."
+      if population_results[:add][:failure].any?
+        logger.error "Failed to add #{population_results[:add][:failure].count} addresses to #{self.list_name}: #{population_results[:add][:failure].join ', '}"
+      end
+
+      logger.info "Removed #{population_results[:remove][:success]} of #{population_results[:remove][:total]} former site members."
+      if population_results[:remove][:failure].any?
+        logger.error "Failed to remove #{population_results[:remove][:failure].count} addresses from #{self.list_name}: #{population_results[:remove][:failure].join ', '}"
+      end
+
+      logger.info "Updated #{population_results[:update][:success]} of #{population_results[:update][:total]} new site members."
+      if population_results[:update][:failure].any?
+        logger.error "Failed to update #{population_results[:update][:failure].count} addresses in #{self.list_name}: #{population_results[:update][:failure].join ', '}"
+      end
+    end
+
+    def name_available?
+      MailingLists::SiteMailingList.find_by(list_name: self.list_name).nil?
+    end
+
+    def remove_member(address)
+      if (member = self.members.find_by email_address: address)
+        member.destroy
+      end
+    end
+
+    def update_member(member, course_user_data)
+      member.update_attributes course_user_data.slice(:first_name, :last_name, :can_send)
+    end
+
+    def update_required?(member, course_user_data)
+      [:first_name, :last_name, :can_send].any? { |attr| course_user_data[attr] != member.send(attr) }
+    end
+  end
+end

--- a/app/models/mailing_lists/member.rb
+++ b/app/models/mailing_lists/member.rb
@@ -1,0 +1,13 @@
+module MailingLists
+  class Member < ActiveRecord::Base
+    include ActiveRecordHelper
+    include ClassLogger
+
+    belongs_to :mailing_list, class_name: 'MailingLists::SiteMailingList', foreign_key: 'mailing_list_id'
+
+    self.table_name = 'canvas_site_mailing_list_members'
+
+    attr_accessible :first_name, :last_name, :email_address, :can_send, :mailing_list_id
+
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -166,6 +166,9 @@ eft_proxy:
   base_url: 'https://eftstudent-qa.berkeley.edu/api/'
   token: 'secret'
 
+mailgun_proxy:
+  domain: 'example.mailgun.com'
+
 regstatus_proxy:
   fake: false
   app_id: ''

--- a/db/developer-seed-data.sql
+++ b/db/developer-seed-data.sql
@@ -14,6 +14,8 @@ DROP INDEX public.index_user_auths_on_uid;
 DROP INDEX public.index_summer_sub_terms_on_year_and_sub_term_code;
 DROP INDEX public.index_service_alerts_on_display_and_created_at;
 DROP INDEX public.index_fin_aid_years_on_current_year;
+DROP INDEX public.index_canvas_site_mailing_lists_on_canvas_site_id;
+DROP INDEX public.mailing_list_membership_index;
 ALTER TABLE ONLY public.user_roles DROP CONSTRAINT user_roles_pkey;
 ALTER TABLE ONLY public.user_auths DROP CONSTRAINT user_auths_pkey;
 ALTER TABLE ONLY public.summer_sub_terms DROP CONSTRAINT summer_sub_terms_pkey;
@@ -25,6 +27,8 @@ ALTER TABLE ONLY public.links DROP CONSTRAINT links_pkey;
 ALTER TABLE ONLY public.link_sections DROP CONSTRAINT link_sections_pkey;
 ALTER TABLE ONLY public.link_categories DROP CONSTRAINT link_categories_pkey;
 ALTER TABLE ONLY public.fin_aid_years DROP CONSTRAINT fin_aid_years_pkey;
+ALTER TABLE ONLY public.canvas_site_mailing_lists DROP CONSTRAINT canvas_site_mailing_lists_pkey;
+ALTER TABLE ONLY public.canvas_site_mailing_list_members DROP CONSTRAINT canvas_site_mailing_list_members_pkey;
 ALTER TABLE public.user_roles ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE public.user_auths ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE public.summer_sub_terms ALTER COLUMN id DROP DEFAULT;
@@ -34,6 +38,8 @@ ALTER TABLE public.links ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE public.link_sections ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE public.link_categories ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE public.fin_aid_years ALTER COLUMN id DROP DEFAULT;
+ALTER TABLE public.canvas_site_mailing_lists ALTER COLUMN id DROP DEFAULT;
+ALTER TABLE public.canvas_site_mailing_list_members ALTER COLUMN id DROP DEFAULT;
 DROP SEQUENCE public.user_roles_id_seq;
 DROP TABLE public.user_roles;
 DROP SEQUENCE public.user_auths_id_seq;
@@ -55,11 +61,84 @@ DROP SEQUENCE public.link_categories_id_seq;
 DROP TABLE public.link_categories;
 DROP SEQUENCE public.fin_aid_years_id_seq;
 DROP TABLE public.fin_aid_years;
+DROP SEQUENCE public.canvas_site_mailing_lists_id_seq;
+DROP TABLE public.canvas_site_mailing_lists;
+DROP SEQUENCE public.canvas_site_mailing_list_members_id_seq;
+DROP TABLE public.canvas_site_mailing_list_members;
 SET search_path = public, pg_catalog;
 
 SET default_tablespace = '';
 
 SET default_with_oids = false;
+
+--
+-- Name: canvas_site_mailing_list_members; Type: TABLE; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE TABLE canvas_site_mailing_list_members (
+  id integer NOT NULL,
+  mailing_list_id integer NOT NULL,
+  first_name character varying(255),
+  last_name character varying(255),
+  email_address character varying(255) NOT NULL,
+  can_send boolean DEFAULT false NOT NULL,
+  created_at timestamp without time zone,
+  updated_at timestamp without time zone
+);
+
+--
+-- Name: canvas_site_mailing_list_members_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE canvas_site_mailing_list_members_id_seq
+START WITH 1
+INCREMENT BY 1
+NO MINVALUE
+NO MAXVALUE
+CACHE 1;
+
+
+--
+-- Name: canvas_site_mailing_list_members_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE canvas_site_mailing_list_members_id_seq OWNED BY canvas_site_mailing_list_members.id;
+
+--
+-- Name: canvas_site_mailing_lists; Type: TABLE; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE TABLE canvas_site_mailing_lists (
+  id integer NOT NULL,
+  canvas_site_id character varying(255),
+  list_name character varying(255),
+  state character varying(255),
+  populated_at timestamp without time zone,
+  created_at timestamp without time zone,
+  updated_at timestamp without time zone,
+  members_count integer,
+  populate_add_errors integer,
+  populate_remove_errors integer,
+  type character varying(255)
+);
+
+--
+-- Name: canvas_site_mailing_lists_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE canvas_site_mailing_lists_id_seq
+START WITH 1
+INCREMENT BY 1
+NO MINVALUE
+NO MAXVALUE
+CACHE 1;
+
+--
+-- Name: canvas_site_mailing_lists_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE canvas_site_mailing_lists_id_seq OWNED BY canvas_site_mailing_lists.id;
+
 
 --
 -- Name: fin_aid_years; Type: TABLE; Schema: public; Owner: -; Tablespace:
@@ -393,6 +472,20 @@ CREATE SEQUENCE user_roles_id_seq
 --
 
 ALTER SEQUENCE user_roles_id_seq OWNED BY user_roles.id;
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY canvas_site_mailing_list_members ALTER COLUMN id SET DEFAULT nextval('canvas_site_mailing_list_members_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY canvas_site_mailing_lists ALTER COLUMN id SET DEFAULT nextval('canvas_site_mailing_lists_id_seq'::regclass);
 
 
 --
@@ -1962,6 +2055,21 @@ SELECT pg_catalog.setval('user_roles_id_seq', 3, true);
 
 
 --
+-- Name: canvas_site_mailing_list_members_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY canvas_site_mailing_list_members
+  ADD CONSTRAINT canvas_site_mailing_list_members_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: canvas_site_mailing_lists_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY canvas_site_mailing_lists
+  ADD CONSTRAINT canvas_site_mailing_lists_pkey PRIMARY KEY (id);
+
+--
 -- Name: fin_aid_years_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
@@ -2034,6 +2142,13 @@ ALTER TABLE ONLY user_roles
 
 
 --
+-- Name: index_canvas_site_mailing_lists_on_canvas_site_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE UNIQUE INDEX index_canvas_site_mailing_lists_on_canvas_site_id ON canvas_site_mailing_lists USING btree (canvas_site_id);
+
+
+--
 -- Name: index_fin_aid_years_on_current_year; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
@@ -2073,6 +2188,13 @@ CREATE INDEX index_summer_sub_terms_on_year_and_sub_term_code ON summer_sub_term
 --
 
 CREATE UNIQUE INDEX index_user_auths_on_uid ON user_auths USING btree (uid);
+
+
+--
+-- Name: mailing_list_membership_index; Type: INDEX; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE UNIQUE INDEX mailing_list_membership_index ON canvas_site_mailing_list_members USING btree (mailing_list_id, email_address);
 
 
 --

--- a/db/migrate/20161017234930_add_type_to_canvas_site_mailing_lists.rb
+++ b/db/migrate/20161017234930_add_type_to_canvas_site_mailing_lists.rb
@@ -1,0 +1,15 @@
+class AddTypeToCanvasSiteMailingLists < ActiveRecord::Migration
+  def change
+    add_column :canvas_site_mailing_lists, :type, :string
+
+    # All lists created pre-migration are of the CalmailList type.
+    reversible do |dir|
+      dir.up do
+        MailingLists::SiteMailingList.update_all type: 'MailingLists::CalmailList'
+      end
+      dir.down do
+        # The column should be dropped.
+      end
+    end
+  end
+end

--- a/db/migrate/20161017235830_create_canvas_site_mailing_list_members.rb
+++ b/db/migrate/20161017235830_create_canvas_site_mailing_list_members.rb
@@ -1,0 +1,15 @@
+class CreateCanvasSiteMailingListMembers < ActiveRecord::Migration
+  def change
+    create_table :canvas_site_mailing_list_members do |t|
+      t.integer :mailing_list_id, null: false
+      t.string :first_name
+      t.string :last_name
+      t.string :email_address, null: false
+      t.boolean :can_send, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :canvas_site_mailing_list_members, [:mailing_list_id, :email_address], unique: true, name: 'mailing_list_membership_index'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151222002724) do
+ActiveRecord::Schema.define(version: 20161017235830) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "canvas_site_mailing_list_members", force: true do |t|
+    t.integer  "mailing_list_id",                 null: false
+    t.string   "first_name"
+    t.string   "last_name"
+    t.string   "email_address",                   null: false
+    t.boolean  "can_send",        default: false, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "canvas_site_mailing_list_members", ["mailing_list_id", "email_address"], name: "mailing_list_membership_index", unique: true, using: :btree
 
   create_table "canvas_site_mailing_lists", force: true do |t|
     t.string   "canvas_site_id"
@@ -26,6 +38,7 @@ ActiveRecord::Schema.define(version: 20151222002724) do
     t.integer  "members_count"
     t.integer  "populate_add_errors"
     t.integer  "populate_remove_errors"
+    t.string   "type"
   end
 
   add_index "canvas_site_mailing_lists", ["canvas_site_id"], name: "index_canvas_site_mailing_lists_on_canvas_site_id", unique: true, using: :btree

--- a/spec/controllers/canvas_mailing_lists_controller_spec.rb
+++ b/spec/controllers/canvas_mailing_lists_controller_spec.rb
@@ -45,15 +45,38 @@ describe CanvasMailingListsController do
   end
 
   describe '#create' do
-    let(:make_request) { post :create, canvas_course_id: course_id, list_name: 'digression_analysis-sp15' }
+    let(:make_request) { post :create, canvas_course_id: course_id, listName: 'digression_analysis-sp15', listType: list_type }
+    let(:list_type) { nil }
     include_examples 'authorization and error handling'
 
-    it 'returns a fake pending mailing list' do
-      allow(MailingLists::SiteMailingList).to receive(:create).and_return fake_mailing_list('canvas_site_mailing_list_pending.json')
+    context 'no list type specified' do
+      it 'returns a Calmail list' do
+        expect(MailingLists::CalmailList).to receive(:create).and_return fake_mailing_list('canvas_site_mailing_list_pending.json')
 
-      make_request
-      expect(response.status).to eq 200
-      expect(response.body).to include '"state":"pending"'
+        make_request
+        expect(response.status).to eq 200
+        expect(response.body).to include '"state":"pending"'
+      end
+    end
+
+    context 'Mailgun list specified' do
+      let(:list_type) { 'MailgunList' }
+
+      it 'returns a Mailgun list' do
+        expect(MailingLists::MailgunList).to receive(:create).and_return fake_mailing_list('canvas_site_mailing_list_pending.json')
+
+        make_request
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'unknown list type specified' do
+      let(:list_type) { 'typo' }
+
+      it 'returns an error' do
+        make_request
+        expect(response.status).to eq 400
+      end
     end
   end
 

--- a/spec/models/mailing_lists/mailgun_list_spec.rb
+++ b/spec/models/mailing_lists/mailgun_list_spec.rb
@@ -1,0 +1,243 @@
+describe MailingLists::MailgunList do
+  let(:canvas_site_id) { '1121' }
+  let(:fake_course_data) { Canvas::Course.new(canvas_course_id: canvas_site_id, fake: true).course[:body] }
+  before { allow_any_instance_of(Canvas::Course).to receive(:course).and_return(statusCode: 200, body: fake_course_data) }
+
+  let(:response) { JSON.parse list.to_json}
+  let(:list_domain) { Settings.mailgun_proxy.domain }
+
+  include_examples 'a newly initialized mailing list'
+
+  context 'creating a list' do
+    let(:create_list) { described_class.create(canvas_site_id: canvas_site_id) }
+    let(:list) { create_list }
+
+    it 'reports list created' do
+      count = described_class.count
+      create_list
+      expect(described_class.count).to eq count+1
+      expect(response['mailingList']['state']).to eq 'created'
+    end
+
+    include_examples 'mailing list creation errors'
+  end
+
+  context 'an existing list record' do
+    before { described_class.create(canvas_site_id: canvas_site_id)  }
+    let(:list) { described_class.find_by(canvas_site_id: canvas_site_id) }
+
+    it 'reports state as created' do
+      expect(response['mailingList']['state']).to eq 'created'
+      expect(response['mailingList']['creationUrl']).not_to be_present
+      expect(response['mailingList']).not_to include('timeLastPopulated')
+    end
+
+    context 'populating list' do
+      let(:course_users) { Canvas::CourseUsers.new(canvas_course_id: canvas_site_id, fake: true) }
+
+      let(:oliver) do {
+        'login_id' => '12345',
+        'first_name' => 'Oliver',
+        'last_name' => 'Heyer',
+        'email_address' => 'oheyer@berkeley.edu',
+        'enrollments' => [{'role' => 'TeacherEnrollment'}]
+      } end
+      let(:ray) do {
+        'login_id' => '67890',
+        'first_name' => 'Ray',
+        'last_name' => 'Davis',
+        'email_address' => 'raydavis@berkeley.edu',
+        'enrollments' => [{'role' => 'StudentEnrollment'}]
+      } end
+      let(:paul) do {
+        'login_id' => '65536',
+        'first_name' => 'Paul',
+        'last_name' => 'Kerschen',
+        'email_address' => 'kerschen@berkeley.edu',
+        'enrollments' => [{'role' => 'StudentEnrollment'}]
+      } end
+
+      def basic_attributes(user)
+        {
+          ldap_uid: user['login_id'],
+          first_name: user['first_name'],
+          last_name: user['last_name'],
+          email_address: user['email_address']
+        }
+      end
+
+      def create_mailing_list_members(*users)
+        users.each do |user|
+          MailingLists::Member.create!(
+            mailing_list_id: list.id,
+            first_name: user['first_name'],
+            last_name: user['last_name'],
+            email_address: user['email_address'],
+            can_send: (user['enrollments'][0]['role'] == 'TeacherEnrollment')
+          )
+        end
+      end
+
+      before do
+        allow(Canvas::CourseUsers).to receive(:new).and_return course_users
+        expect(course_users).to receive(:course_users).exactly(1).times.and_return(statusCode: 200, body: canvas_site_members)
+        expect(User::BasicAttributes).to receive(:attributes_for_uids).exactly(1).times.and_return(canvas_site_members.map { |user| basic_attributes user })
+      end
+
+      def expect_empty_population_results(list, action)
+        expect(list.population_results[action][:total]).to eq 0
+        expect(list.population_results[action][:success]).to eq 0
+        expect(list.population_results[action][:failure]).to eq []
+      end
+
+      context 'populating an empty list' do
+        let(:canvas_site_members) { [oliver, ray, paul] }
+
+        it 'requests addition and reports success' do
+          expect(list.members.count).to eq 0
+
+          expect(MailingLists::Member).to receive(:create!).exactly(3).times.and_call_original
+          expect_any_instance_of(MailingLists::Member).not_to receive(:destroy)
+          expect_any_instance_of(MailingLists::Member).not_to receive(:update_attributes)
+          list.populate
+
+          expect(list.population_results[:add][:success]).to eq 3
+          expect_empty_population_results(list, :remove)
+          expect_empty_population_results(list, :update)
+
+          expect(response['populationResults']['success']).to eq true
+          expect(response['populationResults']['messages']).to eq ['3 new members were added.']
+          expect(list.members.count).to eq 3
+        end
+
+        it 'enables sending permission for teacher role only' do
+          list.populate
+
+          expect(list.members.find_by(email_address: 'oheyer@berkeley.edu').can_send).to eq true
+          expect(list.members.find_by(email_address: 'raydavis@berkeley.edu').can_send).to eq false
+          expect(list.members.find_by(email_address: 'kerschen@berkeley.edu').can_send).to eq false
+        end
+      end
+
+      context 'no change in list membership' do
+        let(:canvas_site_members) { [oliver, ray, paul] }
+        before { create_mailing_list_members(oliver, ray, paul) }
+
+        it 'makes no changes' do
+          expect(list.members.count).to eq 3
+          expect(MailingLists::Member).not_to receive(:create!)
+          expect_any_instance_of(MailingLists::Member).not_to receive(:destroy)
+          expect_any_instance_of(MailingLists::Member).not_to receive(:update_attributes)
+          list.populate
+          expect(list.members.count).to eq 3
+        end
+
+        it 'returns time, no errors and empty results' do
+          list.populate
+          expect(response['mailingList']['timeLastPopulated']).to be_present
+          expect(response).not_to include 'errorMessages'
+          expect_empty_population_results(list, :add)
+          expect_empty_population_results(list, :remove)
+          expect_empty_population_results(list, :update)
+          expect(response['populationResults']['success']).to eq true
+          expect(response['populationResults']['messages']).to eq []
+        end
+      end
+
+      context 'new users in course site' do
+        let(:canvas_site_members) { [oliver, ray, paul] }
+        before { create_mailing_list_members(oliver) }
+
+        it 'requests addition of new users only' do
+          expect(list.members.count).to eq 1
+
+          expect(MailingLists::Member).to receive(:create!).exactly(1).times.with(
+            email_address: 'raydavis@berkeley.edu',
+            first_name: 'Ray',
+            last_name: 'Davis',
+            can_send: false,
+            mailing_list_id: list.id
+          ).and_call_original
+          expect(MailingLists::Member).to receive(:create!).exactly(1).times.with(
+            email_address: 'kerschen@berkeley.edu',
+            first_name: 'Paul',
+            last_name: 'Kerschen',
+            can_send: false,
+            mailing_list_id: list.id
+          ).and_call_original
+          expect_any_instance_of(MailingLists::Member).not_to receive(:destroy)
+          expect_any_instance_of(MailingLists::Member).not_to receive(:update_attributes)
+
+          list.populate
+
+          expect(list.population_results[:add][:total]).to eq 2
+          expect(list.population_results[:add][:success]).to eq 2
+          expect(list.population_results[:add][:failure]).to eq []
+          expect_empty_population_results(list, :remove)
+          expect_empty_population_results(list, :update)
+
+          expect(response['populationResults']['success']).to eq true
+          expect(response['populationResults']['messages']).to eq ['2 new members were added.']
+
+          expect(list.members.count).to eq 3
+        end
+      end
+
+      context 'users no longer in course site' do
+        let(:canvas_site_members) { [oliver, ray] }
+        before { create_mailing_list_members(oliver, ray, paul) }
+
+        it 'requests removal of departed users only' do
+          expect(list.members.count).to eq 3
+
+          expect(MailingLists::Member).not_to receive(:create!)
+          expect_any_instance_of(MailingLists::Member).not_to receive(:update_attributes)
+          expect_any_instance_of(MailingLists::Member).to receive(:destroy).exactly(1).times.and_call_original
+
+          list.populate
+
+          expect_empty_population_results(list, :add)
+          expect(list.population_results[:remove][:total]).to eq 1
+          expect(list.population_results[:remove][:success]).to eq 1
+          expect(list.population_results[:remove][:failure]).to eq []
+          expect(response['populationResults']['success']).to eq true
+          expect(response['populationResults']['messages']).to eq ['1 former member was removed.']
+
+          expect(list.members.count).to eq 2
+          expect(list.members.reload.map { |member| member.email_address}).not_to include 'kerschen@berkeley.edu'
+        end
+      end
+
+      context 'user with changed permissions' do
+        let(:canvas_site_members) { [oliver, ray, paul] }
+        before do
+          student_oliver = oliver.merge({'enrollments' => [{'role' => 'StudentEnrollment'}]})
+          create_mailing_list_members(student_oliver, ray, paul)
+        end
+
+        it 'updates user\'s sending permission' do
+          expect(list.members.count).to eq 3
+          expect(list.members.find_by(email_address: 'oheyer@berkeley.edu').can_send).to eq false
+
+          expect(MailingLists::Member).not_to receive(:create!)
+          expect_any_instance_of(MailingLists::Member).not_to receive(:destroy)
+          expect_any_instance_of(MailingLists::Member).to receive(:update_attributes).exactly(1).times.and_call_original
+
+          list.populate
+
+          expect(list.members.count).to eq 3
+          expect(list.members.find_by(email_address: 'oheyer@berkeley.edu').can_send).to eq true
+
+          expect_empty_population_results(list, :add)
+          expect_empty_population_results(list, :remove)
+          expect(list.population_results[:update][:total]).to eq 1
+          expect(list.population_results[:update][:success]).to eq 1
+          expect(list.population_results[:update][:failure]).to eq []
+          expect(response['populationResults']['success']).to eq true
+          expect(response['populationResults']['messages']).to eq ['1 member was updated.']
+        end
+      end
+    end
+  end
+
+end

--- a/spec/support/mailing_list_shared_examples.rb
+++ b/spec/support/mailing_list_shared_examples.rb
@@ -1,0 +1,99 @@
+# encoding: UTF-8
+
+shared_examples 'a newly initialized mailing list' do
+  let(:list) { described_class.new(canvas_site_id: canvas_site_id) }
+
+  it 'is valid' do
+    expect(response).not_to include 'errorMessages'
+  end
+
+  it 'returns Canvas site data' do
+    expect(response['canvasSite']['canvasCourseId']).to eq fake_course_data['id'].to_s
+    expect(response['canvasSite']['url']).to include fake_course_data['id'].to_s
+    expect(response['canvasSite']['courseCode']).to eq fake_course_data['course_code']
+    expect(response['canvasSite']['sisCourseId']).to eq fake_course_data['sis_course_id']
+    expect(response['canvasSite']['name']).to eq fake_course_data['name']
+  end
+
+  it 'initializes as unregistered' do
+    expect(response['mailingList']['state']).to eq 'unregistered'
+    expect(response['mailingList']['domain']).to eq list_domain
+    expect(response['mailingList']).not_to include('creationUrl')
+    expect(response['mailingList']).not_to include('timeLastPopulated')
+  end
+
+  it 'returns error on attempt to populate before save' do
+    list.populate
+    expect(response['errorMessages']).to include("Mailing list \"#{list.list_name}\" must be created before being populated.")
+    expect(response['mailingList']).not_to include('timeLastPopulated')
+  end
+
+  describe 'normalizing list names' do
+    it 'normalizes caps and spaces' do
+      fake_course_data['name'] = 'CHEM 1A LEC 003'
+      expect(response['mailingList']['name']).to eq 'chem_1a_lec_003-fa13'
+    end
+
+    it 'normalizes punctuation' do
+      fake_course_data['name'] = 'The "Wild"-"Wild" West?'
+      expect(response['mailingList']['name']).to eq 'the_wild_wild_west-fa13'
+    end
+
+    it 'removes invalid leading and trailing characters' do
+      fake_course_data['name'] = '{{design}}'
+      expect(response['mailingList']['name']).to eq 'design-fa13'
+    end
+
+    it 'normalizes diacritics' do
+      fake_course_data['name'] = 'Conversation intermédiaire'
+      expect(response['mailingList']['name']).to eq 'conversation_intermediaire-fa13'
+    end
+  end
+
+  context 'nonexistent Canvas site' do
+    before { allow_any_instance_of(Canvas::Course).to receive(:course).and_return(statusCode: 404, error: [{message: 'The specified resource was not found.'}]) }
+
+    it 'returns error data' do
+      expect(response).not_to include :mailingList
+      expect(response['errorMessages']).to include("No bCourses site with ID \"#{canvas_site_id}\" was found.")
+    end
+  end
+end
+
+shared_examples 'mailing list creation errors' do
+
+  context 'invalid list name' do
+    let(:create_list) { described_class.create(canvas_site_id: canvas_site_id, list_name: '$crooge McDuck and the 1%') }
+
+    it 'does not create a list with an invalid name' do
+      count = described_class.count
+      create_list
+      expect(described_class.count).to eq count
+      expect(response['errorMessages']).to include('List name may contain only lowercase, numeric, underscore and hyphen characters.')
+    end
+  end
+
+  context 'list name already exists in database' do
+    let(:list_name) { random_string(15) }
+    let(:create_list) { described_class.create(canvas_site_id: canvas_site_id, list_name: list_name) }
+    before { described_class.create(canvas_site_id: random_id, list_name: list_name)  }
+
+    it 'does not create list and returns error' do
+      count = described_class.count
+      create_list
+      expect(described_class.count).to eq count
+      expect(response['errorMessages']).to include("List name \"#{list_name}\" has already been reserved.")
+    end
+  end
+
+  context 'course id already exists in database' do
+    before { described_class.create(canvas_site_id: canvas_site_id)  }
+
+    it 'does not create new record and returns error' do
+      count = described_class.count
+      create_list
+      expect(described_class.count).to eq count
+      expect(response['errorMessages']).to include("Canvas site ID \"#{canvas_site_id}\" has already reserved a mailing list.")
+    end
+  end
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6464
https://jira.ets.berkeley.edu/jira/browse/CLC-6465

We handle the split between old Calmail lists and new Mailgun lists by creating two subclasses for MailingLists::SiteMailingList, and using Rails single-table inheritance to associate those subclasses with a new `type` column. For now, lists created through the bCourses admin tool still default to Calmail.

Membership logic for Mailgun lists is a bit simpler than that for Calmail, since we're using a local database rather than an external API. However, we do now need to track "is sender?" permissions, since no external service is managing those.

Bamboo build https://bamboo.ets.berkeley.edu/bamboo/browse/CPB-CPT389-2 has no mailing list failures.