### PR TITLE
SISRP-25362 - Adds Degree Progress (GRAD) card to Student Overview

### DIFF
--- a/app/controllers/advising_student_controller.rb
+++ b/app/controllers/advising_student_controller.rb
@@ -60,6 +60,10 @@ class AdvisingStudentController < ApplicationController
     render json: HubEdos::StudentAttributes.new(user_id: student_uid_param).get
   end
 
+  def degree_progress_graduate
+    render json: DegreeProgress::GraduateMilestones.new(student_uid_param).get_feed_as_json
+  end
+
   private
 
   def authorize_for_student

--- a/app/models/berkeley/degree_progress.rb
+++ b/app/models/berkeley/degree_progress.rb
@@ -13,6 +13,14 @@ module Berkeley
       'Advancement to Candidacy Plan I or Plan II'
     end
 
+    def self.get_form_notification(milestone_code, status_code)
+      form_notifications[milestone_code.strip.upcase] unless (status_code === 'Y' || milestone_code.blank?)
+    end
+
+    def self.get_merged_form_notification
+      '(Plan 1 Requires a Form)'
+    end
+
     def self.milestones
       @milestones ||= {
         'AAGADVMAS1' => 'Advancement to Candidacy Plan I',
@@ -30,7 +38,16 @@ module Berkeley
     def self.statuses
       @statuses ||= {
         'Y' => 'Completed',
-        'N' => 'Not Satisfied'
+        'N' => 'Not Satisfied',
+        'P' => 'Partially Passed'
+      }
+    end
+
+    def self.form_notifications
+      @form_notifications ||= {
+        'AAGADVMAS1' => '(Form Required)',
+        'AAGADVMAS2' => '(Form Required)',
+        'AAGQEAPRV' => '(Form Required)'
       }
     end
   end

--- a/app/models/campus_solutions/degree_progress_feature_flagged.rb
+++ b/app/models/campus_solutions/degree_progress_feature_flagged.rb
@@ -1,7 +1,0 @@
-module CampusSolutions
-  module DegreeProgressFeatureFlagged
-    def is_feature_enabled
-      Settings.features.cs_degree_progress
-    end
-  end
-end

--- a/app/models/campus_solutions/degree_progress_grad_advising_feature_flagged.rb
+++ b/app/models/campus_solutions/degree_progress_grad_advising_feature_flagged.rb
@@ -1,0 +1,7 @@
+module CampusSolutions
+  module DegreeProgressGradAdvisingFeatureFlagged
+    def is_feature_enabled
+      Settings.features.cs_degree_progress_grad_advising
+    end
+  end
+end

--- a/app/models/campus_solutions/degree_progress_grad_student_feature_flagged.rb
+++ b/app/models/campus_solutions/degree_progress_grad_student_feature_flagged.rb
@@ -1,0 +1,7 @@
+module CampusSolutions
+  module DegreeProgressGradStudentFeatureFlagged
+    def is_feature_enabled
+      Settings.features.cs_degree_progress_grad_student
+    end
+  end
+end

--- a/app/models/degree_progress/graduate_milestones.rb
+++ b/app/models/degree_progress/graduate_milestones.rb
@@ -5,16 +5,20 @@ module DegreeProgress
     include Cache::CachedFeed
     include Cache::JsonifiedFeed
     include Cache::UserCacheExpiry
-    include CampusSolutions::DegreeProgressFeatureFlagged
+    include CampusSolutions::DegreeProgressGradAdvisingFeatureFlagged
     include MilestonesModule
 
     def get_feed_internal
-      return {} unless is_feature_enabled
+      return {} unless is_feature_enabled && authorized?
       response = CampusSolutions::DegreeProgress::GraduateMilestones.new(user_id: @uid).get
       response[:feed] = HashConverter.camelize({
         degree_progress: process(response),
       })
       response
+    end
+
+    def authorized?
+      authentication_state.policy.can_view_as?
     end
   end
 end

--- a/app/models/degree_progress/milestones_module.rb
+++ b/app/models/degree_progress/milestones_module.rb
@@ -40,7 +40,8 @@ module DegreeProgress
         name = Berkeley::DegreeProgress.get_description(requirement[:code])
         if name
           requirement[:name] = name
-          requirement[:status] = Berkeley::DegreeProgress.get_status(requirement[:status])
+          requirement[:status_descr] = Berkeley::DegreeProgress.get_status(requirement[:status])
+          requirement[:form_notification] = Berkeley::DegreeProgress.get_form_notification(requirement[:code], requirement[:status])
           requirement
         end
       end
@@ -49,24 +50,25 @@ module DegreeProgress
 
     def merge(requirements)
       merge_candidates = []
-      merged_requirements = []
+      result = []
 
       requirements.each do |requirement|
         if is_merge_candidate requirement
           merge_candidates.push requirement
         else
-          merged_requirements.push requirement
+          result.push requirement
         end
       end
 
       if merge_candidates.length > 1
         first = find_first merge_candidates
         first[:name] = Berkeley::DegreeProgress.get_merged_description
-        merged_requirements.unshift(first)
+        first[:form_notification] = Berkeley::DegreeProgress.get_merged_form_notification
+        result.unshift(first)
       elsif merge_candidates.length === 1
-        merged_requirements.unshift(merge_candidates.first)
+        result.unshift(merge_candidates.first)
       end
-      merged_requirements
+      result
     end
 
     def is_merge_candidate(requirement)

--- a/app/models/degree_progress/my_graduate_milestones.rb
+++ b/app/models/degree_progress/my_graduate_milestones.rb
@@ -5,7 +5,7 @@ module DegreeProgress
     include Cache::CachedFeed
     include Cache::JsonifiedFeed
     include Cache::UserCacheExpiry
-    include CampusSolutions::DegreeProgressFeatureFlagged
+    include CampusSolutions::DegreeProgressGradStudentFeatureFlagged
     include MilestonesModule
 
     LINKS_CONFIG = [
@@ -14,7 +14,7 @@ module DegreeProgress
     ]
 
     def get_feed_internal
-      return {} unless is_feature_enabled
+      return {} unless is_feature_enabled && authorized?
       response = CampusSolutions::DegreeProgress::GraduateMilestones.new(user_id: @uid).get
       response[:feed] = HashConverter.camelize({
         degree_progress: process(response),
@@ -38,6 +38,10 @@ module DegreeProgress
       end
       logger.error "Could not retrieve CS link #{link_key} for Degree Progress feed, uid = #{@uid}" unless link
       link
+    end
+
+    def authorized?
+      authentication_state.policy.can_view_as? || authentication_state.policy.graduate_student? || authentication_state.policy.law_student?
     end
   end
 end

--- a/app/policies/authentication_state_policy.rb
+++ b/app/policies/authentication_state_policy.rb
@@ -87,4 +87,15 @@ class AuthenticationStatePolicy
     real_auth.is_superuser? || has_advisor_role
   end
 
+  def graduate_student?
+    return false unless @user.real_user_auth.active?
+    attributes = User::AggregatedAttributes.new(@user.user_id).get_feed
+    attributes.try(:[], :roles).try(:[], :graduate)
+  end
+
+  def law_student?
+    return false unless @user.real_user_auth.active?
+    attributes = User::AggregatedAttributes.new(@user.user_id).get_feed
+    attributes.try(:[], :roles).try(:[], :law)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,6 +159,7 @@ Calcentral::Application.routes.draw do
   get '/api/advising/student_attributes/:student_uid' => 'advising_student#student_attributes', :defaults => { :format => 'json' }
   get '/api/advising/advising/:student_uid' => 'advising_student#advising', :defaults => { :format => 'json' }
   get '/api/advising/student_success/:student_uid' => 'advising_student#student_success', :defaults => { :format => 'json' }
+  get '/api/advising/degree_progress/grad/:student_uid' => 'advising_student#degree_progress_graduate', :defaults => { :format => 'json' }
   post '/advisor_act_as' => 'advisor_act_as#start'
   post '/stop_advisor_act_as' => 'advisor_act_as#stop'
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -497,8 +497,9 @@ features:
   cs_advising_links: false
   cs_advisor_student_lookup: false
   cs_billing: false
-  cs_degree_progress: false
   cs_committees: false
+  cs_degree_progress_grad_advising: false
+  cs_degree_progress_grad_student: false
   cs_delegated_access: false
   cs_enrollment_card: false
   cs_fin_aid: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -89,8 +89,9 @@ features:
   cs_academic_progress_report: true
   cs_advisor_student_lookup: true
   cs_billing: true
-  cs_degree_progress: true
   cs_committees: true
+  cs_degree_progress_grad_advising: true
+  cs_degree_progress_grad_student: true
   cs_delegated_access: true
   cs_enrollment_card: true
   cs_fin_aid: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -102,8 +102,9 @@ features:
   cs_academic_progress_report: true
   cs_advisor_student_lookup: true
   cs_billing: true
-  cs_degree_progress: true
   cs_committees: true
+  cs_degree_progress_grad_advising: true
+  cs_degree_progress_grad_student: true
   cs_delegated_access: true
   cs_enrollment_card: true
   cs_fin_aid: true

--- a/config/settings/testext.yml
+++ b/config/settings/testext.yml
@@ -71,7 +71,8 @@ features:
   cs_academic_progress_report: true
   cs_advisor_student_lookup: true
   cs_billing: true
-  cs_degree_progress: true
+  cs_degree_progress_grad_advising: true
+  cs_degree_progress_grad_student: true
   cs_delegated_access: true
   cs_enrollment_card: true
   cs_fin_aid: true

--- a/fixtures/xml/campus_solutions/degree_progress_graduate.xml
+++ b/fixtures/xml/campus_solutions/degree_progress_graduate.xml
@@ -12,8 +12,8 @@
         <REQUIREMENT>
           <NAME>Advancement to Candidacy Mas2</NAME>
           <NUMBER>10</NUMBER>
-          <STATUS>Y</STATUS>
-          <DATE>2016-12-22</DATE>
+          <STATUS>N</STATUS>
+          <DATE></DATE>
           <CODE>AAGADVMAS2</CODE>
         </REQUIREMENT>
         <REQUIREMENT>
@@ -80,7 +80,7 @@
         <REQUIREMENT>
           <NAME>Qualifying Exam Results</NAME>
           <NUMBER>20</NUMBER>
-          <STATUS>Partially Passed</STATUS>
+          <STATUS>P</STATUS>
           <DATE>2016-12-26</DATE>
           <CODE>AAGQERESLT</CODE>
         </REQUIREMENT>

--- a/script/sis/verify_sis_api_endpoints.sh
+++ b/script/sis/verify_sis_api_endpoints.sh
@@ -277,7 +277,10 @@ verify_cs 'cs_advisor_student_lookup' "${yml_features_cs_advisor_student_lookup}
 verify_cs 'cs_profile_emergency_contacts' "${yml_features_cs_profile_emergency_contacts}" \
   "/UcApiEmergencyContactGet.v1/?EMPLID=${CAMPUS_SOLUTIONS_ID}"
 
-verify_cs 'cs_degree_progress' "${yml_features_cs_degree_progress}" \
+verify_cs 'cs_degree_progress_grad_advising' "${yml_features_cs_degree_progress_grad_advising}" \
+  "/UC_AA_PROGRESS_GET.v1/UC_AA_PROGRESS_GET?EMPLID=${CAMPUS_SOLUTIONS_ID}"
+
+verify_cs 'cs_degree_progress_grad_student' "${yml_features_cs_degree_progress_grad_student}" \
   "/UC_AA_PROGRESS_GET.v1/UC_AA_PROGRESS_GET?EMPLID=${CAMPUS_SOLUTIONS_ID}"
 
 verify_hub 'always_enabled' true \

--- a/spec/controllers/advising_student_controller_spec.rb
+++ b/spec/controllers/advising_student_controller_spec.rb
@@ -26,10 +26,21 @@ describe AdvisingStudentController do
     allow(User::AggregatedAttributes).to receive(:new).with(session_user_id).and_return double get_feed: session_user_attributes
   end
 
-  context 'no user in session' do
-    subject { get :profile, student_uid: student_uid }
+  shared_examples 'an endpoint receiving an unauthenticated request' do
     it 'should return empty json' do
       expect(JSON.parse subject.body).to be_empty
+    end
+  end
+
+  shared_examples 'an endpoint refusing a request' do
+    it 'should raise an error' do
+      expect(subject.status).to eq 403
+    end
+  end
+
+  shared_examples 'an endpoint receiving a valid request' do
+    it 'should send a successful response' do
+      expect(subject.status).to eq 200
     end
   end
 
@@ -42,9 +53,7 @@ describe AdvisingStudentController do
     subject { get :academics, student_uid: student_uid }
 
     context 'cannot view_as for all UIDs' do
-      it 'should raise an error' do
-        expect(subject.status).to eq 403
-      end
+      it_behaves_like 'an endpoint refusing a request'
     end
     context 'requested user must be a student' do
       let(:session_user_is_advisor) { true }
@@ -54,33 +63,27 @@ describe AdvisingStudentController do
         before do
           allow(Settings.features).to receive(:cs_advisor_student_lookup).and_return false
         end
-        it 'should raise an error' do
-          expect(subject.status).to eq 403
-        end
+        it_behaves_like 'an endpoint refusing a request'
       end
       context 'not a student' do
-        it 'should raise an error' do
-          expect(subject.status).to eq 403
-        end
+        it_behaves_like 'an endpoint refusing a request'
       end
       context 'student' do
         let(:student) { true }
+        it_behaves_like 'an endpoint receiving a valid request'
         it 'should provide a filtered academics feed' do
-          expect(response.status).to eq 200
           feed = JSON.parse(body = subject.body)
           expect(feed['collegeAndLevel']).to eq true
         end
       end
       context 'ex-student' do
         let(:ex_student) { true }
-        it 'should fail' do
-          expect(subject.status).to eq 403
-        end
+        it_behaves_like 'an endpoint refusing a request'
       end
       context 'applicant' do
         let(:applicant) { true }
-        it 'should succeed' do
-          expect(subject.status).to eq 200
+        it_behaves_like 'an endpoint receiving a valid request'
+        it 'should return data' do
           feed = JSON.parse(body = subject.body)
           expect(feed['collegeAndLevel']).to eq true
         end
@@ -89,21 +92,53 @@ describe AdvisingStudentController do
   end
 
   describe '#profile' do
-    let(:session_user_id) { random_id }
-    before do
-      allow(HubEdos::Contacts).to receive(:new).and_return double get: {}
-    end
     subject { get :profile, student_uid: student_uid }
 
+    context 'when no user in session' do
+      let(:student_id) { nil }
+      it_behaves_like 'an endpoint receiving an unauthenticated request'
+    end
+
     context 'student' do
+      before do
+        allow(HubEdos::Contacts).to receive(:new).and_return double get: {}
+      end
+      let(:session_user_id) { random_id }
       let(:session_user_is_advisor) { true }
       let(:student) { true }
-      it 'should succeed' do
-        expect(subject.status).to eq 200
+
+      it_behaves_like 'an endpoint receiving a valid request'
+      it 'should return data' do
         roles = (JSON.parse subject.body)['attributes']['roles']
         student_attributes[:roles].each do |key, value|
           expect(roles[key.to_s]).to be value
         end
+      end
+    end
+  end
+
+  describe '#degree_progress_graduate' do
+    subject { get :degree_progress_graduate, student_uid: student_uid }
+
+    before do
+      allow_any_instance_of(AuthenticationStatePolicy).to receive(:can_view_as?).and_return(true)
+    end
+
+    context 'when no user in session' do
+      let(:student_id) { nil }
+      it_behaves_like 'an endpoint receiving an unauthenticated request'
+    end
+
+    context 'student' do
+      let(:session_user_id) { random_id }
+      let(:session_user_is_advisor) { true }
+      let(:student) { true }
+
+      it_behaves_like 'an endpoint receiving a valid request'
+      it 'should return data' do
+        feed = JSON.parse(body = subject.body)
+        expect(feed['feed']['degreeProgress']).to be
+        expect(feed['feed']['links']).not_to be
       end
     end
   end

--- a/spec/controllers/campus_solutions/degree_progress_controller_spec.rb
+++ b/spec/controllers/campus_solutions/degree_progress_controller_spec.rb
@@ -3,6 +3,10 @@ describe CampusSolutions::DegreeProgressController do
   context '#get' do
     let(:feed) { :get }
 
+    before do
+      allow_any_instance_of(AuthenticationStatePolicy).to receive(:graduate_student?).and_return(true)
+    end
+
     it_behaves_like 'an unauthenticated user'
 
     context 'authenticated user' do

--- a/spec/models/berkeley/degree_progress_spec.rb
+++ b/spec/models/berkeley/degree_progress_spec.rb
@@ -41,4 +41,34 @@ describe Berkeley::DegreeProgress do
       it {should eq 'Dissertation File Date'}
     end
   end
+
+  describe '#get_form_notification' do
+    subject { described_class.get_form_notification(milestone_code, status_code) }
+
+    context 'when milestone_code is nil' do
+      let(:milestone_code) {nil}
+      let(:status_code) {'N'}
+      it {should be nil}
+    end
+    context 'when milestone_code is garbage' do
+      let(:milestone_code) {'garbage'}
+      let(:status_code) {'N'}
+      it {should be nil}
+    end
+    context 'when milestone is completed' do
+      let(:milestone_code) {'AAGADVMAS1'}
+      let(:status_code) {'Y'}
+      it {should be nil}
+    end
+    context 'when milestone_code exists in @statuses' do
+      let(:milestone_code) {'AAGADVMAS1'}
+      let(:status_code) {'N'}
+      it {should eq '(Form Required)'}
+    end
+    context 'when milestone_code exists in @statuses but is lowercase' do
+      let(:milestone_code) {'aagqeaprv'}
+      let(:status_code) {'N'}
+      it {should eq '(Form Required)'}
+    end
+  end
 end

--- a/spec/models/degree_progress/graduate_milestones_spec.rb
+++ b/spec/models/degree_progress/graduate_milestones_spec.rb
@@ -3,13 +3,30 @@ describe DegreeProgress::GraduateMilestones do
   let(:model) { described_class.new(user_id) }
   let(:user_id) { '12345' }
 
+  before do
+    allow_any_instance_of(AuthenticationStatePolicy).to receive(:can_view_as?).and_return(can_view_as)
+  end
+
   describe '#get_feed_internal' do
     subject { model.get_feed_internal }
 
-    it_behaves_like 'a proxy that returns graduate milestone data'
+    context 'when user has view-as privilege' do
+      let(:can_view_as) { true }
 
-    it 'does not include links in the response' do
-      expect(subject[:feed][:links]).not_to be
+      it_behaves_like 'a proxy that returns graduate milestone data'
+      it_behaves_like 'a proxy that properly observes the graduate degree progress for advisor feature flag'
+
+      it 'does not include links in the response' do
+        expect(subject[:feed][:links]).not_to be
+      end
+    end
+
+    context 'when user is not authorized' do
+      let(:can_view_as) { false }
+
+      it 'returns an empty response' do
+        expect(subject).to eq({})
+      end
     end
   end
 end

--- a/spec/models/degree_progress/my_graduate_milestones_spec.rb
+++ b/spec/models/degree_progress/my_graduate_milestones_spec.rb
@@ -3,15 +3,68 @@ describe DegreeProgress::MyGraduateMilestones do
   let(:model) { described_class.new(user_id) }
   let(:user_id) { '12345' }
 
+  before do
+    allow_any_instance_of(AuthenticationStatePolicy).to receive(:can_view_as?).and_return(can_view_as)
+    allow_any_instance_of(AuthenticationStatePolicy).to receive(:graduate_student?).and_return(graduate_student)
+    allow_any_instance_of(AuthenticationStatePolicy).to receive(:law_student?).and_return(law_student)
+  end
+
   describe '#get_feed_internal' do
     subject { model.get_feed_internal }
 
-    it_behaves_like 'a proxy that returns graduate milestone data'
+    context 'when user is a graduate student' do
+      let(:can_view_as) { false }
+      let(:graduate_student) { true }
+      let(:law_student) { false }
 
-    it 'includes links in the response' do
-      expect(subject[:feed][:links]).to be
-      expect(subject[:feed][:links][:advancementFormSubmit]).to be
-      expect(subject[:feed][:links][:advancementFormView]).to be
+      it_behaves_like 'a proxy that returns graduate milestone data'
+      it_behaves_like 'a proxy that properly observes the graduate degree progress for student feature flag'
+
+      it 'includes links in the response' do
+        expect(subject[:feed][:links]).to be
+        expect(subject[:feed][:links][:advancementFormSubmit]).to be
+        expect(subject[:feed][:links][:advancementFormView]).to be
+      end
+    end
+
+    context 'when user is a law student' do
+      let(:can_view_as) { false }
+      let(:graduate_student) { false }
+      let(:law_student) { true }
+
+      it_behaves_like 'a proxy that returns graduate milestone data'
+      it_behaves_like 'a proxy that properly observes the graduate degree progress for student feature flag'
+
+      it 'includes links in the response' do
+        expect(subject[:feed][:links]).to be
+        expect(subject[:feed][:links][:advancementFormSubmit]).to be
+        expect(subject[:feed][:links][:advancementFormView]).to be
+      end
+    end
+
+    context 'when user has view-as privilege' do
+      let(:can_view_as) { true }
+      let(:graduate_student) { false }
+      let(:law_student) { false }
+
+      it_behaves_like 'a proxy that returns graduate milestone data'
+      it_behaves_like 'a proxy that properly observes the graduate degree progress for student feature flag'
+
+      it 'includes links in the response' do
+        expect(subject[:feed][:links]).to be
+        expect(subject[:feed][:links][:advancementFormSubmit]).to be
+        expect(subject[:feed][:links][:advancementFormView]).to be
+      end
+    end
+
+    context 'when user is not authorized' do
+      let(:can_view_as) { false }
+      let(:graduate_student) { false }
+      let(:law_student) { false }
+
+      it 'returns an empty response' do
+        expect(subject).to eq({})
+      end
     end
   end
 end

--- a/spec/support/campus_solutions_helper_module.rb
+++ b/spec/support/campus_solutions_helper_module.rb
@@ -118,8 +118,13 @@ module CampusSolutionsHelperModule
     it_behaves_like 'a proxy that observes a feature flag'
   end
 
-  shared_examples 'a proxy that properly observes the degree progress feature flag' do
-    let(:flag) { :cs_degree_progress }
+  shared_examples 'a proxy that properly observes the graduate degree progress for advisor feature flag' do
+    let(:flag) { :cs_degree_progress_grad_advising }
+    it_behaves_like 'a proxy that observes a feature flag'
+  end
+
+  shared_examples 'a proxy that properly observes the graduate degree progress for student feature flag' do
+    let(:flag) { :cs_degree_progress_grad_student }
     it_behaves_like 'a proxy that observes a feature flag'
   end
 

--- a/spec/support/degree_progress_shared_examples.rb
+++ b/spec/support/degree_progress_shared_examples.rb
@@ -1,7 +1,5 @@
 shared_examples 'a proxy that returns graduate milestone data' do
 
-  it_behaves_like 'a proxy that properly observes the degree progress feature flag'
-
   it 'returns data with the expected structure' do
     expect(subject[:feed][:degreeProgress]).to be
     expect(subject[:feed][:degreeProgress].first[:acadCareer]).to be
@@ -25,9 +23,18 @@ shared_examples 'a proxy that returns graduate milestone data' do
   end
 
   it 'replaces codes with descriptive names' do
+    expect(subject[:feed][:degreeProgress][0][:requirements][0][:name]).to eql('Advancement to Candidacy Plan II')
+    expect(subject[:feed][:degreeProgress][0][:requirements][0][:statusDescr]).to eql('Not Satisfied')
     expect(subject[:feed][:degreeProgress][1][:requirements][0][:name]).to eql('Advancement to Candidacy Plan I or Plan II')
-    expect(subject[:feed][:degreeProgress][1][:requirements][0][:status]).to be nil
+    expect(subject[:feed][:degreeProgress][1][:requirements][0][:statusDescr]).to be nil
     expect(subject[:feed][:degreeProgress][2][:requirements][0][:name]).to eql('Approval for Qualifying Exam')
-    expect(subject[:feed][:degreeProgress][2][:requirements][0][:status]).to eql('Completed')
+    expect(subject[:feed][:degreeProgress][2][:requirements][0][:statusDescr]).to eql('Completed')
+  end
+
+  it 'attaches a notification if the milestone is incomplete and requires a form' do
+    puts subject[:feed][:degreeProgress].pretty_inspect
+    expect(subject[:feed][:degreeProgress][0][:requirements][0][:formNotification]).to eql('(Form Required)')
+    expect(subject[:feed][:degreeProgress][1][:requirements][0][:formNotification]).to eql('(Plan 1 Requires a Form)')
+    expect(subject[:feed][:degreeProgress][2][:requirements][0][:formNotification]).to be nil
   end
 end

--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -52,6 +52,9 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
     },
     isLoading: true
   };
+  $scope.degreeProgress = {
+    isLoading: true
+  };
 
   $scope.$watchGroup(['regStatus.registrations[0].summary', 'api.user.profile.features.csHolds'], function(newValues) {
     var enabledSections = [];
@@ -194,6 +197,17 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
     });
   };
 
