### PR TITLE
CLC-6478, GoogleAuthController variant to manage OEC-specific Google tokens

### DIFF
--- a/app/controllers/google_auth_controller.rb
+++ b/app/controllers/google_auth_controller.rb
@@ -1,119 +1,63 @@
-require 'google/api_client'
-
 class GoogleAuthController < ApplicationController
-  include ClassLogger
 
   before_filter :check_google_access
   before_filter :authenticate
   respond_to :json
 
-  def request_authorization
-    expire
-    @scope = Settings.google_proxy.scope
-    if params['scope'].present?
-      additional_scope = params['scope'].is_a?(Array) ? params['scope'].join(' ') : params['scope']
-      @scope += " #{additional_scope}"
-    end
-    final_redirect = params['final_redirect'] || '/'
-    if params['force_domain'].present? && params['force_domain'] == 'false'
-      client = get_client(final_redirect, force_domain = false)
-    end
-    client ||= get_client final_redirect
-    url = client.authorization_uri(approval_prompt: 'force').to_s
-    logger.debug "Initiating Oauth2 authorization request for user #{session['user_id']} - redirecting to #{url}"
+  def refresh_tokens
+    url = google.refresh_oauth2_tokens_url(opts[:scope], params)
     redirect_to url
   end
 
   def handle_callback
-    client = get_client
-    logger.debug "Handling Oauth2 authorization callback for user #{session['user_id']}"
-    if params['code'] && params['error'].blank?
-      client.code = params['code']
-      client.fetch_access_token!
-      logger.warn "Saving #{app_id} access token for user #{session['user_id']}"
-      User::Oauth2Data.new_or_update(
-        session['user_id'],
-        app_id,
-        client.access_token.to_s,
-        client.refresh_token,
-        if client.expires_in.blank?
-          0
-        else
-          client.issued_at.to_i + client.expires_in
-        end
-      )
-      User::Oauth2Data.update_google_email! session['user_id']
-    else
-      logger.warn "Deleting #{app_id} access token for user #{session['user_id']} because auth callback had an error. Error: #{params['error']}"
-      User::Oauth2Data.remove(session['user_id'], app_id)
-    end
-
-    expire
-
-    if (final_redirect = params['state'])
-      redirect_to Base64.decode64(final_redirect)
-    else
-      redirect_to url_for_path('/')
-    end
+    google.process_callback(params, opts)
+    url = (final_redirect = params['state']) ? Base64.decode64(final_redirect) : url_for_path('/')
+    redirect_to url
   end
 
   def current_scope
-    uid = session['user_id']
-    if GoogleApps::Proxy.access_granted?(uid)
-      scope = GoogleApps::Userinfo.new(user_id: uid).current_scope
-    else
-      scope = []
-    end
-    render json: {'currentScope' => scope}
+    render json: {
+      currentScope: google.scope_granted
+    }
   end
 
   def remove_authorization
-    logger.warn "Deleting #{app_id} access token for user #{session['user_id']} at the user's request."
-    GoogleApps::Revoke.new(user_id: session['user_id']).revoke
-    Calendar::User.delete_all({uid: session['user_id']})
-    User::Oauth2Data.remove(session['user_id'], app_id)
-    expire
-    render :nothing => true, :status => 204
+    google.remove_user_authorization
+    render nothing: true, status: 204
   end
 
   def dismiss_reminder
     result = false
-    if (!GoogleApps::Proxy.access_granted? session['user_id'])
-      result = User::Oauth2Data.dismiss_google_reminder(session['user_id'])
+    unless GoogleApps::Proxy.access_granted? user_id
+      result = User::Oauth2Data.dismiss_google_reminder user_id
     end
-    User::Api.expire(session['user_id'])
-    render json: {:result => result}
+    User::Api.expire user_id
+    render json: {
+      result: result
+    }
   end
 
-  def expire
-    Cache::UserCacheExpiry.notify session['user_id']
+  private
+
+  def google
+    @google ||= GoogleApps::Oauth2TokensGrant.new(
+      user_id,
+      GoogleApps::Proxy::APP_ID,
+      opts[:client_id],
+      opts[:client_secret],
+      client_redirect_uri)
   end
 
-  def app_id
-    GoogleApps::Proxy::APP_ID
+  def user_id
+    session['user_id']
   end
 
