### PR TITLE
CLC-6478, eliminate need for Google access- and refresh-tokens in YAML file (OEC)

### DIFF
--- a/app/controllers/google_auth_controller.rb
+++ b/app/controllers/google_auth_controller.rb
@@ -5,13 +5,14 @@ class GoogleAuthController < ApplicationController
   respond_to :json
 
   def refresh_tokens
-    url = google.refresh_oauth2_tokens_url(opts[:scope], params)
+    url = google.refresh_oauth2_tokens_url params
     redirect_to url
   end
 
   def handle_callback
     google.process_callback(params, opts)
-    url = (final_redirect = params['state']) ? Base64.decode64(final_redirect) : url_for_path('/')
+    final_redirect = params['state']
+    url = final_redirect ? Base64.decode64(final_redirect) : url_for_path('/')
     redirect_to url
   end
 
@@ -40,16 +41,15 @@ class GoogleAuthController < ApplicationController
   private
 
   def google
-    @google ||= GoogleApps::Oauth2TokensGrant.new(
-      user_id,
-      GoogleApps::Proxy::APP_ID,
-      opts[:client_id],
-      opts[:client_secret],
-      client_redirect_uri)
+    @google ||= GoogleApps::Oauth2TokensGrant.new(user_id, app_id, client_redirect_uri)
   end
 
   def user_id
     session['user_id']
+  end
+
+  def app_id
+    GoogleApps::Proxy::APP_ID
   end
 
   def opts

--- a/app/controllers/oec_google_auth_controller.rb
+++ b/app/controllers/oec_google_auth_controller.rb
@@ -11,13 +11,12 @@ class OecGoogleAuthController < GoogleAuthController
 
   private
 
-  def google
-    @google ||= GoogleApps::Oauth2TokensGrant.new(
-      opts[:uid],
-      GoogleApps::Proxy::OEC_APP_ID,
-      opts[:client_id],
-      opts[:client_secret],
-      client_redirect_uri)
+  def user_id
+    opts[:uid]
+  end
+
+  def app_id
+    GoogleApps::Proxy::OEC_APP_ID
   end
 
   def opts

--- a/app/models/canvas_csv/base.rb
+++ b/app/models/canvas_csv/base.rb
@@ -89,7 +89,7 @@ module CanvasCsv
     end
 
     def sheets_manager
-      @sheets_manager ||=  @reporter_uid.present? ? GoogleApps::SheetsManager.new(@reporter_uid) : nil
+      @sheets_manager ||=  @reporter_uid.present? ? GoogleApps::SheetsManager.new(GoogleApps::Proxy::APP_ID, @reporter_uid) : nil
     end
 
     def reports_folder

--- a/app/models/google_apps/credential_store.rb
+++ b/app/models/google_apps/credential_store.rb
@@ -2,73 +2,73 @@ module GoogleApps
   class CredentialStore
     include ClassLogger
 
-    def initialize(uid, options = {})
+    def initialize(app_id, uid, opts={})
+      raise ArgumentError, 'Credential store lookup requires both app_id and user_id' if app_id.blank? || uid.blank?
+      @app_id = app_id
       @uid = uid
-      raise ArgumentError, 'UID is blank' if @uid.blank?
-      @options = options.symbolize_keys
+      @opts = opts || {}
     end
 
+    # Do not change the signature of this method because it is invoked by Google::APIClient
     def load_credentials
-      credentials = load_credentials_from_db
-      if credentials.nil? && @options.has_key?(:access_token) && @options.has_key?(:refresh_token)
-        logger.warn "Writing Google auth tokens to database using values found in options hash. UID: #{@uid}"
-        write_credentials @options
-        credentials = load_credentials_from_db
+      oauth2_data = User::Oauth2Data.get(@uid, @app_id)
+      return nil if oauth2_data.empty?
+      credentials = CredentialStore.settings_of @app_id
+      credentials.merge! oauth2_data
+      # Infer times
+      unless credentials[:expires_in] && credentials[:issued_at]
+        credentials[:expires_in] = 3600
+        expiration_time = credentials[:expiration_time].to_i
+        credentials[:issued_at] = Time.at(expiration_time - 3600)
       end
-      logger.error "No Google OAuth tokens found where UID=#{@uid}" if credentials.nil?
       credentials
     end
 
-    ##
-    # Write the credentials to database.
-    #
-    # @param [Signet::OAuth2::Client] auth
+    # Do not change the signature of this method because it is invoked by Google::APIClient
     def write_credentials(auth = nil)
