### PR TITLE
CLC-6471 bCourses mailing lists: fix attachment handling

### DIFF
--- a/spec/controllers/mailing_lists_message_controller_spec.rb
+++ b/spec/controllers/mailing_lists_message_controller_spec.rb
@@ -78,22 +78,18 @@ describe MailingListsMessageController do
 
     context 'message with attachments' do
       let(:attachment_1) do
-        {
-          'filename' => 'reactor_design.jpeg',
-          'head' => "Content-Disposition: form-data; name=\"attachment-1\"; filename=\"reactor_design.jpeg\"\r\nContent-Type: image/jpeg\r\nContent-Length: 6970\r\n",
-          'name' => 'attachment-1',
-          'tempfile' => 'fake file 1',
-          'type' => 'image/jpeg'
-        }
+        ActionDispatch::Http::UploadedFile.new(
+          filename: 'sample_student_72x96.jpg',
+          tempfile: File.new(Rails.root.join 'public', 'dummy', 'images', 'sample_student_72x96.jpg'),
+          type: 'image/jpg'
+        )
       end
       let(:attachment_2) do
-        {
-          'filename' => 'reactor_notes.pdf',
-          'head' => "Content-Disposition: form-data; name=\"attachment-2\"; filename=\"reactor_notes.rtf\"\r\nContent-Type: application/pdf\r\nContent-Length: 14702\r\n",
-          'name' => 'attachment-2',
-          'tempfile' => 'fake file 2',
-          'type' => 'application/pdf'
-        }
+        ActionDispatch::Http::UploadedFile.new(
+          filename: 'academic_dates.json',
+          tempfile: File.new(Rails.root.join 'public', 'dummy', 'json', 'academic_dates.json'),
+          type: 'application/json'
+        )
       end
       before do
         message_params['attachment-1'] = attachment_1

--- a/spec/models/mailing_lists/outgoing_message_spec.rb
+++ b/spec/models/mailing_lists/outgoing_message_spec.rb
@@ -89,18 +89,16 @@ describe MailingLists::OutgoingMessage do
         message_opts[:attachments] = {
           count: 2,
           data: {
-            'attachment-1' => {
-              'filename' => 'sample_student_72x96.jpg',
-              'name' => 'attachment-1',
-              'tempfile' => File.new(Rails.root.join 'public', 'dummy', 'images', 'sample_student_72x96.jpg'),
-              'type' => 'image/jpg'
-            },
-            'attachment-2' => {
-              'filename' => 'academic_dates.json',
-              'name' => 'attachment-2',
-              'tempfile' => File.new(Rails.root.join 'public', 'dummy', 'json', 'academic_dates.json'),
-              'type' => 'application/json'
-            }
+            'attachment-1' => ActionDispatch::Http::UploadedFile.new(
+              filename: 'sample_student_72x96.jpg',
+              tempfile: File.new(Rails.root.join 'public', 'dummy', 'images', 'sample_student_72x96.jpg'),
+              type: 'image/jpg'
+            ),
+            'attachment-2' => ActionDispatch::Http::UploadedFile.new(
+              filename: 'academic_dates.json',
+              tempfile: File.new(Rails.root.join 'public', 'dummy', 'json', 'academic_dates.json'),
+              type: 'application/json'
+            )
           }
         }
       end
@@ -130,12 +128,11 @@ describe MailingLists::OutgoingMessage do
             'EC2CE1CA-4686-4412-88C7-EC9A2176D97F' => 'attachment-1'
           },
           data: {
-            'attachment-1' => {
-              'filename' => 'sample_student_72x96.jpg',
-              'name' => 'attachment-1',
-              'tempfile' => File.new(Rails.root.join 'public', 'dummy', 'images', 'sample_student_72x96.jpg'),
-              'type' => 'image/jpg'
-            }
+            'attachment-1' => ActionDispatch::Http::UploadedFile.new(
+              filename: 'sample_student_72x96.jpg',
+              tempfile: File.new(Rails.root.join 'public', 'dummy', 'images', 'sample_student_72x96.jpg'),
+              type: 'image/jpg'
+            )
           }
         }
         message_opts[:body][:html] = '<html><body>Keep this man away from the reactor: <img src="cid:EC2CE1CA-4686-4412-88C7-EC9A2176D97F"><br><br></body></html>'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6471

Another try at attachment handling. Local testing had encouraged a bad assumption about how Rails represents multipart uploads (custom objects, not hashes).