### PR TITLE
CLC-6467 bCourses mailing lists: stay out of ActionController's vocabulary

### DIFF
--- a/app/controllers/mailing_lists_message_controller.rb
+++ b/app/controllers/mailing_lists_message_controller.rb
@@ -5,7 +5,7 @@ class MailingListsMessageController < ApplicationController
   # POST /api/mailing_lists/message
   # Handle a received message.
 
-  def dispatch
+  def relay
     # See https://documentation.mailgun.com/api-sending.html#retrieving-stored-messages for Mailgun's message parameters.
     message_attrs = {
       # Capitalized params are unaltered headers from the original message.
@@ -23,8 +23,8 @@ class MailingListsMessageController < ApplicationController
       attachments: extract_attachments
     }
 
-    dispatched = MailingLists::IncomingMessage.new(message_attrs).dispatch
-    render json: {success: dispatched}
+    relayed = MailingLists::IncomingMessage.new(message_attrs).relay
+    render json: {success: relayed}
   end
 
   private

--- a/app/models/mailing_lists/incoming_message.rb
+++ b/app/models/mailing_lists/incoming_message.rb
@@ -9,9 +9,9 @@ module MailingLists
       @recipient_address = Mail::Address.new @opts[:recipient]
     end
 
-    def dispatch
+    def relay
       if !@sender_address.address || !@recipient_address.address
-        logger.error "Could not dispatch mailing list message with bad properties: #{@opts}"
+        logger.error "Could not relay mailing list message with bad properties: #{@opts}"
         return false
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -242,7 +242,7 @@ Calcentral::Application.routes.draw do
   get '/api/edos/work_experience' => 'hub_edo#work_experience', :via => :get, :defaults => { :format => 'json' }
 
   # Incoming email messages
-  post '/api/mailing_lists/message' => 'mailing_lists_message#dispatch', :defaults => { :format => 'json' }
+  post '/api/mailing_lists/message' => 'mailing_lists_message#relay', :defaults => { :format => 'json' }
 
   # All the other paths should use the bootstrap page
   # We need this because we use html5mode=true

--- a/spec/controllers/mailing_lists_message_controller_spec.rb
+++ b/spec/controllers/mailing_lists_message_controller_spec.rb
@@ -1,6 +1,6 @@
 describe MailingListsMessageController do
   let(:message_params) { JSON.parse File.read(Rails.root.join('fixtures', 'json', 'mailgun_incoming_message.json')) }
-  let(:make_request) { post :dispatch, message_params }
+  let(:make_request) { post :relay, message_params }
 
   shared_examples 'verification failed' do
     it 'returns empty 401' do
@@ -49,7 +49,7 @@ describe MailingListsMessageController do
         Settings.mailgun_proxy.api_key,
         message_params.values_at('timestamp', 'token').join
       )
-      expect_any_instance_of(MailingLists::IncomingMessage).to receive(:dispatch).and_return true
+      expect_any_instance_of(MailingLists::IncomingMessage).to receive(:relay).and_return true
     end
 
     it 'forwards to model and returns success' do
@@ -69,10 +69,10 @@ describe MailingListsMessageController do
     end
 
     it 'forbids repeated signatures' do
-      post :dispatch, message_params
+      post :relay, message_params
       expect(response.status).to eq 200
 
-      post :dispatch, message_params
+      post :relay, message_params
       expect(response.status).to eq 401
     end
 

--- a/spec/models/mailing_lists/incoming_message_spec.rb
+++ b/spec/models/mailing_lists/incoming_message_spec.rb
@@ -57,7 +57,7 @@ describe MailingLists::IncomingMessage do
       expect_any_instance_of(Mailgun::SendMessage).to receive(:post).with(bounce_matcher).and_return(
         response: {sending: true}
       )
-      expect(subject.dispatch).to be_truthy
+      expect(subject.relay).to be_truthy
     end
   end
 
@@ -68,7 +68,7 @@ describe MailingLists::IncomingMessage do
       )
     end
     it 'reports proxy failure' do
-      expect(subject.dispatch).to be_falsey
+      expect(subject.relay).to be_falsey
     end
   end
 
@@ -103,7 +103,7 @@ describe MailingLists::IncomingMessage do
           monty = list.members.find_by email_address: 'monty@berkeley.edu'
           expect(MailingLists::OutgoingMessage).to receive(:new).with(list, monty, message_opts)
            .and_return double(send_message: {response: {sending: true}})
-          expect(subject.dispatch).to be_truthy
+          expect(subject.relay).to be_truthy
         end
         include_examples 'proxy failure handling'
       end
@@ -113,8 +113,8 @@ describe MailingLists::IncomingMessage do
   context 'bad args on initialization' do
     let(:message_opts) { {arrant: :nonsense} }
     it 'reports failure' do
-      expect(Rails.logger).to receive(:error).with /Could not dispatch/
-      expect(subject.dispatch).to be_falsey
+      expect(Rails.logger).to receive(:error).with /Could not relay/
+      expect(subject.relay).to be_falsey
     end
   end
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6467

End-to-end testing immediately proves its worth! The Rails controller has its own uses for `dispatch` and doesn't like having its toes stepped on.