### PR TITLE
CLC-6473 Per-course LTI tool for mailing list creation

### DIFF
--- a/app/controllers/canvas_lti_controller.rb
+++ b/app/controllers/canvas_lti_controller.rb
@@ -91,6 +91,10 @@ class CanvasLtiController < ApplicationController
     lti_xml_configuration
   end
 
+  def lti_site_mailing_list
+    lti_xml_configuration
+  end
+
   def lti_site_mailing_lists
     lti_xml_configuration
   end

--- a/app/controllers/canvas_mailing_list_controller.rb
+++ b/app/controllers/canvas_mailing_list_controller.rb
@@ -1,0 +1,38 @@
+# This mailing list controller (singular) allows instructors and admins to manage a single mailing list for a single
+# course site, as distinct from CanvasMailingListsController (plural), which allows admins to administer mailing lists
+# across a Canvas instance.
+
+class CanvasMailingListController < ApplicationController
+  include AllowLti
+  include DisallowAdvisorViewAs
+  include ClassLogger
+  include SpecificToCourseSite
+
+  before_action :api_authenticate
+  before_action :authorize_mailing_list_management
+  rescue_from StandardError, with: :handle_api_exception
+  rescue_from Errors::ClientError, with: :handle_client_error
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  def authorize_mailing_list_management
+    course_id = canvas_course_id
+    raise Pundit::NotAuthorizedError, 'Canvas Course ID not present' if course_id.blank?
+    canvas_course = Canvas::Course.new(user_id: session['user_id'], canvas_course_id: course_id)
+    authorize canvas_course, :can_manage_mailing_list?
+  end
+
+  # GET /api/academics/canvas/mailing_list
+
+  def show
+    list = MailingLists::SiteMailingList.find_or_initialize_by canvas_site_id: canvas_course_id.to_s
+    render json: list.to_json
+  end
+
+  # POST /api/academics/canvas/mailing_list/create
+
+  def create
+    list = MailingLists::MailgunList.create! canvas_site_id: canvas_course_id.to_s
+    list.populate
+    render json: list.to_json
+  end
+end

--- a/app/controllers/canvas_mailing_lists_controller.rb
+++ b/app/controllers/canvas_mailing_lists_controller.rb
@@ -1,3 +1,7 @@
+# This mailing lists controller (plural) allows admins to administer mailing lists across a Canvas
+# instance, as distinct from CanvasMailingListController (singular), which allows instructors and
+# course admins to administer a single mailing list for a single course site.
+
 class CanvasMailingListsController < ApplicationController
   include AllowLti
   include DisallowAdvisorViewAs

--- a/app/models/canvas/course_policy.rb
+++ b/app/models/canvas/course_policy.rb
@@ -11,6 +11,10 @@ module Canvas
       (is_canvas_user? && is_canvas_course_user? && is_canvas_course_teacher?) || is_canvas_account_admin?
     end
 
+    def can_manage_mailing_list?
+      is_canvas_course_teacher_or_assistant? || is_canvas_course_reader? || is_canvas_account_admin?
+    end
+
     def can_view_course?
       is_canvas_course_user? || is_canvas_account_admin?
     end
@@ -41,6 +45,10 @@ module Canvas
 
     def is_canvas_account_admin?
       Canvas::Admins.new.admin_user?(@user.user_id)
+    end
+
+    def is_canvas_course_reader?
+      is_canvas_user? && Canvas::CourseUser.is_course_reader?(canvas_course_user)
     end
 
     def is_canvas_course_teacher_or_assistant?

--- a/app/models/canvas_lti/external_app_configurations.rb
+++ b/app/models/canvas_lti/external_app_configurations.rb
@@ -44,6 +44,11 @@ module CanvasLti
           xml_name: 'lti_course_grade_export',
           app_name: 'Download E-Grades',
           account: official_courses_account_id
+        },
+        'site_mailing_list' => {
+          xml_name: 'lti_site_mailing_list',
+          app_name: 'Mailing List',
+          account: official_courses_account_id
         }
       }
     end

--- a/app/models/mailing_lists/site_mailing_list.rb
+++ b/app/models/mailing_lists/site_mailing_list.rb
@@ -98,15 +98,17 @@ module MailingLists
     end
 
     def generate_list_name
-      # 'CHEM 1A LEC 003' => 'chem_1a_lec_003-sp15'
+      # 'CHEM 1A LEC 003' => 'chem-1a-lec-003-sp15'
       # {{design}} => 'design-sp15'
-      # 'The "Wild"-"Wild" West?' => 'the_wild_wild_west-sp15'
-      # 'Conversation intermédiaire' => 'conversation_intermediaire-sp15'
-      # 'Global Health: Disaster Preparedness and Response' => 'global_health_disaster_preparedness_and_respo-sp15'
+      # 'The "Wild"-"Wild" West?' => 'the-wild-wild-west-sp15'
+      # 'Conversation intermédiaire' => 'conversation-intermediaire-sp15'
+      # 'Global Health: Disaster Preparedness and Response' => 'global-health-disaster-preparedness-and-respo-sp15'
       if @canvas_site
-        normalized_name = I18n.transliterate(@canvas_site['name']).downcase.split(/[^a-z0-9]+/).reject(&:blank?).join('_').slice(0, 45)
+        normalized_name = I18n.transliterate(@canvas_site['name']).downcase.split(/[^a-z0-9]+/).reject(&:blank?).join('-').slice(0, 45)
         if (term = Canvas::Terms.sis_term_id_to_term @canvas_site['term']['sis_term_id'])
           normalized_name << "-#{Berkeley::TermCodes.to_abbreviation(term[:term_yr], term[:term_cd])}"
+        else
+          normalized_name << '-list'
         end
         normalized_name
       end

--- a/app/views/canvas_lti/lti_site_mailing_list.xml.erb
+++ b/app/views/canvas_lti/lti_site_mailing_list.xml.erb
@@ -8,18 +8,18 @@
     http://www.imsglobal.org/xsd/imsbasiclti_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imsbasiclti_v1p0.xsd
     http://www.imsglobal.org/xsd/imslticm_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticm_v1p0.xsd
     http://www.imsglobal.org/xsd/imslticp_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticp_v1p0.xsd">
-    <blti:title>Mailing Lists</blti:title>
-    <blti:description>Create and manage mailing lists for all course sites</blti:description>
+    <blti:title>Mailing List</blti:title>
+    <blti:description>Create and manage a mailing list for a course site</blti:description>
     <blti:icon>NO ICO</blti:icon>
     <blti:launch_url><%= @launch_url_for_app %></blti:launch_url>
     <blti:extensions platform="canvas.instructure.com">
