### PR TITLE
CLC-6489, OEC-related testext uses Bamboo-only refresh_token

### DIFF
--- a/config/settings/testext.yml
+++ b/config/settings/testext.yml
@@ -60,6 +60,18 @@ cache:
 calnet_crosswalk_proxy:
   fake: true
 
+# Bamboo (testext) only:
+# - OEC-related spec relies on oec.google.testext.refresh_token
+# - UID is arbitrary
+# - See google_proxy configs on Bamboo for guidance
+oec:
+  google:
+    uid: '1'
+    client_id: ''
+    client_secret: ''
+    testext:
+      refresh_token: ''
+
 features:
   advising: true
   advising_student_success: true

--- a/spec/models/google_apps/credential_store_spec.rb
+++ b/spec/models/google_apps/credential_store_spec.rb
@@ -3,8 +3,8 @@ describe GoogleApps::CredentialStore do
   let(:app_id) { GoogleApps::Proxy::APP_ID }
   let(:uid) { random_id }
   let(:settings) { GoogleApps::CredentialStore.settings_of app_id }
-  let(:access_token) { random_string(10) }
-  let(:refresh_token) { random_string(10) }
+  let(:access_token) { random_string 10 }
+  let(:refresh_token) { random_string 10 }
   let(:oauth2_tokens) {
     {
       access_token: access_token,
@@ -88,32 +88,6 @@ describe GoogleApps::CredentialStore do
           expect{ store.write_credentials({}) }.to raise_error
         end
       end
-    end
-  end
-
-  context '#real', testext: true, order: :defined do
-    let(:options) { oauth2_tokens.merge issued_at: 1440628381, expires_in: 3600, app_data: 'johndoe@berkeley.edu' }
-
-    before do
-      existing_data = User::Oauth2Data.get(uid, app_id)
-      raise 'The random and very large id matches real data. Abort!' if existing_data.any?
-      # Values in options hash will be written to the database
-      GoogleApps::CredentialStore.new(app_id, uid).write_credentials options
-    end
-
-    after do
-      User::Oauth2Data.remove(uid, app_id)
-    end
-
-    it 'should load credentials written by Store' do
-      c = GoogleApps::CredentialStore.new(app_id, uid).load_credentials
-      expect(c).to_not be_nil
-      expect(c[:access_token]).to eq options[:access_token]
-      expect(c[:refresh_token]).to eq options[:refresh_token]
-      expect(c[:expires_in]).to eq 3600
-      expect(c[:client_id]).to eq settings[:client_id]
-      expect(c[:client_secret]).to eq settings[:client_secret]
-      expect(c[:scope]).to eq settings[:scope]
     end
   end
 end

--- a/spec/models/google_apps/sheets_manager_spec.rb
+++ b/spec/models/google_apps/sheets_manager_spec.rb
@@ -1,84 +1,99 @@
 describe GoogleApps::SheetsManager do
 
   context '#real', testext: true, order: :defined do
-
     before(:all) do
-      settings = Settings.oec.google.marshal_dump
-      @sheet_manager = GoogleApps::SheetsManager.new(GoogleApps::Proxy::OEC_APP_ID, settings[:uid], settings)
-      now = DateTime.now.strftime('%m/%d/%Y at %I:%M%p')
-      @folder = @sheet_manager.create_folder "#{GoogleApps::SheetsManager.name} test, #{now}"
+      # Google OAuth2
+      @app_id = GoogleApps::Proxy::OEC_APP_ID
+      @uid = Settings.oec.google.uid
+      refresh_token = Settings.oec.google.testext.refresh_token
+      raise ArgumentError, 'testext.local.yml is missing config: oec.google.testext.refresh_token' if refresh_token.blank?
+      GoogleApps::CredentialStore.new(@app_id, @uid).write('expired-access-token', refresh_token)
+
+      # Aw sheets!
+      now = DateTime.now.strftime '%m/%d/%Y at %I:%M%p'
+      @sheets = GoogleApps::SheetsManager.new(@app_id, @uid)
+      @folder = @sheets.create_folder "#{GoogleApps::SheetsManager.name} test, #{now}"
       @spreadsheet_title = "Sheet from CSV, #{now}"
       @worksheet_title = "Primary worksheet, #{now}"
       # No CSV files will be created by this test
       @sis_import_sheet = Oec::SisImportSheet.new(dept_code: 'LPSPP')
-      course_codes = [Oec::CourseCode.new(dept_name: 'SPANISH', catalog_id: '', dept_code: 'LPSPP', include_in_oec: true)]
-      Oec::SisImportTask.new(:term_code => '2014-C').import_courses(@sis_import_sheet, course_codes)
-      @spreadsheet = @sheet_manager.upload_to_spreadsheet(@spreadsheet_title, @sis_import_sheet.to_io, @folder.id, @worksheet_title)
+      course_codes = [
+        Oec::CourseCode.new(
+          dept_name: 'SPANISH',
+          catalog_id: '',
+          dept_code: 'LPSPP',
+          include_in_oec: true)
+      ]
+      Oec::SisImportTask.new(term_code: '2014-C').import_courses(@sis_import_sheet, course_codes)
+      @spreadsheet = @sheets.upload_to_spreadsheet(@spreadsheet_title, @sis_import_sheet.to_io, @folder.id, @worksheet_title)
     end
 
     after(:all) do
-      @sheet_manager.trash_item(@folder, permanently_delete: true) if @folder
+      @sheets.trash_item(@folder, permanently_delete: true) if @folder
+      User::Oauth2Data.where(app_id: @app_id, uid: @uid).delete_all
     end
 
-    it 'should upload csv to spreadsheet in target folder' do
-      expect(@spreadsheet).to_not be_nil
-    end
-
-    it 'should get spreadsheet by id' do
-      sheet_by_id = @sheet_manager.spreadsheet_by_id @spreadsheet.id
-      expect(sheet_by_id).to_not be nil
-      spreadsheets = @sheet_manager.spreadsheets_by_title @spreadsheet_title
-      expect(spreadsheets).to have(1).item
-      sheet_by_title = spreadsheets[0]
-      expect(sheet_by_title).to_not be nil
-      # Arbitrary comparison
-      expect(sheet_by_id.worksheets[0][2, 2]).to eq sheet_by_title.worksheets[0][2, 2]
-    end
-
-    it 'should output the same CSV values that were put in' do
-      spreadsheet_file = @sheet_manager.find_items(parent_id: @folder.id).first
-      csv_export = @sheet_manager.export_csv spreadsheet_file
-      parsed_csv = CSV.parse csv_export
-      expect(parsed_csv[0]).to eq @sis_import_sheet.headers
-      @sis_import_sheet.each_sorted_with_index do |row, i|
-        expect(parsed_csv[i+1][0]).to eq row['COURSE_ID']
-        expect(parsed_csv[i+1][@sis_import_sheet.headers.index('EVALUATION_TYPE')]).to eq row['EVALUATION_TYPE']
+    context 'spreadsheets' do
+      it 'should upload csv to spreadsheet in target folder' do
+        expect(@spreadsheet).to_not be_nil
       end
-    end
 
-    it 'should update cells in batch' do
-      spreadsheet_file = @sheet_manager.find_items(parent_id: @folder.id).first
-      worksheet = @sheet_manager.spreadsheet_by_id(@spreadsheet.id).worksheets.first
-      @sheet_manager.update_worksheet(worksheet, {
-        [2, 2] => 'Kilroy',
-        [2, 3] => 'was',
-        [4, 4] => 'here'
-      })
-      csv_export = @sheet_manager.export_csv spreadsheet_file
-      parsed_csv = CSV.parse csv_export
-      # The CSV export is indexed from zero, but the Sheets API is indexed from one.
-      expect(parsed_csv[1][1]).to eq 'Kilroy'
-      expect(parsed_csv[1][2]).to eq 'was'
-      expect(parsed_csv[3][3]).to eq 'here'
-      # Other cells are unmodified.
-      @sis_import_sheet.each_sorted_with_index do |row, i|
-        expect(parsed_csv[i+1][0]).to eq row['COURSE_ID']
+      it 'should get spreadsheet by id' do
+        sheet_by_id = @sheets.spreadsheet_by_id @spreadsheet.id
+        expect(sheet_by_id).to_not be nil
+        spreadsheets = @sheets.spreadsheets_by_title @spreadsheet_title
+        expect(spreadsheets).to have(1).item
+        sheet_by_title = spreadsheets[0]
+        expect(sheet_by_title).to_not be nil
+        # Arbitrary comparison
+        expect(sheet_by_id.worksheets[0][2, 2]).to eq sheet_by_title.worksheets[0][2, 2]
       end
-    end
 
-    it 'should have named the worksheet as well as the Sheets file' do
-      worksheet = @sheet_manager.spreadsheet_by_id(@spreadsheet.id).worksheets.first
-      expect(worksheet.title).to eq @worksheet_title
-    end
+      it 'should output the same CSV values that were put in' do
+        spreadsheet_file = @sheets.find_items(parent_id: @folder.id).first
+        csv_export = @sheets.export_csv spreadsheet_file
+        parsed_csv = CSV.parse csv_export
+        expect(parsed_csv[0]).to eq @sis_import_sheet.headers
+        @sis_import_sheet.each_sorted_with_index do |row, i|
+          expect(parsed_csv[i+1][0]).to eq row['COURSE_ID']
+          expect(parsed_csv[i+1][@sis_import_sheet.headers.index('EVALUATION_TYPE')]).to eq row['EVALUATION_TYPE']
+        end
+      end
 
-    it 'should find no spreadsheet mapped to bogus id' do
-      sheet_by_id = @sheet_manager.spreadsheet_by_id 'bogus-id'
-      expect(sheet_by_id).to be_nil
-    end
+      it 'should update cells in batch' do
+        spreadsheet_file = @sheets.find_items(parent_id: @folder.id).first
+        worksheet = @sheets.spreadsheet_by_id(@spreadsheet.id).worksheets.first
+        @sheets.update_worksheet(worksheet, {
+          [2, 2] => 'Kilroy',
+          [2, 3] => 'was',
+          [4, 4] => 'here'
+        })
+        csv_export = @sheets.export_csv spreadsheet_file
+        parsed_csv = CSV.parse csv_export
+        # The CSV export is indexed from zero, but the Sheets API is indexed from one.
+        expect(parsed_csv[1][1]).to eq 'Kilroy'
+        expect(parsed_csv[1][2]).to eq 'was'
+        expect(parsed_csv[3][3]).to eq 'here'
+        # Other cells are unmodified.
+        @sis_import_sheet.each_sorted_with_index do |row, i|
+          expect(parsed_csv[i+1][0]).to eq row['COURSE_ID']
+        end
+      end
 
-    it 'should find no spreadsheets with bogus title' do
-      spreadsheets = @sheet_manager.spreadsheets_by_title 'let us hope that no spreadsheets have this ridiculous name'
-      expect(spreadsheets).to be_empty
+      it 'should have named the worksheet as well as the Sheets file' do
+        worksheet = @sheets.spreadsheet_by_id(@spreadsheet.id).worksheets.first
+        expect(worksheet.title).to eq @worksheet_title
+      end
+
+      it 'should find no spreadsheet mapped to bogus id' do
+        sheet_by_id = @sheets.spreadsheet_by_id 'bogus-id'
+        expect(sheet_by_id).to be_nil
+      end
+
+      it 'should find no spreadsheets with bogus title' do
+        spreadsheets = @sheets.spreadsheets_by_title 'let us hope that no spreadsheets have this ridiculous name'
+        expect(spreadsheets).to be_empty
+      end
     end
 
   end

--- a/spec/models/oec/remote_drive_spec.rb
+++ b/spec/models/oec/remote_drive_spec.rb
@@ -6,6 +6,13 @@ describe Oec::RemoteDrive do
   let(:now) { DateTime.now }
 
   context '#real', testext: true, :order => :defined do
+    before(:all) do
+      # Google OAuth2
+      refresh_token = Settings.oec.google.testext.refresh_token
+      raise ArgumentError, 'testext.local.yml is missing config: oec.google.testext.refresh_token' if refresh_token.blank?
+      store = GoogleApps::CredentialStore.new(GoogleApps::Proxy::OEC_APP_ID, Settings.oec.google.uid)
+      store.write('expired-access-token', refresh_token)
+    end
 
     context 'find no match' do
       it 'should return nil when term not found' do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6489

Notes:
* The #real test in `credential_store_spec` was of little value; it is gone.
* But, the #realness of `sheets_manager_spec` and `remote_drive_spec` is valuable. I followed the pattern of `google_proxy` configs on Bamboo and add new setting: `oec.google. testext.refresh_token`

I updated `testext.local.yml` on Bamboo (docker), ran a personal build and it's green: https://bamboo.ets.berkeley.edu/bamboo/browse/CPB-CJT86-4
