### PR TITLE
CLC-6475, JVM - during sync-canvas-new-users script - gets large Max Heap Size

### DIFF
--- a/script/sync-canvas-new-users.sh
+++ b/script/sync-canvas-new-users.sh
@@ -3,26 +3,26 @@
 
 # Make sure the normal shell environment is in place, since it may not be
 # when running as a cron job.
-source "$HOME/.bash_profile"
+source "${HOME}/.bash_profile"
 
 cd $( dirname "${BASH_SOURCE[0]}" )/..
 
-LOG=`date +"$PWD/log/canvas_new_user_sync_%Y-%m-%d.log"`
+LOG=$(date +"$PWD/log/canvas_new_user_sync_%Y-%m-%d.log")
 LOGIT="tee -a $LOG"
 
 # Enable rvm and use the correct Ruby version and gem set.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
+[[ -s "${HOME}/.rvm/scripts/rvm" ]] && . "${HOME}/.rvm/scripts/rvm"
 source .rvmrc
 
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="--dev"
+export JRUBY_OPTS="--dev -J-Xmn512m -J-Xms2048m -J-Xmx2048m -J-XX:+HeapDumpOnOutOfMemoryError"
 
-echo | $LOGIT
-echo "------------------------------------------" | $LOGIT
-echo "`date`: About to run the new campus user sync script..." | $LOGIT
+echo | ${LOGIT}
+echo "------------------------------------------" | ${LOGIT}
+echo "$(date): About to run the new campus user sync script..." | ${LOGIT}
 
 cd deploy
 
-bundle exec rake canvas:new_user_sync | $LOGIT
+bundle exec rake canvas:new_user_sync | ${LOGIT}


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6475

2GB max heap size; HeapDumpOnOutOfMemoryError enabled.

@dkawase says that the script crashed in prod (again) last night so I'll propose a QA PR when this is merged.  @raydavis should chime in.

According to recent [Stack Overflow post](http://stackoverflow.com/questions/35930340/xxheapdumponoutofmemoryerror-max-file-size-limit), "there is no overhead in running with [the HeapDumpOnOutOfMemoryError] option".
