### PR TITLE
SISRP-27492 - Advising Dashboard - Remove Academic Progress Link and What If Report Link

### DIFF
--- a/app/models/campus_solutions/advising_resources.rb
+++ b/app/models/campus_solutions/advising_resources.rb
@@ -44,7 +44,6 @@ module CampusSolutions
 
       advising_link_settings = [
         # advisors see these on advisor-specific views
-        { feed_key: :uc_academic_progress_report, cs_link_key: 'UC_CX_APR_RPT'},
         { feed_key: :uc_administrative_transcript, cs_link_key: 'UC_CX_ADM_TRANSCRIPT' },
         { feed_key: :uc_advising_assignments, cs_link_key: 'UC_CX_STUDENT_ADVISOR' },
         # hide this until after 7.2, thanks :)
@@ -56,8 +55,7 @@ module CampusSolutions
         { feed_key: :uc_multi_year_academic_planner_generic, cs_link_key: 'UC_CX_PLANNER_ADV' },
         { feed_key: :uc_reporting_center, cs_link_key: 'UC_CX_REPORTING_CENTER' },
         { feed_key: :uc_service_indicators, cs_link_key: 'UC_CX_SERVICE_IND_DATA' },
-        { feed_key: :uc_transfer_credit_report, cs_link_key: 'UC_CX_XFER_CREDIT_REPORT' },
-        { feed_key: :uc_what_if_reports, cs_link_key: 'UC_CX_WHIF_RPT'}
+        { feed_key: :uc_transfer_credit_report, cs_link_key: 'UC_CX_XFER_CREDIT_REPORT' }
       ]
 
       advising_link_settings.each do |setting|

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -496,7 +496,6 @@ features:
   course_manage_official_sections: false
   cs_academic_planner: false
   cs_academic_profile_prefers_legacy: true
-  cs_academic_progress_report: false
   cs_advising_links: false
   cs_advisor_student_lookup: false
   cs_billing: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -86,7 +86,6 @@ features:
   class_info_enrollment_tab: true
   course_manage_official_sections: true
   cs_academic_planner: true
-  cs_academic_progress_report: true
   cs_advisor_student_lookup: true
   cs_billing: true
   cs_committees: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -103,7 +103,6 @@ features:
   cal1card: true
   class_info_enrollment_tab: true
   cs_academic_planner: true
-  cs_academic_progress_report: true
   cs_advisor_student_lookup: true
   cs_billing: true
   cs_committees: true

--- a/config/settings/testext.yml
+++ b/config/settings/testext.yml
@@ -80,7 +80,6 @@ features:
   cal1card: true
   class_info_enrollment_tab: true
   cs_academic_planner: true
-  cs_academic_progress_report: true
   cs_advisor_student_lookup: true
   cs_billing: true
   cs_degree_progress_grad_advising: true

--- a/src/assets/templates/widgets/advisor/advising_links.html
+++ b/src/assets/templates/widgets/advisor/advising_links.html
@@ -53,18 +53,6 @@
         data-link="csLinks.ucAdministrativeTranscript"
       ></div>
     </li>
-    <li data-ng-if="api.user.profile.features.csAcademicProgressReport && links.ucAcademicProgressReport.url">
-      <div
-        data-cc-campus-solutions-link-item-directive
-        data-link="links.ucAcademicProgressReport"
-      ></div>
-    </li>
-    <li data-ng-if="csLinks.ucWhatIfReports.url">
-      <div
-        data-cc-campus-solutions-link-item-directive
-        data-link="csLinks.ucWhatIfReports"
-      ></div>
-    </li>
     <li data-ng-if="csLinks.ucTransferCreditReport.url">
       <div
         data-cc-campus-solutions-link-item-directive


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-27492

Succinct explanation from Liz (functional owner) so you don't have to dig through the JIRA:

> We will remove these two links from the Advising Resources card from the Advisor Dashboard for GL 7.2. Both links exist on the Student Overview Page > Personal Summary card and has a better experience as the EMPLID of the student is passed in they land exactly where they need to in Campus Solutions without having extra clicks and a page view that we were trying to avoid them having.

* QA PR to come upon merge.