### PR TITLE
CLC-6471 bCourses mailing lists: send authenticated messages to list members

### DIFF
--- a/app/controllers/mailing_lists_message_controller.rb
+++ b/app/controllers/mailing_lists_message_controller.rb
@@ -34,12 +34,18 @@ class MailingListsMessageController < ApplicationController
     if params['attachment-count']
       attachments[:count] = params['attachment-count'].to_i
       attachments[:data] = {}
-      attachments[:cid_map] = JSON.parse(params['content-id-map']) if params['content-id-map']
+
+      if params['content-id-map']
+        attachments[:cid_map] = {}
+        JSON.parse(params['content-id-map']).each do |cid, attachment_name|
+          stripped_cid = cid.tr('<>', '')
+          attachments[:cid_map][stripped_cid] = attachment_name
+        end
+      end
 
       params.each do |key, value|
-        if (match_data = key.match /\Aattachment-(\d+)\Z/)
-          attachment_number = match_data[1].to_i
-          attachments[:data][attachment_number] = value
+        if key.match /\Aattachment-\d+\Z/
+          attachments[:data][key] = value
         end
       end
     end

--- a/app/models/mailgun/send_message.rb
+++ b/app/models/mailgun/send_message.rb
@@ -8,7 +8,7 @@ module Mailgun
           method: :post,
           body: message_opts
         })
-        if response.code == 200
+        if response.status == 200
           {
             statusCode: 200,
             sending: true

--- a/app/models/mailing_lists/outgoing_message.rb
+++ b/app/models/mailing_lists/outgoing_message.rb
@@ -1,19 +1,81 @@
 module MailingLists
   class OutgoingMessage
+    include ClassLogger
 
-    def initialize(member, mailing_list, opts={})
-      @member = member
+    def initialize(mailing_list, member, opts={})
       @mailing_list = mailing_list
+      @member = member
       @opts = opts
     end
 
     def send_message
-      # TODO set parameters for outgoing message
-      Mailgun::SendMessage.new.post(
-        from: '',
-        to: '',
-        subject: ''
-      )
+      payload = {
+        'subject' => @opts[:subject],
+        'h:Reply-To' => @opts[:from],
+        'html' => @opts[:body][:html],
+        'text' => @opts[:body][:plain]
+      }
+
+      payload['Message-Id'] = @opts[:id] if @opts[:id]
+      payload['text'] = ' ' if payload['html'].blank? && payload['text'].blank?
+
+      set_attachments payload
+      set_from payload
+      set_recipients payload
+
+      Mailgun::SendMessage.new.post payload
+    end
+
+    private
+
+    def set_attachments(payload)
+      return unless @opts[:attachments][:data]
+
+      @opts[:attachments][:data].each_value do |attachment_data|
+        attachment_data['filename'] ||= ''
+        attachment_data['type'] ||= 'application/octet-stream'
+      end
+
+      if @opts[:attachments][:cid_map]
+        payload['inline'] = @opts[:attachments][:cid_map].map do |cid, key|
+          if (attachment_data = @opts[:attachments][:data].delete key)
+            # Mailgun expects inline attachments to be specified by filename, not content-id.
+            %w(html plain).each { |key| payload[key].try :gsub!, cid, attachment_data['filename'] }
+            to_upload_io attachment_data
+          end
+        end
+      end
+
+      if @opts[:attachments][:data].any?
+        payload['attachment'] = @opts[:attachments][:data].map { |key, attachment_data| to_upload_io attachment_data }
+      end
+    end
+
+    # To keep spam filters happy, the 'From:' address must have the same domain as the mailing list. However, we
+    # can set the display name to match the original sender.
+    def set_from(payload)
+      address = Mail::Address.new
+      address.address = ['no-reply', @mailing_list.class.domain].join '@'
+      address.display_name = [@member.first_name, @member.last_name].join ' '
+      payload['from'] = address.to_s
+    end
+
+    # The empty hashes under 'recipient-variables' tell Mailgun not to include all member addresses in the 'To:' field.
+    # See https://documentation.mailgun.com/user_manual.html#batch-sending
+    def set_recipients(payload)
+      payload['to'] = []
+      payload['recipient-variables'] = {}
+      @mailing_list.members.each do |member|
+        payload['to'] << member.email_address
+        payload['recipient-variables'][member.email_address] = {}
+      end
+    end
+
+    def to_upload_io(attachment_data)
+      Faraday::UploadIO.new(attachment_data['tempfile'], attachment_data['type'], attachment_data['filename'])
+    rescue => e
+      logger.error "Could not create UploadIO instance from attachment data #{attachment_data}: #{e.class}: #{e.message}\n #{e.backtrace.join("\n ")}"
+      nil
     end
 
   end

--- a/spec/controllers/mailing_lists_message_controller_spec.rb
+++ b/spec/controllers/mailing_lists_message_controller_spec.rb
@@ -107,11 +107,11 @@ describe MailingListsMessageController do
           attachments: {
             count: 2,
             cid_map: {
-              '<EC2CE1CA-4686-4412-88C7-EC9A2176D97F>' => 'attachment-1'
+              'EC2CE1CA-4686-4412-88C7-EC9A2176D97F' => 'attachment-1'
             },
             data: {
-              1 => attachment_1,
-              2 => attachment_2
+              'attachment-1' => attachment_1,
+              'attachment-2' => attachment_2
             }
           }
         )).and_call_original