-      <lticm:property name="tool_id">calcentral_site_mailing_lists</lticm:property>
+      <lticm:property name="tool_id">calcentral_site_mailing_list</lticm:property>
       <lticm:property name="privacy_level">public</lticm:property>
-      <lticm:options name="account_navigation">
+      <lticm:options name="course_navigation">
         <lticm:property name="url"><%= @launch_url_for_app %></lticm:property>
-        <lticm:property name="text">Mailing Lists</lticm:property>
+        <lticm:property name="text">Mailing List</lticm:property>
         <lticm:property name="visibility">admins</lticm:property>
-        <lticm:property name="default">enabled</lticm:property>
+        <lticm:property name="default">disabled</lticm:property>
         <lticm:property name="enabled">true</lticm:property>
       </lticm:options>
     </blti:extensions>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Calcentral::Application.routes.draw do
   post '/canvas/embedded/*url' => 'canvas_lti#embedded', :defaults => { :format => 'html' }
   get '/canvas/lti_roster_photos' => 'canvas_lti#lti_roster_photos', :defaults => { :format => 'xml' }
   get '/canvas/lti_site_creation' => 'canvas_lti#lti_site_creation', :defaults => { :format => 'xml' }
+  get '/canvas/lti_site_mailing_list' => 'canvas_lti#lti_site_mailing_list', :defaults => { :format => 'xml' }
   get '/canvas/lti_site_mailing_lists' => 'canvas_lti#lti_site_mailing_lists', :defaults => { :format => 'xml' }
   get '/canvas/lti_user_provision' => 'canvas_lti#lti_user_provision', :defaults => { :format => 'xml' }
   get '/canvas/lti_course_add_user' => 'canvas_lti#lti_course_add_user', :defaults => { :format => 'xml' }
@@ -93,6 +94,10 @@ Calcentral::Application.routes.draw do
   get '/api/academics/canvas/course_add_user/:canvas_course_id/course_sections' => 'canvas_course_add_user#course_sections', :via => :get, :as => :canvas_course_add_user_course_sections, :defaults => { :format => 'json' }
   post '/api/academics/canvas/course_add_user/:canvas_course_id/add_user' => 'canvas_course_add_user#add_user', :via => :post, :as => :canvas_course_add_user_add_user, :defaults => { :format => 'json' }
   get '/api/canvas/media/:canvas_course_id' => 'canvas_webcast_recordings#get_media', :defaults => { :format => 'json' }
+  # Administer Canvas mailing list for a single course site
+  get '/api/academics/canvas/mailing_list/:canvas_course_id' => 'canvas_mailing_list#show', :defaults => { :format => 'json' }
+  post '/api/academics/canvas/mailing_list/:canvas_course_id/create' => 'canvas_mailing_list#create', :defaults => { :format => 'json' }
+  # Administer Canvas mailing lists for any course site
   get '/api/academics/canvas/mailing_lists/:canvas_course_id' => 'canvas_mailing_lists#show', :defaults => { :format => 'json' }
   post '/api/academics/canvas/mailing_lists/:canvas_course_id/create' => 'canvas_mailing_lists#create', :defaults => { :format => 'json' }
   post '/api/academics/canvas/mailing_lists/:canvas_course_id/populate' => 'canvas_mailing_lists#populate', :defaults => { :format => 'json' }

--- a/spec/controllers/canvas_mailing_list_controller_spec.rb
+++ b/spec/controllers/canvas_mailing_list_controller_spec.rb
@@ -1,0 +1,91 @@
+describe CanvasMailingListController do
+  let(:canvas_course_id) { rand(99999) }
+
+  shared_examples 'a protected controller' do
+    let(:user_id) { rand(99999).to_s }
+    before do
+      session['user_id'] = user_id
+      allow_any_instance_of(Canvas::SisUserProfile).to receive(:get).and_return({
+        'id' => user_id
+      })
+      allow_any_instance_of(Canvas::Admins).to receive(:admin_user?).with(user_id).and_return(is_admin)
+      allow(Canvas::CourseUser).to receive(:new).with(user_id: user_id, course_id: canvas_course_id).and_return(
+        double(course_user: course_user)
+      )
+    end
+
+    shared_examples 'not authorized' do
+      it 'forbids list lookup' do
+        expect(MailingLists::SiteMailingList).to_not receive(:find_or_initialize_by)
+        lookup_request
+        expect(response.status).to eq(403)
+      end
+
+      it 'forbids list creation' do
+        expect(MailingLists::MailgunList).to_not receive(:create!)
+        create_request
+        expect(response.status).to eq(403)
+      end
+    end
+
+    shared_examples 'authorized' do
+      it 'allows list lookup' do
+        expect(MailingLists::SiteMailingList).to receive(:find_or_initialize_by).and_call_original
+        lookup_request
+        expect(response.status).to eq 200
+        response_json = JSON.parse(response.body)
+        expect(response_json['mailingList']['state']).to eq 'unregistered'
+      end
+
+      it 'allows list creation' do
+        expect(MailingLists::MailgunList).to receive(:create!).and_call_original
+        create_request
+        expect(response.status).to eq 200
+        response_json = JSON.parse(response.body)
+        expect(response_json['mailingList']['state']).to eq 'created'
+      end
+    end
+
+    context 'when user is not in the course site' do
+      let(:is_admin) { false }
+      let(:course_user) { nil }
+      include_examples 'not authorized'
+    end
+
+    context 'when user is a student in the course site' do
+      let(:is_admin) { false }
+      let(:course_user) { {'enrollments' => [{'role' => 'StudentEnrollment'}]} }
+      include_examples 'not authorized'
+    end
+
+    context 'when user is a teacher in the course site' do
+      let(:is_admin) { false }
+      let(:course_user) { {'enrollments' => [{'role' => 'TeacherEnrollment'}]} }
+      include_examples 'authorized'
+    end
+
+    context 'when user is a Canvas admin' do
+      let(:is_admin) { true }
+      let(:course_user) { nil }
+      include_examples 'authorized'
+    end
+  end
+
+  let(:make_request) { lookup_request }
+
+  context 'in CalCentral context with explicit Canvas course ID' do
+    let(:lookup_request) { get :show, canvas_course_id: canvas_course_id.to_s }
+    let(:create_request) { post :create, canvas_course_id: canvas_course_id.to_s }
+    it_behaves_like 'a user authenticated api endpoint'
+    it_behaves_like 'a protected controller'
+  end
+
+  context 'in LTI context' do
+    let(:lookup_request) { get :show, canvas_course_id: 'embedded' }
+    let(:create_request) { post :create, canvas_course_id: 'embedded' }
+    before do
+      session['canvas_course_id'] = canvas_course_id.to_s
+    end
+    it_behaves_like 'a protected controller'
+  end
+end

