### PR TITLE
CLC-6480 bCourses mailing lists: tweak admin tool to handle Mailgun lists

### DIFF
--- a/app/models/mailing_lists/mailgun_list.rb
+++ b/app/models/mailing_lists/mailgun_list.rb
@@ -9,10 +9,6 @@ module MailingLists
       Settings.mailgun_proxy.domain
     end
 
-    def add_list_urls(feed)
-      # No-op; Mailgun lists have no external administration URLs.
-    end
-
     def add_member(address, first_name, last_name, can_send)
       MailingLists::Member.create!(
         email_address: address,
@@ -47,10 +43,6 @@ module MailingLists
       if population_results[:update][:failure].any?
         logger.error "Failed to update #{population_results[:update][:failure].count} addresses in #{self.list_name}: #{population_results[:update][:failure].join ', '}"
       end
-    end
-
-    def name_available?
-      MailingLists::SiteMailingList.find_by(list_name: self.list_name).nil?
     end
 
     def remove_member(address)

--- a/app/models/mailing_lists/site_mailing_list.rb
+++ b/app/models/mailing_lists/site_mailing_list.rb
@@ -31,6 +31,9 @@ module MailingLists
     after_initialize :get_canvas_site, if: :new_record?
     after_initialize :init_unregistered, if: :new_record?
 
+    # Subclasses override.
+    def self.domain; end
+
     def populate
       if self.state != 'created'
         self.request_failure = "Mailing list \"#{self.list_name}\" must be created before being populated."
@@ -82,6 +85,9 @@ module MailingLists
     end
 
     private
+
+    # Subclasses may override if they have external administration URLs.
+    def add_list_urls(feed); end
 
     def any_population_failures?
       self.population_results[:add][:failure].any? || self.population_results[:remove][:failure].any?
@@ -140,6 +146,11 @@ module MailingLists
           failure: []
         }
       }
+    end
+
+    def name_available?
+      return if list_name.blank?
+      MailingLists::SiteMailingList.find_by(list_name: self.list_name).nil?
     end
 
     def parse_term(term)

--- a/src/assets/javascripts/angular/controllers/pages/canvasSiteMailingListController.js
+++ b/src/assets/javascripts/angular/controllers/pages/canvasSiteMailingListController.js
@@ -33,6 +33,11 @@ angular.module('calcentral.controllers').controller('CanvasSiteMailingListContro
       setCodeAndTerm($scope.canvasSite);
     }
 
+    if (!$scope.listRegistered) {
+      // For Fall 2016, the list admin tool should continue to default to CalMail.
+      $scope.mailingList.listType = 'CalmailList';
+    }
+
     if ($scope.listCreated) {
       setListLastPopulated(data.mailingList);
     }
