### PR TITLE
CLC-6495 bCourses mailing lists: allow email address override from Canvas

### DIFF
--- a/app/models/canvas/course_users.rb
+++ b/app/models/canvas/course_users.rb
@@ -10,7 +10,7 @@ module Canvas
 
     def course_users(options = {})
       optional_cache(options, key: "#{@course_id}/#{@user_id}", default: true) do
-        paged_get(request_path, include: ['enrollments']) do |response|
+        paged_get(request_path, include: %w(email enrollments)) do |response|
           if @paging_callback.present?
             parsed_link_header = LinkHeader.parse(response['link'])
             last_link = parsed_link_header.find_link(['rel', 'last']).href

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -359,6 +359,7 @@ background_jobs_check:
 youtube_splash_id: '3Iz1NT9QKjI'
 
 canvas_mailing_lists:
+  prefer_canvas_email_addresses: false
   timestamp_tolerance: 60
 
 oec:

--- a/fixtures/json/canvas_course_users_page_1.json
+++ b/fixtures/json/canvas_course_users_page_1.json
@@ -6,6 +6,7 @@
     "short_name": "Ted Andrew Greenwald",
     "sis_user_id": "UID:4000123",
     "sis_login_id": "4000123",
+    "email": "ted_andrew_greenwald@berkeley.edu",
     "login_id": "4000123",
     "enrollments": [
       {
@@ -41,6 +42,7 @@
     "sis_user_id": "UID:4000169",
     "sis_login_id": "4000169",
     "login_id": "4000169",
+    "email": "harold_arnold_dacus@berkeley.edu",
     "enrollments": [
       {
         "associated_user_id": null,
@@ -67,6 +69,7 @@
     "sis_user_id": "UID:4000309",
     "sis_login_id": "4000309",
     "login_id": "4000309",
+    "email": "michael_david_ward@berkeley.edu",
     "enrollments": [
       {
         "associated_user_id": null,
@@ -101,6 +104,7 @@
     "sis_user_id": "UID:4000189",
     "sis_login_id": "4000189",
     "login_id": "4000189",
+    "email": "melissa_w_gafford@berkeley.edu",
     "enrollments": [
       {
         "associated_user_id": null,
@@ -135,6 +139,7 @@
     "sis_user_id": "UID:4000199",
     "sis_login_id": "4000199",
     "login_id": "4000199",
+    "email": "robert_vannatta@berkeley.edu",
     "enrollments": [
       {
         "associated_user_id": null,
@@ -169,6 +174,7 @@
     "sis_user_id": "20629333",
     "sis_login_id": "4000272",
     "login_id": "4000272",
+    "email": "laura_clarice_eisenberg@berkeley.edu",
     "enrollments": [
       {
         "associated_user_id": null,

--- a/fixtures/json/canvas_course_users_page_2.json
+++ b/fixtures/json/canvas_course_users_page_2.json
@@ -9,6 +9,7 @@
     "sis_login_id": "870001",
     "sis_import_id": 6168758,
     "login_id": "870001",
+    "email": "walter_upchurch@berkeley.edu",
     "enrollments": [
       {
         "associated_user_id": null,
@@ -55,6 +56,7 @@
     "sis_login_id": "870002",
     "sis_import_id": 5995310,
     "login_id": "870002",
+    "email": "walter_upchurch@berkeley.edu",
     "enrollments": [
       {
         "associated_user_id": null,
@@ -101,6 +103,7 @@
     "sis_login_id": "870003",
     "sis_import_id": 6205188,
     "login_id": "870003",
+    "email": "walter_upchurch@berkeley.edu",
     "enrollments": [
       {
         "associated_user_id": null,
@@ -147,6 +150,7 @@
     "sis_login_id": "870004",
     "sis_import_id": 6169732,
     "login_id": "870004",
+    "email": "walter_upchurch@berkeley.edu",
     "enrollments": [
       {
         "associated_user_id": null,
@@ -193,6 +197,7 @@
     "sis_login_id": "870005",
     "sis_import_id": 6198014,
     "login_id": "870005",
+    "email": "walter_upchurch@berkeley.edu",
     "enrollments": [
       {
         "associated_user_id": null,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6495

We expect this feature flag to remain turned off in the normal course of business, but QA will appreciate the ability to turn it on.

This does require adding email addresses to our Canvas::CourseUsers feed, which doesn't strike me as a serious performance concern.