-  def get_client(final_redirect = '', force_domain = true)
-    google_client = Google::APIClient.new(options={:application_name => 'CalCentral', :application_version => 'v1', :retries => 3})
-    client = google_client.authorization
-    unless force_domain == false
-      client.authorization_uri= URI 'https://accounts.google.com/o/oauth2/auth?hd=berkeley.edu'
-    end
-    client.client_id = Settings.google_proxy.client_id
-    client.client_secret = Settings.google_proxy.client_secret
-    client.redirect_uri = url_for(
-      :only_path => false,
-      :controller => 'google_auth',
-      :action => 'handle_callback')
-    client.state = Base64.encode64 final_redirect
-    if @scope.present?
-      client.scope = @scope
-      # Do not lose any manually added authorizations when refreshing the more generic list.
-      client.update!(
-        :additional_parameters => {'include_granted_scopes' => 'true'}
-      )
-    end
-    client
+  def opts
+    @opts ||= Settings.google_proxy.marshal_dump
+  end
+
+  def client_redirect_uri
+    url_for only_path: false, controller: 'google_auth', action: 'handle_callback'
   end
 
 end

--- a/app/controllers/oec_google_auth_controller.rb
+++ b/app/controllers/oec_google_auth_controller.rb
@@ -1,0 +1,31 @@
+class OecGoogleAuthController < GoogleAuthController
+  include ClassLogger
+
+  before_filter :check_google_access
+  before_action :authorize_oec_administration
+  respond_to :json
+
+  def authorize_oec_administration
+    authorize current_user, :can_administer_oec?
+  end
+
+  private
+
+  def google
+    @google ||= GoogleApps::Oauth2TokensGrant.new(
+      opts[:uid],
+      GoogleApps::Proxy::OEC_APP_ID,
+      opts[:client_id],
+      opts[:client_secret],
+      client_redirect_uri)
+  end
+
+  def opts
+    @opts ||= Settings.oec.google.marshal_dump
+  end
+
+  def client_redirect_uri
+    url_for only_path: false, controller: 'oec_google_auth', action: 'handle_callback'
+  end
+
+end

--- a/app/controllers/oec_tasks_controller.rb
+++ b/app/controllers/oec_tasks_controller.rb
@@ -13,7 +13,7 @@ class OecTasksController < ApplicationController
     authorize current_user, :can_administer_oec?
   end
 
-  # GET /api/oec_tasks
+  # GET /api/oec/tasks
 
   def index
     render json: {
@@ -24,7 +24,7 @@ class OecTasksController < ApplicationController
     }
   end
 
-  # POST /api/oec_tasks/:task_name
+  # POST /api/oec/tasks/:task_name
 
   def run
     task_class = "Oec::#{params['task_name']}".constantize
@@ -37,7 +37,7 @@ class OecTasksController < ApplicationController
     }
   end
 
-  # GET /api/oec_tasks/status/:task_id
+  # GET /api/oec/tasks/status/:task_id
 
   def task_status
     task_status = Oec::Task.fetch_from_cache params['task_id']

