### PR TITLE
SISRP-27057 - CalCentral Prod: EFT status & EFT account info not displaying

### DIFF
--- a/app/models/eft/my_eft_enrollment.rb
+++ b/app/models/eft/my_eft_enrollment.rb
@@ -20,19 +20,19 @@ module Eft
       "Failed to connect with EFT system"
     end
 
-    def lookup_student_id
-      if @uid
-        @campus_solutions_id = CalnetCrosswalk::ByUid.new(user_id: @uid).lookup_campus_solutions_id
-      end
+    def campus_solutions_id
+      @campus_solutions_id ||= CalnetCrosswalk::ByUid.new(user_id: @uid).lookup_campus_solutions_id
     end
 
     def get_feed_internal
-      return {} if @campus_solutions_id.nil? || !Settings.features.cs_billing
+      if campus_solutions_id.nil?
+        logger.warn "No Campus Solutions ID found for UID #{@uid}"
+        return {}
+      end
       get_parsed_response
     end
 
     def get_parsed_response
-      lookup_student_id
       url = "#{@settings.base_url}eft_status?studentId=#{@campus_solutions_id}"
       logger.info "get_parsed_response: Fake = #{@fake}; Making request to #{url} on behalf of user #{@uid}; cache expiration #{self.class.expires_in}"
       response = get_response(

--- a/spec/models/eft/my_eft_enrollment_spec.rb
+++ b/spec/models/eft/my_eft_enrollment_spec.rb
@@ -11,17 +11,6 @@ describe Eft::MyEftEnrollment do
         subject.get_feed_as_json
       end
     end
-
-    context 'disabled feature flag' do
-      subject { fake_model }
-      before do
-        Settings.features.stub(:cs_billing).and_return(false)
-      end
-      it 'returns an empty feed' do
-        feed = subject.get_feed_as_json
-        expect(feed).to eq '{}'
-      end
-    end
   end
 
   describe '#get_parsed_response' do

--- a/src/assets/javascripts/angular/controllers/widgets/financesLinksController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/financesLinksController.js
@@ -79,7 +79,7 @@ angular.module('calcentral.controllers').controller('FinancesLinksController', f
    **/
   var parseEftEnrollment = function(data) {
     angular.merge($scope.eft, data);
-    if ($scope.eft.data.statusCode === 404 || $scope.eft.data.data.eftStatus === 'inactive') {
+    if (_.get($scope.eft, 'data.statusCode') === 404 || _.get($scope.eft, 'data.data.eftStatus') === 'inactive') {
       $scope.eft.studentActive = false;
     }
   };


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-27057

* `#get_internal` was getting hit, and returning `{}` because `@campus_solutions_id` would not be available yet.  `@campus_solutions_id` becomes available when `#get_parsed_response` calls `#lookup_student_id`
* So, we were not making the API call, and sending the front-end an empty object.  I've added some logging to help diagnose this, and moved the call to `#lookup_student_id` to the correct place.  Also added a nil-check security blanket for the front-end.
* It's perplexing because I'm not sure why this was previously working.  It shouldn't have - the only thing I can think of that might have changed are @raydavis's recent changes to the caching mechanisms.  But even tracing those thru their histories, I couldn't find any bypass of `#get_internal` or any trace of `@campus_solutions_id` being made available earlier.  If only I could ask younger, less experienced me.