### PR TITLE
SISRP-26578 Give Advisors access to ex-students' academic data

### DIFF
--- a/app/controllers/concerns/advisor_authorization.rb
+++ b/app/controllers/concerns/advisor_authorization.rb
@@ -12,11 +12,11 @@ module AdvisorAuthorization
     # It therefore needs to pull from a cached feed.
     opts = {
       id: student_uid,
-      roles: [:applicant, :student, :recentStudent]
+      roles: [:applicant, :student, :exStudent]
     }
     filtered_user = User::SearchUsersByUid.new(opts).search_users_by_uid
     unless filtered_user
-      raise Pundit::NotAuthorizedError.new "User with UID #{student_uid} does not appear to be a current, recent, or incoming student."
+      raise Pundit::NotAuthorizedError.new "User with UID #{student_uid} does not appear to be a current, past, or incoming student."
     end
   end
 

--- a/app/controllers/search_users_controller.rb
+++ b/app/controllers/search_users_controller.rb
@@ -53,7 +53,7 @@ class SearchUsersController < ApplicationController
     else
       require_advisor current_user.user_id
       {
-        roles: [:applicant, :student, :recentStudent]
+        roles: [:applicant, :student, :exStudent]
       }
     end
   end

--- a/app/models/berkeley/user_roles.rb
+++ b/app/models/berkeley/user_roles.rb
@@ -41,9 +41,7 @@ module Berkeley
       roles_from_affiliations affiliations
     end
 
-    def roles_from_ldap_groups(ldap_groups, expired_student)
-      # TODO: Confirm that there is no CalGroup membership marker for 'STUDENT-TYPE-NOT REGISTERED'.
-      # TODO: What is the difference between 'edu:berkeley:official:affiliates:concurrent' and 'edu:berkeley:official:students:concurrent'?
+    def roles_from_ldap_groups(ldap_groups)
       return {} if ldap_groups.nil? || ldap_groups.empty?
 
       # Active-but-not-registered students have exactly the same list of memberships as registered students.
@@ -54,15 +52,6 @@ module Berkeley
         "#{group_prefix}:graduate,#{group_suffix}" => :graduate,
         "#{group_prefix}:undergrad,#{group_suffix}" => :undergrad
       })
-      # We check for 'recentStudent' status if and only if (1) the more reliable LDAP affiliations tell us that this user
-      # is an ex_student and (2) the user was not identified as an active student in the logic above.
-      if expired_student && [:student, :undergrad, :graduate].none? { |s| roles[s] }
-        roles.merge! find_matching_roles(ldap_groups, {
-          "#{group_prefix}:students-grad-grace,#{group_suffix}" => :recentStudent,
-          "#{group_prefix}:students-ug-grace,#{group_suffix}" => :recentStudent,
-          "#{group_prefix}:summer-grace,#{group_suffix}" => :recentStudent
-        })
-      end
       roles
     end
 

--- a/app/models/user/aggregated_attributes.rb
+++ b/app/models/user/aggregated_attributes.rb
@@ -45,7 +45,7 @@ module User
       if @sis_profile_visible
         edo_roles = (@edo_attributes && @edo_attributes[:roles]) || {}
         # Do not introduce conflicts if CS is more up-to-date on active student status.
-        campus_roles.except!(:exStudent, :recentStudent) if edo_roles[:student]
+        campus_roles.except!(:exStudent) if edo_roles[:student]
         campus_roles.merge edo_roles
       else
         campus_roles

--- a/app/models/user/parser.rb
+++ b/app/models/user/parser.rb
@@ -8,7 +8,7 @@ module User
 
     def parse(ldap_record)
       affiliation_roles = Berkeley::UserRoles.roles_from_ldap_affiliations ldap_record
