### PR TITLE
SISRP-26969 - Remove inactive status filtering from MyAcademics::CollegeAndLevel

### DIFF
--- a/app/models/my_academics/college_and_level.rb
+++ b/app/models/my_academics/college_and_level.rb
@@ -124,9 +124,8 @@ module MyAcademics
       }
 
       filtered_statuses = filter_inactive_status_plans(statuses)
-      active_statuses = active_academic_statuses(filtered_statuses)
 
-      active_statuses.each do |status|
+      filtered_statuses.each do |status|
         Array.wrap(status.try(:[], 'studentPlans')).each do |plan|
           flattened_plan = flatten_plan(plan)
           plan_set[:plans] << flattened_plan
@@ -166,13 +165,6 @@ module MyAcademics
         end
       end
       statuses
-    end
-
-    def active_academic_statuses(statuses)
-      active_statuses = statuses.select do |status|
-        status.try(:[], 'studentPlans').try(:count).to_i > 0
-      end
-      active_statuses
     end
 
     def parse_hub_term_name(term)

--- a/spec/models/my_academics/college_and_level_spec.rb
+++ b/spec/models/my_academics/college_and_level_spec.rb
@@ -718,24 +718,6 @@ describe MyAcademics::CollegeAndLevel do
       })
     end
 
-    context 'when filtering out inactive academic statuses' do
-      let(:hub_academic_statuses) { [hub_academic_status, hub_academic_status_secondary] }
-      let(:active_statuses) { subject.active_academic_statuses(hub_academic_statuses) }
-      let(:hub_academic_status_secondary) do
-        {
-          "cumulativeGPA" => {},
-          "cumulativeUnits" => [],
-          "currentRegistration" => {},
-          "studentCareer" => {},
-          "studentPlans" => []
-        }
-      end
-      it 'returns academic statuses that have active plans present' do
-        expect(active_statuses.count).to eq 1
-        expect(active_statuses[0]['studentCareer']['academicCareer']['code']).to eq 'UGRD'
-      end
-    end
-
     context 'when filtering out inactive plans from statuses' do
       let(:filtered_academic_statuses) { subject.filter_inactive_status_plans(hub_academic_statuses) }
       it 'removes inactive plans from each status' do


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26969

Replacement for #6064. Removes application of code that filters out inactive academic statuses now that the iHub Academic Status API should no longer return academic statuses that have no active plans present.