+  var loadDegreeProgressGraduate = function() {
+    advisingFactory.getDegreeProgress({
+      uid: $routeParams.uid
+    }).success(function(data) {
+      $scope.degreeProgress.progresses = _.get(data, 'feed.degreeProgress');
+      $scope.degreeProgress.errored = _.get(data, 'data.errored');
+    }).finally(function() {
+      $scope.degreeProgress.isLoading = false;
+    });
+  };
+
   var parseTermGpa = function() {
     var termGpa = [];
     _.forEach($scope.studentSuccess.termGpa, function(term) {
@@ -252,6 +266,7 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
       .then(loadStudentSuccess)
       .then(loadHolds)
       .then(loadRegistrations)
+      .then(loadDegreeProgressGraduate)
       .then(getRegMessages);
     }
   });

--- a/src/assets/javascripts/angular/controllers/widgets/academics/degreeProgressController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/academics/degreeProgressController.js
@@ -5,39 +5,14 @@ var _ = require('lodash');
 
 angular.module('calcentral.controllers').controller('DegreeProgressController', function(degreeProgressFactory, $scope) {
 
-  var config = {
-    AAGADVMAS1: {
-      hasForm: true
-    },
-    AAGQEAPRV: {
-      hasForm: true
-    },
-    AAGADVPHD: {
-      hasForm: true
-    }
-  };
   $scope.degreeProgress = {
     isLoading: true
-  };
-
-  var transformRequirements = function(progress) {
-    _.each(progress.requirements, function(requirement) {
-      requirement.hasForm = _.get(config, '[' + requirement.code + '][hasForm]', false);
-    });
-  };
-
-  var transform = function(data) {
-    var progresses = _.get(data, 'data.feed.degreeProgress');
-    _.each(progresses, transformRequirements);
-    return {
-      progresses: progresses
-    };
   };
 
   var loadDegreeProgress = function() {
     degreeProgressFactory.getDegreeProgress()
       .then(function(data) {
-        angular.extend($scope.degreeProgress, transform(data));
+        $scope.degreeProgress.progresses = _.get(data, 'data.feed.degreeProgress');
         $scope.degreeProgress.links = _.get(data, 'data.feed.links');
         $scope.degreeProgress.errored = _.get(data, 'data.errored');
       })

--- a/src/assets/javascripts/angular/factories/advisingFactory.js
+++ b/src/assets/javascripts/angular/factories/advisingFactory.js
@@ -18,6 +18,8 @@ angular.module('calcentral.factories').factory('advisingFactory', function(apiSe
   // var urlAdvisingRegistrations = 'dummy/json/advising_registrations.json';
   var urlAdvisingStudentSuccess = '/api/advising/student_success/';
   // var urlAdvisingStudentSuccess = '/dummy/json/advising_student_success.json';
+  var urlAdvisingDegreeProgress = '/api/advising/degree_progress/grad/';
+  // var urlAdvisingDegreeProgress = '/dummy/json/degree_progress_graduate.json';
 
   var getResources = function(options) {
     return apiService.http.request(options, urlResources);
@@ -43,12 +45,17 @@ angular.module('calcentral.factories').factory('advisingFactory', function(apiSe
     return apiService.http.request(options, urlAdvisingStudentSuccess + options.uid);
   };
 
+  var getDegreeProgress = function(options) {
+    return apiService.http.request(options, urlAdvisingDegreeProgress + options.uid);
+  };
+
   return {
     getAdvisingResources: getAdvisingResources,
     getResources: getResources,
     getStudent: getStudent,
     getStudentAcademics: getStudentAcademics,
     getStudentRegistrations: getStudentRegistrations,
-    getStudentSuccess: getStudentSuccess
+    getStudentSuccess: getStudentSuccess,
+    getDegreeProgress: getDegreeProgress
   };
 });

--- a/src/assets/templates/academics.html
+++ b/src/assets/templates/academics.html
@@ -22,7 +22,7 @@
       data-ng-class="{'medium-6':(api.user.profile.roles.student), 'medium-4':(!api.user.profile.roles.student)}"
       class="large-4 columns cc-column-2 cc-academics-row-margin">
       <div data-ng-include src="'academics_semesters.html'" data-ng-if="api.user.profile.hasStudentHistory && semesters.length"></div>
-      <div data-ng-include src="'widgets/academics/degree_progress.html'" data-ng-if="api.user.profile.features.csDegreeProgress && (api.user.profile.roles.graduate || api.user.profile.roles.law)"></div>
+      <div data-ng-include src="'widgets/academics/degree_progress_graduate.html'" data-ng-controller="DegreeProgressController"  data-ng-if="api.user.profile.features.csDegreeProgressStudent && (api.user.profile.roles.graduate || api.user.profile.roles.law)"></div>
       <div data-ng-include src="'academics_teaching.html'" data-ng-if="!api.user.profile.delegateActingAsUid && hasTeachingClasses"></div>
       <div data-ng-include src="'academics_higher_degree_committees.html'" data-ng-if="api.user.profile.features.csCommmittees && api.user.profile.roles.student && !api.user.profile.roles.faculty"></div>
       <div data-ng-include src="'academics_higher_degree_faculty_committees.html'" data-ng-if="api.user.profile.features.csCommmittees && !api.user.profile.roles.student && api.user.profile.roles.faculty"></div>

--- a/src/assets/templates/user_overview.html
+++ b/src/assets/templates/user_overview.html
@@ -8,6 +8,7 @@
     </div>
     <div class="medium-4 columns cc-column-2">
       <div data-ng-include="'widgets/student_success/student_success.html'" data-ng-if="api.user.profile.features.advisingStudentSuccess"></div>
+      <div data-ng-include src="'widgets/academics/degree_progress_graduate.html'" data-ng-if="api.user.profile.features.csDegreeProgressAdvising && (targetUser.roles.graduate || targetUser.roles.law)"></div>
       <div data-ng-include src="'academics_semesters.html'" data-ng-if="semesters.length"></div>
       <div data-ng-include="'widgets/student_university_requirements.html'" data-ng-if="targetUser.isLoading || !targetUser.campusSolutionsStudent && targetUser.roles.undergrad"></div>
       <div data-ng-include="'widgets/status_and_holds.html'"></div>

--- a/src/assets/templates/widgets/academics/degree_progress_graduate.html
+++ b/src/assets/templates/widgets/academics/degree_progress_graduate.html
@@ -1,4 +1,4 @@
-<div class="cc-widget cc-degree-progress-card" data-ng-controller="DegreeProgressController">
+<div class="cc-widget cc-degree-progress-card">
   <div class="cc-widget-title">
     <h2>Degree Progress</h2>
   </div>
@@ -19,10 +19,10 @@
     </ul>
     <ul>
       <li data-ng-repeat="plan in degreeProgress.progresses">
-        <h3 data-ng-bind="plan.acadPlan + ' &mdash; Graduate Division Milestones'"></h3>
+        <h3 data-ng-bind="plan.acadPlanDescr + ' &mdash; Graduate Division Milestones'"></h3>
         <div data-ng-repeat="requirement in plan.requirements">
           <h4 data-ng-bind="requirement.name"></h4>
-          <span data-ng-bind="requirement.status"></span>&nbsp;<span data-ng-bind="requirement.date"></span>
+          <span data-ng-bind="requirement.statusDescr"></span>&nbsp;<span data-ng-bind="requirement.date"></span>&nbsp;<span data-ng-bind="requirement.formNotification">
         </div>
       </li>
     </ul>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-25362

Advisors will see the Degree Progress card when they do Student Lookup on a GRAD or LAW student.
I added a separate feature flag for the advisor version of the card.  The advisor version is planned for 7.2 and the student version is planned for 7.3+ at the moment.

This is the UI side of the work; the backend work was reviewed under https://github.com/ets-berkeley-edu/calcentral/pull/6027.