--- a/app/models/google_apps/oauth2_tokens_grant.rb
+++ b/app/models/google_apps/oauth2_tokens_grant.rb
@@ -1,0 +1,109 @@
+require 'google/api_client'
+
+module GoogleApps
+  class Oauth2TokensGrant
+    include ClassLogger
+
+    def initialize(user_id, app_id, client_id, client_secret, client_redirect_uri)
+      unless client_id && client_secret
+        raise ArgumentError, 'Google API client requires client_id and client_secret'
+      end
+      @user_id = user_id
+      @app_id = app_id
+      @client_id = client_id
+      @client_secret = client_secret
+      @client_redirect_uri = client_redirect_uri
+    end
+
+    def refresh_oauth2_tokens_url(scope, params)
+      expire
+      if (scope_override = params['scope']).present?
+        additional_scope = scope_override.is_a?(Array) ? scope_override.join(' ') : scope_override
+        scope += " #{additional_scope}"
+      end
+      opts = {
+        scope: scope,
+        final_redirect: params['final_redirect'] || '/',
+        omit_domain_restriction: params['force_domain'].present? && params['force_domain'] == 'false'
+      }
+      client = get_client opts
+      url = client.authorization_uri(approval_prompt: 'force').to_s
+      logger.debug "Initiating OAuth2 authorization for user #{@user_id} via #{url}"
+      url
+    end
+
+    def process_callback(params, opts={})
+      logger.debug "Handling Google authorization callback for user #{@user_id}"
+      if params['code'] && params['error'].blank?
+        # Clone hash then remove :scope. Google will reject fetch_access_token! if :scope is present.
+        modified_opts = opts.clone
+        modified_opts.delete :scope
+        client = get_client modified_opts
+        client.code = params['code']
+        client.fetch_access_token!
+        logger.warn "Saving #{@app_id} access token for user #{@user_id}"
+        expiration_time = client.expires_in.blank? ? 0 : (client.issued_at.to_i + client.expires_in)
+        User::Oauth2Data.new_or_update(
+          @user_id,
+          @app_id,
+          client.access_token.to_s,
+          client.refresh_token,
+          expiration_time
+        )
+        if @app_id == GoogleApps::Proxy::APP_ID
+          User::Oauth2Data.update_google_email! @user_id
+        end
+      else
+        logger.warn "Deleting the Google OAuth2 tokens of user #{@user_id} (app_id: #{@app_id}) because callback reported an error: #{params['error']}"
+        User::Oauth2Data.remove(@user_id, @app_id)
+      end
+
+      expire
+    end
+
+    def remove_user_authorization
+      logger.warn "Deleting Google OAuth2 tokens of user #{@user_id} (app_id: #{@app_id}) per user request"
+      GoogleApps::Revoke.new(user_id: @user_id).revoke
+      Calendar::User.delete_all(uid: @user_id)
+      User::Oauth2Data.remove(@user_id, @app_id)
+      expire
+    end
+
+    def scope_granted
+      return [] unless GoogleApps::Proxy.access_granted? @user_id
+      GoogleApps::Userinfo.new(user_id: @user_id).current_scope
+    end
+
+    def expire
+      Cache::UserCacheExpiry.notify @user_id
+    end
+
+    def get_client(opts={})
+      google_client = Google::APIClient.new(options={
+        application_name: 'CalCentral',
+        application_version: 'v1',
+        retries: 3
+      })
+      client = google_client.authorization
+      unless opts[:omit_domain_restriction]
+        client.authorization_uri = URI 'https://accounts.google.com/o/oauth2/auth?hd=berkeley.edu'
+      end
+      client.client_id = @client_id
+      client.client_secret = @client_secret
+      client.redirect_uri = @client_redirect_uri
+      final_redirect = opts[:final_redirect] || ''
+      client.state = Base64.encode64 final_redirect
+      if opts[:scope]
+        client.scope = opts[:scope]
+        # Do not lose any manually added authorizations when refreshing the more generic list.
+        client.update!(
+          additional_parameters: {
+            'include_granted_scopes' => 'true'
+          }
+        )
+      end
+      client
+    end
+
+  end
+end

--- a/app/models/google_apps/proxy.rb
+++ b/app/models/google_apps/proxy.rb
@@ -8,7 +8,9 @@ module GoogleApps
 
     attr_accessor :authorization, :json_filename
 
-    APP_ID = "Google"
+    APP_ID = 'Google'
+
+    OEC_APP_ID = 'OEC'
 
     def initialize(options = {})
       super(Settings.google_proxy, options)