-      group_roles = Berkeley::UserRoles.roles_from_ldap_groups(ldap_record[:berkeleyeduismemberof], !!affiliation_roles[:exStudent])
+      group_roles = Berkeley::UserRoles.roles_from_ldap_groups(ldap_record[:berkeleyeduismemberof])
       roles = group_roles.merge affiliation_roles
       {
         email_address: string_attribute(ldap_record, :mail) || string_attribute(ldap_record, :berkeleyeduofficialemail),

--- a/spec/controllers/advising_student_controller_spec.rb
+++ b/spec/controllers/advising_student_controller_spec.rb
@@ -78,7 +78,11 @@ describe AdvisingStudentController do
       end
       context 'ex-student' do
         let(:ex_student) { true }
-        it_behaves_like 'an endpoint refusing a request'
+        it_behaves_like 'an endpoint receiving a valid request'
+        it 'should provide a filtered academics feed' do
+          feed = JSON.parse(body = subject.body)
+          expect(feed['collegeAndLevel']).to eq true
+        end
       end
       context 'applicant' do
         let(:applicant) { true }

--- a/spec/controllers/concerns/advisor_authorization_spec.rb
+++ b/spec/controllers/concerns/advisor_authorization_spec.rb
@@ -14,13 +14,13 @@ describe AdvisorAuthorization do
   describe '#authorize_advisor_view_as' do
     let(:student_uid) { random_id }
     let(:is_student) { false }
-    let(:is_recent_student) { false }
+    let(:was_student) { false }
     before {
       feed = {
         roles:
           {
             student: is_student,
-            recentStudent: is_recent_student
+            exStudent: was_student
           }
       }
       allow(User::AggregatedAttributes).to receive(:new).with(student_uid).and_return double(get_feed: feed)
@@ -46,9 +46,9 @@ describe AdvisorAuthorization do
         expect{ subject }.to_not raise_error
       end
     end
-    context 'advisor looking up recentStudent' do
+    context 'advisor looking up exStudent' do
       let(:is_advisor) { true }
-      let(:is_recent_student) { true }
+      let(:was_student) { true }
       it 'should pass' do
         expect{ subject }.to_not raise_error
       end

--- a/spec/models/berkeley/user_roles_spec.rb
+++ b/spec/models/berkeley/user_roles_spec.rb
@@ -348,8 +348,7 @@ describe Berkeley::UserRoles do
   end
 
   describe '#roles_from_ldap_groups' do
-    let(:ex_student) { false }
-    subject { Berkeley::UserRoles.roles_from_ldap_groups(groups, ex_student) }
+    subject { Berkeley::UserRoles.roles_from_ldap_groups(groups) }
     context 'current undergrad' do
       let(:groups) do
         [
@@ -367,34 +366,6 @@ describe Berkeley::UserRoles do
         ]
       end
       it_behaves_like 'a parser for roles', [:student, :graduate]
-    end
-    context 'graduate student was recently an undergrad so we omit recentStudent role' do
-      let(:groups) do
-        [
-          'cn=edu:berkeley:official:students:students-ug-grace,ou=campus groups,dc=berkeley,dc=edu',
-          'cn=edu:berkeley:official:students:graduate,ou=campus groups,dc=berkeley,dc=edu'
-        ]
-      end
-      it_behaves_like 'a parser for roles', [:graduate]
-    end
-    context 'no recentStudent check if exStudent is false' do
-      let(:groups) do
-        [
-          'cn=edu:berkeley:official:students:students-ug-grace,ou=campus groups,dc=berkeley,dc=edu',
-          'cn=edu:berkeley:ignore:this:garbage,ou=campus groups,dc=berkeley,dc=edu'
-        ]
-      end
-      it_behaves_like 'a parser for roles', []
-    end
-    context 'recentStudent is an exStudent who is still in the grace period' do
-      let(:ex_student) { true }
-      let(:groups) do
-        [
-          'cn=edu:berkeley:official:students:students-ug-grace,ou=campus groups,dc=berkeley,dc=edu',
-          'cn=edu:berkeley:ignore:this:garbage,ou=campus groups,dc=berkeley,dc=edu'
-        ]
-      end
-      it_behaves_like 'a parser for roles', [:recentStudent]
     end
   end
 

--- a/spec/models/user/aggregated_attributes_spec.rb
+++ b/spec/models/user/aggregated_attributes_spec.rb
@@ -20,7 +20,7 @@ describe User::AggregatedAttributes do
   let(:ldap_attributes) do
     {
       roles: {
-        recentStudent: true
+        exStudent: true
       }
     }
   end
@@ -42,7 +42,7 @@ describe User::AggregatedAttributes do
         expect(subject[:campusSolutionsId]).to eq campus_solutions_id
         expect(subject[:studentId]).to eq campus_solutions_id
         expect(subject[:ldapUid]).to eq uid
-        expect(subject[:roles][:recentStudent]).to be_falsey
+        expect(subject[:roles][:exStudent]).to be_falsey
         expect(subject[:unknown]).to be_falsey
       end
     end
@@ -57,7 +57,6 @@ describe User::AggregatedAttributes do
         roles: {
           student: is_active_student,
           exStudent: !is_active_student,
-          recentStudent: !is_active_student,
           faculty: false,
           staff: true
         }
@@ -68,7 +67,6 @@ describe User::AggregatedAttributes do
       it 'should prefer EDO' do
         expect(subject[:officialBmailAddress]).to eq bmail_from_edo
         expect(subject[:roles][:student]).to be true
-        expect(subject[:roles][:recentStudent]).to be_falsey
         expect(subject[:roles][:exStudent]).to be_falsey
         expect(subject[:unknown]).to be_falsey
       end
@@ -78,7 +76,6 @@ describe User::AggregatedAttributes do
       it 'should still prefer EDO when EDO claims active student status' do
         expect(subject[:officialBmailAddress]).to eq bmail_from_edo
         expect(subject[:roles][:student]).to be true
-        expect(subject[:roles][:recentStudent]).to be_falsey
         expect(subject[:roles][:exStudent]).to be_falsey
         expect(subject[:unknown]).to be_falsey
       end
@@ -99,7 +96,6 @@ describe User::AggregatedAttributes do
         it 'fills in former student status and other attributes from LDAP' do
           expect(subject[:officialBmailAddress]).to eq bmail_from_ldap
           expect(subject[:roles][:student]).to be false
-          expect(subject[:roles][:recentStudent]).to be true
           expect(subject[:roles][:exStudent]).to be true
           expect(subject[:roles][:advisor]).to be true
           expect(subject[:unknown]).to be_falsey
@@ -123,7 +119,7 @@ describe User::AggregatedAttributes do
       let(:is_active_student) { false }
       it 'should prefer EDO' do
         expect(subject[:officialBmailAddress]).to eq bmail_from_edo
-        expect(subject[:roles][:recentStudent]).to be true
+        expect(subject[:roles][:applicant]).to be true
         expect(subject[:unknown]).to be_falsey
       end
     end
@@ -172,7 +168,7 @@ describe User::AggregatedAttributes do
       it 'relies on LDAP and Oracle' do
         expect(subject[:officialBmailAddress]).to eq bmail_from_ldap
         expect(subject[:roles][:student]).to be true
-        expect(subject[:roles][:recentStudent]).to be false
+        expect(subject[:roles][:exStudent]).to be false
         expect(subject[:ldapUid]).to eq uid
       end
     end

--- a/spec/models/user/search_users_by_name_spec.rb
+++ b/spec/models/user/search_users_by_name_spec.rb
@@ -45,11 +45,11 @@ describe User::SearchUsersByName do
     end
     context 'filter by role' do
       let(:name) { random_name }
-      let(:roles) { [:student, :recentStudent] }
+      let(:roles) { [:student, :exStudent] }
       let(:uid) { random_id }
       before {
         allow(CalnetLdap::Client).to receive(:new).and_return (client = double)
-        ldap_records = [:faculty, :student, :staff, :recentStudent, :exStudent]
+        ldap_records = [:faculty, :student, :staff, :exStudent]
         allow(client).to receive(:search_by_name).with(name, true).and_return ldap_records
         ldap_records.each_index do |idx|
           # To avoid a complex spec, each ldap_record translate very nicely into a user role and UID.
@@ -63,7 +63,7 @@ describe User::SearchUsersByName do
         expect(subject).to have(2).items
         expect(subject[0]).to include(roles: { student: true })
         expect(subject[0][:ldapUid]).to eq '2'
-        expect(subject[1]).to include(roles: { recentStudent: true })
+        expect(subject[1]).to include(roles: { exStudent: true })
         expect(subject[1][:ldapUid]).to eq '4'
       end
     end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26578

This functional change has been approved for Sunday's release, and so a QA PR will quickly follow.

I've done a quick verification on my laptop against the Dev LDAP server.