### PR TITLE
SISRP-27641, User::StoredUsers: avoid destroy call on nil:NilClass

### DIFF
--- a/app/models/user/stored_users.rb
+++ b/app/models/user/stored_users.rb
@@ -4,8 +4,8 @@ module User
 
     def self.get(uid)
       users = {
-        :saved => [],
-        :recent => []
+        saved: [],
+        recent: []
       }
 
       uid_entries = get_stored_uid_entries(uid)
@@ -73,13 +73,13 @@ module User
     def self.delete_saved_uid(uid, uid_to_delete)
       user = get_user(uid)
       return error_response("Could not find user #{uid}.") unless user
-      delete(user.saved_uids, uid, uid_to_delete)
+      delete(user.saved_uids, uid_to_delete)
     end
 
     def self.delete_recent_uid(uid, uid_to_delete)
       user = get_user(uid)
       return error_response("Could not find user #{uid}.") unless user
-      delete(user.recent_uids, uid, uid_to_delete)
+      delete(user.recent_uids, uid_to_delete)
     end
 
     def self.delete_all_recent(uid)
@@ -98,8 +98,8 @@ module User
 
     def self.get_stored_uid_entries(uid)
       stored_entries = {
-        :saved => [],
-        :recent => []
+        saved: [],
+        recent: []
       }
       user = get_user(uid)
       if user
@@ -110,18 +110,17 @@ module User
     end
 
     def self.store(model, uid, uid_to_store)
-      if (model.where(:stored_uid => uid_to_store.to_s).size == 0)
-        model.create(:stored_uid => uid_to_store.to_s)
+      if model.where(stored_uid: uid_to_store.to_s).size == 0
+        model.create(stored_uid: uid_to_store.to_s)
         success_response
       else
         error_response("UID #{uid_to_store} is already stored.")
       end
     end
 
-    def self.delete(model, uid, uid_to_delete)
-      found = model.where(:stored_uid => uid_to_delete.to_s)
-      if (found.size > 0)
-        found.first.destroy
+    def self.delete(model, uid_to_delete)
+      if (found = model.find_by stored_uid: uid_to_delete.to_s)
+        found.destroy
       end
       success_response
     end
@@ -133,20 +132,20 @@ module User
 
     def self.get_user(uid)
       use_pooled_connection {
-        User::Data.where(:uid => uid.to_s).first
+        User::Data.where(uid: uid.to_s).first
       }
     end
 
     def self.success_response
       {
-        :success => true
+        success: true
       }
     end
 
     def self.error_response(msg)
       {
-        :success => false,
-        :message => msg.to_s
+        success: false,
+        message: msg.to_s
       }
     end
 

