### PR TITLE
SISRP-25362 - Updates Degree Progress (GRAD) text translation 

### DIFF
--- a/app/models/berkeley/degree_progress_graduate.rb
+++ b/app/models/berkeley/degree_progress_graduate.rb
@@ -37,16 +37,18 @@ module Berkeley
 
     def self.statuses
       @statuses ||= {
-        'Y' => 'Completed',
+        'F' => 'Failed',
+        'I' => 'In Progress',
         'N' => 'Not Satisfied',
-        'P' => 'Partially Passed'
+        'P' => 'Passed',
+        'S' => 'Partially Passed',
+        'Y' => 'Completed'
       }
     end
 
     def self.form_notifications
       @form_notifications ||= {
         'AAGADVMAS1' => '(Form Required)',
-        'AAGADVMAS2' => '(Form Required)',
         'AAGQEAPRV' => '(Form Required)'
       }
     end

--- a/fixtures/xml/campus_solutions/degree_progress_graduate.xml
+++ b/fixtures/xml/campus_solutions/degree_progress_graduate.xml
@@ -9,11 +9,11 @@
       <ACAD_PROG>Law Academic Programs</ACAD_PROG>
       <REQUIREMENTS type="array">
         <REQUIREMENT>
-          <NAME>Advancement to Candidacy Mas2</NAME>
+          <NAME>Advancement to Candidacy Mas1</NAME>
           <NUMBER>10</NUMBER>
           <STATUS>N</STATUS>
           <DATE></DATE>
-          <CODE>AAGADVMAS2</CODE>
+          <CODE>AAGADVMAS1</CODE>
         </REQUIREMENT>
         <REQUIREMENT>
           <NAME>Capstone</NAME>

--- a/spec/support/degree_progress_shared_examples.rb
+++ b/spec/support/degree_progress_shared_examples.rb
@@ -22,7 +22,7 @@ shared_examples 'a proxy that returns graduate milestone data' do
   end
 
   it 'replaces codes with descriptive names' do
-    expect(subject[:feed][:degreeProgress][0][:requirements][0][:name]).to eql('Advancement to Candidacy Plan II')
+    expect(subject[:feed][:degreeProgress][0][:requirements][0][:name]).to eql('Advancement to Candidacy Plan I')
     expect(subject[:feed][:degreeProgress][0][:requirements][0][:statusDescr]).to eql('Not Satisfied')
     expect(subject[:feed][:degreeProgress][1][:requirements][0][:name]).to eql('Advancement to Candidacy Plan I or Plan II')
     expect(subject[:feed][:degreeProgress][1][:requirements][0][:statusDescr]).to be nil


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-25362

- Removes form notification from Adv to Cand Plan II milestone. 
- Adds new codes to grad milestone status map