### PR TITLE
CLC-6475, we risk OutOfMemoryError in scripts not using standard JVM arg setup

### DIFF
--- a/script/calcentral-update.sh
+++ b/script/calcentral-update.sh
@@ -1,18 +1,28 @@
 #!/bin/bash
-# Script to run capistrano
+
+######################################################
+#
+# Run Capistrano
+#
+######################################################
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
-source .rvmrc
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
+source "${PWD}/.rvmrc"
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
-export JRUBY_OPTS="--dev"
+
+# JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
 
 echo "------------------------------------------"
-echo "`date`: Redeploying CalCentral on app nodes..."
+echo "$(date): Redeploying CalCentral on app nodes..."
 
-echo "`date`: cap calcentral_dev:update..."
+echo "$(date): cap calcentral_dev:update..."
+
 cap -l STDOUT calcentral_dev:update || { echo "ERROR: capistrano deploy failed" ; exit 1 ; }
+
+exit 0

--- a/script/calendar.sh
+++ b/script/calendar.sh
@@ -1,28 +1,40 @@
 #!/bin/bash
-# Script to run student class calendar export. This is intended to be run from cron.
 
-# Make sure the normal shell environment is in place, since it may not be
-# when running as a cron job.
-source "$HOME/.bash_profile"
+######################################################
+#
+# Class calendar export, run from cron.
+#
+# Make sure the normal shell environment is in place,
+# since it may not be when running as a cron job.
+#
+######################################################
+
+source "${HOME}/.bash_profile"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG=`date +"$PWD/log/calendar_%Y-%m-%d.log"`
-LOGIT="tee -a $LOG"
+LOG=$(date +"${PWD}/log/calendar_%Y-%m-%d.log")
+LOGIT="tee -a ${LOG}"
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
-source .rvmrc
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
+source "${PWD}/.rvmrc"
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: Calendar export started on app node: `hostname -s`..." | $LOGIT
+# JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
+
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Calendar export started on app node: $(hostname -s)..." | ${LOGIT}
 
 cd deploy
-bundle exec rake calendar:preprocess calendar:export | $LOGIT
 
-echo "`date`: Calendar export completed" | $LOGIT
+bundle exec rake calendar:preprocess calendar:export | ${LOGIT}
+
+echo "$(date): Calendar export completed" | ${LOGIT}
+
+exit 0

--- a/script/configure-all-canvas-apps-from-current-host.sh
+++ b/script/configure-all-canvas-apps-from-current-host.sh
@@ -1,30 +1,41 @@
 #!/bin/bash
-# Script to configure (or reconfigure) all LTI apps on the linked bCourses server and provided
-# by the current CalCentral server. This will add any new apps and overwrite current LTI
-# keys and secrets.
 
-# Make sure the normal shell environment is in place, since it may not be
-# when running as a cron job.
-source "$HOME/.bash_profile"
+######################################################
+#
+# Configure, or reconfigure, all LTI apps on the
+# linked bCourses server and provided by the current
+# CalCentral server. This will add any new apps and
+# overwrite current LTI keys and secrets.
+#
+# Make sure the normal shell environment is in place,
+# since it may not be when running as a cron job.
+#
+######################################################
+
+source "${HOME}/.bash_profile"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG=`date +"$PWD/log/canvas_configure_all_apps_%Y-%m-%d.log"`
-LOGIT="tee -a $LOG"
+LOG=$(date +"${PWD}/log/canvas_configure_all_apps_%Y-%m-%d.log")
+LOGIT="tee -a ${LOG}"
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
-source .rvmrc
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
+source "${PWD}/.rvmrc"
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="--dev"
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to run the LTI application configuration script..." | $LOGIT
+# Set JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
+
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Run LTI application configuration script..." | ${LOGIT}
 
 cd deploy
 
-bundle exec rake canvas:configure_all_apps_from_current_host | $LOGIT
+bundle exec rake canvas:configure_all_apps_from_current_host | ${LOGIT}
+
+exit 0

--- a/script/export-cached-csv-enrollments-set.sh
+++ b/script/export-cached-csv-enrollments-set.sh
@@ -1,28 +1,39 @@
 #!/bin/bash
