### PR TITLE
CLC-6475, revert to 'source' on relative path in calcentral-update

### DIFF
--- a/script/calcentral-update.sh
+++ b/script/calcentral-update.sh
@@ -10,13 +10,13 @@ cd $( dirname "${BASH_SOURCE[0]}" )/..
 
 # Enable rvm and use the correct Ruby version and gem set.
 [[ -s "${HOME}/.rvm/scripts/rvm" ]] && source "${HOME}/.rvm/scripts/rvm"
-source "${PWD}/.rvmrc"
+source .rvmrc
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 
 # JVM args per CalCentral convention
-source "${PWD}/script/standard-calcentral-JVM-OPTS-profile"
+source script/standard-calcentral-JVM-OPTS-profile
 
 echo "------------------------------------------"
 echo "$(date): Redeploying CalCentral on app nodes..."


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6475

Prior to PR #6041, we had `source .rvmrc`. In my preference for absolute paths, I changed it to `source "${PWD}/.rvmrc"`.  That might have made Bamboo unhappy: https://bamboo.ets.berkeley.edu/bamboo/browse/CLCD-CQDC

After this merge, if Bamboo passes then I'll restore `source .rvmrc` (relative path) on all scripts.