-      credentials = nil
-      if auth
-        if auth.is_a?(Hash) && auth.has_key?(:access_token) && auth.has_key?(:refresh_token)
-          logger.debug "OAuth tokens in hash, where UID=#{@uid}"
-          credentials = update_tokens(auth[:access_token], auth[:refresh_token], auth[:issued_at], auth[:expires_in], @options)
-        elsif auth.is_a?(Signet::OAuth2::Client) && auth.access_token && auth.refresh_token
-          logger.debug "OAuth tokens in OAuth2 instance, where UID=#{@uid}"
-          credentials = update_tokens(auth.access_token, auth.refresh_token, auth.issued_at, auth.expires_in, @options)
-        end
+      return nil if auth.nil?
+      if auth.is_a? Hash
+        logger.debug "OAuth tokens in hash (app_id: #{@app_id}; uid: #{@uid})"
+        opts = @opts.merge auth.symbolize_keys
+        write(auth[:access_token], auth[:refresh_token], opts)
+      elsif auth.is_a?(Signet::OAuth2::Client) && auth.access_token && auth.refresh_token
+        logger.debug "OAuth tokens in #{auth.class} (app_id: #{@app_id}; uid: #{@uid})"
+        opts = @opts.merge({
+          issued_at: auth.issued_at,
+          expires_in: auth.expires_in
+        })
+        write(auth.access_token, auth.refresh_token, opts)
+      else
+        raise ArgumentError, "Signet::OAuth2 is missing tokens OR we have unsupported type of OAuth2 client auth: #{auth}"
       end
-      logger.warn "Google OAuth tokens not found during attempted database update. UID=#{@uid}; auth.class #{auth.class}" if credentials.nil?
-      credentials
     end
 
-    private
-
-    def update_tokens(access_token, refresh_token, issued_at, expires_in, options = {})
-      tokens_missing = access_token.blank? || refresh_token.blank?
-      raise ArgumentError, "Google 'access_token' and/or 'refresh_token' are blank where UID=#{@uid}" if tokens_missing
-      expiration_time = issued_at.blank? || expires_in.blank? ? 0 : issued_at.to_i + expires_in.to_i
-      logger.debug "Put OAuth tokens to db where UID=#{@uid}"
-      User::Oauth2Data.new_or_update(@uid.to_s, GoogleApps::Proxy::APP_ID, access_token, refresh_token,
-                                     expiration_time, options)
-    end
-
-    def load_credentials_from_db
-      client_id = @options[:client_id] || Settings.google_proxy.client_id
-      client_secret = @options[:client_secret] || Settings.google_proxy.client_secret
-      scope = @options[:scope] || Settings.google_proxy.scope
-      raise ArgumentError "Incomplete Google credential configuration where client_id=#{client_id}" if client_id.blank? || client_secret.blank? || scope.blank?
-      oauth2_data = User::Oauth2Data.get(@uid, GoogleApps::Proxy::APP_ID)
-      credentials = nil
-      if !oauth2_data.nil? && oauth2_data.any?
-        credentials = { :client_id => client_id, :client_secret => client_secret, :scope => scope }
-        credentials.merge! oauth2_data.symbolize_keys
-        # Infer properties wanted by Google
-        unless credentials[:expires_in] && credentials[:issued_at]
-          credentials[:expires_in] = 3600
-          expiration_time = credentials[:expiration_time].to_i
-          credentials[:issued_at] = Time.at(expiration_time - 3600)
-        end
-        credentials[:token_credential_uri] = 'https://accounts.google.com/o/oauth2/token'
+    def write(access_token, refresh_token, opts={})
+      raise ArgumentError, 'Both access_token and refresh_token are required in credential store' if access_token.blank? || refresh_token.blank?
+      issued_at = opts[:issued_at]
+      expires_in = opts[:expires_in]
+      unless (expiration_time = opts[:expiration_time])
+        insufficient_info = issued_at.blank? || expires_in.blank?
+        expiration_time = insufficient_info ? 0 : issued_at.to_i + expires_in.to_i
       end
-      credentials
+      User::Oauth2Data.new_or_update(
+        @uid,
+        @app_id,
+        access_token,
+        refresh_token,
+        expiration_time,
+        opts)
     end
 
+    def self.settings_of(app_id)
+      return nil unless (settings = Proxy.config_of app_id)
+      {
+        client_id: settings.client_id,
+        client_secret: settings.client_secret,
+        scope: settings.scope,
+        token_credential_uri: Google::APIClient::Storage::TOKEN_CREDENTIAL_URI,
+        authorization_uri: Google::APIClient::Storage::AUTHORIZATION_URI
+      }
+    end
   end
 end

--- a/app/models/google_apps/revoke.rb
+++ b/app/models/google_apps/revoke.rb
@@ -4,11 +4,19 @@ module GoogleApps
     include ClassLogger
 
     def revoke
+      unless (access_token = @authorization.access_token)
+        logger.error "Nil access_token for #{@uid}; revoking Google OAuth privileges is not possible."
+        return false
+      end
       # Google::APIClient does not implement the token revocation endpoint, so we get it via a regular HTTParty request.
       response = get_response(
         'https://accounts.google.com/o/oauth2/revoke',
-        query: {token: @authorization.access_token},
-        on_error: {rescue_status: :all}
+        query: {
+          token: access_token
+        },
+        on_error: {
+          rescue_status: :all
+        }
       )
       if response.code == 200
         logger.warn "Successfully revoked Google access token for user #{@uid}"

--- a/app/models/google_apps/sheets_manager.rb
+++ b/app/models/google_apps/sheets_manager.rb
@@ -19,8 +19,8 @@ module GoogleApps
       end
     end
 
