### PR TITLE
[QA] SISRP-26980 SISRP-26578 CS & CalNet affiliation changes

### DIFF
--- a/app/models/user/aggregated_attributes.rb
+++ b/app/models/user/aggregated_attributes.rb
@@ -44,8 +44,8 @@ module User
       campus_roles = oracle_roles.merge ldap_roles
       if @sis_profile_visible
         edo_roles = (@edo_attributes && @edo_attributes[:roles]) || {}
-        # While we're in the split-brain stage, LDAP and Oracle are more trusted on ex-student status.
-        edo_roles.delete(:student) if campus_roles[:exStudent]
+        # Do not introduce conflicts if CS is more up-to-date on active student status.
+        campus_roles.except!(:exStudent, :recentStudent) if edo_roles[:student]
         campus_roles.merge edo_roles
       else
         campus_roles

--- a/spec/models/berkeley/user_roles_spec.rb
+++ b/spec/models/berkeley/user_roles_spec.rb
@@ -306,15 +306,9 @@ describe Berkeley::UserRoles do
   describe '#roles_from_ldap_affiliations' do
     let(:ldap_record) do
       {
-        berkeleyeduaffiliations: affiliations,
-        berkeleyeduaffexpdate: affiliate_exp_dates,
-        berkeleyeduempexpdate: employee_exp_dates,
-        berkeleyedustuexpdate: student_exp_dates
+        berkeleyeduaffiliations: affiliations
       }
     end
-    let(:affiliate_exp_dates) { [] }
-    let(:employee_exp_dates) { [] }
-    let(:student_exp_dates) { [] }
     subject { Berkeley::UserRoles.roles_from_ldap_affiliations(ldap_record) }
     context 'current student' do
       let(:affiliations) { ['STUDENT-TYPE-REGISTERED'] }
@@ -337,42 +331,19 @@ describe Berkeley::UserRoles do
       it_behaves_like 'a parser for roles', [:staff, :student, :registered]
     end
     context 'academic employee and ex-student' do
-      let(:affiliations) { ['EMPLOYEE-TYPE-ACADEMIC', 'STUDENT-STATUS-EXPIRED'] }
+      let(:affiliations) { ['EMPLOYEE-TYPE-ACADEMIC', 'FORMER-STUDENT'] }
       it_behaves_like 'a parser for roles', [:exStudent, :faculty]
     end
-    context 'ex-student in LDAP grace period' do
-      let(:affiliations) { ['STUDENT-STATUS-EXPIRED', 'STUDENT-TYPE-REGISTERED'] }
-      let(:student_exp_dates) { ['20140901145959Z'] }
-      it_behaves_like 'a parser for roles', [:student, :registered]
-    end
-    context 'returned ex-student with future expiration' do
-      let(:affiliations) { ['STUDENT-STATUS-EXPIRED', 'STUDENT-TYPE-REGISTERED'] }
-      let(:student_exp_dates) { [DateTime.now.advance(hours: 1).utc.strftime('%Y%m%d%H%M%SZ')] }
-      it_behaves_like 'a parser for roles', [:student, :registered]
-    end
-    context 'returned ex-student with unspecified expiration' do
-      let(:affiliations) { ['STUDENT-STATUS-EXPIRED', 'STUDENT-TYPE-REGISTERED'] }
-      it_behaves_like 'a parser for roles', [:student, :registered]
-    end
-    context 'recidivist ex-employee' do
-      let(:affiliations) { ['EMPLOYEE-STATUS-EXPIRED', 'EMPLOYEE-TYPE-STAFF'] }
-      let(:employee_exp_dates) { ['20150901145959Z'] }
+    context 'ex-employee' do
+      let(:affiliations) { ['FORMER-EMPLOYEE'] }
       it_behaves_like 'a parser for roles', []
     end
-    context 'returned ex-employee with future expiration' do
-      let(:affiliations) { ['EMPLOYEE-STATUS-EXPIRED', 'EMPLOYEE-TYPE-STAFF'] }
-      let(:employee_exp_dates) { [DateTime.now.advance(hours: 1).utc.strftime('%Y%m%d%H%M%SZ')] }
-      it_behaves_like 'a parser for roles', [:staff]
-    end
-    context 'ex-concurrent-enrollment in LDAP grace period' do
-      let(:affiliations) { ['AFFILIATE-STATUS-EXPIRED', 'AFFILIATE-TYPE-CONCURR ENROLL'] }
-      let(:affiliate_exp_dates) { ['20140901145959Z'] }
-      it_behaves_like 'a parser for roles', []
-    end
-    context 'returned ex-concurrent-enrollment with future expiration' do
-      let(:affiliations) { ['AFFILIATE-STATUS-EXPIRED', 'AFFILIATE-TYPE-CONCURR ENROLL'] }
-      let(:affiliate_exp_dates) { [DateTime.now.advance(hours: 1).utc.strftime('%Y%m%d%H%M%SZ')] }
-      it_behaves_like 'a parser for roles', [:concurrentEnrollmentStudent]
+    # TODO Remove this after the new CalNet scheme lands in production.
+    context 'legacy historical affiliations' do
+      context 'academic employee and ex-student' do
+        let(:affiliations) { ['EMPLOYEE-TYPE-ACADEMIC', 'STUDENT-STATUS-EXPIRED'] }
+        it_behaves_like 'a parser for roles', [:exStudent, :faculty]
+      end
     end
   end
 

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -4,10 +4,7 @@ describe User::Api do
   let(:preferred_name) { 'Sid Vicious' }
   let(:edo_roles) do
     {
-      student: true,
-      exStudent: false,
-      faculty: false,
-      staff: false
+      student: true
     }
   end
   let(:edo_attributes) do
@@ -75,7 +72,7 @@ describe User::Api do
     end
     context 'advisor user' do
       let(:edo_roles) do
-        {student: false, exStudent: false, faculty: false, advisor: true}
+        {advisor: true}
       end
       it 'allows viewing grades' do
         api = User::Api.new(uid).get_feed
@@ -302,6 +299,15 @@ describe User::Api do
     end
     context 'former student' do
       let(:is_active_student) { false }
+      let(:edo_attributes) do
+        {
+          person_name: preferred_name,
+          campus_solutions_id: '12345678', # 8-digit ID means legacy
+          is_legacy_student: true,
+          roles: {
+          }
+        }
+      end
       it 'relies on LDAP and Oracle' do
         expect(subject[:officialBmailAddress]).to eq 'bar@bar.edu'
       end
@@ -551,7 +557,7 @@ describe User::Api do
       include_examples 'handling bad behavior'
     end
 
-    context 'when ex-student is incorrectly reported active' do
+    context 'when ex-student is reported by CS as now again active' do
       let(:uid) { '2040' }
       let(:edo_attributes) do
         {
@@ -560,9 +566,9 @@ describe User::Api do
           }
         }
       end
-      it 'should give precedence to campus Oracle on ex-student status' do
-        expect(feed[:roles][:exStudent]).to eq true
-        expect(feed[:roles][:student]).to eq false
+      it 'should give precedence to CS' do
+        expect(feed[:roles][:exStudent]).to be_falsey
+        expect(feed[:roles][:student]).to eq true
       end
     end
   end


### PR DESCRIPTION
QA version of https://github.com/ets-berkeley-edu/calcentral/pull/6092

The key CalNet change is due to land in production on Nov. 3. The key CS change has already happened. Under the circumstances, I think there's less risk with this PR than without it, despite the ludicrously limited testing.