--- a/spec/support/mailing_list_shared_examples.rb
+++ b/spec/support/mailing_list_shared_examples.rb
@@ -31,12 +31,12 @@ shared_examples 'a newly initialized mailing list' do
   describe 'normalizing list names' do
     it 'normalizes caps and spaces' do
       fake_course_data['name'] = 'CHEM 1A LEC 003'
-      expect(response['mailingList']['name']).to eq 'chem_1a_lec_003-fa13'
+      expect(response['mailingList']['name']).to eq 'chem-1a-lec-003-fa13'
     end
 
     it 'normalizes punctuation' do
       fake_course_data['name'] = 'The "Wild"-"Wild" West?'
-      expect(response['mailingList']['name']).to eq 'the_wild_wild_west-fa13'
+      expect(response['mailingList']['name']).to eq 'the-wild-wild-west-fa13'
     end
 
     it 'removes invalid leading and trailing characters' do
@@ -46,7 +46,7 @@ shared_examples 'a newly initialized mailing list' do
 
     it 'normalizes diacritics' do
       fake_course_data['name'] = 'Conversation intermédiaire'
-      expect(response['mailingList']['name']).to eq 'conversation_intermediaire-fa13'
+      expect(response['mailingList']['name']).to eq 'conversation-intermediaire-fa13'
     end
   end
 

--- a/src/assets/javascripts/angular/configuration/routeConfiguration.js
+++ b/src/assets/javascripts/angular/configuration/routeConfiguration.js
@@ -128,9 +128,15 @@ angular.module('calcentral.config').config(function($routeProvider) {
     isBcourses: true,
     isEmbedded: true
   }).