-    def initialize(uid, options = {})
-      super uid, options
+    def initialize(app_id, uid, opts={})
+      super(app_id, uid, opts)
       auth = get_google_api.authorization
       # See https://github.com/gimite/google-drive-ruby
       @session = GoogleDrive::Session.login_with_oauth auth.access_token

--- a/app/models/oec/remote_drive.rb
+++ b/app/models/oec/remote_drive.rb
@@ -4,7 +4,7 @@ module Oec
     HUMAN_URL = 'https://drive.google.com/drive/my-drive'
 
     def initialize
-      super(Settings.oec.google.uid, Settings.oec.google.marshal_dump)
+      super(GoogleApps::Proxy::OEC_APP_ID, Settings.oec.google.uid, Settings.oec.google.marshal_dump)
     end
 
     def check_conflicts_and_copy_file(file, dest_folder, opts={})

--- a/app/models/oec/task.rb
+++ b/app/models/oec/task.rb
@@ -25,6 +25,7 @@ module Oec
       term_code = ENV['term_code']
       raise ArgumentError, 'term_code required' unless term_code
       {
+        app_id: GoogleApps::Proxy::OEC_APP_ID,
         term_code: term_code,
         allow_past_term: ENV['allow_past_term'].present?,
         local_write: ENV['local_write'].present?,

--- a/app/models/user/oauth2_data.rb
+++ b/app/models/user/oauth2_data.rb
@@ -23,7 +23,7 @@ module User
           oauth2_data.attributes.each { |key, value| hash[key] = value }
         end
       }
-      hash
+      hash.symbolize_keys
     end
 
     def self.remove(uid, app_id)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -374,8 +374,6 @@ oec:
     uid: ''
     client_id: 'oecClientId'
     client_secret: 'oecClientSecret'