-# Exports Section Enrollments from Canvas to CSV for cached queries
 
-# Make sure the normal shell environment is in place, since it may not be
-# when running as a cron job.
-source "$HOME/.bash_profile"
+######################################################
+#
+# Exports Section Enrollments from Canvas to CSV for
+# cached queries
+#
+# Make sure the normal shell environment is in place,
+# since it may not be when running as a cron job.
+#
+######################################################
+
+source "${HOME}/.bash_profile"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG=`date +"$PWD/log/canvas_cached_enrollments_csv_%Y-%m-%d.log"`
-LOGIT="tee -a $LOG"
+LOG=$(date +"${PWD}/log/canvas_cached_enrollments_csv_%Y-%m-%d.log")
+LOGIT="tee -a ${LOG}"
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
-source .rvmrc
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
+source "${PWD}/.rvmrc"
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcompile.invokedynamic=false -Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled -J-Xmx1024m"
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to run the Canvas cached enrollments CSV export script..." | $LOGIT
+# JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
+
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Run the Canvas cached enrollments CSV export script..." | ${LOGIT}
 
 cd deploy
 
-bundle exec rake canvas:export_enrollments_to_csv_set | $LOGIT
+bundle exec rake canvas:export_enrollments_to_csv_set | ${LOGIT}
+
+exit 0

--- a/script/load-test-dev.sh
+++ b/script/load-test-dev.sh
@@ -1,55 +1,65 @@
 #!/bin/bash
-# Script to run load tests.
 
-# Make sure the normal shell environment is in place, since it may not be
-# when running as a cron job.
-source "$HOME/.bash_profile"
+######################################################
+#
+# Run load tests.
+#
+# Make sure the normal shell environment is in place,
+# since it may not be when running as a cron job.
+#
+######################################################
+
+source "${HOME}/.bash_profile"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG=`date +"$PWD/log/load_test_%Y-%m-%d.log"`
-LOGIT="tee -a $LOG"
+LOG=$(date +"${PWD}/log/load_test_%Y-%m-%d.log")
+LOGIT="tee -a ${LOG}"
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
-source .rvmrc
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
+source "${PWD}/.rvmrc"
 
 export RAILS_ENV=${RAILS_ENV:-production}
-export JRUBY_OPTS="--dev"
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to restart CalCentral..." | $LOGIT
+# JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
 
-~/init.d/calcentral restart | $LOGIT
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Restart CalCentral..." | ${LOGIT}
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to clear cache and cache statisics..." | $LOGIT
+~/init.d/calcentral restart | ${LOGIT}
+
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Clear cache and cache statisics..." | ${LOGIT}
 
 cd ~/calcentral/deploy
-bundle exec rake memcached:clear | $LOGIT
+bundle exec rake memcached:clear | ${LOGIT}
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to start empty-cache load test on $LOAD_TEST_AGENT ..." | $LOGIT
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Start empty-cache load test on ${LOAD_TEST_AGENT}..." | ${LOGIT}
 
-ssh $LOAD_TEST_AGENT "cd tsung && ./automated_tsung.sh calcentral-dev" | $LOGIT
+ssh ${LOAD_TEST_AGENT} "cd tsung && ./automated_tsung.sh calcentral-dev" | ${LOGIT}
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to get cache statistics for empty-cache load test..." | $LOGIT
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Get cache statistics for empty-cache load test..." | ${LOGIT}
 
-bundle exec rake memcached:get_stats | $LOGIT
+bundle exec rake memcached:get_stats | ${LOGIT}
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to start primed-cache load test on $LOAD_TEST_AGENT ..." | $LOGIT
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Start primed-cache load test on ${LOAD_TEST_AGENT}..." | ${LOGIT}
 
-ssh $LOAD_TEST_AGENT "cd tsung && ./automated_tsung.sh calcentral-dev-cached" | $LOGIT
+ssh ${LOAD_TEST_AGENT} "cd tsung && ./automated_tsung.sh calcentral-dev-cached" | ${LOGIT}
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to get cache statistics for primed-cache load test..." | $LOGIT
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Get cache statistics for primed-cache load test..." | ${LOGIT}
 