--- a/spec/models/mailgun/send_message_spec.rb
+++ b/spec/models/mailgun/send_message_spec.rb
@@ -12,8 +12,6 @@ describe Mailgun::SendMessage do
       )
     end
 
-    it_behaves_like 'a polite HTTP client'
-
     it 'reports success' do
       expect(subject[:response][:statusCode]).to eq 200
       expect(subject[:response][:sending]).to be_truthy
@@ -25,9 +23,8 @@ describe Mailgun::SendMessage do
       let(:body) { '{"message": "I would prefer not to send email."}' }
       before { proxy.set_response(status: status, body: body) }
 
-      include_context 'expecting logs from server errors'
-
       it 'reports failure' do
+        expect(Rails.logger).to receive(:error).with(/Error sending message/)
         expect(subject[:response][:statusCode]).to eq 503
         expect(subject[:response][:sending]).to be_falsey
         expect(subject[:exception]).to be_truthy

--- a/spec/models/mailing_lists/incoming_message_spec.rb
+++ b/spec/models/mailing_lists/incoming_message_spec.rb
@@ -3,19 +3,14 @@ describe MailingLists::IncomingMessage do
   let(:message_opts) do
     {
       id: '<DLOAsW7ZwDP1yvQOabwgZ1AvXNGoGpJgRoV4HoVq9tjQKyD1f1w@mail.gmail.com>',
-        sender: sender,
-        recipient: recipient,
-        subject: 'A message of teaching and learning',
-        body: {
+      sender: sender,
+      recipient: recipient,
+      subject: 'A message of teaching and learning',
+      body: {
         html: '<html><body>Instructional content goes here.<br><br><br>Paul Kerschen<br>Programming and Design Group<br>Educational Technology Services, UC Berkeley</body></html>',
         plain: "Instructional content goes here.\r\n\r\n\r\nPaul Kerschen\r\nProgramming and Design Group\r\nEducational Technology Services, UC Berkeley",
       },
-        attachments: {
-        count: 1,
-        data: {
-          1 => 'fake attachment'
-        }
-      }
+      attachments: {}
     }
   end
 

--- a/spec/models/mailing_lists/outgoing_message_spec.rb
+++ b/spec/models/mailing_lists/outgoing_message_spec.rb
@@ -1,0 +1,153 @@
+describe MailingLists::OutgoingMessage do
+
+  let(:list) do
+    MailingLists::MailgunList.create!(
+      canvas_site_id: random_id,
+      list_name: 'design_analysis_of_nuclear_reactors-sp17'
+    )
+  end
+
+  before do
+    MailingLists::Member.create!(
+      email_address: 'monty@berkeley.edu',
+      first_name: 'Montgomery',
+      last_name: 'Burns',
+      can_send: true,
+      mailing_list_id: list.id
+    )
+    MailingLists::Member.create!(
+      email_address: 'smithers@berkeley.edu',
+      first_name: 'Waylon',
+      last_name: 'Smithers',
+      can_send: false,
+      mailing_list_id: list.id
+    )
+  end
+
+  let(:member) { list.members.find_by(can_send: true) }
+
+  let(:message_opts) do
+    {
+      id: '<DLOAsW7ZwDP1yvQOabwgZ1AvXNGoGpJgRoV4HoVq9tjQKyD1f1w@mail.gmail.com>',
+      from: 'Montgomery Burns <monty@berkeley.edu>',
+      subject: 'A message of teaching and learning',
+      body: {
+        html: '<html><body>Instructional content goes here.<br><br><br>Montgomery Burns<br>Programming and Design Group<br>Educational Technology Services, UC Berkeley</body></html>',
+        plain: "Instructional content goes here.\r\n\r\n\r\nMontgomery Burns\r\nProgramming and Design Group\r\nEducational Technology Services, UC Berkeley",
+      },
+      attachments: {}
+    }
+  end
+
+  subject { described_class.new(list, member, message_opts) }
+
+  shared_examples 'proper forwarding' do
+    it 'makes a proxy request and reports success' do
+      expect_any_instance_of(Mailgun::SendMessage).to receive(:post).with(request_matcher).and_return(
+        response: {sending: true}
+      )
+      expect(subject.send_message).to be_truthy
+    end
+  end
+
+  let(:request_matcher) do
+    satisfy do |params|
+      expect(params).to include({
+        'Message-Id' => '<DLOAsW7ZwDP1yvQOabwgZ1AvXNGoGpJgRoV4HoVq9tjQKyD1f1w@mail.gmail.com>',
+        'from' => 'Montgomery Burns <no-reply@bcourses-mail.berkeley.edu>',
+        'to' => %w(monty@berkeley.edu smithers@berkeley.edu),
+        'subject' => 'A message of teaching and learning',
+        'h:Reply-To' => 'Montgomery Burns <monty@berkeley.edu>',
+        'html' => message_opts[:body][:html],
+        'text' => message_opts[:body][:plain]
+      })
+    end
+  end
+
+  context 'a straightforward message' do
+    include_examples 'proper forwarding'
+  end
+
+  context 'a message with blank body' do
+    before do
+      message_opts[:body][:html] = ''
+      message_opts[:body][:plain] = ''
+    end
+    context 'expecting space padding' do
+      let(:request_matcher) do
+        satisfy do |params|
+          expect(params['text']).to eq ' '
+        end
+      end
+      include_examples 'proper forwarding'
+    end
+  end
+
+  context 'a message with attachments' do
+    before do
+      message_opts[:attachments] = {
+        count: 2,
+        data: {
+          'attachment-1' => {
+            'filename' => 'sample_student_72x96.jpg',
+            'name' => 'attachment-1',
+            'tempfile' => File.new(Rails.root.join 'public', 'dummy', 'images', 'sample_student_72x96.jpg'),
+            'type' => 'image/jpg'
+          },
+          'attachment-2' => {
+            'filename' => 'academic_dates.json',
+            'name' => 'attachment-2',
+            'tempfile' => File.new(Rails.root.join 'public', 'dummy', 'json', 'academic_dates.json'),
+            'type' => 'application/json'
+          }
+        }
+      }
+    end
+    context 'expecting multipart upload' do
+      let(:request_matcher) do
+        satisfy do |params|
+          expect(params['attachment'].count).to eq 2
+          expect(params['attachment'][0].content_type).to eq 'image/jpg'
+          expect(params['attachment'][0].io.size).to be > 0
+          expect(params['attachment'][0].local_path).to eq "#{Rails.root}/public/dummy/images/sample_student_72x96.jpg"
+          expect(params['attachment'][0].original_filename).to eq 'sample_student_72x96.jpg'
+          expect(params['attachment'][1].content_type).to eq 'application/json'
+          expect(params['attachment'][1].io.size).to be > 0
+          expect(params['attachment'][1].local_path).to eq "#{Rails.root}/public/dummy/json/academic_dates.json"
+          expect(params['attachment'][1].original_filename).to eq 'academic_dates.json'
+        end
+      end
+      include_examples 'proper forwarding'
+    end
+  end
+
+  context 'a message with inline attachments' do
+    before do
+      message_opts[:attachments] = {
+        count: 1,
+        cid_map: {
+          'EC2CE1CA-4686-4412-88C7-EC9A2176D97F' => 'attachment-1'
+        },
+        data: {
+          'attachment-1' => {
+            'filename' => 'sample_student_72x96.jpg',
+            'name' => 'attachment-1',
+            'tempfile' => File.new(Rails.root.join 'public', 'dummy', 'images', 'sample_student_72x96.jpg'),
+            'type' => 'image/jpg'
+          }
+        }
+      }
+      message_opts[:body][:html] = '<html><body>Keep this man away from the reactor: <img src="cid:EC2CE1CA-4686-4412-88C7-EC9A2176D97F"><br><br></body></html>'
+    end
+    context 'expecting multipart upload with inline references' do
+      let(:request_matcher) do
+        satisfy do |params|
+          expect(params['inline'].count).to eq 1
+          expect(params['inline'][0].original_filename).to eq 'sample_student_72x96.jpg'
+          expect(params['html']).to eq '<html><body>Keep this man away from the reactor: <img src="cid:sample_student_72x96.jpg"><br><br></body></html>'
+        end
+      end
+      include_examples 'proper forwarding'
+    end
+  end
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6471

Since attachment handling involves multipart file upload, which isn't supported by HTTParty, we have to switch the Mailgun proxy over to unpartying old Faraday.