--- a/app/models/oec/api_task_wrapper.rb
+++ b/app/models/oec/api_task_wrapper.rb
@@ -6,7 +6,7 @@ module Oec
       {
         name: 'TermSetupTask',
         friendlyName: 'Term setup',
-        htmlDescription: 'Create a Google Drive folder under a new term code (e.g., <strong>2015-D</strong>) and populate it with initial folders and files.',
+        htmlDescription: 'Create a Google Drive folder under a new term code (e.g., <strong>2017-D</strong>) and populate it with initial folders and files.',
         acceptsDepartmentOptions: false
       },
       {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,9 +99,13 @@ Calcentral::Application.routes.draw do
   post '/api/academics/canvas/mailing_lists/:canvas_course_id/delete' => 'canvas_mailing_lists#destroy', :defaults => { :format => 'json' }
 
   # OEC endpoints
-  get '/api/oec_tasks' => 'oec_tasks#index', :defaults => { :format => 'json' }
-  post '/api/oec_tasks/:task_name' => 'oec_tasks#run', :defaults => { :format => 'json' }
-  get '/api/oec_tasks/status/:task_id' => 'oec_tasks#task_status',  :defaults => { :format => 'json' }
+  get '/api/oec/google/request_authorization'=> 'oec_google_auth#refresh_tokens', :defaults => { :format => 'json' }
+  get '/api/oec/google/handle_callback' => 'oec_google_auth#handle_callback', :defaults => { :format => 'json' }
+  get '/api/oec/google/current_scope' => 'oec_google_auth#current_scope', :defaults => { :format => 'json' }
+  get '/api/oec/google/remove_authorization' => 'oec_google_auth#remove_authorization', :via => :post
+  get '/api/oec/tasks' => 'oec_tasks#index', :defaults => { :format => 'json' }
+  post '/api/oec/tasks/:task_name' => 'oec_tasks#run', :defaults => { :format => 'json' }
+  get '/api/oec/tasks/status/:task_id' => 'oec_tasks#task_status',  :defaults => { :format => 'json' }
 
   # System utility endpoints
   get '/api/cache/clear' => 'cache#clear', :defaults => { :format => 'json' }
@@ -116,7 +120,7 @@ Calcentral::Application.routes.draw do
   get '/api/smoke_test_routes' => 'routes_list#smoke_test_routes', :as => :all_routes, :defaults => { :format => 'json' }
 
   # Oauth endpoints: Google
-  get '/api/google/request_authorization'=> 'google_auth#request_authorization'
+  get '/api/google/request_authorization'=> 'google_auth#refresh_tokens'
   get '/api/google/handle_callback' => 'google_auth#handle_callback'
   get '/api/google/current_scope' => 'google_auth#current_scope'
   post '/api/google/remove_authorization' => 'google_auth#remove_authorization', :via => :post

--- a/spec/controllers/google_auth_controller_spec.rb
+++ b/spec/controllers/google_auth_controller_spec.rb
@@ -1,15 +1,114 @@
 describe GoogleAuthController do
 
+  let(:settings) { Settings.google_proxy }
   let(:user_id) { random_id }
+  let(:app_id) { GoogleApps::Proxy::APP_ID }
+  let(:params) { {} }
 
   before do
     session['user_id'] = user_id
   end
 
+  describe 'Google transaction' do
+    let(:google_url) { random_string 10 }
+    let(:omit_domain_restriction) { false }
+    let(:default_scope) { settings.scope }
+    let(:expected_scope) { default_scope }
+    let(:client) {
+      expect(Google::APIClient).to receive(:new).and_return (google_api = double)
+      expect(google_api).to receive(:authorization).and_return (client = double)
+      client
+    }
+
+    before do
+      allow(GoogleApps::Proxy).to receive(:access_granted?).with(user_id).and_return true
+      allow(Google::APIClient).to receive(:authorization_uri).and_return google_url
+    end
+
+    before do
+      expect(client).to receive(:client_id=).with(settings.client_id)
+      expect(client).to receive(:client_secret=).with(settings.client_secret)
+      expect(client).to receive(:redirect_uri=)
+      expect(client).to receive(:state=)
+      expect(client).to receive(:authorization_uri=).exactly(omit_domain_restriction ? 0 : 1).times
+    end
+
+    describe '#refresh_tokens' do
+      before do
+        expect(client).to receive(:scope=).and_return expected_scope
+        expect(client).to receive(:update!)
+        expect(client).to receive(:authorization_uri)
+      end
+
+      subject do
+        post :refresh_tokens, params
+      end
+
+      context 'user can refresh Google OAuth tokens' do
+        let(:params) { {} }
+
+        context 'omit domain restriction' do
+          # The 'force_domain' param determines use of client.authorization_uri=
+          let(:params) { { 'force_domain' => 'false' } }
+          let(:omit_domain_restriction) { true }
+
+          it 'should redirect to Google with ' do
+            post :refresh_tokens, params
+            expect(response).to have_http_status 302
+          end
+        end
+
+        context 'custom scope' do
+          let(:params) { { 'scope' => 'extra1 extra2' } }
+          let(:expected_scope) { "#{default_scope} extra1 extra2" }
+          it 'should redirect to Google' do
+            post :refresh_tokens, params
+            expect(response).to have_http_status 302
+          end
+        end
+      end
+    end
+
+    describe '#process_callback' do
+      context 'handle Google callback' do
+        let(:params) { { 'code' => random_string(10) } }
+        let(:access_token) { random_string 10 }
+        let(:refresh_token) { random_string 10 }
+        before do
+          expect(client).to receive(:code=).with params['code']
+          expect(client).to receive(:fetch_access_token!)
+          expect(client).to receive(:expires_in).and_return nil
+          expect(client).to receive(:access_token).and_return access_token
+          expect(client).to receive(:refresh_token).and_return refresh_token
+          expect(User::Oauth2Data).to receive(:new_or_update).with(user_id, app_id, access_token, refresh_token, 0)
+          expect(User::Oauth2Data).to receive(:update_google_email!).with(user_id)
+        end
+        it 'should record new client_id and client_secret' do
+          post :handle_callback, params
+          expect(response).to have_http_status 302
+        end
+      end
+    end
+  end
+
+  describe '#error' do
+    context 'Google reports an error' do
+      before do
+        expect(Google::APIClient).to receive(:new).never
+        expect(User::Oauth2Data).to receive(:remove).with(user_id, app_id)
+      end
+
+      it 'should not record client_id and client_secret' do
+        post :handle_callback, { 'error' => 'Houston, we have a problem!' }
+        expect(response).to have_http_status 302
+      end
+    end
+  end
+
   describe '#dismiss_reminder' do
     it 'should store a dismiss_reminder key-value when there is no token for a user' do
       allow(GoogleApps::Proxy).to receive(:access_granted?).with(user_id).and_return false
-      post :dismiss_reminder, { :format => 'json' }
+      post :dismiss_reminder, { format: 'json' }
       expect(response).to have_http_status :success
       response_body = JSON.parse response.body
       expect(response_body['result']).to be true
@@ -17,10 +116,55 @@ describe GoogleAuthController do
 
     it 'should not store a dismiss_reminder key-value when there is an existing token' do
       allow(GoogleApps::Proxy).to receive(:access_granted?).with(user_id).and_return true
-      post :dismiss_reminder, { :format => 'json' }
+      post :dismiss_reminder, { format: 'json' }
       expect(response).to have_http_status :success
       response_body = JSON.parse response.body
       expect(response_body['result']).to be false
+    end
+  end
+
+  describe '#current_scope' do
+    let(:access_granted) { true }
+    before do
+      expect(GoogleApps::Proxy).to receive(:access_granted?).with(user_id).and_return access_granted
+    end
+    subject {
+      post :current_scope, { format: 'json' }
+      expect(response).to have_http_status :success
+      json = JSON.parse response.body
+      json['currentScope']
+    }
+
+    context 'access granted' do
+      let(:current_scope) { [ random_string(5), random_string(5) ] }
+      before do
+        expect(GoogleApps::Userinfo).to receive(:new).with(user_id: user_id).and_return (user_info = double)
+        expect(user_info).to receive(:current_scope).and_return current_scope
+      end
+
+      it 'should return scope information' do
+        expect(subject).to eq current_scope
+      end
+    end
+    context 'access not granted' do
+      let(:access_granted) { false }
+      it 'should return scope information' do
+        expect(subject).to eq []
+      end
+    end
+  end
+
+  describe '#remove_authorization' do
+    before do
+      expect(GoogleApps::Revoke).to receive(:new).with(user_id: user_id).and_return(google = double)
+      expect(google).to receive(:revoke)
+      expect(Calendar::User).to receive(:delete_all).with(uid: user_id)
+      expect(User::Oauth2Data).to receive(:remove).with(user_id, app_id)
+      expect(Cache::UserCacheExpiry).to receive(:notify)
+    end
+
+    it 'should delete all tokens, everywhere' do
+      post :remove_authorization
     end
   end
 
@@ -30,7 +174,7 @@ describe GoogleAuthController do
       allow(Google::APIClient).to receive(:new).never
     end
     subject do
-      post :request_authorization, {}
+      post :refresh_tokens, params
     end
     context 'viewing as' do
       before do

--- a/spec/controllers/oec_google_auth_controller_spec.rb
+++ b/spec/controllers/oec_google_auth_controller_spec.rb
@@ -1,0 +1,116 @@
+describe OecGoogleAuthController do
+
+  let(:settings) { Settings.oec.google }
+  let(:user_id) { Settings.oec.google.uid }
+  let(:can_administer_oec) { true }
+  let(:app_id) { GoogleApps::Proxy::OEC_APP_ID }
+  let(:params) { {} }
+
+  before do
+    session['user_id'] = user_id
+    allow(Oec::Administrator).to receive(:is_admin?).and_return can_administer_oec
+  end
+
+  describe 'Google transaction' do
+    let(:google_url) { random_string 10 }
+    let(:omit_domain_restriction) { false }
+    let(:default_scope) { settings.scope }
+    let(:expected_scope) { default_scope }
+    let(:client) {
+      expect(Google::APIClient).to receive(:new).and_return (google_api = double)
+      expect(google_api).to receive(:authorization).and_return (client = double)
+      client
+    }
+
+    before do
+      allow(GoogleApps::Proxy).to receive(:access_granted?).with(user_id).and_return true
+      allow(Google::APIClient).to receive(:authorization_uri).and_return google_url
+    end
+
+    before do
+      expect(client).to receive(:client_id=).with(settings.client_id)
+      expect(client).to receive(:client_secret=).with(settings.client_secret)
+      expect(client).to receive(:redirect_uri=)
+      expect(client).to receive(:state=)
+      expect(client).to receive(:authorization_uri=).exactly(omit_domain_restriction ? 0 : 1).times
+    end
+
+    describe '#refresh_tokens' do
+      before do
+        expect(client).to receive(:authorization_uri)
+        expect(client).to receive(:scope=).and_return expected_scope
+        expect(client).to receive(:update!)
+      end
+
+      subject do
+        post :refresh_tokens, params
+      end
+
+      context 'user can refresh Google OAuth tokens' do
+        let(:params) { {} }
+
+        context 'custom scope' do
+          let(:params) { { 'scope' => 'extra1 extra2' } }
+          let(:expected_scope) { "#{default_scope} extra1 extra2" }
+          it 'should redirect to Google' do
+            post :refresh_tokens, params
+            expect(response).to have_http_status 302
+          end
+        end
+      end
+    end
+
+    describe '#process_callback' do
+      context 'handle Google callback' do
+        let(:params) { { 'code' => random_string(10) } }
+        let(:access_token) { random_string 10 }
+        let(:refresh_token) { random_string 10 }
+        before do
+          expect(client).to receive(:code=).with params['code']
+          expect(client).to receive(:fetch_access_token!)
+          expect(client).to receive(:expires_in).and_return nil
+          expect(client).to receive(:access_token).and_return access_token
+          expect(client).to receive(:refresh_token).and_return refresh_token
+          expect(User::Oauth2Data).to receive(:new_or_update).with(user_id, app_id, access_token, refresh_token, 0)
+          expect(User::Oauth2Data).to receive(:update_google_email!).never
+        end
+        it 'should record new client_id and client_secret' do
+          post :handle_callback, params
+          expect(response).to have_http_status 302
+        end
+      end
+    end
+  end
+
+  context 'cannot administer OEC' do
+    let(:can_administer_oec) { false }
+
+    it 'should reject user as unauthorized' do
+      post :refresh_tokens
+      expect(response).to have_http_status 403
+    end
+  end
+
+  context 'indirectly authenticated' do
+    before do
+      allow(GoogleApps::Proxy).to receive(:access_granted?).with(user_id).and_return true
+      allow(Google::APIClient).to receive(:new).never
+    end
+    subject do
+      post :refresh_tokens, params
+    end
+    context 'viewing as' do
+      before do
+        session[SessionKey.original_user_id] = random_id
+      end
+      it { is_expected.not_to have_http_status :success }
+    end
+    context 'LTI embedded' do
+      before do
+        session['lti_authenticated_only'] = true
+      end
+      it { is_expected.not_to have_http_status :success }
+    end
+  end
+
+end

--- a/src/assets/javascripts/angular/factories/oecFactory.js
+++ b/src/assets/javascripts/angular/factories/oecFactory.js
@@ -7,15 +7,15 @@ var angular = require('angular');
  */
 angular.module('calcentral.factories').factory('oecFactory', function($http) {
   var getOecTasks = function() {
-    return $http.get('/api/oec_tasks');
+    return $http.get('/api/oec/tasks');
   };
 
   var oecTaskStatus = function(oecTaskId) {
-    return $http.get('/api/oec_tasks/status/' + oecTaskId);
+    return $http.get('/api/oec/tasks/status/' + oecTaskId);
   };
 
   var runOecTask = function(taskName, parameters) {
-    return $http.post('/api/oec_tasks/' + taskName, parameters);
+    return $http.post('/api/oec/tasks/' + taskName, parameters);
   };
 
   return {


### PR DESCRIPTION
This PR is a cleaner version of #6071 (closed)

https://jira.ets.berkeley.edu/jira/browse/CLC-6478

This is the first half of the CLC-6478 story. The logic of `GoogleAuthController` was moved to a the reusable model `GoogleApps::Oauth2TokensGrant`. Next, a dedicated OEC controller was added, with stricter access rules, that allows the same kind of token management.

A lot more test coverage.

The next step will be removal OEC's client_id and client_secret from YAML.