-bundle exec rake memcached:get_stats | $LOGIT
+bundle exec rake memcached:get_stats | ${LOGIT}
+
+exit 0

--- a/script/memcached-stats.sh
+++ b/script/memcached-stats.sh
@@ -1,28 +1,34 @@
 #!/bin/bash
-# Script to summarize memcached usage and effectiveness.
 
-# Make sure the normal shell environment is in place.
-source "$HOME/.bash_profile"
+######################################################
+#
+# Summarize memcached usage and effectiveness.
+#
+######################################################
 
-DT=$(date +"%Y-%m-%d")
+source "${HOME}/.bash_profile"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG="$PWD/log/memcached_stats_$DT.log"
-LOGIT="tee -a $LOG"
+LOG="${PWD}/log/memcached_stats_$(date +"%Y-%m-%d").log"
+LOGIT="tee -a ${LOG}"
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
-source .rvmrc
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
+source "${PWD}/.rvmrc"
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="--dev"
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
+# JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
+
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
 
 cd deploy
 
-bundle exec rake memcached:get_stats | $LOGIT
+bundle exec rake memcached:get_stats | ${LOGIT}
+
+exit 0

--- a/script/migrate.sh
+++ b/script/migrate.sh
@@ -24,14 +24,16 @@ fi
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
-export JRUBY_OPTS="--dev"
+
+# JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
 
 LOG_DIR=${CALCENTRAL_LOG_DIR:=$(pwd)"/log"}
 export CALCENTRAL_LOG_DIR=${LOG_DIR}
 
 # Enable rvm and use the correct Ruby version and gem set.
 [[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
-source .rvmrc
+source "${PWD}/.rvmrc"
 
 echo | ${LOGIT}
 echo "------------------------------------------" | ${LOGIT}

--- a/script/reconfigure-canvas-test-servers.sh
+++ b/script/reconfigure-canvas-test-servers.sh
@@ -1,36 +1,47 @@
 #!/bin/bash
-# Script to check for overwritten configurations on bCourses test/beta,
-# to reset their CAS authentication base URLs if needed (see CLC-3917),
-# and to enable the test-only admin if needed (see CLC-5516).
 
-# Make sure the normal shell environment is in place, since it may not be
-# when running as a cron job.
-source "$HOME/.bash_profile"
+######################################################
+#
+# Check for overwritten configurations on
+# bCourses test/beta. Reset CAS authentication base
+# URLs if needed (see CLC-3917) and enable the
+# test-only admin if needed (see CLC-5516).
+#
+# Make sure the normal shell environment is in place,
+# since it may not be when running as a cron job.
+#
+######################################################
+
+source "${HOME}/.bash_profile"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG=`date +"$PWD/log/canvas_reconfigure_cas_authorization_%Y-%m-%d.log"`
-LOGIT="tee -a $LOG"
+LOG=$(date +"${PWD}/log/canvas_reconfigure_cas_authorization_%Y-%m-%d.log")
+LOGIT="tee -a ${LOG}"
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
-source .rvmrc
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && . "${HOME}/.rvm/scripts/rvm"
+source "${PWD}/.rvmrc"
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="--dev"
+
+# JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
 
 cd deploy
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to run the CAS Authentication reconfiguration script..." | $LOGIT
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Run the CAS Authentication reconfiguration script..." | ${LOGIT}
 
-bundle exec rake canvas:reconfigure_auth_url | $LOGIT
+bundle exec rake canvas:reconfigure_auth_url | ${LOGIT}
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to run the Test Admin reconfiguration script..." | $LOGIT
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Run the Test Admin reconfiguration script..." | ${LOGIT}
 
-bundle exec rake canvas:add_test_admin | $LOGIT
+bundle exec rake canvas:add_test_admin | ${LOGIT}
+
+exit 0

--- a/script/refresh-all-canvas-enrollments.sh
+++ b/script/refresh-all-canvas-enrollments.sh
@@ -1,29 +1,39 @@
 #!/bin/bash
-# Script to create user and enrollment CSV files in "tmp/canvas" and then
-# upload them to Canvas.
 
-# Make sure the normal shell environment is in place, since it may not be
-# when running as a cron job.
-source "$HOME/.bash_profile"
+######################################################
+#
+# Create user and enrollment CSV files in "tmp/canvas"
+# and then upload them to Canvas.
+#
+# Make sure the normal shell environment is in place,
+# since it may not be when running as a cron job.
+#
+######################################################
+
+source "${HOME}/.bash_profile"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG=`date +"$PWD/log/canvas_refresh_%Y-%m-%d.log"`
-LOGIT="tee -a $LOG"
+LOG=$(date +"${PWD}/log/canvas_refresh_%Y-%m-%d.log")
+LOGIT="tee -a ${LOG}"
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
-source .rvmrc
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
+source "${PWD}/.rvmrc"
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcompile.invokedynamic=false -Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled -J-Xmx1024m"
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to run the refresh script..." | $LOGIT
+# Set JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
+
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Run the refresh script..." | ${LOGIT}
 
 cd deploy
 
-bundle exec rake canvas:batch_refresh | $LOGIT
+bundle exec rake canvas:batch_refresh | ${LOGIT}
+
+exit 0

--- a/script/refresh-canvas-enrollments.sh
+++ b/script/refresh-canvas-enrollments.sh
@@ -1,29 +1,39 @@
 #!/bin/bash
-# Script to create user and enrollment CSV files in "tmp/canvas" and then
-# upload them to Canvas.
 
-# Make sure the normal shell environment is in place, since it may not be
-# when running as a cron job.
-source "$HOME/.bash_profile"
+######################################################
+#
+# Create user and enrollment CSV files and then upload
+# them to Canvas.
+#
+# Make sure the normal shell environment is in place,
+# since it may not be when running as a cron job.
+#
+######################################################
+
+source "${HOME}/.bash_profile"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG=`date +"$PWD/log/canvas_refresh_%Y-%m-%d.log"`
-LOGIT="tee -a $LOG"
+LOG=$(date +"${PWD}/log/canvas_refresh_%Y-%m-%d.log")
+LOGIT="tee -a ${LOG}"
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
-source .rvmrc
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
+source "${PWD}/.rvmrc"
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcompile.invokedynamic=false -Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled -J-Xmx1024m"
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to run the refresh script..." | $LOGIT
+# JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
+
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Run the refresh script..." | ${LOGIT}
 
 cd deploy
 
-bundle exec rake canvas:incremental_refresh | $LOGIT
+bundle exec rake canvas:incremental_refresh | ${LOGIT}
+
+exit 0

--- a/script/refresh-canvas-users.sh
+++ b/script/refresh-canvas-users.sh
@@ -1,28 +1,38 @@
 #!/bin/bash
-# Script to create user CSV file in "tmp/canvas" and upload it to Canvas.
 
-# Make sure the normal shell environment is in place, since it may not be
-# when running as a cron job.
-source "$HOME/.bash_profile"
+######################################################
+#
+# Create user CSV file and upload it to Canvas.
+#
+# Make sure the normal shell environment is in place,
+# since it may not be when running as a cron job.
+#
+######################################################
+
+source "${HOME}/.bash_profile"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG=`date +"$PWD/log/canvas_refresh_users_%Y-%m-%d.log"`
-LOGIT="tee -a $LOG"
+LOG=$(date +"${PWD}/log/canvas_refresh_users_%Y-%m-%d.log")
+LOGIT="tee -a ${LOG}"
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
-source .rvmrc
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
+source "${PWD}/.rvmrc"
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="-Xcompile.invokedynamic=false -Xcext.enabled=true -J-XX:+UseConcMarkSweepGC -J-XX:+CMSPermGenSweepingEnabled -J-XX:+CMSClassUnloadingEnabled -J-Xmx1024m"
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to run the refresh script..." | $LOGIT
+# JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
+
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Run the refresh script..." | ${LOGIT}
 
 cd deploy
 
-bundle exec rake canvas:user_accounts_refresh | $LOGIT
+bundle exec rake canvas:user_accounts_refresh | ${LOGIT}
+
+exit 0

--- a/script/report-lti-usage.sh
+++ b/script/report-lti-usage.sh
@@ -1,28 +1,39 @@
 #!/bin/bash
-# Script to generate two CSV reports on LTI applications configured during a term in bCourses.
 
-# Make sure the normal shell environment is in place, since it may not be
-# when running as a cron job.
-source "$HOME/.bash_profile"
+######################################################
+#
+# Generate CSV reports on LTI applications configured
+# during a term in bCourses.
+#
+# Make sure the normal shell environment is in place,
+# since it may not be when running as a cron job.
+#
+######################################################
+
+source "${HOME}/.bash_profile"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG=`date +"$PWD/log/report_lti_usage_%Y-%m-%d.log"`
-LOGIT="tee -a $LOG"
+LOG=$(date +"${PWD}/log/report_lti_usage_%Y-%m-%d.log")
+LOGIT="tee -a ${LOG}"
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
-source .rvmrc
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
+source "${PWD}/.rvmrc"
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="--dev"
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to run the LTI usage reporting script..." | $LOGIT
+# JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
+
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Run the LTI usage reporting script..." | ${LOGIT}
 
 cd deploy
 
-bundle exec rake canvas:report_lti_usage | $LOGIT
+bundle exec rake canvas:report_lti_usage | ${LOGIT}
+
+exit 0

--- a/script/report-turnitin-usage.sh
+++ b/script/report-turnitin-usage.sh
@@ -1,28 +1,39 @@
 #!/bin/bash
-# Script to generate a CSV report on TurnItIn usage for a term in bCourses.
 
-# Make sure the normal shell environment is in place, since it may not be
-# when running as a cron job.
-source "$HOME/.bash_profile"
+######################################################
+#
+# Generate a CSV report on TurnItIn usage for a term
+# in bCourses.
+#
+# Make sure the normal shell environment is in place,
+# since it may not be when running as a cron job.
+#
+######################################################
+
+source "${HOME}/.bash_profile"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG=`date +"$PWD/log/report_turnitin_usage_%Y-%m-%d.log"`
-LOGIT="tee -a $LOG"
+LOG=$(date +"${PWD}/log/report_turnitin_usage_%Y-%m-%d.log")
+LOGIT="tee -a ${LOG}"
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
-source .rvmrc
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
+source "${PWD}/.rvmrc"
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="--dev"
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to run the TurnItIn usage reporting script..." | $LOGIT
+# JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
+
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Run the TurnItIn usage reporting script..." | ${LOGIT}
 
 cd deploy
 
-bundle exec rake canvas:report_turnitin | $LOGIT
+bundle exec rake canvas:report_turnitin | ${LOGIT}
+
+exit 0

--- a/script/run-oec-task.sh
+++ b/script/run-oec-task.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
-# Script delegates to oec.rake tasks.
 
-# Make sure the normal shell environment is in place, since it may not be when running as a cron job.
+######################################################
+#
+# Online Course Evaluations (OEC) tasks
+#
+# Make sure the normal shell environment is in place,
+# since it may not be when running as a cron job.
+#
+######################################################
+
 PROFILE="${HOME}/.bash_profile"
 test -f "${PROFILE}" && source "${PROFILE}"
 
@@ -22,13 +29,15 @@ if [[ " ${TASK_OPTIONS[*]} " == *" ${TASK} "* ]]
 then
   echo | ${LOGIT}
   # Enable rvm and use the correct Ruby version and gem set.
-  [[ -s "${HOME}/.rvm/scripts/rvm" ]] && . "${HOME}/.rvm/scripts/rvm"
-  source .rvmrc
+  [[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
+  source "${PWD}/.rvmrc"
 
   export RAILS_ENV=${RAILS_ENV:-production}
   export LOGGER_STDOUT=only
   export LOGGER_LEVEL=INFO
-  export JRUBY_OPTS="--dev"
+
+  # JVM args per CalCentral convention
+  source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
 
   echo "[$(date +"%F %H:%M:%S")] [INFO] Begin oec:${TASK} on $(hostname -s)" | ${LOGIT}
 
@@ -51,4 +60,5 @@ echo | ${LOGIT}
 echo "------------------------------------------" | ${LOGIT}
 
 cd "${WORKING_DIR}"
+
 exit 0

--- a/script/standard-calcentral-JVM-OPTS-profile
+++ b/script/standard-calcentral-JVM-OPTS-profile
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+######################################################
+#
+# CalCentral scripts wanting the standard JVM args
+# should 'source' this file prior to starting JRuby
+# and/or Java processes.
+#
+######################################################
+
+DEFAULT_JVM_OPTS="-Xmn500m -Xms3000m -Xmx3000m -XX:+CMSParallelRemarkEnabled -XX:+CMSScavengeBeforeRemark -XX:+PrintGCCause -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+ScavengeBeforeFullGC -XX:+UseCMSInitiatingOccupancyOnly -XX:+UseCodeCacheFlushing -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:MaxMetaspaceSize=1024m -XX:ReservedCodeCacheSize=256m"
+
+# Standard JVM args for JRuby with override option available
+export JRUBY_OPTS=${CALCENTRAL_JRUBY_OPTS:="--dev -Xcext.enabled=true -Xcompile.invokedynamic=false ${DEFAULT_JVM_OPTS}"}
+
+# Standard JVM args with override option available
+export JVM_OPTS=${CALCENTRAL_JVM_OPTS:=${DEFAULT_JVM_OPTS}}
+
+# Standard JVM args escaped used, for example, by: torquebox run --jvm-options ...
+export ESCAPED_JVM_OPTS="$(echo "${JVM_OPTS}" | sed 's/^-/\\-/g' | sed 's/ \-/ \\-/g')"

--- a/script/start-torquebox.sh
+++ b/script/start-torquebox.sh
@@ -8,15 +8,16 @@
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG=`date +"${PWD}/log/start-stop_%Y-%m-%d.log"`
-TORQUEBOX_LOG=`date +"${PWD}/log/torquebox_%Y-%m-%d.log"`
+LOG=$(date +"${PWD}/log/start-stop_%Y-%m-%d.log")
+TORQUEBOX_LOG=$(date +"${PWD}/log/torquebox_%Y-%m-%d.log")
 
 LOGIT="tee -a ${LOG}"
 
 # Kill active Torquebox processes, if any.
 echo | ${LOGIT}
 echo "------------------------------------------" | ${LOGIT}
-echo "`date`: Stopping running instances of CalCentral..." | ${LOGIT}
+echo "$(date): Stopping running instances of CalCentral..." | ${LOGIT}
+
 ./script/stop-torquebox.sh
 
 # Enable rvm and use the correct Ruby version and gem set.
@@ -27,24 +28,31 @@ export RAILS_ENV=${RAILS_ENV:-production}
 
 echo | ${LOGIT}
 echo "------------------------------------------" | ${LOGIT}
-echo "`date`: Starting CalCentral..." | ${LOGIT}
-OPTS=${CALCENTRAL_JRUBY_OPTS:="-Xcompile.invokedynamic=false -Xcext.enabled=true -J-Djruby.thread.pool.enabled=true -J-Djava.io.tmpdir=${PWD}/tmp"}
-export JRUBY_OPTS=${OPTS}
+echo "$(date): Starting CalCentral..." | ${LOGIT}
 
-# The CALCENTRAL_JVM_OPTS env variable (optional) will override default JVM args
-JVM_OPTS=${CALCENTRAL_JVM_OPTS:="\-server \-verbose:gc \-Xmn500m \-Xms3000m \-Xmx3000m \-XX:+CMSParallelRemarkEnabled \-XX:+CMSScavengeBeforeRemark \-XX:+PrintGCCause \-XX:+PrintGCDateStamps \-XX:+PrintGCDetails \-XX:+ScavengeBeforeFullGC \-XX:+UseCMSInitiatingOccupancyOnly \-XX:+UseCodeCacheFlushing \-XX:+UseConcMarkSweepGC \-XX:CMSInitiatingOccupancyFraction=70 \-XX:MaxMetaspaceSize=1024m \-XX:ReservedCodeCacheSize=256m"}
+# Set JVM args per CalCentral convention
+./script/export-JVM-args-per-calcentral-standards.sh
 
-LOG_DIR=${CALCENTRAL_LOG_DIR:=`pwd`"/log"}
+# Custom additions to JRuby JVM_OPTS
+export JRUBY_OPTS="${JRUBY_OPTS} -J-Djruby.thread.pool.enabled=true -J-Djava.io.tmpdir=${PWD}/tmp"
+
 MAX_THREADS=${CALCENTRAL_MAX_THREADS:="90"}
-export CALCENTRAL_LOG_DIR=${LOG_DIR}
-IP_ADDR=`/sbin/ifconfig | grep 'inet addr:'| grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1}'`
+
+export CALCENTRAL_LOG_DIR=${CALCENTRAL_LOG_DIR:="$(pwd)/log"}
+
+IP_ADDR=$(/sbin/ifconfig | grep 'inet addr:'| grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1}')
 
 cd deploy
 
-JBOSS_HOME=`bundle exec torquebox env jboss_home`
+JBOSS_HOME=$(bundle exec torquebox env jboss_home)
+
 cp ~/.calcentral_config/standalone-ha.xml ${JBOSS_HOME}/standalone/configuration/
 
-nohup bundle exec torquebox run -b ${IP_ADDR} -p=3000 --jvm-options="${JVM_OPTS}" --clustered --max-threads=${MAX_THREADS} < /dev/null >> ${TORQUEBOX_LOG} 2>> ${LOG} &
+# Set JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
+
+nohup bundle exec torquebox run -b ${IP_ADDR} -p=3000 --jvm-options="\-server \-verbose:gc ${ESCAPED_JVM_OPTS}" --clustered --max-threads=${MAX_THREADS} < /dev/null >> ${TORQUEBOX_LOG} 2>> ${LOG} &
+
 cd ..
 
 # Verify that CalCentral is alive and warm up caches.

--- a/script/stop-torquebox.sh
+++ b/script/stop-torquebox.sh
@@ -40,5 +40,4 @@ do
   done
 done
 
-# Protect against process-not-found exit statuses
 exit 0

--- a/script/sync-canvas-guest-users.sh
+++ b/script/sync-canvas-guest-users.sh
@@ -1,28 +1,38 @@
 #!/bin/bash
-# Script to update guest users within Canvas
 
-# Make sure the normal shell environment is in place, since it may not be
-# when running as a cron job.
-source "$HOME/.bash_profile"
+######################################################
+#
+# Update guest users within Canvas
+#
+# Make sure the normal shell environment is in place,
+# since it may not be when running as a cron job.
+#
+######################################################
+
+source "${HOME}/.bash_profile"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG=`date +"$PWD/log/canvas_guest_user_sync_%Y-%m-%d.log"`
-LOGIT="tee -a $LOG"
+LOG=$(date +"${PWD}/log/canvas_guest_user_sync_%Y-%m-%d.log")
+LOGIT="tee -a ${LOG}"
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
-source .rvmrc
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
+source "${PWD}/.rvmrc"
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="--dev"
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to run the guest user sync script..." | $LOGIT
+# Set JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
+
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Run guest user sync script..." | ${LOGIT}
 
 cd deploy
 
-bundle exec rake canvas:guest_user_sync | $LOGIT
+bundle exec rake canvas:guest_user_sync | ${LOGIT}
+
+exit 0

--- a/script/sync-canvas-new-users.sh
+++ b/script/sync-canvas-new-users.sh
@@ -1,28 +1,38 @@
 #!/bin/bash
-# Script to update all users within Canvas from People/Guest Oracle view
 
-# Make sure the normal shell environment is in place, since it may not be
-# when running as a cron job.
-source "$HOME/.bash_profile"
+######################################################
+#
+# Update all users in Canvas
+#
+# Make sure the normal shell environment is in place,
+# since it may not be when running as a cron job.
+#
+######################################################
+
+source "${HOME}/.bash_profile"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG=`date +"$PWD/log/canvas_new_user_sync_%Y-%m-%d.log"`
-LOGIT="tee -a $LOG"
+LOG=$(date +"${PWD}/log/canvas_new_user_sync_%Y-%m-%d.log")
+LOGIT="tee -a ${LOG}"
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
-source .rvmrc
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
+source "${PWD}/.rvmrc"
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="--dev"
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to run the new campus user sync script..." | $LOGIT
+# JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
+
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Run the new campus user sync script..." | ${LOGIT}
 
 cd deploy
 
-bundle exec rake canvas:new_user_sync | $LOGIT
+bundle exec rake canvas:new_user_sync | ${LOGIT}
+
+exit 0

--- a/script/update-mailing-list-memberships.sh
+++ b/script/update-mailing-list-memberships.sh
@@ -1,29 +1,40 @@
 #!/bin/bash
-# Script to update all site mailing list memberships with the current roster of site users
-# in bCourses. New users will be added; former users will be removed.
 
-# Make sure the normal shell environment is in place, since it may not be
-# when running as a cron job.
-source "$HOME/.bash_profile"
+######################################################
+#
+# Update all site mailing list memberships with the
+# current roster of site users in bCourses. New users
+# will be added; former users will be removed.
+#
+# Make sure the normal shell environment is in place,
+# since it may not be when running as a cron job.
+#
+######################################################
+
+source "${HOME}/.bash_profile"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG=`date +"$PWD/log/mailing_list_population_update_%Y-%m-%d.log"`
-LOGIT="tee -a $LOG"
+LOG=$(date +"${PWD}/log/mailing_list_population_update_%Y-%m-%d.log")
+LOGIT="tee -a ${LOG}"
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
-source .rvmrc
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
+source "${PWD}/.rvmrc"
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="--dev"
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to run the mailing list population update script..." | $LOGIT
+# JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
+
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Run the mailing list population update script..." | ${LOGIT}
 
 cd deploy
 
-bundle exec rake mailing_lists:populate | $LOGIT
+bundle exec rake mailing_lists:populate | ${LOGIT}
+
+exit 0

--- a/script/webcast_lti_refresh.sh
+++ b/script/webcast_lti_refresh.sh
@@ -1,27 +1,39 @@
 #!/bin/bash
-# Script to manage Webcast LTI tool settings in Canvas. This is intended to be run from cron.
 
-# Make sure the normal shell environment is in place, since it may not be when running as a cron job.
+######################################################
+#
+# Manage Webcast LTI tool settings in Canvas
+#
+# Make sure the normal shell environment is in place,
+# since it may not be when running as a cron job.
+#
+######################################################
+
 source "${HOME}/.bash_profile"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG=`date +"${PWD}/log/webcast_%Y-%m-%d.log"`
+LOG=$(date +"${PWD}/log/webcast_%Y-%m-%d.log")
 LOGIT="tee -a ${LOG}"
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "${HOME}/.rvm/scripts/rvm" ]] && . "${HOME}/.rvm/scripts/rvm"
-source .rvmrc
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
+source "${PWD}/.rvmrc"
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: Webcast LTI app visibility check started on app node: `hostname -s`..." | $LOGIT
+# JVM args per CalCentral convention
+source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
+
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): Webcast LTI app visibility check started on app node: $(hostname -s)..." | ${LOGIT}
 
 cd deploy
-bundle exec rake canvas:webcast_lti_refresh | $LOGIT
+bundle exec rake canvas:webcast_lti_refresh | ${LOGIT}
 
-echo "`date`: Webcast LTI app visibility check  is done" | $LOGIT
+echo "$(date): Webcast LTI app visibility check  is done" | ${LOGIT}
+
+exit 0


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6475

New `script/standard-calcentral-JVM-OPTS-profile` to be sourced by scripts needing our default JVM/JRUBY args. In this JIRA, the OutOfMemoryError was hit by `sync-canvas-new-users.sh` but it could happen in other Canvas related scripts running nothing more than `export JRUBY_OPTS="--dev"`

In addition to standardization in many of our shell scripts, this PR does tidying which makes the scripts more readable and reliable.