### PR TITLE
CLC-6489, DriveManager might pass non-symbol keys to CredentialStore

### DIFF
--- a/app/models/google_apps/credential_store.rb
+++ b/app/models/google_apps/credential_store.rb
@@ -28,6 +28,7 @@ module GoogleApps
     def write_credentials(auth = nil)
       return nil if auth.nil?
       if auth.is_a? Hash
+        auth.symbolize_keys!
         logger.debug "OAuth tokens in hash (app_id: #{@app_id}; uid: #{@uid})"
         opts = @opts.merge auth.symbolize_keys
         write(auth[:access_token], auth[:refresh_token], opts)

--- a/spec/models/google_apps/credential_store_spec.rb
+++ b/spec/models/google_apps/credential_store_spec.rb
@@ -105,13 +105,11 @@ describe GoogleApps::CredentialStore do
       User::Oauth2Data.remove(uid, app_id)
     end
 
-    it 'should find no match in oauth2_data' do
-      expiration_time = random_id.to_i
-      c = GoogleApps::CredentialStore.new(app_id, uid, expiration_time: expiration_time).load_credentials
+    it 'should load credentials written by Store' do
+      c = GoogleApps::CredentialStore.new(app_id, uid).load_credentials
       expect(c).to_not be_nil
       expect(c[:access_token]).to eq options[:access_token]
       expect(c[:refresh_token]).to eq options[:refresh_token]
-      expect(c[:expiration_time]).to eq expiration_time
       expect(c[:expires_in]).to eq 3600
       expect(c[:client_id]).to eq settings[:client_id]
       expect(c[:client_secret]).to eq settings[:client_secret]


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6489

Two things:
1. We guarantee symbolized hash keys prior to `write_credentials`.
1. Fix 'real' rspec: `load_credentials` should not expect  custom override of expiration_time. It's purely a read operation.