@@ -112,7 +117,7 @@ angular.module('calcentral.controllers').controller('CanvasSiteMailingListContro
 
   $scope.registerMailingList = function() {
     $scope.isProcessing = true;
-    return canvasSiteMailingListFactory.registerSiteMailingList($scope.canvasSite.canvasCourseId, $scope.mailingList.name).success(function(data) {
+    return canvasSiteMailingListFactory.registerSiteMailingList($scope.canvasSite.canvasCourseId, $scope.mailingList).success(function(data) {
       setStateFromData(data);
     }).error(function() {
       $scope.displayError = 'failure';

--- a/src/assets/javascripts/angular/factories/canvasSiteMailingListFactory.js
+++ b/src/assets/javascripts/angular/factories/canvasSiteMailingListFactory.js
@@ -18,9 +18,10 @@ angular.module('calcentral.factories').factory('canvasSiteMailingListFactory', f
     return $http.post('/api/academics/canvas/mailing_lists/' + canvasCourseId + '/populate');
   };
 
-  var registerSiteMailingList = function(canvasCourseId, listName) {
+  var registerSiteMailingList = function(canvasCourseId, list) {
     return $http.post('/api/academics/canvas/mailing_lists/' + canvasCourseId + '/create', {
-      listName: listName
+      listName: list.listName,
+      listType: list.listType
     });
   };
 

--- a/src/assets/stylesheets/_canvas_site_mailing_list.scss
+++ b/src/assets/stylesheets/_canvas_site_mailing_list.scss
@@ -34,6 +34,12 @@
     text-align: right;
   }
 
+  .bc-page-site-mailing-list-form-label-long {
+    display: inline;
+    font-weight: 300;
+    text-align: left;
+  }
+
   .bc-page-site-mailing-list-notice-message {
     margin-left: 30px;
   }

--- a/src/assets/templates/canvas_embedded/site_mailing_list.html
+++ b/src/assets/templates/canvas_embedded/site_mailing_list.html
@@ -54,7 +54,7 @@
         <div data-ng-if="listCreated">
           <div data-ng-pluralize count="mailingList.membersCount||0" when="{'0':'No members','one':'1 member','other':'{} members'}"></div>
           <div>Membership last updated: <strong data-ng-bind="listLastPopulated | lowercase"></strong></div>
-          <a data-ng-href="{{mailingList.administrationUrl}}" data-ng-click="api.analytics.trackExternalLink('Canvas Site Mailing List', 'Calmail', mailingList.administrationUrl)">
+          <a data-ng-href="{{mailingList.administrationUrl}}" data-ng-if="mailingList.administrationUrl" data-ng-click="api.analytics.trackExternalLink('Canvas Site Mailing List', 'Calmail', mailingList.administrationUrl)">
             View in CalMail
           </a>
         </div>
@@ -73,7 +73,7 @@
       </div>
 
       <div class="bc-page-site-mailing-list-text" data-ng-if="!listRegistered">
-        No mailing list name has been reserved for this site. Choose a name to reserve before creating a list.
+        No mailing list name has been reserved for this site.
       </div>
 
       <div data-ng-if="listPending">
@@ -89,19 +89,35 @@
       </div>
 
       <form class="bc-canvas-page-form bc-canvas-form">
-        <div class="row bc-page-site-mailing-list-form-input-row" data-ng-if="!listRegistered">
-          <div class="medium-3 small-12 columns">
-            <label for="mailingListName" class="bc-page-site-mailing-list-form-label">New Mailing List Name:</label>
+        <div data-ng-if="!listRegistered">
+          <div class="row bc-page-site-mailing-list-text">
+            <input type="radio" id="listTypeCalmail" data-ng-model="mailingList.listType" data-ng-value="'CalmailList'">
+            <label for="listTypeCalmail" class="bc-page-site-mailing-list-form-label-long">Reserve this name for a CalMail list (you will create the list on the next screen).</label>
           </div>
-          <div class="medium-9 small-12 columns">
-            <input type="text" id="mailingListName" class="cc-left bc-canvas-form-input-text" data-ng-model="mailingList.name" required aria-required="true">
+          <div class="row bc-page-site-mailing-list-text">
+            <input type="radio" id="listTypeMailgun" data-ng-model="mailingList.listType" data-ng-value="'MailgunList'">
+            <label for="listTypeMailgun" class="bc-page-site-mailing-list-form-label-long">Create a Mailgun list now.</label>
+          </div>
+          <div class="row bc-page-site-mailing-list-form-input-row">
+            <div class="medium-3 small-12 columns">
+              <label for="mailingListName" class="bc-page-site-mailing-list-form-label">New Mailing List Name:</label>
+            </div>
+            <div class="medium-9 small-12 columns">
+              <input type="text" id="mailingListName" class="cc-left bc-canvas-form-input-text" data-ng-model="mailingList.name" required aria-required="true">
+            </div>
           </div>
         </div>
 
         <div class="bc-form-actions">
           <button data-ng-if="!listRegistered" data-ng-click="registerMailingList()" class="bc-canvas-button bc-canvas-button-primary" aria-controls="cc-page-reader-alert">
-            <span data-ng-if="!isProcessing">Reserve mailing list name</span>
-            <span data-ng-if="isProcessing"><i class="fa fa-spinner fa-spin"></i> Reserving ...</span>
+            <span data-ng-if="!isProcessing">
+              <span data-ng-if="mailingList.listType !== 'MailgunList'">Reserve mailing list name</span>
+              <span data-ng-if="mailingList.listType === 'MailgunList'">Create mailing list</span>
+            </span>
+            <span data-ng-if="isProcessing"><i class="fa fa-spinner fa-spin"></i>
+              <span data-ng-if="mailingList.listType !== 'MailgunList'">Reserving ...</span>
+              <span data-ng-if="mailingList.listType === 'MailgunList'">Creating ...</span>
+            </span>
           </button>
           <div data-ng-if="listPending">
             <a data-ng-href="{{mailingList.creationUrl}}" class="bc-canvas-button bc-canvas-button-primary bc-page-site-mailing-list-button-primary"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6480

The Mailgun workflow is simpler than the CalMail workflow. CalMail lists are first "registered" in the Junction database and then created in CalMail; but Mailgun lists live only in Junction and can be created in one shot.

A couple of methods are moved into the MailingLists::SiteMailingList superclass to avoid errors when we first instantiate a placeholder list without yet knowing what subclass it will be.