### PR TITLE
SISRP-25637 SISRP-27636 Update term transition logic in Academics Profile & Status

### DIFF
--- a/src/assets/javascripts/angular/controllers/pages/academicsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicsController.js
@@ -164,9 +164,6 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
     $scope.isLSStudent = academicsService.isLSStudent($scope.collegeAndLevel);
     $scope.isUndergraduate = _.includes(_.get($scope.collegeAndLevel, 'careers'), 'Undergraduate');
     $scope.isProfileCurrent = !$scope.transitionTerm || $scope.transitionTerm.isProfileCurrent;
-    // The isEmpty check will be true if collegeAndLevel.errored or collegeAndLevel.empty.
-    $scope.showProfileMessage = (!$scope.isProfileCurrent || !$scope.collegeAndLevel || _.isEmpty($scope.collegeAndLevel.careers));
-
     $scope.hasTeachingClasses = academicsService.hasTeachingClasses(data.teachingSemesters);
 
     // Get selected semester from URL params and extract data from semesters array
@@ -196,6 +193,7 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
                                  ($scope.numberOfHolds));
     $scope.showLegacyAdvising = !$scope.filteredForDelegate && $scope.api.user.profile.features.legacyAdvising && $scope.isLSStudent;
     $scope.showAdvising = !$scope.filteredForDelegate && apiService.user.profile.features.advising && apiService.user.profile.roles.student && isMbaJdOrNotLaw();
