### PR TITLE
SISRP-27745 - Update jruby-openssl gem to newest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,9 +61,7 @@ gem 'active_attr', '~> 0.8.5'
 gem 'jruby-activemq', '~> 5.13.0', git: 'https://github.com/ets-berkeley-edu/jruby-activemq.git'
 
 # To support SSL TLSv1.2.
-# jruby-openssl versions 0.9.8 through 0.9.16 trigger runaway memory consumption in CalCentral.
-# Track progress at https://github.com/jruby/jruby-openssl/issues/86 and SISRP-18781.
-gem 'jruby-openssl', '0.9.7'
+gem 'jruby-openssl', '0.9.17'
 
 # Addressable is a replacement for the URI implementation that is part of Ruby's standard library.
 # https://github.com/sporkmonger/addressable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.0)
       railties (>= 3.2.16)
-    jruby-openssl (0.9.7-java)
+    jruby-openssl (0.9.17-java)
     json (1.8.3-java)
     jwt (1.5.4)
     kaminari (0.16.1)
@@ -484,7 +484,7 @@ DEPENDENCIES
   icalendar (~> 2.2.2)
   ims-lti!
   jruby-activemq (~> 5.13.0)!
-  jruby-openssl (= 0.9.7)
+  jruby-openssl (= 0.9.17)
   json (~> 1.8.0)
   link_header (~> 0.0.7)
   log4r (~> 1.1)


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-27745

As this is my first time updating a gem, I'd like to run through what I did to ensure we're all on the same page:
* Updated `Gemfile` with newest version - this ensures we don't automatically update with each new released version.
* In ~/calcentral, ran `bundle update jruby-openssl`, followed with `gem cleanup jruby-openssl` to remove older, unused versions that don't have any dependencies.
* Would I go through the same process on each node upon merge, to update the gem on each cluster?

Additionally:
* Testing on my local machine seemed totally fine - no breaks or unexpected behavior.
* @raydavis, you mentioned getting this onto CC-QA as soon as possible - shall I open a QA PR for that upon merge of this PR?