### PR TITLE
CLC-6471 bCourses mailing lists: improvements to message forwarding

### DIFF
--- a/app/models/mailing_lists/incoming_message.rb
+++ b/app/models/mailing_lists/incoming_message.rb
@@ -29,8 +29,10 @@ module MailingLists
     private
 
     def find_mailing_list
-      if @recipient_address
-        MailingLists::SiteMailingList.find_by list_name: @recipient_address.local
+      if @recipient_address && @recipient_address.local.present?
+        # Remove any suffix used to route to a specific CalCentral environment.
+        list_name = @recipient_address.local.sub(/-cc-[a-z\-]{2,8}\Z/, '')
+        MailingLists::SiteMailingList.find_by list_name: list_name
       end
     end
 
@@ -67,7 +69,7 @@ module MailingLists
     end
 
     def bounce(reason)
-      message_text = "#{reason.squish}\n\n-------------\nFrom: #{@opts[:from]}\nTo: #{@opts[:to]}\nSubject: #{@opts[:subject]}\n#{@opts[:body][:plain]}"
+      message_text = "#{reason.squish}\n\n-------------\nFrom: #{@opts[:from]}\nTo: #{@opts[:to]}\nSubject: #{@opts[:subject]}\n\n#{@opts[:body][:plain]}"
       response = Mailgun::SendMessage.new.post(
         from: 'bCourses Mailing Lists <no-reply@bcourses-mail.berkeley.edu>',
         to: @opts[:sender],

--- a/app/models/mailing_lists/outgoing_message.rb
+++ b/app/models/mailing_lists/outgoing_message.rb
@@ -57,6 +57,7 @@ module MailingLists
       address = Mail::Address.new
       address.address = ['no-reply', @mailing_list.class.domain].join '@'
       address.display_name = [@member.first_name, @member.last_name].join ' '
+      address.display_name << " (#{@mailing_list.canvas_site_name})" if @mailing_list.canvas_site_name
       payload['from'] = address.to_s
     end
 
@@ -69,6 +70,7 @@ module MailingLists
         payload['to'] << member.email_address
         payload['recipient-variables'][member.email_address] = {}
       end
+      payload['recipient-variables'] = payload['recipient-variables'].to_json
     end
 
     def to_upload_io(attachment_data)

--- a/app/models/mailing_lists/site_mailing_list.rb
+++ b/app/models/mailing_lists/site_mailing_list.rb
@@ -6,7 +6,7 @@ module MailingLists
 
     self.table_name = 'canvas_site_mailing_lists'
 
-    attr_accessible :canvas_site_id, :list_name, :state, :members_count, :populated_at, :populate_add_errors, :populate_remove_errors
+    attr_accessible :canvas_site_id, :list_name, :canvas_site_name, :state, :members_count, :populated_at, :populate_add_errors, :populate_remove_errors
     attr_accessor :request_failure
     attr_accessor :population_results
 
@@ -59,7 +59,7 @@ module MailingLists
         feed[:canvasSite] = {
           canvasCourseId: self.canvas_site_id,
           sisCourseId: @canvas_site['sis_course_id'],
-          name: @canvas_site['name'],
+          name: self.canvas_site_name,
           courseCode: @canvas_site['course_code'],
           url: "#{Settings.canvas_proxy.url_root}/courses/#{@canvas_site['id']}",
           term: parse_term(@canvas_site['term'])
@@ -114,7 +114,10 @@ module MailingLists
 
     def get_canvas_site
       return if self.canvas_site_id.blank? || @canvas_site
-      unless (@canvas_site = Canvas::Course.new(canvas_course_id: self.canvas_site_id).course[:body])
+      if (@canvas_site = Canvas::Course.new(canvas_course_id: self.canvas_site_id).course[:body])
+        self.canvas_site_name = @canvas_site['name'].strip
+        save if (self.persisted? && self.changed?)
+      else
         self.request_failure = "No bCourses site with ID \"#{self.canvas_site_id}\" was found."
       end
     end

--- a/db/developer-seed-data.sql
+++ b/db/developer-seed-data.sql
@@ -111,6 +111,7 @@ ALTER SEQUENCE canvas_site_mailing_list_members_id_seq OWNED BY canvas_site_mail
 CREATE TABLE canvas_site_mailing_lists (
   id integer NOT NULL,
   canvas_site_id character varying(255),
+  canvas_site_name character varying(255),
   list_name character varying(255),
   state character varying(255),
   populated_at timestamp without time zone,

--- a/db/migrate/20161026183144_add_canvas_site_name_to_canvas_site_mailing_lists.rb
+++ b/db/migrate/20161026183144_add_canvas_site_name_to_canvas_site_mailing_lists.rb
@@ -1,0 +1,5 @@
+class AddCanvasSiteNameToCanvasSiteMailingLists < ActiveRecord::Migration
+  def change
+    add_column :canvas_site_mailing_lists, :canvas_site_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161017235830) do
+ActiveRecord::Schema.define(version: 20161026183144) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 20161017235830) do
     t.integer  "populate_add_errors"
     t.integer  "populate_remove_errors"
     t.string   "type"
+    t.string   "canvas_site_name"
   end
 
   add_index "canvas_site_mailing_lists", ["canvas_site_id"], name: "index_canvas_site_mailing_lists_on_canvas_site_id", unique: true, using: :btree

--- a/spec/models/mailing_lists/incoming_message_spec.rb
+++ b/spec/models/mailing_lists/incoming_message_spec.rb
@@ -97,15 +97,24 @@ describe MailingLists::IncomingMessage do
         include_examples 'proxy failure handling'
       end
 
-      context 'member with sending privileges' do
-        let(:sender) { 'Montgomery Burns <monty@berkeley.edu>' }
+      shared_examples 'successful forwarding' do
         it 'forwards to list' do
           monty = list.members.find_by email_address: 'monty@berkeley.edu'
           expect(MailingLists::OutgoingMessage).to receive(:new).with(list, monty, message_opts)
            .and_return double(send_message: {response: {sending: true}})
           expect(subject.relay).to be_truthy
         end
+      end
+
+      context 'member with sending privileges' do
+        let(:sender) { 'Montgomery Burns <monty@berkeley.edu>' }
+        include_examples 'successful forwarding'
         include_examples 'proxy failure handling'
+
+        context 'recipient with environment-specific suffix' do
+          before { recipient.sub! '@', '-cc-sis-dev@' }
+          include_examples 'successful forwarding'
+        end
       end
     end
   end

--- a/spec/models/mailing_lists/outgoing_message_spec.rb
+++ b/spec/models/mailing_lists/outgoing_message_spec.rb
@@ -1,6 +1,7 @@
 describe MailingLists::OutgoingMessage do
 
   let(:list) do
+    allow_any_instance_of(Canvas::Course).to receive(:course).and_return({body: {'name' => 'Design Analysis of Nuclear Reactors'}})
     MailingLists::MailgunList.create!(
       canvas_site_id: random_id,
       list_name: 'design_analysis_of_nuclear_reactors-sp17'
@@ -52,15 +53,14 @@ describe MailingLists::OutgoingMessage do
 
   let(:request_matcher) do
     satisfy do |params|
-      expect(params).to include({
-        'Message-Id' => '<DLOAsW7ZwDP1yvQOabwgZ1AvXNGoGpJgRoV4HoVq9tjQKyD1f1w@mail.gmail.com>',
-        'from' => 'Montgomery Burns <no-reply@bcourses-mail.berkeley.edu>',
-        'to' => %w(monty@berkeley.edu smithers@berkeley.edu),
-        'subject' => 'A message of teaching and learning',
-        'h:Reply-To' => 'Montgomery Burns <monty@berkeley.edu>',
-        'html' => message_opts[:body][:html],
-        'text' => message_opts[:body][:plain]
-      })
+      expect(params['Message-Id']).to eq '<DLOAsW7ZwDP1yvQOabwgZ1AvXNGoGpJgRoV4HoVq9tjQKyD1f1w@mail.gmail.com>'
+      expect(params['from']).to eq '"Montgomery Burns (Design Analysis of Nuclear Reactors)" <no-reply@bcourses-mail.berkeley.edu>'
+      expect(params['to']).to match_array %w(monty@berkeley.edu smithers@berkeley.edu)
+      expect(params['subject']).to eq 'A message of teaching and learning'
+      expect(params['h:Reply-To']).to eq 'Montgomery Burns <monty@berkeley.edu>'
+      expect(JSON.parse params['recipient-variables']).to eq({'monty@berkeley.edu' => {}, 'smithers@berkeley.edu' => {}})
+      expect(params['html']).to eq message_opts[:body][:html]
+      expect(params['text']).to eq message_opts[:body][:plain]
     end
   end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6471

Follow-up to #6053 with a few improvements:
- Handle the magic suffixes that will route test messages to non-prod environments;
- JSONify the outgoing `recipient-variables` param so Mailgun handles it properly;
- Add the Canvas site name to the sender's display name (which requires us to store the site name on our end).