-  when('/canvas/embedded/site_mailing_lists', {
+  when('/canvas/embedded/site_mailing_list', {
     templateUrl: 'canvas_embedded/site_mailing_list.html',
     controller: 'CanvasSiteMailingListController',
+    isBcourses: true,
+    isEmbedded: true
+  }).
+  when('/canvas/embedded/site_mailing_lists', {
+    templateUrl: 'canvas_embedded/site_mailing_lists.html',
+    controller: 'CanvasSiteMailingListsController',
     isBcourses: true,
     isEmbedded: true
   }).
@@ -204,9 +210,14 @@ angular.module('calcentral.config').config(function($routeProvider) {
     controller: 'CanvasCourseGradeExportController',
     isBcourses: true
   }).
-  when('/canvas/site_mailing_list', {
+  when('/canvas/site_mailing_list/:canvasCourseId', {
     templateUrl: 'canvas_embedded/site_mailing_list.html',
     controller: 'CanvasSiteMailingListController',
+    isBcourses: true
+  }).
+  when('/canvas/site_mailing_lists', {
+    templateUrl: 'canvas_embedded/site_mailing_lists.html',
+    controller: 'CanvasSiteMailingListsController',
     isBcourses: true
   }).
   when('/canvas/user_provision', {

--- a/src/assets/javascripts/angular/controllers/pages/canvasSiteMailingListController.js
+++ b/src/assets/javascripts/angular/controllers/pages/canvasSiteMailingListController.js
@@ -3,144 +3,44 @@
 var angular = require('angular');
 
 /**
- * Canvas Site Mailing List app controller
+ * Canvas Site Mailing List app controller; for the course-level tool allowing creation of a single bCourses mailing list.
  */
-angular.module('calcentral.controllers').controller('CanvasSiteMailingListController', function(apiService, canvasSiteMailingListFactory, dateFilter, $scope) {
-  apiService.util.setTitle('Manage Site Mailing List');
+angular.module('calcentral.controllers').controller('CanvasSiteMailingListController', function(apiService, canvasSharedFactory, canvasSiteMailingListFactory, $routeParams, $scope) {
+  apiService.util.setTitle('Mailing List');
 
-  /*
-   * Initializes application upon loading.
-   */
-  var initState = function() {
-    $scope.canvasSite = {};
-    $scope.mailingList = {};
-    setStateFromData({});
-  };
-
-  var setStateFromData = function(data) {
-    $scope.isProcessing = false;
-    $scope.alerts = {
-      error: (data.errorMessages || []),
-      success: []
-    };
+  var showMailingList = function(data) {
     angular.extend($scope, data);
-    $scope.siteSelected = (data.canvasSite && !!data.canvasSite.canvasCourseId);
-    $scope.listRegistered = (data.mailingList && data.mailingList.state !== 'unregistered');
+    $scope.isCreating = false;
+    $scope.isLoading = false;
     $scope.listCreated = (data.mailingList && data.mailingList.state === 'created');
-    $scope.listPending = $scope.listRegistered && !$scope.listCreated;
-
-    if ($scope.siteSelected) {
-      setCodeAndTerm($scope.canvasSite);
-    }
-
-    if (!$scope.listRegistered) {
-      // For Fall 2016, the list admin tool should continue to default to CalMail.
-      $scope.mailingList.listType = 'CalmailList';
-    }
-
-    if ($scope.listCreated) {
-      setListLastPopulated(data.mailingList);
-    }
-
-    if (data.populationResults) {
-      showPopulationResults(data.populationResults);
-    }
   };
 
-  var setCodeAndTerm = function(canvasSite) {
-    var codeAndTermArray = [];
-    if (canvasSite.courseCode !== canvasSite.name) {
-      codeAndTermArray.push(canvasSite.courseCode);
-    }
-    if (canvasSite.term && canvasSite.term.name) {
-      codeAndTermArray.push(canvasSite.term.name);
-    }
-    canvasSite.codeAndTerm = codeAndTermArray.join(', ');
+  var showError = function() {
+    $scope.isCreating = false;
+    $scope.isLoading = false;
+    $scope.displayError = 'failure';
   };
 
-  var setListLastPopulated = function(list) {
-    if (list.timeLastPopulated) {
-      $scope.listLastPopulated = dateFilter((list.timeLastPopulated.epoch * 1000), 'short');
-    } else {
-      $scope.listLastPopulated = 'never';
-    }
+  var getMailingList = function() {
+    return canvasSiteMailingListFactory.getMailingList($scope.canvasCourseId).success(function(data) {
+      showMailingList(data);
+    }).error(showError);
   };
 
-  var showPopulationResults = function(results) {
-    if (results.success) {
-      $scope.alerts.success.push('Memberships were successfully updated.');
-      if (results.messages.length) {
-        $scope.alerts.success = $scope.alerts.success.concat(results.messages);
-      } else {
-        $scope.alerts.success.push('No changes in membership were found.');
-      }
-    } else {
-      $scope.alerts.error.push('There were errors during the last membership update.');
-      $scope.alerts.error = $scope.alerts.error.concat(results.messages);
-      $scope.alerts.error.push('You can attempt to correct the errors by running the update again.');
-    }
+  $scope.createMailingList = function() {
+    $scope.isCreating = true;
+    return canvasSiteMailingListFactory.createMailingList($scope.canvasCourseId).success(function(data) {
+      showMailingList(data);
+    }).error(showError);
   };
 
-  $scope.confirmCreation = function() {
-    $scope.isConfirmingCreation = true;
-    return canvasSiteMailingListFactory.getSiteMailingList($scope.canvasSite.canvasCourseId).success(function(data) {
-      $scope.isConfirmingCreation = false;
-      setStateFromData(data);
-      if (!$scope.listCreated && !$scope.alerts.error.count) {
-        $scope.alerts.error.push('You cannot update memberships before the list is created in CalMail.');
-      }
-    }).error(function() {
-      $scope.displayError = 'failure';
-    });
-  };
-
-  $scope.findSiteMailingList = function() {
-    $scope.isProcessing = true;
-    return canvasSiteMailingListFactory.getSiteMailingList($scope.canvasSite.canvasCourseId).success(function(data) {
-      setStateFromData(data);
-    }).error(function() {
-      $scope.displayError = 'failure';
-    });
-  };
-
-  $scope.populateMailingList = function() {
-    $scope.isProcessing = true;
-    return canvasSiteMailingListFactory.populateSiteMailingList($scope.canvasSite.canvasCourseId).success(function(data) {
-      setStateFromData(data);
-      if (!data.populationResults) {
-        $scope.alerts.error.push('The mailing list could not be populated.');
-      }
-    }).error(function() {
-      $scope.displayError = 'failure';
-    });
-  };
-
-  $scope.registerMailingList = function() {
-    $scope.isProcessing = true;
-    return canvasSiteMailingListFactory.registerSiteMailingList($scope.canvasSite.canvasCourseId, $scope.mailingList).success(function(data) {
-      setStateFromData(data);
-    }).error(function() {
-      $scope.displayError = 'failure';
-    });
-  };
-
-  $scope.resetForm = function() {
-    initState();
-  };
-
-  $scope.unregisterMailingList = function() {
-    $scope.isProcessing = true;
-    return canvasSiteMailingListFactory.deleteSiteMailingList($scope.canvasSite.canvasCourseId).success(function() {
-      initState();
-    }).error(function() {
-      $scope.displayError = 'failure';
-    });
-  };
+  $scope.isLoading = true;
+  $scope.canvasCourseId = $routeParams.canvasCourseId || 'embedded';
 
   // Wait until user profile is fully loaded before starting.
   $scope.$on('calcentral.api.user.isAuthenticated', function(event, isAuthenticated) {
     if (isAuthenticated) {
-      initState();
+      getMailingList();
     }
   });
 });

--- a/src/assets/javascripts/angular/controllers/pages/canvasSiteMailingListsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/canvasSiteMailingListsController.js
@@ -1,0 +1,146 @@
+'use strict';
+
+var angular = require('angular');
+
+/**
+ * Canvas Site Mailing Lists app controller; for the admin-level tool allowing administration of all bCourses mailing lists.
+ */
+angular.module('calcentral.controllers').controller('CanvasSiteMailingListsController', function(apiService, canvasSiteMailingListsFactory, dateFilter, $scope) {
+  apiService.util.setTitle('Manage Site Mailing List');
+
+  /*
+   * Initializes application upon loading.
+   */
+  var initState = function() {
+    $scope.canvasSite = {};
+    $scope.mailingList = {};
+    setStateFromData({});
+  };
+
+  var setStateFromData = function(data) {
+    $scope.isProcessing = false;
+    $scope.alerts = {
+      error: (data.errorMessages || []),
+      success: []
+    };
+    angular.extend($scope, data);
+    $scope.siteSelected = (data.canvasSite && !!data.canvasSite.canvasCourseId);
+    $scope.listRegistered = (data.mailingList && data.mailingList.state !== 'unregistered');
+    $scope.listCreated = (data.mailingList && data.mailingList.state === 'created');
+    $scope.listPending = $scope.listRegistered && !$scope.listCreated;
+
+    if ($scope.siteSelected) {
+      setCodeAndTerm($scope.canvasSite);
+    }
+
+    if (!$scope.listRegistered) {
+      // For Fall 2016, the list admin tool should continue to default to CalMail.
+      $scope.mailingList.listType = 'CalmailList';
+    }
+
+    if ($scope.listCreated) {
+      setListLastPopulated(data.mailingList);
+    }
+
+    if (data.populationResults) {
+      showPopulationResults(data.populationResults);
+    }
+  };
+
+  var setCodeAndTerm = function(canvasSite) {
+    var codeAndTermArray = [];
+    if (canvasSite.courseCode !== canvasSite.name) {
+      codeAndTermArray.push(canvasSite.courseCode);
+    }
+    if (canvasSite.term && canvasSite.term.name) {
+      codeAndTermArray.push(canvasSite.term.name);
+    }
+    canvasSite.codeAndTerm = codeAndTermArray.join(', ');
+  };
+
+  var setListLastPopulated = function(list) {
+    if (list.timeLastPopulated) {
+      $scope.listLastPopulated = dateFilter((list.timeLastPopulated.epoch * 1000), 'short');
+    } else {
+      $scope.listLastPopulated = 'never';
+    }
+  };
+
+  var showPopulationResults = function(results) {
+    if (results.success) {
+      $scope.alerts.success.push('Memberships were successfully updated.');
+      if (results.messages.length) {
+        $scope.alerts.success = $scope.alerts.success.concat(results.messages);
+      } else {
+        $scope.alerts.success.push('No changes in membership were found.');
+      }
+    } else {
+      $scope.alerts.error.push('There were errors during the last membership update.');
+      $scope.alerts.error = $scope.alerts.error.concat(results.messages);
+      $scope.alerts.error.push('You can attempt to correct the errors by running the update again.');
+    }
+  };
+
+  $scope.confirmCreation = function() {
+    $scope.isConfirmingCreation = true;
+    return canvasSiteMailingListsFactory.getSiteMailingList($scope.canvasSite.canvasCourseId).success(function(data) {
+      $scope.isConfirmingCreation = false;
+      setStateFromData(data);
+      if (!$scope.listCreated && !$scope.alerts.error.count) {
+        $scope.alerts.error.push('You cannot update memberships before the list is created in CalMail.');
+      }
+    }).error(function() {
+      $scope.displayError = 'failure';
+    });
+  };
+
+  $scope.findSiteMailingList = function() {
+    $scope.isProcessing = true;
+    return canvasSiteMailingListsFactory.getSiteMailingList($scope.canvasSite.canvasCourseId).success(function(data) {
+      setStateFromData(data);
+    }).error(function() {
+      $scope.displayError = 'failure';
+    });
+  };
+
+  $scope.populateMailingList = function() {
+    $scope.isProcessing = true;
+    return canvasSiteMailingListsFactory.populateSiteMailingList($scope.canvasSite.canvasCourseId).success(function(data) {
+      setStateFromData(data);
+      if (!data.populationResults) {
+        $scope.alerts.error.push('The mailing list could not be populated.');
+      }
+    }).error(function() {
+      $scope.displayError = 'failure';
+    });
+  };
+
+  $scope.registerMailingList = function() {
+    $scope.isProcessing = true;
+    return canvasSiteMailingListsFactory.registerSiteMailingList($scope.canvasSite.canvasCourseId, $scope.mailingList).success(function(data) {
+      setStateFromData(data);
+    }).error(function() {
+      $scope.displayError = 'failure';
+    });
+  };
+
+  $scope.resetForm = function() {
+    initState();
+  };
+
+  $scope.unregisterMailingList = function() {
+    $scope.isProcessing = true;
+    return canvasSiteMailingListsFactory.deleteSiteMailingList($scope.canvasSite.canvasCourseId).success(function() {
+      initState();
+    }).error(function() {
+      $scope.displayError = 'failure';
+    });
+  };
+
+  // Wait until user profile is fully loaded before starting.
+  $scope.$on('calcentral.api.user.isAuthenticated', function(event, isAuthenticated) {
+    if (isAuthenticated) {
+      initState();
+    }
+  });
+});

--- a/src/assets/javascripts/angular/factories/canvasSiteMailingListFactory.js
+++ b/src/assets/javascripts/angular/factories/canvasSiteMailingListFactory.js
@@ -3,32 +3,19 @@
 var angular = require('angular');
 
 /**
- * Canvas Site Mailing List Factory - Interface for 'Manage a bCourses Site Mailing List' tool API endpoints
+ * Canvas Site Mailing List Factory; API endpoint for the course-level bCourses tool to create a single mailing list.
  */
 angular.module('calcentral.factories').factory('canvasSiteMailingListFactory', function($http) {
-  var deleteSiteMailingList = function(canvasCourseId) {
-    return $http.post('/api/academics/canvas/mailing_lists/' + canvasCourseId + '/delete');
+  var createMailingList = function(canvasCourseId) {
+    return $http.post('/api/academics/canvas/mailing_list/' + canvasCourseId + '/create');
   };
 
-  var getSiteMailingList = function(canvasCourseId) {
-    return $http.get('/api/academics/canvas/mailing_lists/' + canvasCourseId);
-  };
-
-  var populateSiteMailingList = function(canvasCourseId) {
-    return $http.post('/api/academics/canvas/mailing_lists/' + canvasCourseId + '/populate');
-  };
-
-  var registerSiteMailingList = function(canvasCourseId, list) {
-    return $http.post('/api/academics/canvas/mailing_lists/' + canvasCourseId + '/create', {
-      listName: list.name,
-      listType: list.listType
-    });
+  var getMailingList = function(canvasCourseId) {
+    return $http.get('/api/academics/canvas/mailing_list/' + canvasCourseId);
   };
 
   return {
-    deleteSiteMailingList: deleteSiteMailingList,
-    getSiteMailingList: getSiteMailingList,
-    populateSiteMailingList: populateSiteMailingList,
-    registerSiteMailingList: registerSiteMailingList
+    createMailingList: createMailingList,
+    getMailingList: getMailingList
   };
 });

--- a/src/assets/javascripts/angular/factories/canvasSiteMailingListsFactory.js
+++ b/src/assets/javascripts/angular/factories/canvasSiteMailingListsFactory.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var angular = require('angular');
+
+/**
+ * Canvas Site Mailing Lists Factory - API interface for the admin-level 'Manage bCourses Site Mailing Lists' tool.
+ */
+angular.module('calcentral.factories').factory('canvasSiteMailingListsFactory', function($http) {
+  var deleteSiteMailingList = function(canvasCourseId) {
+    return $http.post('/api/academics/canvas/mailing_lists/' + canvasCourseId + '/delete');
+  };
+
+  var getSiteMailingList = function(canvasCourseId) {
+    return $http.get('/api/academics/canvas/mailing_lists/' + canvasCourseId);
+  };
+
+  var populateSiteMailingList = function(canvasCourseId) {
+    return $http.post('/api/academics/canvas/mailing_lists/' + canvasCourseId + '/populate');
+  };
+
+  var registerSiteMailingList = function(canvasCourseId, list) {
+    return $http.post('/api/academics/canvas/mailing_lists/' + canvasCourseId + '/create', {
+      listName: list.name,
+      listType: list.listType
+    });
+  };
+
+  return {
+    deleteSiteMailingList: deleteSiteMailingList,
+    getSiteMailingList: getSiteMailingList,
+    populateSiteMailingList: populateSiteMailingList,
+    registerSiteMailingList: registerSiteMailingList
+  };
+});

--- a/src/assets/templates/canvas_embedded/site_mailing_list.html
+++ b/src/assets/templates/canvas_embedded/site_mailing_list.html
@@ -1,7 +1,9 @@
 <div class="bc-canvas-application bc-page-site-mailing-list">
 
-  <div data-ng-show="!displayError">
-    <h1 class="bc-header bc-header1">Manage a Site Mailing List</h1>
+  <div data-ng-if="isLoading" data-cc-spinner-directive></div>
+
+  <div data-ng-show="!isLoading && !displayError">
+    <h1 class="bc-header bc-header1">Mailing List</h1>
 
     <div role="alert" class="bc-alert bc-alert-error" data-ng-if="alerts.error.length">
       <i class="fa fa-error fa-exclamation-triangle cc-left bc-icon-red bc-canvas-notice-icon"></i>
@@ -10,136 +12,30 @@
       </div>
     </div>
 
-    <div role="alert" class="bc-alert bc-alert-success" data-ng-if="alerts.success.length">
-      <i class="cc-left fa fa-error fa-check-circle bc-icon-green bc-canvas-notice-icon"></i>
-      <div class="bc-page-site-mailing-list-notice-message">
-        <div data-ng-repeat="success in alerts.success" data-ng-bind="success"></div>
+    <div data-ng-if="listCreated" class="bc-alert bc-alert-success">
+      A Mailing List has been created at <strong data-ng-bind-template="{{mailingList.name}}@{{mailingList.domain}}"></strong>.
+      Messages can now be sent through this address.
+    </div>
+
+    <div data-ng-if="!listCreated" class="bc-alert">
+      No Mailing List has yet been created for this site.
+    </div>
+
+    <p class="bc-page-site-mailing-list-text">
+      bCourses Mailing Lists allow Teachers, TAs, Lead TAs and Readers to send email to everyone in a bCourses site by
+      giving the site its own email address. Messages sent to this address from the <strong>official berkeley.edu email
+      address</strong> of a Teacher, TA, Lead TA or Reader will be sent to the official email addresses of all site
+      members. Students and people not in the site cannot send messages through Mailing Lists.
+    </p>
+
+    <form class="bc-canvas-page-form bc-canvas-form" data-ng-if="!listCreated">
+      <div class="bc-form-actions">
+        <button data-ng-click="createMailingList()" class="bc-canvas-button bc-canvas-button-primary" aria-controls="cc-page-reader-alert">
+          <span data-ng-if="!isCreating">Create mailing list</span>
+          <span data-ng-if="isCreating"><i class="fa fa-spinner fa-spin"></i> Creating ...</span>
+        </button>
       </div>
-    </div>
-
-    <div data-ng-if="listPending" class="bc-alert bc-alert-info">
-      The list <strong data-ng-bind-template="{{mailingList.name}}@{{mailingList.domain}}"></strong> has been reserved, but not yet created.
-    </div>
-
-    <div data-ng-if="listCreated && !mailingList.timeLastPopulated" class="bc-alert bc-alert-info">
-      The list <strong data-ng-bind-template="{{mailingList.name}}@{{mailingList.domain}}"></strong> has been created. Choose "Update membership from course site" to add members.
-    </div>
-
-    <div data-ng-if="!siteSelected">
-      <form class="bc-page-site-mailing-list-form">
-        <div class="row">
-          <div class="small-12 medium-3 columns">
-            <label for="bc-page-site-mailing-list-site-id" class="bc-page-site-mailing-list-form-label">Course Site ID:</label>
-          </div>
-          <div class="small-12 medium-6 columns end">
-            <input type="text" id="bc-page-site-mailing-list-site-id" class="cc-left bc-canvas-form-input-text" data-ng-model="canvasSite.canvasCourseId"
-                   placeholder="Enter numeric site ID" required aria-required="true">
-            <button class="bc-canvas-button bc-canvas-button-primary" data-ng-click="findSiteMailingList()" data-ng-disabled="isProcessing || !canvasSite.canvasCourseId">
-              <span data-ng-if="!isProcessing">Get Mailing List</span>
-              <span data-ng-if="isProcessing"><i class="fa fa-spinner fa-spin"></i> Finding ...</span>
-            </button>
-          </div>
-        </div>
-      </form>
-    </div>
-
-    <div data-ng-if="siteSelected">
-
-      <div class="bc-page-site-mailing-list-info-box">
-        <h2 class="bc-header bc-page-site-mailing-list-header2">
-          <span data-ng-if="!listRegistered" class="cc-ellipsis" data-ng-bind="canvasSite.name"></span>
-          <span data-ng-if="listRegistered" class="cc-ellipsis" data-ng-bind-template="{{mailingList.name}}@{{mailingList.domain}}"></span>
-        </h2>
-        <h3 class="bc-header bc-page-site-mailing-list-header3" data-ng-if="listRegistered && !listCreated">Not yet created</h3>
-        <div data-ng-if="listCreated">
-          <div data-ng-pluralize count="mailingList.membersCount||0" when="{'0':'No members','one':'1 member','other':'{} members'}"></div>
-          <div>Membership last updated: <strong data-ng-bind="listLastPopulated | lowercase"></strong></div>
-          <a data-ng-href="{{mailingList.administrationUrl}}" data-ng-if="mailingList.administrationUrl" data-ng-click="api.analytics.trackExternalLink('Canvas Site Mailing List', 'Calmail', mailingList.administrationUrl)">
-            View in CalMail
-          </a>
-        </div>
-        <div data-ng-if="listRegistered">
-          Course site:
-          <a data-ng-if="listRegistered" data-ng-href="{{canvasSite.url}}" data-ng-click="api.analytics.trackExternalLink('Canvas Site Mailing List', 'bCourses', canvasSite.url)"
-             data-ng-bind="canvasSite.name"></a>
-        </div>
-        <div class="row">
-          <div class="small-12 medium-4 columns" data-ng-bind="canvasSite.codeAndTerm"></div>
-          <div class="small-12 medium-6 columns end" data-ng-bind-template="Site ID: {{canvasSite.canvasCourseId}}"></div>
-        </div>
-        <a data-ng-if="!listRegistered" data-ng-href="{{canvasSite.url}}" data-ng-click="api.analytics.trackExternalLink('Canvas Site Mailing List', 'bCourses', canvasSite.url)">
-          View course site
-        </a>
-      </div>
-
-      <div class="bc-page-site-mailing-list-text" data-ng-if="!listRegistered">
-        No mailing list name has been reserved for this site.
-      </div>
-
-      <div data-ng-if="listPending">
-        <div class="bc-page-site-mailing-list-text">
-          <strong>Mailing lists can only be created at the CalMail management site.</strong>
-          When you choose "Create mailing list," a new browser window will open at the CalMail site.
-          If you are not logged in to that site, you will have to log in, close the CalMail browser window, and return to this window to try again.
-        </div>
-        <div class="bc-page-site-mailing-list-text">
-          When the list is first created, it will have no members.
-          <strong>After</strong> you create the list in CalMail, return to this window and choose "I've created the list, go to memberships" to update memberships from the course site.
-        </div>
-      </div>
-
-      <form class="bc-canvas-page-form bc-canvas-form">
-        <div data-ng-if="!listRegistered">
-          <div class="row bc-page-site-mailing-list-text">
-            <input type="radio" id="listTypeCalmail" data-ng-model="mailingList.listType" data-ng-value="'CalmailList'">
-            <label for="listTypeCalmail" class="bc-page-site-mailing-list-form-label-long">Reserve this name for a CalMail list (you will create the list on the next screen).</label>
-          </div>
-          <div class="row bc-page-site-mailing-list-text">
-            <input type="radio" id="listTypeMailgun" data-ng-model="mailingList.listType" data-ng-value="'MailgunList'">
-            <label for="listTypeMailgun" class="bc-page-site-mailing-list-form-label-long">Create a Mailgun list now.</label>
-          </div>
-          <div class="row bc-page-site-mailing-list-form-input-row">
-            <div class="medium-3 small-12 columns">
-              <label for="mailingListName" class="bc-page-site-mailing-list-form-label">New Mailing List Name:</label>
-            </div>
-            <div class="medium-9 small-12 columns">
-              <input type="text" id="mailingListName" class="cc-left bc-canvas-form-input-text" data-ng-model="mailingList.name" required aria-required="true">
-            </div>
-          </div>
-        </div>
-
-        <div class="bc-form-actions">
-          <button data-ng-if="!listRegistered" data-ng-click="registerMailingList()" class="bc-canvas-button bc-canvas-button-primary" aria-controls="cc-page-reader-alert">
-            <span data-ng-if="!isProcessing">
-              <span data-ng-if="mailingList.listType !== 'MailgunList'">Reserve mailing list name</span>
-              <span data-ng-if="mailingList.listType === 'MailgunList'">Create mailing list</span>
-            </span>
-            <span data-ng-if="isProcessing"><i class="fa fa-spinner fa-spin"></i>
-              <span data-ng-if="mailingList.listType !== 'MailgunList'">Reserving ...</span>
-              <span data-ng-if="mailingList.listType === 'MailgunList'">Creating ...</span>
-            </span>
-          </button>
-          <div data-ng-if="listPending">
-            <a data-ng-href="{{mailingList.creationUrl}}" class="bc-canvas-button bc-canvas-button-primary bc-page-site-mailing-list-button-primary"
-            aria-controls="cc-page-reader-alert">Create mailing list</a>
-            <button data-ng-click="confirmCreation()" class="bc-canvas-button" aria-controls="cc-page-reader-alert">
-              <i data-ng-if="isConfirmingCreation" class="fa fa-spinner fa-spin"></i>
-              I've created the list, go to memberships
-            </button>
-            <button data-ng-if="listPending" class="bc-canvas-button" data-ng-click="unregisterMailingList()">
-              <span data-ng-if="!isProcessing">Cancel registration</span>
-              <span data-ng-if="isProcessing"><i class="fa fa-spinner fa-spin"></i> Cancelling ...</span>
-            </button>
-          </div>
-          <button data-ng-if="listCreated" data-ng-click="populateMailingList()" class="bc-canvas-button bc-canvas-button-primary" aria-controls="cc-page-reader-alert">
-            <span data-ng-if="!isProcessing">Update membership from course site</span>
-            <span data-ng-if="isProcessing"><i class="fa fa-spinner fa-spin"></i> Updating ...</span>
-          </button>
-          <button data-ng-if="!listPending" class="bc-canvas-button" data-ng-click="resetForm()">Cancel</button>
-        </div>
-      </form>
-
-    </div>
+    </form>
   </div>
 
   <div data-ng-if="displayError" class="bc-notice-error-container">

--- a/src/assets/templates/canvas_embedded/site_mailing_lists.html
+++ b/src/assets/templates/canvas_embedded/site_mailing_lists.html
@@ -1,0 +1,149 @@
+<div class="bc-canvas-application bc-page-site-mailing-list">
+
+  <div data-ng-show="!displayError">
+    <h1 class="bc-header bc-header1">Manage a Site Mailing List</h1>
+
+    <div role="alert" class="bc-alert bc-alert-error" data-ng-if="alerts.error.length">
+      <i class="fa fa-error fa-exclamation-triangle cc-left bc-icon-red bc-canvas-notice-icon"></i>
+      <div class="bc-page-site-mailing-list-notice-message">
+        <div data-ng-repeat="error in alerts.error" data-ng-bind="error"></div>
+      </div>
+    </div>
+
+    <div role="alert" class="bc-alert bc-alert-success" data-ng-if="alerts.success.length">
+      <i class="cc-left fa fa-error fa-check-circle bc-icon-green bc-canvas-notice-icon"></i>
+      <div class="bc-page-site-mailing-list-notice-message">
+        <div data-ng-repeat="success in alerts.success" data-ng-bind="success"></div>
+      </div>
+    </div>
+
+    <div data-ng-if="listPending" class="bc-alert bc-alert-info">
+      The list <strong data-ng-bind-template="{{mailingList.name}}@{{mailingList.domain}}"></strong> has been reserved, but not yet created.
+    </div>
+
+    <div data-ng-if="listCreated && !mailingList.timeLastPopulated" class="bc-alert bc-alert-info">
+      The list <strong data-ng-bind-template="{{mailingList.name}}@{{mailingList.domain}}"></strong> has been created. Choose "Update membership from course site" to add members.
+    </div>
+
+    <div data-ng-if="!siteSelected">
+      <form class="bc-page-site-mailing-list-form">
+        <div class="row">
+          <div class="small-12 medium-3 columns">
+            <label for="bc-page-site-mailing-list-site-id" class="bc-page-site-mailing-list-form-label">Course Site ID:</label>
+          </div>
+          <div class="small-12 medium-6 columns end">
+            <input type="text" id="bc-page-site-mailing-list-site-id" class="cc-left bc-canvas-form-input-text" data-ng-model="canvasSite.canvasCourseId"
+                   placeholder="Enter numeric site ID" required aria-required="true">
+            <button class="bc-canvas-button bc-canvas-button-primary" data-ng-click="findSiteMailingList()" data-ng-disabled="isProcessing || !canvasSite.canvasCourseId">
+              <span data-ng-if="!isProcessing">Get Mailing List</span>
+              <span data-ng-if="isProcessing"><i class="fa fa-spinner fa-spin"></i> Finding ...</span>
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+
+    <div data-ng-if="siteSelected">
+
+      <div class="bc-page-site-mailing-list-info-box">
+        <h2 class="bc-header bc-page-site-mailing-list-header2">
+          <span data-ng-if="!listRegistered" class="cc-ellipsis" data-ng-bind="canvasSite.name"></span>
+          <span data-ng-if="listRegistered" class="cc-ellipsis" data-ng-bind-template="{{mailingList.name}}@{{mailingList.domain}}"></span>
+        </h2>
+        <h3 class="bc-header bc-page-site-mailing-list-header3" data-ng-if="listRegistered && !listCreated">Not yet created</h3>
+        <div data-ng-if="listCreated">
+          <div data-ng-pluralize count="mailingList.membersCount||0" when="{'0':'No members','one':'1 member','other':'{} members'}"></div>
+          <div>Membership last updated: <strong data-ng-bind="listLastPopulated | lowercase"></strong></div>
+          <a data-ng-href="{{mailingList.administrationUrl}}" data-ng-if="mailingList.administrationUrl" data-ng-click="api.analytics.trackExternalLink('Canvas Site Mailing List', 'Calmail', mailingList.administrationUrl)">
+            View in CalMail
+          </a>
+        </div>
+        <div data-ng-if="listRegistered">
+          Course site:
+          <a data-ng-if="listRegistered" data-ng-href="{{canvasSite.url}}" data-ng-click="api.analytics.trackExternalLink('Canvas Site Mailing List', 'bCourses', canvasSite.url)"
+             data-ng-bind="canvasSite.name"></a>
+        </div>
+        <div class="row">
+          <div class="small-12 medium-4 columns" data-ng-bind="canvasSite.codeAndTerm"></div>
+          <div class="small-12 medium-6 columns end" data-ng-bind-template="Site ID: {{canvasSite.canvasCourseId}}"></div>
+        </div>
+        <a data-ng-if="!listRegistered" data-ng-href="{{canvasSite.url}}" data-ng-click="api.analytics.trackExternalLink('Canvas Site Mailing List', 'bCourses', canvasSite.url)">
+          View course site
+        </a>
+      </div>
+
+      <div class="bc-page-site-mailing-list-text" data-ng-if="!listRegistered">
+        No mailing list name has been reserved for this site.
+      </div>
+
+      <div data-ng-if="listPending">
+        <div class="bc-page-site-mailing-list-text">
+          <strong>Mailing lists can only be created at the CalMail management site.</strong>
+          When you choose "Create mailing list," a new browser window will open at the CalMail site.
+          If you are not logged in to that site, you will have to log in, close the CalMail browser window, and return to this window to try again.
+        </div>
+        <div class="bc-page-site-mailing-list-text">
+          When the list is first created, it will have no members.
+          <strong>After</strong> you create the list in CalMail, return to this window and choose "I've created the list, go to memberships" to update memberships from the course site.
+        </div>
+      </div>
+
+      <form class="bc-canvas-page-form bc-canvas-form">
+        <div data-ng-if="!listRegistered">
+          <div class="row bc-page-site-mailing-list-text">
+            <input type="radio" id="listTypeCalmail" data-ng-model="mailingList.listType" data-ng-value="'CalmailList'">
+            <label for="listTypeCalmail" class="bc-page-site-mailing-list-form-label-long">Reserve this name for a CalMail list (you will create the list on the next screen).</label>
+          </div>
+          <div class="row bc-page-site-mailing-list-text">
+            <input type="radio" id="listTypeMailgun" data-ng-model="mailingList.listType" data-ng-value="'MailgunList'">
+            <label for="listTypeMailgun" class="bc-page-site-mailing-list-form-label-long">Create a Mailgun list now.</label>
+          </div>
+          <div class="row bc-page-site-mailing-list-form-input-row">
+            <div class="medium-3 small-12 columns">
+              <label for="mailingListName" class="bc-page-site-mailing-list-form-label">New Mailing List Name:</label>
+            </div>
+            <div class="medium-9 small-12 columns">
+              <input type="text" id="mailingListName" class="cc-left bc-canvas-form-input-text" data-ng-model="mailingList.name" required aria-required="true">
+            </div>
+          </div>
+        </div>
+
+        <div class="bc-form-actions">
+          <button data-ng-if="!listRegistered" data-ng-click="registerMailingList()" class="bc-canvas-button bc-canvas-button-primary" aria-controls="cc-page-reader-alert">
+            <span data-ng-if="!isProcessing">
+              <span data-ng-if="mailingList.listType !== 'MailgunList'">Reserve mailing list name</span>
+              <span data-ng-if="mailingList.listType === 'MailgunList'">Create mailing list</span>
+            </span>
+            <span data-ng-if="isProcessing"><i class="fa fa-spinner fa-spin"></i>
+              <span data-ng-if="mailingList.listType !== 'MailgunList'">Reserving ...</span>
+              <span data-ng-if="mailingList.listType === 'MailgunList'">Creating ...</span>
+            </span>
+          </button>
+          <div data-ng-if="listPending">
+            <a data-ng-href="{{mailingList.creationUrl}}" class="bc-canvas-button bc-canvas-button-primary bc-page-site-mailing-list-button-primary"
+            aria-controls="cc-page-reader-alert">Create mailing list</a>
+            <button data-ng-click="confirmCreation()" class="bc-canvas-button" aria-controls="cc-page-reader-alert">
+              <i data-ng-if="isConfirmingCreation" class="fa fa-spinner fa-spin"></i>
+              I've created the list, go to memberships
+            </button>
+            <button data-ng-if="listPending" class="bc-canvas-button" data-ng-click="unregisterMailingList()">
+              <span data-ng-if="!isProcessing">Cancel registration</span>
+              <span data-ng-if="isProcessing"><i class="fa fa-spinner fa-spin"></i> Cancelling ...</span>
+            </button>
+          </div>
+          <button data-ng-if="listCreated" data-ng-click="populateMailingList()" class="bc-canvas-button bc-canvas-button-primary" aria-controls="cc-page-reader-alert">
+            <span data-ng-if="!isProcessing">Update membership from course site</span>
+            <span data-ng-if="isProcessing"><i class="fa fa-spinner fa-spin"></i> Updating ...</span>
+          </button>
+          <button data-ng-if="!listPending" class="bc-canvas-button" data-ng-click="resetForm()">Cancel</button>
+        </div>
+      </form>
+
+    </div>
+  </div>
+
+  <div data-ng-if="displayError" class="bc-notice-error-container">
+    <div data-ng-include="'canvas_embedded/_shared/canvas_errors.html'"></div>
+  </div>
+
+</div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6473

The least disruptive way I could find to set up a second mailing list LTI tool alongside the existing one was to enforce a convention up and down the stack where`mailing_list`, `mailingList` code (singular) drives the new course-level tool for creating a single list, while `mailing_lists`, `mailingLists` code (plural) drives the existing admin-level tool for managing all lists. Getting this naming consistent involved a couple of file renames that make the diff harder to read than it should be.