--- a/spec/models/user/stored_users_spec.rb
+++ b/spec/models/user/stored_users_spec.rb
@@ -7,34 +7,34 @@ describe User::StoredUsers do
 
   let(:success_response) do
     {
-      :success => true
+      success: true
     }
   end
 
   let(:already_stored_error) do
     {
-      :success => false,
-      :message => "UID #{uid_to_store} is already stored."
+      success: false,
+      message: "UID #{uid_to_store} is already stored."
     }
   end
 
   let(:not_found_error) do
     {
-      :success => false,
-      :message => "Could not find user #{owner_uid}."
+      success: false,
+      message: "Could not find user #{owner_uid}."
     }
   end
 
   let(:fake_stored_uid_entries) do
     {
-      :saved => [
+      saved: [
         {
-          :stored_uid => stored_uid
+          stored_uid: stored_uid
         }
       ],
-      :recent => [
+      recent: [
         {
-          :stored_uid => stored_uid
+          stored_uid: stored_uid
         }
       ]
     }
@@ -43,31 +43,30 @@ describe User::StoredUsers do
   let(:fake_ldap_user) do
     [
       {
-        :ldap_uid => stored_uid
+        ldap_uid: stored_uid
       }
     ]
   end
 
   describe '#get' do
-
     it 'should return list of users stored by the current user' do
       stub_model = double
       saved_uids_stub = double
       recent_uids_stub = double
 
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(stub_model)
-      stub_model.should_receive(:saved_uids).and_return(saved_uids_stub)
-      stub_model.should_receive(:recent_uids).and_return(recent_uids_stub)
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return stub_model
+      stub_model.should_receive(:saved_uids).and_return saved_uids_stub
+      stub_model.should_receive(:recent_uids).and_return recent_uids_stub
 
-      saved_uids_stub.should_receive(:order).with(:created_at).and_return(saved_uids_stub)
-      saved_uids_stub.should_receive(:reverse_order).and_return(fake_stored_uid_entries[:saved])
+      saved_uids_stub.should_receive(:order).with(:created_at).and_return saved_uids_stub
+      saved_uids_stub.should_receive(:reverse_order).and_return fake_stored_uid_entries[:saved]
 
-      recent_uids_stub.should_receive(:order).with(:created_at).and_return(recent_uids_stub)
-      recent_uids_stub.should_receive(:reverse_order).and_return(fake_stored_uid_entries[:recent])
+      recent_uids_stub.should_receive(:order).with(:created_at).and_return recent_uids_stub
+      recent_uids_stub.should_receive(:reverse_order).and_return fake_stored_uid_entries[:recent]
 
-      User::BasicAttributes.should_receive(:attributes_for_uids).with([stored_uid, stored_uid]).and_return(fake_ldap_user)
+      User::BasicAttributes.should_receive(:attributes_for_uids).with([stored_uid, stored_uid]).and_return fake_ldap_user
 
-      users = User::StoredUsers.get(owner_uid)
+      users = User::StoredUsers.get owner_uid
 
       expect(users[:saved][0][:ldapUid]).to eq stored_uid
       expect(users[:recent][0][:ldapUid]).to eq stored_uid
@@ -76,38 +75,42 @@ describe User::StoredUsers do
     it 'should report whether recent uids are saved' do
       saved_uid = random_id
       unsaved_uid = random_id
-      User::Data.create(uid: owner_uid)
-      User::Data.create(uid: saved_uid)
-      User::Data.create(uid: unsaved_uid)
-      allow_any_instance_of(User::BasicAttributes).to receive(:attributes_for_uids).
-          and_return [{:ldap_uid => owner_uid}, {:ldap_uid => saved_uid}, {:ldap_uid => unsaved_uid}]
+      User::Data.create uid: owner_uid
+      User::Data.create uid: saved_uid
+      User::Data.create uid: unsaved_uid
+      attributes = [
+        {ldap_uid: owner_uid},
+        {ldap_uid: saved_uid},
+        {ldap_uid: unsaved_uid}
+      ]
+      allow_any_instance_of(User::BasicAttributes).to receive(:attributes_for_uids).and_return attributes
 
       User::StoredUsers.store_saved_uid(owner_uid, saved_uid)
       User::StoredUsers.store_recent_uid(owner_uid, saved_uid)
       User::StoredUsers.store_recent_uid(owner_uid, unsaved_uid)
 
-      users = User::StoredUsers.get(owner_uid)
-      expect(users[:recent].find {|u| u[:ldapUid] == saved_uid}).to include(saved: true)
-      expect(users[:recent].find {|u| u[:ldapUid] == unsaved_uid}).to include(saved: false)
+      users = User::StoredUsers.get owner_uid
+      saved = users[:recent].find { |u| u[:ldapUid] == saved_uid }
+      recent = users[:recent].find { |u| u[:ldapUid] == unsaved_uid }
+      expect(saved).to include saved: true
+      expect(recent).to include saved: false
     end
-
   end
 
   describe '#store_saved_uid' do
-
     it 'should store uid successfully if uid is not already stored and current user exists' do
       stub_model = double
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(stub_model)
-      stub_model.should_receive(:saved_uids).and_return(stub_model)
-      stub_model.should_receive(:where).with({ :stored_uid => uid_to_store }).and_return([])
-      stub_model.should_receive(:create).with({ :stored_uid => uid_to_store })
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return stub_model
+      stub_model.should_receive(:saved_uids).and_return stub_model
+      stub_model.should_receive(:where).with({ stored_uid: uid_to_store }).and_return []
+      stub_model.should_receive(:create).with({ stored_uid: uid_to_store })
 
       response = User::StoredUsers.store_saved_uid(owner_uid, uid_to_store)
       expect(response).to eq success_response
     end
 
     it 'should return error if owner_uid does not exist' do
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(nil)
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return nil
 
       response = User::StoredUsers.store_saved_uid(owner_uid, uid_to_store)
       expect(response).to eq not_found_error
@@ -115,24 +118,22 @@ describe User::StoredUsers do
 
     it 'should return error if uid_to_store is already stored' do
       stub_model = double
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(stub_model)
-      stub_model.should_receive(:saved_uids).and_return(stub_model)
-      stub_model.should_receive(:where).with({ :stored_uid => uid_to_store }).and_return([1, 2])
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return stub_model
+      stub_model.should_receive(:saved_uids).and_return stub_model
+      stub_model.should_receive(:where).with({ stored_uid: uid_to_store }).and_return [1, 2]
 
       response = User::StoredUsers.store_saved_uid(owner_uid, uid_to_store)
       expect(response).to eq already_stored_error
     end
-
   end
 
   describe '#store_recent_uid' do
-
     it 'should store uid successfully if uid is not already stored and current user exists' do
       stub_model = double
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(stub_model)
-      stub_model.should_receive(:recent_uids).and_return(stub_model)
-      stub_model.should_receive(:where).with({ :stored_uid => uid_to_store }).and_return([])
-      stub_model.should_receive(:create).with({ :stored_uid => uid_to_store })
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return stub_model
+      stub_model.should_receive(:recent_uids).and_return stub_model
+      stub_model.should_receive(:where).with({ stored_uid: uid_to_store }).and_return []
+      stub_model.should_receive(:create).with({ stored_uid: uid_to_store })
 
       response = User::StoredUsers.store_recent_uid(owner_uid, uid_to_store)
       expect(response).to eq success_response
@@ -158,7 +159,7 @@ describe User::StoredUsers do
     end
 
     it 'should return error if owner_uid does not exist' do
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(nil)
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return nil
 
       response = User::StoredUsers.store_recent_uid(owner_uid, uid_to_store)
       expect(response).to eq not_found_error
@@ -166,26 +167,22 @@ describe User::StoredUsers do
 
     it 'should return error if uid_to_store is already stored' do
       stub_model = double
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(stub_model)
-      stub_model.should_receive(:recent_uids).and_return(stub_model)
-      stub_model.should_receive(:where).with({ :stored_uid => uid_to_store }).and_return([1, 2])
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return stub_model
+      stub_model.should_receive(:recent_uids).and_return stub_model
+      stub_model.should_receive(:where).with({ stored_uid: uid_to_store }).and_return [1, 2]
 
       response = User::StoredUsers.store_recent_uid(owner_uid, uid_to_store)
       expect(response).to eq already_stored_error
     end
-
   end
 
   describe '#delete_saved_uid' do
-
     it 'should delete uid successfully' do
       stub_model = double
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(stub_model)
-      stub_model.should_receive(:saved_uids).and_return(stub_model)
-      stub_model.should_receive(:where).with({ :stored_uid => uid_to_delete }).and_return(stub_model)
-      stub_model.should_receive(:size).and_return(1)
-      stub_model.should_receive(:first).and_return(stub_model)
-      stub_model.should_receive(:destroy)
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return stub_model
+      stub_model.should_receive(:saved_uids).and_return stub_model
+      stub_model.should_receive(:find_by).with(stored_uid: uid_to_delete).and_return stub_model
+      stub_model.should_receive :destroy
 
       response = User::StoredUsers.delete_saved_uid(owner_uid, uid_to_delete)
       expect(response).to eq success_response
@@ -193,34 +190,29 @@ describe User::StoredUsers do
 
     it 'should still return success if uid_to_delete is already absent' do
       stub_model = double
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(stub_model)
-      stub_model.should_receive(:saved_uids).and_return(stub_model)
-      stub_model.should_receive(:where).with({ :stored_uid => uid_to_delete }).and_return(stub_model)
-      stub_model.should_receive(:size).and_return(0)
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return stub_model
+      stub_model.should_receive(:saved_uids).and_return stub_model
+      stub_model.should_receive(:find_by).with(stored_uid: uid_to_delete).and_return nil
 
       response = User::StoredUsers.delete_saved_uid(owner_uid, uid_to_delete)
       expect(response).to eq success_response
     end
 
     it 'should return error if owner_uid does not exist' do
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(nil)
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return nil
 
       response = User::StoredUsers.delete_saved_uid(owner_uid, uid_to_delete)
       expect(response).to eq not_found_error
     end
-
   end
 
   describe '#delete_recent_uid' do
-
     it 'should delete uid successfully' do
       stub_model = double
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(stub_model)
-      stub_model.should_receive(:recent_uids).and_return(stub_model)
-      stub_model.should_receive(:where).with({ :stored_uid => uid_to_delete }).and_return(stub_model)
-      stub_model.should_receive(:size).and_return(1)
-      stub_model.should_receive(:first).and_return(stub_model)
-      stub_model.should_receive(:destroy)
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return stub_model
+      stub_model.should_receive(:recent_uids).and_return stub_model
+      stub_model.should_receive(:find_by).with(stored_uid: uid_to_delete).and_return stub_model
+      stub_model.should_receive :destroy
 
       response = User::StoredUsers.delete_recent_uid(owner_uid, uid_to_delete)
       expect(response).to eq success_response
@@ -228,65 +220,58 @@ describe User::StoredUsers do
 
     it 'should still return success if uid_to_delete is already absent' do
       stub_model = double
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(stub_model)
-      stub_model.should_receive(:recent_uids).and_return(stub_model)
-      stub_model.should_receive(:where).with({ :stored_uid => uid_to_delete }).and_return(stub_model)
-      stub_model.should_receive(:size).and_return(0)
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return stub_model
+      stub_model.should_receive(:recent_uids).and_return stub_model
+      stub_model.should_receive(:find_by).with(stored_uid: uid_to_delete).and_return nil
 
       response = User::StoredUsers.delete_recent_uid(owner_uid, uid_to_delete)
       expect(response).to eq success_response
     end
 
     it 'should return error if owner_uid does not exist' do
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(nil)
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return nil
 
       response = User::StoredUsers.delete_recent_uid(owner_uid, uid_to_delete)
       expect(response).to eq not_found_error
     end
-
   end
 
   describe '#delete_all_recent' do
-
     it 'should delete recent uids successfully' do
       stub_model = double
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(stub_model)
-      stub_model.should_receive(:recent_uids).and_return(stub_model)
-      stub_model.should_receive(:destroy_all)
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return stub_model
+      stub_model.should_receive(:recent_uids).and_return stub_model
+      stub_model.should_receive :destroy_all
 
-      response = User::StoredUsers.delete_all_recent(owner_uid)
+      response = User::StoredUsers.delete_all_recent owner_uid
       expect(response).to eq success_response
     end
 
     it 'should return error if owner_uid does not exist' do
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(nil)
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return nil
 
-      response = User::StoredUsers.delete_all_recent(owner_uid)
+      response = User::StoredUsers.delete_all_recent owner_uid
       expect(response).to eq not_found_error
     end
-
   end
 
-
   describe '#delete_all_saved' do
-
     it 'should delete saved uids successfully' do
       stub_model = double
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(stub_model)
-      stub_model.should_receive(:saved_uids).and_return(stub_model)
-      stub_model.should_receive(:destroy_all)
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return stub_model
+      stub_model.should_receive(:saved_uids).and_return stub_model
+      stub_model.should_receive :destroy_all
 
-      response = User::StoredUsers.delete_all_saved(owner_uid)
+      response = User::StoredUsers.delete_all_saved owner_uid
       expect(response).to eq success_response
     end
 
     it 'should return error if owner_uid does not exist' do
-      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return(nil)
+      User::StoredUsers.should_receive(:get_user).with(owner_uid).and_return nil
 
-      response = User::StoredUsers.delete_all_saved(owner_uid)
+      response = User::StoredUsers.delete_all_saved owner_uid
       expect(response).to eq not_found_error
     end
-
   end
 
 end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-27641

Oddly, we had `found.size > 0` and `found.first` nil. Race condition? This change _should_ avoid recurrence.