+    $scope.showProfileMessage = (!$scope.isAcademicInfoAvailable || !$scope.collegeAndLevel || _.isEmpty($scope.collegeAndLevel.careers));
 
     if (userService.profile.roles.law) {
       $scope.requestTranscript = {

--- a/src/assets/javascripts/angular/controllers/widgets/academicsStatusHoldsBlocksController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/academicsStatusHoldsBlocksController.js
@@ -96,6 +96,7 @@ angular.module('calcentral.controllers').controller('AcademicsStatusHoldsBlocksC
     });
 
     statusHoldsService.matchTermIndicators($scope.regStatus.positiveIndicators, $scope.regStatus.registrations);
+    $scope.hasShownRegistrations = statusHoldsService.checkShownRegistrations($scope.regStatus.registrations);
   };
 
   var getMessages = function() {

--- a/src/assets/javascripts/angular/controllers/widgets/statusController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/statusController.js
@@ -115,7 +115,7 @@ angular.module('calcentral.controllers').controller('StatusController', function
 
   var parseRegistrationCounts = function() {
     _.forEach($scope.regStatus.registrations, function(registration) {
-      if (registration.isSummer || !registration.positiveIndicators.S09 || registration.academicCareer.code === 'UCBX') {
+      if (!registration.isShown) {
         return;
       }
       // Count for registration status
@@ -221,6 +221,7 @@ angular.module('calcentral.controllers').controller('StatusController', function
       // Make sure to hide the spinner when everything is loaded
       $q.all(statusGets).then(function() {
         statusHoldsService.matchTermIndicators($scope.regStatus.positiveIndicators, $scope.regStatus.registrations);
+        statusHoldsService.checkShownRegistrations($scope.regStatus.registrations);
         parseRegistrationCounts();
         if (includeFinancial) {
           parseFinances();

--- a/src/assets/javascripts/angular/services/statusHoldsService.js
+++ b/src/assets/javascripts/angular/services/statusHoldsService.js
@@ -136,7 +136,19 @@ angular.module('calcentral.services').service('statusHoldsService', function() {
     }
   };
 
+  var checkShownRegistrations = function(registrations) {
+    var hasShown = false;
+    _.forEach(registrations, function(registration) {
+      if ((registration.isLegacy || registration.positiveIndicators.S09) && !registration.pastEndOfInstruction && (registration.academicCareer.code !== 'UCBX')) {
+        registration.isShown = true;
+        hasShown = true;
+      }
+    });
+    return hasShown;
+  };
+
   return {
+    checkShownRegistrations: checkShownRegistrations,
     getRegStatusMessages: getRegStatusMessages,
     matchTermIndicators: matchTermIndicators,
     parseCsTerm: parseCsTerm,

--- a/src/assets/templates/academics_student_profile.html
+++ b/src/assets/templates/academics_student_profile.html
@@ -29,22 +29,6 @@
           </div>
         </div>
         <div data-ng-if="(api.user.profile.roles.student || api.user.profile.roles.applicant) && !api.user.profile.roles.concurrentEnrollmentStudent && !isAcademicSummary">
-          <div data-ng-if="!isProfileCurrent">
-            <div data-ng-if="transitionTerm.registered" class="cc-widget-profile-message-text">
-              You are registered for the <span data-ng-bind="transitionTerm.termName"></span> term, but complete profile information is not available.
-            </div>
-            <div data-ng-if="!transitionTerm.registered" class="cc-widget-profile-message-text">
-              You are not officially registered for the <span data-ng-bind="transitionTerm.termName"></span> term.
-            </div>
-          </div>
-          <div data-ng-if="!transitionTerm">
-            <div data-ng-if="api.user.profile.roles.registered" class="cc-widget-profile-message-text">
-              You are registered as a student, but complete profile information is not available.
-            </div>
-            <div data-ng-if="!api.user.profile.roles.registered" class="cc-widget-profile-message-text">
-              You are not registered as a student for the <span data-ng-bind="collegeAndLevel.termName"></span> term.
-            </div>
-          </div>
           <div class="cc-academics-nocontent-container" data-ng-if="!isAcademicInfoAvailable">
             <div class="cc-widget-profile-message-text">
               <span data-ng-if="api.user.profile.roles.registered || (transitionTerm && transitionTerm.registered)">

--- a/src/assets/templates/academics_student_profile.html
+++ b/src/assets/templates/academics_student_profile.html
@@ -11,9 +11,6 @@
     <div data-ng-if="showProfileMessage">
       <div data-ng-if="collegeAndLevel.errored">
         There was a problem reaching campus services.
-        <span data-ng-if="api.user.profile.isLegacyStudent">
-          Please try again later, or check <a href="https://sis.berkeley.edu/bearfacts/student/studentMain.do?bfaction=welcome">Bear Facts</a>.
-        </span>
       </div>
       <div data-ng-if="!collegeAndLevel.errored">
         <div data-ng-if="api.user.profile.roles.concurrentEnrollmentStudent">
@@ -35,10 +32,6 @@
           <div data-ng-if="!isProfileCurrent">
             <div data-ng-if="transitionTerm.registered" class="cc-widget-profile-message-text">
               You are registered for the <span data-ng-bind="transitionTerm.termName"></span> term, but complete profile information is not available.
-              <span data-ng-if="api.user.profile.isLegacyStudent">
-                Please check <a href="https://sis.berkeley.edu/bearfacts/student/studentMain.do?bfaction=welcome">Bear Facts</a>
-                for the most current information.
-              </span>
             </div>
             <div data-ng-if="!transitionTerm.registered" class="cc-widget-profile-message-text">
               You are not officially registered for the <span data-ng-bind="transitionTerm.termName"></span> term.
@@ -47,17 +40,9 @@
           <div data-ng-if="!transitionTerm">
             <div data-ng-if="api.user.profile.roles.registered" class="cc-widget-profile-message-text">
               You are registered as a student, but complete profile information is not available.
-              <span data-ng-if="api.user.profile.isLegacyStudent">
-                Please check <a href="https://sis.berkeley.edu/bearfacts/student/studentMain.do?bfaction=welcome">Bear Facts</a>
-                for the most current information.
-              </span>
             </div>
             <div data-ng-if="!api.user.profile.roles.registered" class="cc-widget-profile-message-text">
               You are not registered as a student for the <span data-ng-bind="collegeAndLevel.termName"></span> term.
-              <span data-ng-if="api.user.profile.isLegacyStudent">
-                Please check <a href="https://sis.berkeley.edu/bearfacts/student/studentMain.do?bfaction=welcome">Bear Facts</a>
-                for information on other terms.
-              </span>
             </div>
           </div>
           <div class="cc-academics-nocontent-container" data-ng-if="!isAcademicInfoAvailable">

--- a/src/assets/templates/widgets/status_and_holds.html
+++ b/src/assets/templates/widgets/status_and_holds.html
@@ -7,8 +7,11 @@
     <div data-cc-spinner-directive="regStatus.isLoading">
       <div data-ng-if="(statusHoldsBlocks.enabledSections.indexOf('Status') !== -1)">
         <h3 class="cc-status-holds-status-header">Status</h3>
+        <div class="cc-status-holds-section" data-ng-if="!hasShownRegistrations">
+          <div class="cc-status-holds-list-item">You are not registered for any upcoming semesters.</div>
+        </div>
         <div class="cc-status-holds-section" data-ng-repeat="registration in regStatus.registrations | orderBy:'-id'">
-          <div data-ng-if="(registration.isLegacy || registration.positiveIndicators.S09) && !registration.pastEndOfInstruction && (registration.academicCareer.code !== 'UCBX')">
+          <div data-ng-if="registration.isShown">
             <h4 data-ng-bind="registration.name"></h4>
             <ul class="cc-widget-list cc-status-holds-list" data-ng-if="api.user.profile.features.regstatus">
               <li class="cc-widget-list-hover"

--- a/src/assets/templates/widgets/status_popover.html
+++ b/src/assets/templates/widgets/status_popover.html
@@ -1,8 +1,8 @@
 <ul class="cc-popover-items" data-ng-click="api.popover.clickThrough('Status')">
   <li class="cc-popover-item"
     data-ng-repeat="registration in regStatus.registrations | orderBy:'-id'"
-    data-ng-if="api.user.profile.roles.student && api.user.profile.features.regstatus && !registration.isSummer &&
-      registration.summary !== 'Officially Registered' && registration.positiveIndicators.S09 && !registration.pastEndOfInstruction && registration.academicCareer.code !== 'UCBX'">
+    data-ng-if="api.user.profile.roles.student && api.user.profile.features.regstatus && registration.isShown &&
+      registration.summary !== 'Officially Registered'">
     <a href="/academics">
       <div class="cc-launcher-status-description">
         <i class="fa fa-exclamation-circle cc-icon-red"></i>


### PR DESCRIPTION
Remove obsolete registration-status messages in My Academics Profile: https://jira.berkeley.edu/browse/SISRP-25637
Add between-terms message in My Academics Status and Holds: https://jira.berkeley.edu/browse/SISRP-25843
Remove obsolete Bear Facts links: https://jira.berkeley.edu/browse/SISRP-27636

As a side effect of other work, https://jira.berkeley.edu/browse/SISRP-26943 (conflicts between "Profile" and "Status and Holds") is also resolved.