-    access_token: 'oecAccessToken'
-    refresh_token: 'oecRefreshToken'
     scope: 'profile email https://mail.google.com/mail/feed/atom/ https://spreadsheets.google.com/feeds/ https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.apps.readonly https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.readonly.metadata https://www.googleapis.com/auth/tasks'
   current_terms_codes: [{
     year: 2015,

--- a/spec/controllers/oec_google_auth_controller_spec.rb
+++ b/spec/controllers/oec_google_auth_controller_spec.rb
@@ -1,20 +1,29 @@
 describe OecGoogleAuthController do
 
-  let(:settings) { Settings.oec.google }
-  let(:user_id) { Settings.oec.google.uid }
+  let(:oec_user_id) { random_id }
+  let(:settings) {
+    {
+      uid: oec_user_id,
+      client_id: Settings.oec.google.client_id,
+      client_secret: Settings.oec.google.client_secret,
+      scope: Settings.oec.google.scope
+    }
+  }
+  let(:session_user_id) { random_id }
   let(:can_administer_oec) { true }
   let(:app_id) { GoogleApps::Proxy::OEC_APP_ID }
   let(:params) { {} }
 
   before do
-    session['user_id'] = user_id
-    allow(Oec::Administrator).to receive(:is_admin?).and_return can_administer_oec
+    session['user_id'] = session_user_id
+    allow(Oec::Administrator).to receive(:is_admin?).with(session_user_id).and_return can_administer_oec
+    allow(Settings.oec.google).to receive(:marshal_dump).and_return settings
   end
 
   describe 'Google transaction' do
     let(:google_url) { random_string 10 }
     let(:omit_domain_restriction) { false }
-    let(:default_scope) { settings.scope }
+    let(:default_scope) { settings[:scope] }
     let(:expected_scope) { default_scope }
     let(:client) {
       expect(Google::APIClient).to receive(:new).and_return (google_api = double)
@@ -23,13 +32,13 @@ describe OecGoogleAuthController do
     }
 
     before do
-      allow(GoogleApps::Proxy).to receive(:access_granted?).with(user_id).and_return true
+      allow(GoogleApps::Proxy).to receive(:access_granted?).with(session_user_id).and_return true
       allow(Google::APIClient).to receive(:authorization_uri).and_return google_url
     end
 
     before do
-      expect(client).to receive(:client_id=).with(settings.client_id)
-      expect(client).to receive(:client_secret=).with(settings.client_secret)
+      expect(client).to receive(:client_id=).with settings[:client_id]
+      expect(client).to receive(:client_secret=).with settings[:client_secret]
       expect(client).to receive(:redirect_uri=)
       expect(client).to receive(:state=)
       expect(client).to receive(:authorization_uri=).exactly(omit_domain_restriction ? 0 : 1).times
@@ -37,9 +46,9 @@ describe OecGoogleAuthController do
 
     describe '#refresh_tokens' do
       before do
-        expect(client).to receive(:authorization_uri)
+        expect(client).to receive :authorization_uri
         expect(client).to receive(:scope=).and_return expected_scope
-        expect(client).to receive(:update!)
+        expect(client).to receive :update!
       end
 
       subject do
@@ -67,11 +76,17 @@ describe OecGoogleAuthController do
         let(:refresh_token) { random_string 10 }
         before do
           expect(client).to receive(:code=).with params['code']
-          expect(client).to receive(:fetch_access_token!)
+          expect(client).to receive :fetch_access_token!
           expect(client).to receive(:expires_in).and_return nil
           expect(client).to receive(:access_token).and_return access_token
           expect(client).to receive(:refresh_token).and_return refresh_token
-          expect(User::Oauth2Data).to receive(:new_or_update).with(user_id, app_id, access_token, refresh_token, 0)
+          expect(User::Oauth2Data).to receive(:new_or_update).with(
+            oec_user_id,
+            app_id,
+            access_token,
+            refresh_token,
+            0,
+            hash_including(:expiration_time))
           expect(User::Oauth2Data).to receive(:update_google_email!).never
         end
         it 'should record new client_id and client_secret' do
@@ -93,12 +108,14 @@ describe OecGoogleAuthController do
 
   context 'indirectly authenticated' do
     before do
-      allow(GoogleApps::Proxy).to receive(:access_granted?).with(user_id).and_return true
+      allow(GoogleApps::Proxy).to receive(:access_granted?).with(session_user_id).and_return true
       allow(Google::APIClient).to receive(:new).never
     end
+
     subject do
       post :refresh_tokens, params
     end
+
     context 'viewing as' do
       before do
         session[SessionKey.original_user_id] = random_id
@@ -112,5 +129,4 @@ describe OecGoogleAuthController do
       it { is_expected.not_to have_http_status :success }
     end
   end
-
 end

--- a/spec/models/google_apps/credential_store_spec.rb
+++ b/spec/models/google_apps/credential_store_spec.rb
@@ -1,24 +1,29 @@
 describe GoogleApps::CredentialStore do
 
+  let(:app_id) { GoogleApps::Proxy::APP_ID }
+  let(:uid) { random_id }
+  let(:settings) { GoogleApps::CredentialStore.settings_of app_id }
+  let(:access_token) { random_string(10) }
+  let(:refresh_token) { random_string(10) }
+  let(:oauth2_tokens) {
+    {
+      access_token: access_token,
+      refresh_token: refresh_token
+    }
+  }
   context '#fake' do
-    let(:client_id) { Settings.google_proxy.client_id }
-    let(:client_secret) { Settings.google_proxy.client_secret }
-    let(:scope) { Settings.google_proxy.scope }
-    let(:oauth2_data) {
-      {
-        :access_token => "access_token-#{rand(999999)}",
-        :refresh_token => "refresh_token-#{rand(999999)}",
-        :expiration_time => 1
-      }
+    let(:opts) { {} }
+    let(:client_id) { settings[:client_id] }
+    let(:client_secret) { settings[:client_secret] }
+    let(:scope) { settings[:scope] }
+    let(:oauth2_data) { oauth2_tokens.merge expiration_time: 1 }
+    let(:store) { GoogleApps::CredentialStore.new(app_id, uid, opts) }
+
+    before {
+      allow(User::Oauth2Data).to receive(:get).with(uid, app_id).and_return oauth2_data
     }
 
     context 'uid has access and refresh token in the database' do
-      let(:uid) { random_id }
-      let(:store) { GoogleApps::CredentialStore.new(uid) }
-      before {
-        allow(User::Oauth2Data).to receive(:get).with(uid, GoogleApps::Proxy::APP_ID).and_return oauth2_data
-      }
-
       it 'should load default calcentral credentials' do
         c = store.load_credentials
         expect(c[:client_id]).to eq client_id
@@ -26,89 +31,91 @@ describe GoogleApps::CredentialStore do
         expect(c[:token_credential_uri]).to_not be_nil
         expect(c[:access_token]).to eq oauth2_data[:access_token]
         expect(c[:refresh_token]).to eq oauth2_data[:refresh_token]
+        expect(c[:expiration_time]).to be > 0
         expect(c[:expires_in]).to_not be_nil
         expect(c[:issued_at]).to_not be_nil
         expect(c[:scope]).to eq scope
       end
     end
 
-    context 'options' do
-      let(:user_does_not_exist) { random_id }
-      let(:store) { GoogleApps::CredentialStore.new(user_does_not_exist, options) }
-      before {
-        allow(User::Oauth2Data).to receive(:get).with(user_does_not_exist, GoogleApps::Proxy::APP_ID).and_return({})
+    context 'infer expiration time' do
+      let(:issued_at) { 10 }
+      let(:expires_in) { 100 }
+      let(:opts) {
+        {
+          issued_at: issued_at,
+          expires_in: expires_in
+        }
       }
 
-      context 'override access and refresh token' do
-        let(:options) {
-          {
-            'access_token' => "access_token_#{DateTime.now.strftime('%m/%d/%Y at %I:%M%p')}",
-            'refresh_token' => "refresh_token_#{DateTime.now.strftime('%m/%d/%Y at %I:%M%p')}"
-          }
-        }
+      before {
+        expect(User::Oauth2Data).to receive(:new_or_update).with(uid, app_id, access_token, refresh_token, kind_of(Numeric), anything)
+      }
+      it 'should compute expiration_time on the fly' do
+        c = store.load_credentials
+        c[:expiration_time] = nil
+        # Expected behavior is asserted in the 'before' block above
+        store.write_credentials c
+      end
+    end
 
-        it 'should not load credentials when UID not found' do
+    context 'OEC' do
+      let(:app_id) { GoogleApps::Proxy::OEC_APP_ID }
+
+      it 'should find settings per app_id' do
+        expect(store.load_credentials).to_not be_nil
+      end
+    end
+
+    context 'errors' do
+      it 'should raise error if uid is blank' do
+        expect{ GoogleApps::CredentialStore.new(app_id, '  ') }.to raise_error ArgumentError
+      end
+
+      context 'no such user' do
+        let(:oauth2_data) { {} }
+
+        it 'should return nil' do
           expect(store.load_credentials).to be_nil
         end
       end
 
-      context 'Google auth scope' do
-        it 'OEC scope should be a superset of default scope' do
-          oec_scope = Settings.oec.google.scope.split(' ')
-          default_scope = Settings.google_proxy.scope.split(' ')
-          expect(oec_scope).to include *default_scope
+      context 'blank refresh_token' do
+        let(:refresh_token) { ' ' }
+
+        it 'should raise error' do
+          store = GoogleApps::CredentialStore.new(random_string(3), random_id)
+          expect{ store.write_credentials({}) }.to raise_error
         end
-
-      end
-    end
-
-    context 'error conditions' do
-      it 'should raise error when UID is blank' do
-        expect{ GoogleApps::CredentialStore.new('  ') }.to raise_error ArgumentError
-      end
-
-      it 'should raise error when client configs are incomplete' do
-        store = GoogleApps::CredentialStore.new(random_id, {client_id: 'someClientId', client_secret: ' '})
-        expect{ store.load_credentials }.to raise_error
       end
     end
   end
 
-  context '#real', testext: true, :order => :defined do
-    let(:options) {
-      {
-        access_token: "access_token_#{DateTime.now.strftime('%m/%d/%Y at %I:%M%p')}",
-        refresh_token: "refresh_token_#{DateTime.now.strftime('%m/%d/%Y at %I:%M%p')}",
-        issued_at: 1440628381,
-        expires_in: 3600,
-        app_data: 'johndoe@berkeley.edu'
-      }
-    }
+  context '#real', testext: true, order: :defined do
+    let(:options) { oauth2_tokens.merge issued_at: 1440628381, expires_in: 3600, app_data: 'johndoe@berkeley.edu' }
 
     before do
-      @uid = 99999.to_s
-      @app_id = GoogleApps::Proxy::APP_ID
-      existing_data = User::Oauth2Data.get(@uid, @app_id)
+      existing_data = User::Oauth2Data.get(uid, app_id)
       raise 'The random and very large id matches real data. Abort!' if existing_data.any?
       # Values in options hash will be written to the database
-      GoogleApps::CredentialStore.new(@uid, options).write_credentials options
+      GoogleApps::CredentialStore.new(app_id, uid).write_credentials options
     end
 
     after do
-      User::Oauth2Data.remove(@uid, @app_id)
+      User::Oauth2Data.remove(uid, app_id)
     end
 
     it 'should find no match in oauth2_data' do
-      c = GoogleApps::CredentialStore.new(@uid).load_credentials
+      expiration_time = random_id.to_i
+      c = GoogleApps::CredentialStore.new(app_id, uid, expiration_time: expiration_time).load_credentials
       expect(c).to_not be_nil
       expect(c[:access_token]).to eq options[:access_token]
       expect(c[:refresh_token]).to eq options[:refresh_token]
-      expect(c[:expiration_time]).to_not be_nil
+      expect(c[:expiration_time]).to eq expiration_time
       expect(c[:expires_in]).to eq 3600
-      expect(c[:client_id]).to eq Settings.google_proxy.client_id
-      expect(c[:client_secret]).to eq Settings.google_proxy.client_secret
-      expect(c[:scope]).to eq Settings.google_proxy.scope
+      expect(c[:client_id]).to eq settings[:client_id]
+      expect(c[:client_secret]).to eq settings[:client_secret]
+      expect(c[:scope]).to eq settings[:scope]
     end
   end
-
 end

--- a/spec/models/google_apps/drive_manager_spec.rb
+++ b/spec/models/google_apps/drive_manager_spec.rb
@@ -1,10 +1,10 @@
 describe GoogleApps::DriveManager do
 
-  context '#real', testext: true, :order => :defined do
+  context '#real', testext: true, order: :defined do
 
     before(:all) do
       settings = Settings.oec.google.marshal_dump
-      @drive = GoogleApps::DriveManager.new Settings.oec.google.uid, settings
+      @drive = GoogleApps::DriveManager.new(GoogleApps::Proxy::OEC_APP_ID, Settings.oec.google.uid, settings)
       now = DateTime.now.strftime('%m/%d/%Y at %I:%M%p')
       title = "#{described_class} tested on #{now}"
       csv_file = 'fixtures/oec/courses.csv'

--- a/spec/models/google_apps/sheets_manager_spec.rb
+++ b/spec/models/google_apps/sheets_manager_spec.rb
@@ -1,10 +1,10 @@
 describe GoogleApps::SheetsManager do
 
-  context '#real', testext: true, :order => :defined do
+  context '#real', testext: true, order: :defined do
 
     before(:all) do
       settings = Settings.oec.google.marshal_dump
-      @sheet_manager = GoogleApps::SheetsManager.new settings[:uid], settings
+      @sheet_manager = GoogleApps::SheetsManager.new(GoogleApps::Proxy::OEC_APP_ID, settings[:uid], settings)
       now = DateTime.now.strftime('%m/%d/%Y at %I:%M%p')
       @folder = @sheet_manager.create_folder "#{GoogleApps::SheetsManager.name} test, #{now}"
       @spreadsheet_title = "Sheet from CSV, #{now}"

--- a/spec/models/user/oauth2_data_spec.rb
+++ b/spec/models/user/oauth2_data_spec.rb
@@ -1,123 +1,169 @@
 describe User::Oauth2Data do
 
-  before do
-    @random_id = rand(999999).to_s
-    @fake_google_userinfo = GoogleApps::Userinfo.new(:fake => true).user_info
-    @real_google_userinfo = GoogleApps::Userinfo.new(
-      :access_token => Settings.google_proxy.test_user_access_token,
-      :refresh_token => Settings.google_proxy.test_user_refresh_token,
-      :expiration_time => 0
-    )
-    @fake_canvas_user_profile = Canvas::SisUserProfile.new(fake: true, user_id: 300846)
+  let(:user_id) { random_id }
+  let(:app_id) { GoogleApps::Proxy::APP_ID }
+  let(:access_token) { random_string 10 }
+  let(:refresh_token) { random_string 10 }
+
+  it 'should not store plaintext access tokens' do
+    allow_any_instance_of(User::Oauth2Data).to receive(:decrypt_tokens).and_return nil
+    oauth2 = User::Oauth2Data.new(uid: user_id, app_id: app_id, access_token: 'plaintext')
+    expect(oauth2.save).to be true
+    access_token = User::Oauth2Data.get(user_id, app_id)[:access_token]
+    expect(access_token).to_not eq 'plaintext'
   end
 
-  it "should not store plaintext access tokens" do
-    allow_any_instance_of(User::Oauth2Data).to receive(:decrypt_tokens).and_return(nil)
-    oauth2 = User::Oauth2Data.new(uid: "test-user", app_id: "test-app", access_token: "test-token")
-    expect(oauth2.save).to be_truthy
-    access_token = User::Oauth2Data.get("test-user", "test-app")["access_token"]
-    expect(access_token).to_not eq "test-token"
-  end
-
-  it "should return decrypted access tokens" do
-    oauth2 = User::Oauth2Data.new(uid: "test-user", app_id: "test-app", access_token: "test-token")
+  it 'should return decrypted access tokens' do
+    oauth2 = User::Oauth2Data.new(uid: user_id, app_id: app_id, access_token: access_token)
     expect(Cache::UserCacheExpiry).to receive(:notify).once
     expect(oauth2.save).to be_truthy
-    access_token = User::Oauth2Data.get("test-user", "test-app")["access_token"]
-    expect(access_token).to eq "test-token"
+    access_token = User::Oauth2Data.get(user_id, app_id)[:access_token]
+    expect(access_token).to eq access_token
   end
 
-  it "should be able to update existing tokens" do
-    User::Oauth2Data.new_or_update("test-user", "test-app", "new-token",
-                                      "some-token", 1)
-    token_hash = User::Oauth2Data.get("test-user", "test-app")
-    expect(token_hash["access_token"]).to eq "new-token"
-    expect(token_hash["refresh_token"]).to eq "some-token"
-    expect(token_hash["expiration_time"]).to eq 1
+  it 'should be able to update existing tokens' do
+    User::Oauth2Data.new_or_update(
+      user_id,
+      app_id,
+      access_token,
+      refresh_token,
+      1)
+    tokens = User::Oauth2Data.get(user_id, app_id)
+    expect(tokens[:access_token]).to eq access_token
+    expect(tokens[:refresh_token]).to eq refresh_token
+    expect(tokens[:expiration_time]).to eq 1
     expect(Cache::UserCacheExpiry).to receive(:notify).once
-    User::Oauth2Data.new_or_update("test-user", "test-app", "updated-token")
-    updated_token_hash = User::Oauth2Data.get("test-user", "test-app")
-    expect(updated_token_hash["access_token"]).to eq "updated-token"
-    expect(updated_token_hash["refresh_token"]).to be_nil
-    expect(updated_token_hash["expiration_time"]).to be_nil
-    expect(updated_token_hash).to_not eq token_hash
+    updated_access_token = random_string 10
+    User::Oauth2Data.new_or_update(user_id, app_id, updated_access_token)
+    updated_tokens = User::Oauth2Data.get(user_id, app_id)
+    expect(updated_tokens[:access_token]).to eq updated_access_token
+    expect(updated_tokens[:refresh_token]).to be_nil
+    expect(updated_tokens[:expiration_time]).to be_nil
+    expect(updated_tokens).to_not eq tokens
   end
 
-  it "should be able to store additional 'hashified' app_data with tokens" do
-    User::Oauth2Data.new_or_update("test-user", "test-app", "new-token",
-                             "some-token", 1, :app_data => {foo: "baz"})
-    token_hash = User::Oauth2Data.get("test-user", "test-app")
-    expect(token_hash["app_data"]).to eq({:foo => "baz"})
+  it 'should be able to store additional app_data with tokens' do
+    app_data = {
+      foo: 'baz'
+    }
+    User::Oauth2Data.new_or_update(
+      user_id,
+      app_id,
+      access_token,
+      refresh_token,
+      1,
+      app_data: app_data)
+    tokens = User::Oauth2Data.get(user_id, app_id)
+    expect(tokens[:app_data]).to eq app_data
   end
 
-  it "should be able to handle a malformed app_data entry" do
+  it 'should be able to handle a malformed app_data entry' do
     suppress_rails_logging do
-      User::Oauth2Data.new_or_update("test-user", "test-app", "new-token",
-                               "some-token", 1, :app_data => "foo")
+      User::Oauth2Data.new_or_update(
+        user_id,
+        app_id,
+        access_token,
+        refresh_token,
+        1,
+        app_data: 'foo')
     end
-    token_hash = User::Oauth2Data.get("test-user", "test-app")
-    expect(token_hash["app_data"]).to be_empty
+    tokens = User::Oauth2Data.get(user_id, app_id)
+    expect(tokens[:app_data]).to be_empty
   end
 
-  it "should be able to get and update google email for authenticated users" do
-    User::Oauth2Data.new_or_update(@random_id, GoogleApps::Proxy::APP_ID, "new-token",
-                             "some-token", 1)
-    User::Oauth2Data.get_google_email(@random_id).blank?.should be_truthy
-    allow_any_instance_of(GoogleApps::Userinfo).to receive(:user_info).and_return(@fake_google_userinfo)
-    User::Oauth2Data.update_google_email!(@random_id)
-    expect(User::Oauth2Data.get_google_email(@random_id)).to eq "tammi.chang.clc@gmail.com"
+  it 'should be able to get and update google email for authenticated users' do
+    User::Oauth2Data.new_or_update(
+      user_id,
+      app_id,
+      access_token,
+      refresh_token,
+      1)
+    expect(User::Oauth2Data.get_google_email(user_id)).to be_blank
+    user_info = GoogleApps::Userinfo.new(fake: true).user_info
+    allow(GoogleApps::Userinfo).to receive(:user_info).and_return user_info
+    User::Oauth2Data.update_google_email! user_id
+    expect(User::Oauth2Data.get_google_email user_id).to eq 'tammi.chang.clc@gmail.com'
   end
 
-  it "should fail updating canvas email on a non-existant Canvas account" do
-    allow_any_instance_of(Canvas::SisUserProfile).to receive(:sis_user_profile).and_return(statusCode: 404, error: [{message: 'Resource not found.'}])
-    User::Oauth2Data.new_or_update(@random_id, Canvas::Proxy::APP_ID, "new-token",
-                             "some-token", 1)
-    User::Oauth2Data.get_canvas_email(@random_id).blank?.should be_truthy
-    User::Oauth2Data.update_canvas_email!(@random_id)
-    User::Oauth2Data.get_canvas_email(@random_id).blank?.should be_truthy
+  it 'should fail updating canvas email on a non-existant Canvas account' do
+    allow_any_instance_of(Canvas::SisUserProfile).to receive(:sis_user_profile).and_return(
+      statusCode: 404,
+      error: [
+        {
+          message: 'Resource not found.'
+        }
+      ]
+    )
+    User::Oauth2Data.new_or_update(
+      user_id,
+      Canvas::Proxy::APP_ID,
+      access_token,
+      refresh_token,
+      1)
+    expect(User::Oauth2Data.get_canvas_email user_id).to be_blank
+    User::Oauth2Data.update_canvas_email! user_id
+    expect(User::Oauth2Data.get_canvas_email user_id).to be_blank
   end
 
-  it "should successfully update a canvas email " do
-    allow(Canvas::SisUserProfile).to receive(:new).and_return(@fake_canvas_user_profile)
-    User::Oauth2Data.new_or_update(@random_id, Canvas::Proxy::APP_ID, "new-token",
-                             "some-token", 1)
-    expect(User::Oauth2Data.get_canvas_email(@random_id).blank?).to be_truthy
-    User::Oauth2Data.update_canvas_email!(@random_id)
-    expect(User::Oauth2Data.get_canvas_email(@random_id).blank?).to be_falsey
+  it 'should successfully update a canvas email ' do
+    user_profile = Canvas::SisUserProfile.new(fake: true, user_id: 300846)
+    allow(Canvas::SisUserProfile).to receive(:new).and_return user_profile
+    User::Oauth2Data.new_or_update(
+      user_id,
+      Canvas::Proxy::APP_ID,
+      access_token,
+      refresh_token,
+      1)
+    expect(User::Oauth2Data.get_canvas_email user_id).to be_blank
+    User::Oauth2Data.update_canvas_email! user_id
+    expect(User::Oauth2Data.get_canvas_email user_id).to_not be_blank
   end
 
-  it "should simulate a non-responsive google", :testext => true do
-    allow_any_instance_of(Google::APIClient).to receive(:execute).and_raise(StandardError)
+  it 'should simulate a non-responsive google', testext: true do
+    allow_any_instance_of(Google::APIClient).to receive(:execute).and_raise StandardError
     allow(Google::APIClient).to receive(:execute).and_raise(StandardError)
-    allow(GoogleApps::Userinfo).to receive(:new).and_return(@real_google_userinfo)
-    User::Oauth2Data.new_or_update(@random_id, GoogleApps::Proxy::APP_ID, "new-token",
-                             "some-token", 1)
+    user_info = GoogleApps::Userinfo.new(
+      access_token: Settings.google_proxy.test_user_access_token,
+      refresh_token: Settings.google_proxy.test_user_refresh_token,
+      expiration_time: 0
+    )
+    allow(GoogleApps::Userinfo).to receive(:new).and_return user_info
+    User::Oauth2Data.new_or_update(
+      user_id,
+      GoogleApps::Proxy::APP_ID,
+      access_token,
+      refresh_token,
+      1)
     expect_any_instance_of(User::Oauth2Data).to_not receive(:save)
-    User::Oauth2Data.update_google_email!(@random_id)
+    User::Oauth2Data.update_google_email! user_id
   end
 
-  it "should invalidate cache when tokens are deleted" do
-    oauth2 = User::Oauth2Data.new(uid: "test-user", app_id: "test-app", access_token: "test-token")
+  it 'should invalidate cache when tokens are deleted' do
+    oauth2 = User::Oauth2Data.new(
+      uid: user_id,
+      app_id: app_id,
+      access_token: access_token)
     expect(Cache::UserCacheExpiry).to receive(:notify).exactly(2).times
-    expect(oauth2.save).to be_truthy
-    User::Oauth2Data.destroy_all(:uid => "test-user", :app_id => "test-app")
-    access_token = User::Oauth2Data.get("test-user", "test-app")["access_token"]
+    expect(oauth2.save).to be true
+    User::Oauth2Data.destroy_all(
+      uid: user_id,
+      app_id: app_id)
+    access_token = User::Oauth2Data.get(user_id, app_id)[:access_token]
     expect(access_token).to be_nil
   end
 
-  it "should remove dismiss_reminder app_data when a new google token is stored" do
-    expect(User::Oauth2Data.dismiss_google_reminder(@random_id)).to be_truthy
-    expect(User::Oauth2Data.is_google_reminder_dismissed(@random_id)).to be_truthy
-    User::Oauth2Data.new_or_update(@random_id, GoogleApps::Proxy::APP_ID, 'top', 'secret')
-    expect(User::Oauth2Data.is_google_reminder_dismissed(@random_id)).to be_empty
+  it 'should remove dismiss_reminder app_data when a new google token is stored' do
+    expect(User::Oauth2Data.dismiss_google_reminder(user_id)).to be true
+    expect(User::Oauth2Data.is_google_reminder_dismissed(user_id)).to be true
+    User::Oauth2Data.new_or_update(user_id, GoogleApps::Proxy::APP_ID, access_token, refresh_token)
+    expect(User::Oauth2Data.is_google_reminder_dismissed user_id).to be_empty
   end
 
-  it "new_or_update should merge new app_data into existing app_data" do
-    User::Oauth2Data.new_or_update(@random_id, GoogleApps::Proxy::APP_ID, 'top', 'secret', 0, {app_data:{'foo' => 'foo?'}})
-    expect(User::Oauth2Data.send(:get_appdata_field, GoogleApps::Proxy::APP_ID, @random_id, 'foo' )).to eq 'foo?'
-    User::Oauth2Data.new_or_update(@random_id, GoogleApps::Proxy::APP_ID, 'top', 'secret', 0, {app_data:{'baz' => 'baz!'}})
-    expect(User::Oauth2Data.send(:get_appdata_field, GoogleApps::Proxy::APP_ID, @random_id, 'baz' )).to eq 'baz!'
-    expect(User::Oauth2Data.send(:get_appdata_field, GoogleApps::Proxy::APP_ID, @random_id, 'foo' )).to eq 'foo?'
+  it 'new_or_update should merge new app_data into existing app_data' do
+    User::Oauth2Data.new_or_update(user_id, GoogleApps::Proxy::APP_ID, access_token, refresh_token, 0, {app_data:{foo: 'foo?'}})
+    expect(User::Oauth2Data.send(:get_appdata_field, GoogleApps::Proxy::APP_ID, user_id, :foo)).to eq 'foo?'
+    User::Oauth2Data.new_or_update(user_id, GoogleApps::Proxy::APP_ID, access_token, refresh_token, 0, {app_data:{baz: 'baz!'}})
+    expect(User::Oauth2Data.send(:get_appdata_field, GoogleApps::Proxy::APP_ID, user_id, :baz)).to eq 'baz!'
+    expect(User::Oauth2Data.send(:get_appdata_field, GoogleApps::Proxy::APP_ID, user_id, :foo)).to eq 'foo?'
   end
-
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6478

Core classes in GoogleApps module now rely on `app_id` to determine which client_id, etc. to use.