### PR TITLE
SISRP-26755 - Schedule Planner link - Campus Solutions page header needs to be removed

### DIFF
--- a/src/assets/templates/widgets/toolbox/user_preview.html
+++ b/src/assets/templates/widgets/toolbox/user_preview.html
@@ -146,11 +146,7 @@
                 <div data-ng-if="ucAdvisingResources.links.schedulePlannerStudentSpecific.url">
                   <a
                     data-ng-bind="ucAdvisingResources.links.schedulePlannerStudentSpecific.name"
-                    data-cc-campus-solutions-link-directive="ucAdvisingResources.links.schedulePlannerStudentSpecific.url"
-                    data-cc-campus-solutions-link-directive-enabled="{{false}}"
-                    data-cc-campus-solutions-link-directive-text="ucAdvisingResources.links.schedulePlannerStudentSpecific.backToText"
-                    data-cc-campus-solutions-link-directive-cache="cache"
-                    data-cc-outbound-enabled="{{true}}"
+                    data-ng-href="{{ucAdvisingResources.links.schedulePlannerStudentSpecific.url}}"
                   ></a>
                 </div>
                 <div data-ng-if="ucAdvisingResources.csLinks.studentWebnowDocuments.url">

--- a/src/assets/templates/widgets/toolbox/user_preview.html
+++ b/src/assets/templates/widgets/toolbox/user_preview.html
@@ -144,10 +144,14 @@
                   ></div>
                 </div>
                 <div data-ng-if="ucAdvisingResources.links.schedulePlannerStudentSpecific.url">
-                  <div
-                    data-cc-campus-solutions-link-item-directive
-                    data-link="ucAdvisingResources.links.schedulePlannerStudentSpecific"
-                  ></div>
+                  <a
+                    data-ng-bind="ucAdvisingResources.links.schedulePlannerStudentSpecific.name"
+                    data-cc-campus-solutions-link-directive="ucAdvisingResources.links.schedulePlannerStudentSpecific.url"
+                    data-cc-campus-solutions-link-directive-enabled="{{false}}"
+                    data-cc-campus-solutions-link-directive-text="ucAdvisingResources.links.schedulePlannerStudentSpecific.backToText"
+                    data-cc-campus-solutions-link-directive-cache="cache"
+                    data-cc-outbound-enabled="{{true}}"
+                  ></a>
                 </div>
                 <div data-ng-if="ucAdvisingResources.csLinks.studentWebnowDocuments.url">
                   <a


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26755

See QA PR #6110

The issue that was occurring was that the `isCsLink` flag is being forced in [CampusSolutions::AdvisingResources](https://github.com/ets-berkeley-edu/calcentral/blob/ed63d211/app/models/campus_solutions/advising_resources.rb#L131), which results in the link not opening in a new window... and the "ucFrom" parameter (and other related parameters) being included.

So instead of using the `ccCampusSolutionsLinkItemDirective` like we do with these links, I just broke this out into using the `ccCampusSolutionsLinkDirective` to force it to behave as specified in the JIRA (open in a new window, do not use ucFrom parameters to make CalCentral banner appear).