### PR TITLE
CLC-6493, UI should report error if no Google OAuth tokens registered to UID of OEC

### DIFF
--- a/app/controllers/oec_tasks_controller.rb
+++ b/app/controllers/oec_tasks_controller.rb
@@ -11,6 +11,7 @@ class OecTasksController < ApplicationController
 
   def authorize_oec_administration
     authorize current_user, :can_administer_oec?
+    google_oauth_token_check
   end
 
   # GET /api/oec/tasks
@@ -45,6 +46,16 @@ class OecTasksController < ApplicationController
     render json: {
       oecTaskStatus: task_status
     }
+  end
+
+  private
+
+  def google_oauth_token_check
+    uid = Settings.oec.google.uid
+    tokens = User::Oauth2Data.get(uid, GoogleApps::Proxy::OEC_APP_ID)
+    if tokens.empty? || tokens[:access_token].blank? || tokens[:refresh_token].blank?
+      raise StandardError.new "OEC features are unavailable because no Google OAuth tokens are registered with UID #{uid}. Please report this problem."
+    end
   end
 
 end

--- a/src/assets/javascripts/angular/controllers/pages/oecController.js
+++ b/src/assets/javascripts/angular/controllers/pages/oecController.js
@@ -27,6 +27,7 @@ angular.module('calcentral.controllers').controller('OecController', function(ap
       } else {
         $scope.displayError = 'failure';
       }
+      $scope.errorMessage = data.error;
     });
   };
 

--- a/src/assets/templates/oec.html
+++ b/src/assets/templates/oec.html
@@ -96,7 +96,10 @@
     <h1 class="cc-heading-page-title">Unexpected Error</h1>
     <div class="cc-oec-content">
       <div class="cc-oec-text">
-        Sorry! Please try again, or, if the error persists, contact CalCentral support.
+        <div data-ng-bind="errorMessage" data-ng-if="errorMessage"></div>
+        <div data-ng-if="!errorMessage">
+          Sorry! Please try again, or, if the error persists, contact CalCentral support.
+        </div>
       </div>
       <button class="cc-button cc-button-blue" data-ng-click="initialize()">Start over</button>
     </div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6493

UI will report, "...features are unavailable because no Google OAuth tokens are registered with UID 12004714. Please report this problem." Thus, less guesswork for our beleaguered OEC admin.