### PR TITLE
CLC-6505, Canvas data refresh must handle nil from Canvas::Report::Sections.get_csv

### DIFF
--- a/app/models/canvas_csv/refresh_all_campus_data.rb
+++ b/app/models/canvas_csv/refresh_all_campus_data.rb
@@ -52,7 +52,7 @@ module CanvasCsv
 
     def refresh_existing_term_sections(term, enrollments_csv, known_users, users_csv, cached_enrollments_provider, sis_user_id_changes)
       canvas_sections_csv = Canvas::Report::Sections.new.get_csv(term)
-      return if canvas_sections_csv.empty?
+      return if canvas_sections_csv.nil? || canvas_sections_csv.empty?
       # Instructure doesn't guarantee anything about sections-CSV ordering, but we need to group sections
       # together by course site.
       course_id_to_csv_rows = canvas_sections_csv.group_by {|row| row['course_id']}

--- a/app/models/canvas_csv/term_enrollments.rb
+++ b/app/models/canvas_csv/term_enrollments.rb
@@ -45,7 +45,7 @@ module CanvasCsv
     # Populates the enrollments CSV for the specified term
     def populate_term_csv_file(term, enrollments_csv)
       canvas_sections_csv = Canvas::Report::Sections.new.get_csv(term)
-      return if canvas_sections_csv.empty?
+      return if canvas_sections_csv.nil? || canvas_sections_csv.empty?
       canvas_section_ids = canvas_sections_csv.collect { |row| row['canvas_section_id'] }
       canvas_section_ids.each do |canvas_section_id|
         canvas_section_enrollments = Canvas::SectionEnrollments.new(section_id: canvas_section_id).list_enrollments

--- a/spec/models/canvas_csv/refresh_all_campus_data_spec.rb
+++ b/spec/models/canvas_csv/refresh_all_campus_data_spec.rb
@@ -91,9 +91,18 @@ describe CanvasCsv::RefreshAllCampusData do
       end
 
       context 'when canvas sections csv is empty' do
-        before { allow_any_instance_of(Canvas::Report::Sections).to receive(:get_csv).and_return(empty_sections_report_csv) }
-        it 'does not perform any processing' do
-          expect(CanvasCsv::SiteMembershipsMaintainer).to_not receive(:process)
+        before { allow_any_instance_of(Canvas::Report::Sections).to receive(:get_csv).and_return csv }
+        context 'empty' do
+          let(:csv) { empty_sections_report_csv }
+          it 'does not perform any processing' do
+            expect(CanvasCsv::SiteMembershipsMaintainer).to_not receive(:process)
+          end
+        end
+        context 'nil' do
+          let(:csv) { nil }
+          it 'does not perform any processing' do
+            expect(CanvasCsv::SiteMembershipsMaintainer).to_not receive(:process)
+          end
         end
       end
     end

--- a/spec/models/canvas_csv/term_enrollments_spec.rb
+++ b/spec/models/canvas_csv/term_enrollments_spec.rb
@@ -185,12 +185,25 @@ describe CanvasCsv::TermEnrollments do
   end
 
   describe '#populate_term_csv_file' do
+    let(:path_to_csv) { "#{export_dir}/canvas-#{today}-TERM_2014-D-term-enrollments-export.csv" }
     context 'when sections report is empty' do
-      before { allow_any_instance_of(Canvas::Report::Sections).to receive(:get_csv).and_return(empty_sections_report_csv) }
-      it 'should escape execution' do
-        enrollments_csv = subject.make_enrollment_export_csv("#{export_dir}/canvas-#{today}-TERM_2014-D-term-enrollments-export.csv")
+      before do
+        allow(Canvas::Report::Sections).to receive(:get_csv).and_return csv
         expect_any_instance_of(Canvas::SectionEnrollments).to_not receive(:new)
-        subject.populate_term_csv_file(current_sis_term_ids[0], enrollments_csv)
+      end
+      context 'empty' do
+        let(:csv) { empty_sections_report_csv }
+        it 'should escape execution' do
+          enrollments_csv = subject.make_enrollment_export_csv path_to_csv
+          subject.populate_term_csv_file(current_sis_term_ids[0], enrollments_csv)
+        end
+      end
+      context 'nil' do
+        let(:csv) { nil }
+        it 'should escape execution' do
+          enrollments_csv = subject.make_enrollment_export_csv path_to_csv
+          subject.populate_term_csv_file(current_sis_term_ids[0], enrollments_csv)
+        end
       end
     end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6505

Steven is contacting Instructure about `ErrorReport:140435606` (as seen in JIRA above). Regardless of what we learn, protecting ourselves from `nil` is a good thing. 