### PR TITLE
CLC-6499, remove Google::APIClient::InstalledAppFlow from DriveManager class

### DIFF
--- a/app/models/google_apps/drive_manager.rb
+++ b/app/models/google_apps/drive_manager.rb
@@ -1,6 +1,5 @@
 module GoogleApps
   class DriveManager
-
     include ClassLogger
 
     def initialize(app_id, uid, options = {})
@@ -10,9 +9,9 @@ module GoogleApps
     end
 
     def get_items_in_folder(parent_id, mime_type = nil)
-      options = {:parent_id => parent_id}
-      options.merge!({ :mime_type => mime_type }) unless mime_type.nil?
-      find_items(options)
+      options = { parent_id: parent_id }
+      options.merge!(mime_type: mime_type) unless mime_type.nil?
+      find_items options
     end
 
     def find_folders_by_title(title, options = {})
@@ -25,19 +24,17 @@ module GoogleApps
     end
 
     def find_items_by_title(title, options = {})
-      find_items options.merge({ :title => title })
+      find_items options.merge(title: title)
     end
 
     def download(file)
-      result = get_google_api.execute(:uri => file.download_url)
+      result = google_api.execute(uri: file.download_url)
       log_response result
       raise Errors::ProxyError, "Failed to download '#{file.title}' (id: #{file.id}).\nError: #{result.data['error']}" if result.error?
       result.body
     end
 
     def find_items(options = {})
-      client = get_google_api
-      drive_api = client.discovered_api('drive', 'v2')
       items = []
       query = 'trashed=false'
       parent_id = options[:parent_id]
@@ -51,9 +48,9 @@ module GoogleApps
       query.concat ' and sharedWithMe' if options[:shared]
       page_token = nil
       begin
-        parameters = { :q => query }
+        parameters = { q: query }
         parameters[:pageToken] = page_token unless page_token.nil?
-        result = client.execute(:api_method => drive_api.files.list, :parameters => parameters)
+        result = google_api.execute(api_method: drive_api.files.list, parameters: parameters)
         log_response result
         case result.status
           when 200
@@ -65,63 +62,61 @@ module GoogleApps
             page_token = nil
           else
             raise Errors::ProxyError, "Error in find_items(#{options}): #{result.data['error']['message']}"
-            page_token = nil
         end
       end while page_token.to_s != ''
       items
     end
 
     def create_folder(title, parent_id = 'root')
-      client = get_google_api
-      drive_api = client.discovered_api('drive', 'v2')
       metadata = {
-        :title => title,
-        :mimeType => 'application/vnd.google-apps.folder'
+        title: title,
+        mimeType: 'application/vnd.google-apps.folder'
       }
       dir = drive_api.files.insert.request_schema.new metadata
-      dir.parents = [{ :id => parent_id }] if parent_id
-      result = client.execute(:api_method => drive_api.files.insert, :body_object => dir)
+      dir.parents = [{ id: parent_id }] if parent_id
+      result = google_api.execute(api_method: drive_api.files.insert, body_object: dir)
       log_response result
       raise Errors::ProxyError, "Error in create_folder(#{title}, ...): #{result.data['error']['message']}" if result.error?
       result.data
     end
 
     def upload_file(title, description, parent_id, mime_type, file_path)
-      client = get_google_api
-      drive_api = client.discovered_api('drive', 'v2')
       metadata = {
-        :title => title,
-        :description => description,
-        :mimeType => mime_type
+        title: title,
+        description: description,
+        mimeType: mime_type
       }
       file = drive_api.files.insert.request_schema.new metadata
       # Target directory is optional
-      file.parents = [{ :id => parent_id }] if parent_id
+      file.parents = [{ id: parent_id }] if parent_id
       media = Google::APIClient::UploadIO.new(file_path, mime_type)
-      result = client.execute(
-        :api_method => drive_api.files.insert,
-        :body_object => file,
-        :media => media,
-        :parameters => { :uploadType => 'multipart', :alt => 'json'})
+      result = google_api.execute(
+        api_method: drive_api.files.insert,
+        body_object: file,
+        media: media,
+        parameters: {
+          uploadType: 'multipart',
+          alt: 'json'
+        })
       log_response result
       raise Errors::ProxyError, "Error in upload_file(#{title}): #{result.data['error']['message']}" if result.error?
       result.data
     end
 
     def trash_item(item, opts={})
-      client = get_google_api
-      drive = client.discovered_api('drive', 'v2')
-      api_method = opts[:permanently_delete] ? drive.files.delete : drive.files.trash
-      result = client.execute(:api_method => api_method, :parameters => { :fileId => item.id })
+      api_method = opts[:permanently_delete] ? drive_api.files.delete : drive_api.files.trash
+      result = google_api.execute(
+        api_method: api_method,
+        parameters: {
+          fileId: item.id
+        })
       log_response result
       raise Errors::ProxyError, "Error in trash_item(#{item.id}): #{result.data['error']['message']}" if result.error?
       result.data
     end
 
     def empty_trash
