### PR TITLE
SISRP-26579 Limit size of advisor student lookups

### DIFF
--- a/app/models/calnet_ldap/client.rb
+++ b/app/models/calnet_ldap/client.rb
@@ -12,6 +12,9 @@ module CalnetLdap
     # TODO Ask CalNet for suggested maximum number of search values.
     BATCH_QUERY_MAXIMUM = 20
 
+    # String based searches must be limited to avoid looping over thousands of results.
+    NAME_SEARCH_SIZE_LIMIT = '30'
+
     def initialize
       @ldap = Net::LDAP.new({
         host: Settings.ldap.host,
@@ -50,8 +53,8 @@ module CalnetLdap
 
     def search_by_filter(filter, include_guest_users=false)
       results = []
-      results.concat search(base: PEOPLE_DN, filter: filter)
-      results.concat search(base: GUEST_DN, filter: filter) if include_guest_users
+      results.concat search(base: PEOPLE_DN, filter: filter, size: NAME_SEARCH_SIZE_LIMIT)
+      results.concat search(base: GUEST_DN, filter: filter, size: NAME_SEARCH_SIZE_LIMIT) if include_guest_users
       results
     end
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26579

Unconstrained name searches can take more than a half-hour to complete, mostly due to the poor performance of data fetches from CS Hub.