### PR TITLE
SISRP-28019 - Committees card need to show Insider/outsider details for committee members

### DIFF
--- a/spec/models/campus_solutions/faculty_committees_spec.rb
+++ b/spec/models/campus_solutions/faculty_committees_spec.rb
@@ -1,6 +1,7 @@
 describe CampusSolutions::FacultyCommittees do
 
-  let(:user_id) { '10634814' }
+  let(:user_id) { random_id }
+  let(:user_cs_id) { random_id }
 
   shared_examples 'a proxy that gets data' do
     subject { proxy.get }
@@ -13,6 +14,10 @@ describe CampusSolutions::FacultyCommittees do
   end
 
   context 'mock proxy' do
+    before do
+      allow(CalnetCrosswalk::ByUid).to receive(:new).with(user_id: user_id).and_return(
+        double(lookup_campus_solutions_id: user_cs_id))
+    end
     let(:proxy) { CampusSolutions::FacultyCommittees.new(fake: true, user_id: user_id) }
     subject { proxy.get }
     it_should_behave_like 'a proxy that gets data'

--- a/spec/models/campus_solutions/student_committees_spec.rb
+++ b/spec/models/campus_solutions/student_committees_spec.rb
@@ -1,6 +1,7 @@
 describe CampusSolutions::StudentCommittees do
 
-  let(:user_id) { '11417698' }
+  let(:user_id) { random_id }
+  let(:user_cs_id) { random_id }
 
   shared_examples 'a proxy that gets data' do
     subject { proxy.get }
@@ -13,6 +14,10 @@ describe CampusSolutions::StudentCommittees do
   end
 
   context 'mock proxy' do
+    before do
+      allow(CalnetCrosswalk::ByUid).to receive(:new).with(user_id: user_id).and_return(
+        double(lookup_campus_solutions_id: user_cs_id))
+    end
     let(:proxy) { CampusSolutions::StudentCommittees.new(fake: true, user_id: user_id) }
     subject { proxy.get }
     it_should_behave_like 'a proxy that gets data'

--- a/spec/models/my_committees/faculty_committees_spec.rb
+++ b/spec/models/my_committees/faculty_committees_spec.rb
@@ -2,14 +2,16 @@ require 'spec_helper'
 
 describe MyCommittees::FacultyCommittees do
   let(:feed) { described_class.new(uid).get_feed }
-
   let(:uid) { random_id }
-  let(:fake_faculty_committees_proxy) { CampusSolutions::FacultyCommittees.new(fake: true) }
+  let(:user_cs_id) { random_id }
+  let(:fake_faculty_committees_proxy) { CampusSolutions::FacultyCommittees.new(fake: true, user_id: uid) }
 
   context 'fake data' do
     before do
       allow(CampusSolutions::FacultyCommittees).to receive(:new).and_return fake_faculty_committees_proxy
       allow(DateTime).to receive(:now).and_return DateTime.parse('2016-11-04')
+      allow(CalnetCrosswalk::ByUid).to receive(:new).with(user_id: uid).and_return(
+        double(lookup_campus_solutions_id: user_cs_id))
     end
     it 'contains the expected faculty data' do
       committees = feed[:facultyCommittees][:completed]

--- a/spec/models/my_committees/student_committees_spec.rb
+++ b/spec/models/my_committees/student_committees_spec.rb
@@ -3,13 +3,17 @@ require 'spec_helper'
 describe MyCommittees::StudentCommittees do
   let(:feed) { described_class.new(uid).get_feed }
   let(:uid) { random_id }
-  let(:fake_student_committees_proxy) { CampusSolutions::StudentCommittees.new(fake: true) }
+  let(:user_cs_id) { random_id }
+  let(:fake_student_committees_proxy) { CampusSolutions::StudentCommittees.new(fake: true, user_id: uid) }
 
   context 'fake data' do
     before do
       allow(CampusSolutions::StudentCommittees).to receive(:new).and_return fake_student_committees_proxy
       allow(DateTime).to receive(:now).and_return DateTime.parse('2016-11-04')
+      allow(CalnetCrosswalk::ByUid).to receive(:new).with(user_id: uid).and_return(
+        double(lookup_campus_solutions_id: user_cs_id))
     end
+
     it 'contains the expected student data for non qualifying exam' do
       committees = feed[:studentCommittees]
       expect(committees[0][:committeeType]).to eq 'STUDENTMILESTONEDESCR1'


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-28019

update 11/15: 
* after discussing with @raydavis, I removed the static UID's and returned them to random ones.
* added mocks to fake the CrossWalk calls 

-------------------------------------------------
* fix testext failures due to random uid. 

This was a tough one. I had to configure my local machine to testext, thank @redconfetti for your help on that.  It was difficult since it was an intermittent error. Some randomly generated uid's being used in the CS proxy calls for the committees API's were sometimes valid and sometimes errored the crosswalk calls. At the end, I'm not sure why the proxy calls are still requiring a valid uid to be passed even though the fake flag is set to true. 