-      client = get_google_api
-      drive = client.discovered_api('drive', 'v2')
-      result = client.execute(:api_method => drive.files.empty_trash)
+      result = google_api.execute(api_method: drive_api.files.empty_trash)
       log_response result
       raise Errors::ProxyError, "Error in empty_trash: #{result.data['error']['message']}" if result.error?
       result.data
@@ -137,13 +132,13 @@ module GoogleApps
     end
 
     def copy_item(id, copy_title)
-      client = get_google_api
-      drive_api = client.discovered_api('drive', 'v2')
       copy_schema = drive_api.files.copy.request_schema.new({'title' => copy_title})
-      result = client.execute(
-        :api_method => drive_api.files.copy,
-        :body_object => copy_schema,
-        :parameters => { :fileId => id }
+      result = google_api.execute(
+        api_method: drive_api.files.copy,
+        body_object: copy_schema,
+        parameters: {
+          fileId: id
+        }
       )
       log_response result
       raise Errors::ProxyError, "Error in copy_item(#{id}): #{result.data['error']['message']}" if result.error?
@@ -151,13 +146,13 @@ module GoogleApps
     end
 
     def add_parent(id, parent_id)
-      client = get_google_api
-      drive_api = client.discovered_api('drive', 'v2')
       new_parent = drive_api.parents.insert.request_schema.new({'id' => parent_id})
-      result = client.execute(
-        :api_method => drive_api.parents.insert,
-        :body_object => new_parent,
-        :parameters => { :fileId => id }
+      result = google_api.execute(
+        api_method: drive_api.parents.insert,
+        body_object: new_parent,
+        parameters: {
+          fileId: id
+        }
       )
       log_response result
       raise Errors::ProxyError, "Error in add_parent(#{id}, #{parent_id}): #{result.data['error']['message']}" if result.error?
@@ -165,11 +160,9 @@ module GoogleApps
     end
 
     def remove_parent(id, parent_id)
-      client = get_google_api
-      drive_api = client.discovered_api('drive', 'v2')
-      result = client.execute(
-        :api_method => drive_api.parents.delete,
-        :parameters => {
+      result = google_api.execute(
+        api_method: drive_api.parents.delete,
+        parameters: {
           'fileId' => id,
           'parentId' => parent_id
         }
@@ -189,23 +182,23 @@ module GoogleApps
 
     private
 
-    def get_google_api
-      if @client.nil?
-        @client = GoogleApps::Client.client
+    def drive_api
+      @drive_api ||= google_api.discovered_api('drive', 'v2')
+    end
+
+    def google_api
+      @client ||= begin
         store = GoogleApps::CredentialStore.new(@app_id, @uid, @options)
         storage = Google::APIClient::Storage.new store
         auth = storage.authorize
-        if auth.nil? || (auth.expired? && auth.refresh_token.nil?)
-          logger.warn "OAuth2 object #{auth.nil? ? 'is nil' : 'is expired'}"
-          flow = Google::APIClient::InstalledAppFlow.new credentials
-          auth = flow.authorize storage
-        end
-        @client.authorization = auth
-        tokens = @client.authorization.fetch_access_token!
-        tokens.merge! refresh_token: @client.authorization.refresh_token
+        raise Errors::ProxyError, "Failed to refresh Google OAuth tokens (app_id: #{@app_id}; uid: #{@uid}" if auth.nil?
+        client = GoogleApps::Client.client
+        client.authorization = auth
+        tokens = client.authorization.fetch_access_token!
+        tokens.merge! refresh_token: client.authorization.refresh_token
         store.write_credentials tokens
+        client
       end
-      @client
     end
 
     def log_response(api_response)

--- a/app/models/google_apps/sheets_manager.rb
+++ b/app/models/google_apps/sheets_manager.rb
@@ -21,7 +21,7 @@ module GoogleApps
 
     def initialize(app_id, uid, opts={})
       super(app_id, uid, opts)
-      auth = get_google_api.authorization
+      auth = google_api.authorization
       # See https://github.com/gimite/google-drive-ruby
       @session = GoogleDrive::Session.login_with_oauth auth.access_token
     end
@@ -123,8 +123,6 @@ module GoogleApps
     end
 
     def upload_to_spreadsheet(sheets_doc_title, path_or_io, parent_id, worksheet_title = nil)
-      client = get_google_api
-      drive_api = client.discovered_api('drive', 'v2')
       media = Google::APIClient::UploadIO.new(path_or_io, 'text/csv')
       metadata = { :title => sheets_doc_title }
       file = drive_api.files.insert.request_schema.new metadata


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6499

Notes:
* read Jira above on `Google::APIClient::InstalledAppFlow` removal
* `google_api` and `drive_api` methods lazy-load API proxy (only one `discovered_api('drive', 'v2')` to maintain)
* `drive_manager_spec` no longer makes real Google API calls; it simply confirms our error handling and handling of multiple rows in Google response 
* hash syntax is cleaner
