### PR TITLE
SISRP-25379 - Student Overview (Advisor) - Academic Plan card

### DIFF
--- a/app/models/campus_solutions/advising_academic_plan.rb
+++ b/app/models/campus_solutions/advising_academic_plan.rb
@@ -1,0 +1,24 @@
+module CampusSolutions
+  class AdvisingAcademicPlan < Proxy
+
+    include CampusSolutionsIdRequired
+
+    def initialize(options = {})
+      super options
+      initialize_mocks if @fake
+    end
+
+    def build_feed(response)
+      (response && response['UC_AA_ACAD_PLANNER']) || {}
+    end
+
+    def xml_filename
+      'advising_academic_plan.xml'
+    end
+
+    def url
+      "#{@settings.base_url}/UC_AA_ACAD_PLANNER.v1/get?EMPLID=#{@campus_solutions_id}"
+    end
+
+  end
+end

--- a/app/models/my_academics/academic_plan.rb
+++ b/app/models/my_academics/academic_plan.rb
@@ -1,0 +1,153 @@
+module MyAcademics
+  class AcademicPlan < UserSpecificModel
+
+    def merge(data)
+      update_url_proxy = CampusSolutions::AcademicPlan.new(user_id: @uid).get
+      data[:updatePlanUrl] = update_url_proxy.try(:[], :feed).try(:[], :updateAcademicPlanner).try(:[], :url)
+      data[:planSemesters] = get_plan_semesters(data[:semesters])
+    end
+
+    def get_plan_semesters(semesters)
+      plan_semesters = []
+      plans = CampusSolutions::AdvisingAcademicPlan.new(user_id: @uid).get
+      all_terms = parse_all_possible_terms(plans, semesters)
+      all_terms.each do |term_id|
+        plan_semesters << build_term_plan_semester(term_id, plans, semesters)
+      end
+      add_prev_next(plan_semesters)
+    end
+
+    def build_term_plan_semester(term_id, plans, semesters)
+      term_codes = Berkeley::TermCodes.from_edo_id(term_id)
+      slug = Berkeley::TermCodes.to_slug(term_codes[:term_yr], term_codes[:term_cd])
+      semester = {
+        edoId: term_id,
+        name:  Berkeley::TermCodes.to_english(term_codes[:term_yr], term_codes[:term_cd]),
+        slug: slug,
+        termCode: term_codes[:term_cd],
+        termYear: term_codes[:term_yr],
+        timeBucket: MyAcademics::AcademicsModule.time_bucket(term_codes[:term_yr], term_codes[:term_cd]),
+      }
+      semester.merge! parse_planned_classes(term_id, plans)
+      semester.merge parse_enrolled_classes(slug, semesters)
+    end
+
+    def add_prev_next(plan_semesters)
+      plan_semesters.each_with_index do |semester, i |
+        semester[:timeBucket] = 'next' if i > 0 && plan_semesters[i-1][:timeBucket] == 'current'
+        semester[:timeBucket] = 'previous' if i < plan_semesters.count - 1 && plan_semesters[i+1][:timeBucket] == 'current'
+      end
+      plan_semesters
+    end
+
+    def parse_planned_classes(term_id, plans)
+      planned_classes = []
+      plans[:feed].try(:[], :acadPlans).try(:each) do |plan|
+        planned_classes << find_classes_in_plan(term_id, plan)
+      end
+      planned_classes = planned_classes.flatten.uniq
+      {
+        plannedClasses: planned_classes,
+        plannedUnits: calc_planned_units(planned_classes)
+      }
+    end
+
+    def calc_planned_units(planned_classes)
+      planned_classes.map {|cls| cls[:units].to_f}.sum.to_f.to_s
+    end
+
+    def find_classes_in_plan(term_id, plan)
+      plan_term = plan.try(:[],:terms).try(:find) do |plan_term|
+        plan_term[:termId] == term_id
+      end
+      parse_plan_term_classes(plan_term)
+    end
+
+    def parse_plan_term_classes(plan_term)
+      planned_classes = []
+      plan_term.try(:[], :plannedClasses).try(:each) do |planned_class|
+        planned_classes << {
+          subjectArea: planned_class[:subjectArea],
+          catalogNumber: planned_class[:catalogNumber],
+          units: planned_class[:units]
+        }
+      end
+      planned_classes
+    end
+
+    def parse_enrolled_classes(slug, semesters)
+      semester = semesters.find { |s| s[:slug] == slug}
+      {
+        campusSolutionsTerm: semester.try(:[], :campusSolutionsTerm),
+        hasEnrollmentData:  semester.try(:[], :hasEnrollmentData),
+        hasEnrolledClasses:  semester.try(:[], :hasEnrolledClasses),
+        summaryFromTranscript:  semester.try(:[], :summaryFromTranscript),
+        enrolledClasses:  semester.try(:[], :classes),
+        notation:  semester.try(:[], :notation),
+        hasWaitlisted: has_waitlisted_classes?(semester),
+        hasClassTranscript: has_class_transcript?(semester)
+      }.merge calc_enrolled_units(semester)
+    end
+
+    def calc_enrolled_units(semester)
+      enrolled_units = 0.0
+      waitlisted_units = 0.0
+      semester.try(:[], :classes).try(:each) do |cls|
+        enrolled_units += cls.try(:[], :transcript).try(:map){ |tran| tran[:units].to_f }.try(:sum).to_f
+        cls.try(:[], :sections).try(:each) do |section|
+          if section[:waitlisted] && section[:is_primary_section]
+            waitlisted_units += section[:units].to_f
+          elsif section[:is_primary_section]
+            enrolled_units += section[:units].to_f
+          end
+        end
+      end
+      {
+        enrolledUnits: enrolled_units.to_f.to_s,
+        waitlistedUnits: waitlisted_units.to_f.to_s
+      }
+    end
+
+    def has_waitlisted_classes?(semester)
+      return false unless semester && !semester[:summaryFromTranscript] && semester[:hasEnrolledClasses]
+      !!semester.try(:[], :classes).try(:find) do |cls|
+          !!cls[:sections].try(:find) do |section|
+            section[:waitlisted]
+          end
+      end
+    end
+
+    def has_class_transcript?(semester)
+      return false unless semester && semester[:summaryFromTranscript]
+      !!semester.try(:[], :classes).try(:find) do |cls|
+        cls[:transcript].present?
+      end
+    end
+
+    def parse_all_possible_terms(plans, semesters)
+      term_codes = []
+      term_codes << parse_all_plan_terms(plans)
+      term_codes << parse_all_semester_terms(semesters)
+      term_codes.flatten.compact.uniq.sort
+    end
+
+    def parse_all_semester_terms(semesters)
+      semester_term_codes = []
+      semesters.try(:each) do |semester|
+        semester_term_codes << Berkeley::TermCodes.slug_to_edo_id(semester[:slug])
+      end
+      semester_term_codes
+    end
+
+    def parse_all_plan_terms(plans)
+      plan_term_codes = []
+      plans[:feed].try(:[], :acadPlans).try(:each) do |plan|
+        plan.try(:[],:terms).try(:each) do |plan_term|
+          plan_term_codes << plan_term[:termId]
+        end
+      end
+      plan_term_codes
+    end
+
+  end
+end

--- a/app/models/my_academics/filtered_for_advisor.rb
+++ b/app/models/my_academics/filtered_for_advisor.rb
@@ -12,7 +12,8 @@ module MyAcademics
         GpaUnits,
         Semesters,
         TransferCredit,
-        Exams
+        Exams,
+        AcademicPlan
       ]
     end
 

--- a/fixtures/xml/campus_solutions/advising_academic_plan.xml
+++ b/fixtures/xml/campus_solutions/advising_academic_plan.xml
@@ -1,0 +1,49 @@
+<UC_AA_ACAD_PLANNER>
+  <EMPLID>26632289</EMPLID>
+  <ACAD_PLANS type="array">
+    <ACAD_PLAN>
+      <PLAN_DESCR>Bioengineering BS</PLAN_DESCR>
+      <TERMS type="array">
+        <TERM>
+          <TERM_ID>2172</TERM_ID>
+          <TERM_DESCR>Spring 2017</TERM_DESCR>
+          <PLANNED_CLASSES type="array">
+            <CLASS>
+              <SUBJECT_AREA>
+                <CODE>ENGLISH</CODE>
+              </SUBJECT_AREA>
+              <CATALOG_NUMBER>
+                <FORMATTED>C107</FORMATTED>
+              </CATALOG_NUMBER>
+              <UNITS>3.0</UNITS>
+            </CLASS>
+            <CLASS>
+              <SUBJECT_AREA>
+                <CODE>ELECTRICAL ENGINEERING</CODE>
+              </SUBJECT_AREA>
+              <CATALOG_NUMBER>
+                <FORMATTED>EE20</FORMATTED>
+              </CATALOG_NUMBER>
+              <UNITS>4.0</UNITS>
+            </CLASS>
+          </PLANNED_CLASSES>
+        </TERM>
+        <TERM>
+          <TERM_ID>2168</TERM_ID>
+          <TERM_DESCR>Fall 2016</TERM_DESCR>
+          <PLANNED_CLASSES type="array">
+            <CLASS>
+              <SUBJECT_AREA>
+                <CODE>ENGLISH</CODE>
+              </SUBJECT_AREA>
+              <CATALOG_NUMBER>
+                <FORMATTED>C108</FORMATTED>
+              </CATALOG_NUMBER>
+              <UNITS>3.0</UNITS>
+            </CLASS>
+          </PLANNED_CLASSES>
+        </TERM>
+      </TERMS>
+    </ACAD_PLAN>
+  </ACAD_PLANS>
+</UC_AA_ACAD_PLANNER>

--- a/public/dummy/json/advising_student_academics.json
+++ b/public/dummy/json/advising_student_academics.json
@@ -166,6 +166,654 @@
       ]
     }
   ],
+  "planSemesters": [
+    {
+      "name": "Fall 2007",
+      "slug": "fall-2007",
+      "termCode": "D",
+      "termYear": "2007",
+      "timeBucket": "past",
+      "campusSolutionsTerm": true,
+      "summaryFromTranscript": false,
+      "hasEnrolledClasses": false,
+      "plannedUnits": "0.0",
+      "enrolledUnits": "19.0",
+      "waitlistedUnits": "0.0"
+    },
+    {
+      "name": "Fall 2008",
+      "slug": "fall-2008",
+      "termCode": "D",
+      "termYear": "2008",
+      "timeBucket": "past",
+      "campusSolutionsTerm": true,
+      "notation": "Education Abroad",
+      "enrolledClasses": [
+        {
+          "title": "SPORTS \u0026 EDUCATION",
+          "dept": "EDUC",
+          "courseCatalog": "75AC",
+          "course_code": "EDUC 75AC",
+          "sections": [],
+          "transcript": [
+            {
+              "units": "3.0",
+              "grade": "B"
+            }
+          ]
+        },
+        {
+          "title": "INTRO TO OCEANS",
+          "dept": "INTEGBI",
+          "courseCatalog": "C82",
+          "course_code": "INTEGBI C82",
+          "sections": [],
+          "transcript": [
+            {
+              "units": "2.0",
+              "grade": "P"
+            }
+          ]
+        },
+        {
+          "title": "DESCRIPTIVE INTRO",
+          "dept": "L \u0026 S",
+          "courseCatalog": "C70V",
+          "course_code": "L \u0026 S C70V",
+          "sections": [],
+          "transcript": [
+            {
+              "units": "3.0",
+              "grade": "B-"
+            }
+          ]
+        },
+        {
+          "title": "MYTH, MEMORY, HIST",
+          "dept": "NATAMST",
+          "courseCatalog": "90",
+          "course_code": "NATAMST 90",
+          "sections": [],
+          "transcript": [
+            {
+              "units": "4.0",
+              "grade": "C+"
+            }
+          ]
+        },
+        {
+          "title": "PE ACTIVITIES",
+          "dept": "PHYS ED",
+          "courseCatalog": "11",
+          "course_code": "PHYS ED 11",
+          "sections": [],
+          "transcript": [
+            {
+              "units": "0.5",
+              "grade": "A"
+            }
+          ]
+        },
+        {
+          "title": "PE ACTIVITIES",
+          "dept": "PHYS ED",
+          "courseCatalog": "11",
+          "course_code": "PHYS ED 11",
+          "sections": [],
+          "transcript": [
+            {
+              "units": "0.5",
+              "grade": "A"
+            }
+          ]
+        },
+        {
+          "title": "PE ACTIVITIES",
+          "dept": "PHYS ED",
+          "courseCatalog": "11",
+          "course_code": "PHYS ED 11",
+          "sections": [],
+          "transcript": [
+            {
+              "units": "0.5",
+              "grade": "A"
+            }
+          ]
+        },
+        {
+          "title": "PE ACTIVITIES",
+          "dept": "PHYS ED",
+          "courseCatalog": "11",
+          "course_code": "PHYS ED 11",
+          "sections": [],
+          "transcript": [
+            {
+              "units": "0.5",
+              "grade": "A"
+            }
+          ]
+        }
+      ],
+      "hasEnrollmentData": false,
+      "summaryFromTranscript": true,
+      "hasEnrolledClasses": false,
+      "hasClassTranscript": true,
+      "plannedUnits": "0.0",
+      "enrolledUnits": "19.0",
+      "waitlistedUnits": "0.0"
+    },
+    {
+      "name": "Spring 2009",
+      "slug": "spring-2009",
+      "termCode": "B",
+      "termYear": "2009",
+      "timeBucket": "previous",
+      "campusSolutionsTerm": true,
+      "enrolledClasses": [
+        {
+          "title": "DIRECTED GROUP STDY",
+          "dept": "AFRICAM",
+          "courseCatalog": "98",
+          "course_code": "AFRICAM 98",
+          "sections": [],
+          "transcript": [
+            {
+              "units": "1.0",
+              "grade": "P"
+            }
+          ]
+        },
+        {
+          "title": "INTRO TO ECONOMICS",
+          "dept": "ECON",
+          "courseCatalog": "1",
+          "course_code": "ECON 1",
+          "sections": [],
+          "transcript": [
+            {
+              "units": "4.0",
+              "grade": "C-"
+            }
+          ]
+        },
+        {
+          "title": "GEN SEX RAC GLO POL",
+          "dept": "GWS",
+          "courseCatalog": "14",
+          "course_code": "GWS 14",
+          "sections": [],
+          "transcript": [
+            {
+              "units": "4.0",
+              "grade": "C"
+            }
+          ]
+        },
+        {
+          "title": "DIRECTED GROUP STDY",
+          "dept": "INTEGBI",
+          "courseCatalog": "98",
+          "course_code": "INTEGBI 98",
+          "sections": [],
+          "transcript": [
+            {
+              "units": "2.0",
+              "grade": "P"
+            }
+          ]
+        },
+        {
+          "title": "PE ACTIVITIES",
+          "dept": "PHYS ED",
+          "courseCatalog": "11",
+          "course_code": "PHYS ED 11",
+          "sections": [],
+          "transcript": [
+            {
+              "units": "0.5",
+              "grade": "A"
+            }
+          ]
+        },
+        {
+          "title": "PE ACTIVITIES",
+          "dept": "PHYS ED",
+          "courseCatalog": "11",
+          "course_code": "PHYS ED 11",
+          "sections": [],
+          "transcript": [
+            {
+              "units": "0.5",
+              "grade": "A"
+            }
+          ]
+        },
+        {
+          "title": "PE ACTIVITIES",
+          "dept": "PHYS ED",
+          "courseCatalog": "11",
+          "course_code": "PHYS ED 11",
+          "sections": [],
+          "transcript": [
+            {
+              "units": "0.5",
+              "grade": "A"
+            }
+          ]
+        },
+        {
+          "title": "PE ACTIVITIES",
+          "dept": "PHYS ED",
+          "courseCatalog": "11",
+          "course_code": "PHYS ED 11",
+          "sections": [],
+          "transcript": [
+            {
+              "units": "0.5",
+              "grade": "A"
+            }
+          ]
+        }
+      ],
+      "hasEnrollmentData": false,
+      "summaryFromTranscript": true,
+      "hasEnrolledClasses": false,
+      "hasClassTranscript": true,
+      "plannedUnits": "0.0",
+      "enrolledUnits": "19.0",
+      "waitlistedUnits": "0.0"
+    },
+    {
+      "name": "Fall 2016",
+      "slug": "fall-2016",
+      "termCode": "D",
+      "termYear": "2016",
+      "timeBucket": "current",
+      "enrolledClasses": [
+        {
+          "role": "Student",
+          "sections": [
+            {
+              "ccn": "07311",
+              "enroll_limit": "35",
+              "instruction_format": "DIS",
+              "instructors": [],
+              "is_primary_section": true,
+              "schedules": {
+                "oneTime": [],
+                "recurring": []
+              },
+              "section_label": "DIS 005",
+              "section_number": "005",
+              "waitlisted": true,
+              "units": "2.0",
+              "waitlistPosition": "3"
+            },
+            {
+              "ccn": "34458",
+              "instruction_format": "LEC",
+              "is_primary_section": true,
+              "section_label": "LEC 001",
+              "section_number": "001",
+              "units": "2.0",
+              "grading_basis": "GRD",
+              "instructors": [
+                {
+                  "name": "James Robinson",
+                  "role": "PI",
+                  "uid": "3893"
+                }
+              ],
+              "schedules": {
+                "oneTime": [],
+                "recurring": [
+                  {
+                    "buildingName": "Lewis",
+                    "roomNumber": "100",
+                    "schedule": "M 10:00A-11:59A"
+                  }
+                ]
+              },
+              "final_exams": [
+                {
+                  "exam_type": "Y",
+                  "location": null,
+                  "exam_date": null,
+                  "exam_start_time": null,
+                  "exam_end_time": null
+                }
+              ],
+              "gradeOption": "Letter"
+            },
+            {
+              "ccn": "34459",
+              "instruction_format": "DIS",
+              "is_primary_section": false,
+              "section_label": "DIS 101",
+              "section_number": "101",
+              "associated_primary_id": "34458.0",
+              "instructors": [],
+              "schedules": {
+                "oneTime": [],
+                "recurring": [
+                  {
+                    "buildingName": "LeConte",
+                    "roomNumber": "2",
+                    "schedule": "F 11:00A-11:59A"
+                  }
+                ]
+              },
+              "final_exams": []
+            }
+          ],
+          "slug": "pb_hlth-200j",
+          "title": "Health Policy and Management Breadth Course",
+          "url": "/academics/semester/fall-2016/class/pb_hlth-200j",
+          "course_code": "PB HLTH 200J",
+          "dept": "PB HLTH",
+          "courseCatalog": "200J",
+          "course_id": "pb_hlth-200j-2016-D"
+        },
+        {
+          "role": "Student",
+          "sections": [
+            {
+              "ccn": "34462",
+              "instruction_format": "LEC",
+              "is_primary_section": true,
+              "section_label": "LEC 1",
+              "section_number": "1",
+              "units": "2.0",
+              "grading_basis": "GRD",
+              "instructors": [
+                {
+                  "name": "Ralph A. CATALANO",
+                  "role": "PI",
+                  "uid": "7620"
+                }
+              ],
+              "schedules": {
+                "oneTime": [],
+                "recurring": [
+                  {
+                    "buildingName": "Lewis",
+                    "roomNumber": "100",
+                    "schedule": "W 10:00A-11:59A"
+                  }
+                ]
+              },
+              "final_exams": [],
+              "gradeOption": "Letter"
+            },
+            {
+              "ccn": "34463",
+              "instruction_format": "DIS",
+              "is_primary_section": false,
+              "section_label": "DIS 102",
+              "section_number": "102",
+              "associated_primary_id": "34462.0",
+              "instructors": [],
+              "schedules": {
+                "oneTime": [],
+                "recurring": []
+              },
+              "final_exams": []
+            }
+          ],
+          "slug": "pb_hlth-200l",
+          "title": "Health and Social Behavior Breadth",
+          "url": "/academics/semester/fall-2016/class/pb_hlth-200l",
+          "course_code": "PB HLTH 200L",
+          "dept": "PB HLTH",
+          "courseCatalog": "200L",
+          "course_id": "pb_hlth-200l-2016-D"
+        },
+        {
+          "role": "Student",
+          "sections": [
+            {
+              "ccn": "29690",
+              "instruction_format": "LEC",
+              "is_primary_section": true,
+              "section_label": "LEC 001",
+              "section_number": "001",
+              "units": "3.0",
+              "grading_basis": "GRD",
+              "instructors": [
+                {
+                  "name": "Cheri A. PIES",
+                  "role": "PI",
+                  "uid": "125356"
+                }
+              ],
+              "schedules": {
+                "oneTime": [],
+                "recurring": [
+                  {
+                    "buildingName": "Barker",
+                    "roomNumber": "110",
+                    "schedule": "W 2:00P-4:59P"
+                  }
+                ]
+              },
+              "final_exams": [],
+              "gradeOption": "Letter"
+            }
+          ],
+          "slug": "pb_hlth-210",
+          "title": "Maternal and Child Health Specialty Area Core Course",
+          "url": "/academics/semester/fall-2016/class/pb_hlth-210",
+          "course_code": "PB HLTH 210",
+          "dept": "PB HLTH",
+          "courseCatalog": "210",
+          "course_id": "pb_hlth-210-2016-D"
+        },
+        {
+          "role": "Student",
+          "sections": [
+            {
+              "ccn": "29777",
+              "instruction_format": "LEC",
+              "is_primary_section": true,
+              "section_label": "LEC 001",
+              "section_number": "001",
+              "units": "3.0",
+              "grading_basis": "SUS",
+              "instructors": [
+                {
+                  "name": "Kim HARLEY",
+                  "role": "PI",
+                  "uid": "77677"
+                }
+              ],
+              "schedules": {
+                "oneTime": [],
+                "recurring": [
+                  {
+                    "buildingName": "Morgan",
+                    "roomNumber": "138",
+                    "schedule": "W 12:00P-1:59P"
+                  }
+                ]
+              },
+              "final_exams": [],
+              "gradeOption": "S/U"
+            },
+            {
+              "ccn": "32696",
+              "instruction_format": "DIS",
+              "is_primary_section": false,
+              "section_label": "DIS 101",
+              "section_number": "101",
+              "associated_primary_id": "29777.0",
+              "instructors": [],
+              "schedules": {
+                "oneTime": [],
+                "recurring": [
+                  {
+                    "buildingName": "Latimer",
+                    "roomNumber": "121",
+                    "schedule": "M 12:00P-1:59P"
+                  }
+                ]
+              },
+              "final_exams": []
+            }
+          ],
+          "slug": "pb_hlth-210e",
+          "title": "Practicum in MCH Data Analysis I",
+          "url": "/academics/semester/fall-2016/class/pb_hlth-210e",
+          "course_code": "PB HLTH 210E",
+          "dept": "PB HLTH",
+          "courseCatalog": "210E",
+          "course_id": "pb_hlth-210e-2016-D"
+        },
+        {
+          "role": "Student",
+          "sections": [
+            {
+              "ccn": "29757",
+              "instruction_format": "LEC",
+              "is_primary_section": true,
+              "section_label": "LEC 001",
+              "section_number": "001",
+              "units": "3.0",
+              "grading_basis": "GRD",
+              "instructors": [
+                {
+                  "name": "Ndola Prata",
+                  "role": "PI",
+                  "uid": "111162"
+                }
+              ],
+              "schedules": {
+                "oneTime": [],
+                "recurring": [
+                  {
+                    "buildingName": "Barker",
+                    "roomNumber": "110",
+                    "schedule": "TuTh 2:00P-3:29P"
+                  }
+                ]
+              },
+              "final_exams": [
+                {
+                  "exam_type": "Y",
+                  "location": null,
+                  "exam_date": null,
+                  "exam_start_time": null,
+                  "exam_end_time": null
+                }
+              ],
+              "gradeOption": "Letter"
+            }
+          ],
+          "slug": "pb_hlth-213a",
+          "title": "Family Planning, Population Change, and Health",
+          "url": "/academics/semester/fall-2016/class/pb_hlth-213a",
+          "course_code": "PB HLTH 213A",
+          "dept": "PB HLTH",
+          "courseCatalog": "213A",
+          "course_id": "pb_hlth-213a-2016-D"
+        },
+        {
+          "role": "Student",
+          "sections": [
+            {
+              "ccn": "32214",
+              "instruction_format": "SEM",
+              "is_primary_section": true,
+              "section_label": "SEM 003",
+              "section_number": "003",
+              "units": "4.0",
+              "grading_basis": "GRD",
+              "instructors": [
+                {
+                  "name": "Maureen LAHIFF",
+                  "role": "PI",
+                  "uid": "8648"
+                }
+              ],
+              "schedules": {
+                "oneTime": [],
+                "recurring": [
+                  {
+                    "buildingName": "Cory",
+                    "roomNumber": "289",
+                    "schedule": "MW 5:00P-6:29P"
+                  }
+                ]
+              },
+              "final_exams": [],
+              "gradeOption": "Letter"
+            }
+          ],
+          "slug": "pb_hlth-290",
+          "title": "Health Issues Seminars",
+          "url": "/academics/semester/fall-2016/class/pb_hlth-290",
+          "course_code": "PB HLTH 290",
+          "dept": "PB HLTH",
+          "courseCatalog": "290",
+          "course_id": "pb_hlth-290-2016-D"
+        },
+        {
+          "role": "Student",
+          "sections": [
+            {
+              "ccn": "29833",
+              "instruction_format": "SEM",
+              "is_primary_section": true,
+              "section_label": "SEM 002",
+              "section_number": "002",
+              "units": "2.0",
+              "grading_basis": "GRD",
+              "instructors": [
+                {
+                  "name": "Sylvia Guendelman",
+                  "role": "PI",
+                  "uid": "1818"
+                }
+              ],
+              "schedules": {
+                "oneTime": [],
+                "recurring": [
+                  {
+                    "buildingName": "Morgan",
+                    "roomNumber": "138",
+                    "schedule": "Tu 12:00P-1:59P"
+                  }
+                ]
+              },
+              "final_exams": [],
+              "gradeOption": "Letter"
+            }
+          ],
+          "slug": "pb_hlth-293",
+          "title": "Doctoral Seminar",
+          "url": "/academics/semester/fall-2016/class/pb_hlth-293",
+          "course_code": "PB HLTH 293",
+          "dept": "PB HLTH",
+          "courseCatalog": "293",
+          "course_id": "pb_hlth-293-2016-D"
+        }
+      ],
+      "hasEnrollmentData": true,
+      "summaryFromTranscript": false,
+      "hasEnrolledClasses": true,
+      "hasWaitlisted": true,
+      "plannedUnits": "3.0",
+      "enrolledUnits": "19.0",
+      "waitlistedUnits": "2.0",
+      "plannedClasses": [
+        {
+          "subjectArea": "ENGLISH",
+          "CatalogNumber": "C108",
+          "units": "3.0"
+        }
+      ]
+    }
+  ],
+  "updatePlanUrl" : "https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SCI_PLNR_FL.SCI_PLNR_FL.GBL?ucInstitution=UCB01",
   "lastModified":{
     "hash":"ffabb092eb078bba9c5717705bfb543166b3305e",
     "timestamp":{

--- a/script/sis/verify_sis_api_endpoints.sh
+++ b/script/sis/verify_sis_api_endpoints.sh
@@ -220,6 +220,7 @@ verify_cs 'always_enabled' true \
   "/UC_SR_TRNSCPT_DATA.v1/Get?EMPLID=${CAMPUS_SOLUTIONS_ID}" \
   "/UC_SR_TRANSFER_CREDIT.v1/get?EMPLID=${CAMPUS_SOLUTIONS_ID}" \
   "/UC_SR_FACULTY_GRADING.v1/Get?EMPLID=${CAMPUS_SOLUTIONS_ID}"
+  "/UC_AA_ACAD_PLANNER.v1/get?EMPLID=${CAMPUS_SOLUTIONS_ID}"
 
 verify_cs 'advising_student_success' "${yml_features_advising_student_success}" \
   "/UC_AA_STDNT_GPA_TERMS.v1/get?EMPLID=${CAMPUS_SOLUTIONS_ID}" \

--- a/spec/models/campus_solutions/advising_academic_plan_spec.rb
+++ b/spec/models/campus_solutions/advising_academic_plan_spec.rb
@@ -1,15 +1,13 @@
-describe CampusSolutions::AcademicPlan do
-
+describe CampusSolutions::AdvisingAcademicPlan do
   let(:user_id) { random_id }
   let(:user_cs_id) { random_id }
 
   shared_examples 'a proxy that gets data' do
     subject { proxy.get }
     it_should_behave_like 'a simple proxy that returns errors'
-    it_behaves_like 'a proxy that properly observes the enrollment card flag'
     it_behaves_like 'a proxy that got data successfully'
     it 'returns data with the expected structure' do
-      expect(subject[:feed][:updateAcademicPlanner]).to be
+      expect(subject[:feed][:acadPlans]).to be
     end
   end
 
@@ -18,12 +16,12 @@ describe CampusSolutions::AcademicPlan do
       allow(CalnetCrosswalk::ByUid).to receive(:new).with(user_id: user_id).and_return(
         double(lookup_campus_solutions_id: user_cs_id))
     end
-    let(:proxy) { CampusSolutions::AcademicPlan.new(fake: true, user_id: user_id, term_id: '2176') }
+    let(:proxy) { CampusSolutions::AdvisingAcademicPlan.new(fake: true, user_id: user_id) }
     subject { proxy.get }
     it_should_behave_like 'a proxy that gets data'
     it 'includes specific mock data' do
-      expect(subject[:feed][:studentId]).to eq '24437121'
-      expect(subject[:feed][:updateAcademicPlanner][:url]).to eq 'https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SCI_PLNR_FL.SCI_PLNR_FL.GBL?ucInstitution=UCB01'
+      expect(subject[:feed][:emplid]).to eq '26632289'
+      expect(subject[:feed][:acadPlans][0][:planDescr]).to eq 'Bioengineering BS'
     end
   end
 end

--- a/spec/models/my_academics/academic_plan_spec.rb
+++ b/spec/models/my_academics/academic_plan_spec.rb
@@ -1,0 +1,133 @@
+describe MyAcademics::AcademicPlan do
+
+  let(:uid) { random_id }
+  let(:user_cs_id) { random_id }
+  let(:fake) { true }
+
+  let(:plan_proxy) { CampusSolutions::AdvisingAcademicPlan.new(user_id: uid, fake: fake) }
+  let(:semesters_data) {
+    { semesters: [
+      {
+        :name => 'Fall 2016',
+        :slug => 'fall-2016',
+        :termCode => 'D',
+        :termYear => '2016',
+        :timeBucket => 'current',
+        :campusSolutionsTerm => true,
+        :gradingInProgress => nil,
+        :classes => [
+          {
+            course_code: 'EDUC 75AC',
+            sections: [
+              {
+                is_primary_section: true,
+                units: '3.0'
+              },
+              {
+                is_primary_section: false,
+                units: '3.0'
+              }]
+
+          }],
+        :hasEnrollmentData => true,
+        :summaryFromTranscript => false,
+        :hasEnrolledClasses => true
+      },
+      {
+        :name => 'Fall 2017',
+        :slug => 'fall-2017',
+        :termCode => 'D',
+        :termYear => '2017',
+        :timeBucket => 'future',
+        :campusSolutionsTerm => true,
+        :gradingInProgress => nil,
+        :classes => [
+          {
+            course_code: 'INTEGBI C82',
+            sections: [
+              {
+                is_primary_section: true,
+                waitlisted: true,
+                units: '4.0',
+                waitlistPosition: '3'
+              }]
+          },
+          {
+            course_code: 'EDUC 75AC',
+            sections: [
+              {
+                is_primary_section: true,
+                units: '2.0'
+              },
+              {
+                is_primary_section: true,
+                units: '3.0'
+              }
+            ]
+          }],
+        :hasEnrollmentData => true,
+        :summaryFromTranscript => false,
+        :hasEnrolledClasses => true
+      }
+    ]
+    }
+  }
+
+  before do
+    allow(CampusSolutions::AdvisingAcademicPlan).to receive(:get).and_return(plan_proxy)
+    allow(CalnetCrosswalk::ByUid).to receive(:new).with(user_id: uid).and_return(
+      double(lookup_campus_solutions_id: user_cs_id))
+  end
+
+  subject do
+    semesters_data.tap {|x| MyAcademics::AcademicPlan.new(uid).merge(x)}
+  end
+
+  context 'when grading returns statuses for a teaching semester' do
+
+    it 'it should combine the planned and enrolled semesters sorted' do
+      expect(subject[:planSemesters].length).to eq 3
+      expect(subject[:planSemesters][0][:edoId]).to eq '2168'
+      expect(subject[:planSemesters][1][:edoId]).to eq '2172'
+      expect(subject[:planSemesters][2][:edoId]).to eq '2178'
+    end
+
+    it 'it should parse enrolled semesters correctly' do
+      expect(subject[:planSemesters][0][:enrolledClasses].length).to eq 1
+      expect(subject[:planSemesters][1][:enrolledClasses]).to be_nil
+      expect(subject[:planSemesters][2][:enrolledClasses].length).to eq 2
+    end
+
+    it 'it should parse planned semesters correctly' do
+      expect(subject[:planSemesters][0][:plannedClasses].length).to eq 1
+      expect(subject[:planSemesters][1][:plannedClasses].length).to eq 2
+      expect(subject[:planSemesters][2][:plannedClasses].length).to eq 0
+    end
+
+    it 'it should parse hasWaitlisted flag  correctly' do
+      expect(subject[:planSemesters][0][:hasWaitlisted]).to eq false
+      expect(subject[:planSemesters][1][:hasWaitlisted]).to eq false
+      expect(subject[:planSemesters][2][:hasWaitlisted]).to eq true
+    end
+
+    it 'it should calc plannedUnits correctly' do
+      expect(subject[:planSemesters][0][:plannedUnits]).to eq '3.0'
+      expect(subject[:planSemesters][1][:plannedUnits]).to eq '7.0'
+      expect(subject[:planSemesters][2][:plannedUnits]).to eq '0.0'
+    end
+
+    it 'it should calc enrolledUnits correctly' do
+      expect(subject[:planSemesters][0][:enrolledUnits]).to eq '3.0'
+      expect(subject[:planSemesters][1][:enrolledUnits]).to eq '0.0'
+      expect(subject[:planSemesters][2][:enrolledUnits]).to eq '5.0'
+    end
+
+    it 'it should calc waitlistedunits correctly' do
+      expect(subject[:planSemesters][0][:waitlistedUnits]).to eq '0.0'
+      expect(subject[:planSemesters][1][:waitlistedUnits]).to eq '0.0'
+      expect(subject[:planSemesters][2][:waitlistedUnits]).to eq '4.0'
+    end
+
+  end
+
+end

--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -15,6 +15,9 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
   $scope.ucAdvisingResources = {
     isLoading: true
   };
+  $scope.planSemestersInfo = {
+    isLoading: true
+  };
   $scope.holdsInfo = {
     isLoading: true
   };
@@ -139,10 +142,18 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
       uid: $routeParams.uid
     }).success(function(data) {
       angular.extend($scope, data);
+      _.forEach($scope.planSemesters, function(semester) {
+        angular.extend(
+          semester,
+          {
+            show: ['current', 'previous', 'next'].indexOf(semester.timeBucket) > -1
+          });
+      });
     }).error(function(data, status) {
       $scope.academics.error = errorReport(status, data.error);
     }).finally(function() {
       $scope.academics.isLoading = false;
+      $scope.planSemestersInfo.isLoading = false;
     });
   };
 

--- a/src/assets/stylesheets/_academics.scss
+++ b/src/assets/stylesheets/_academics.scss
@@ -309,6 +309,18 @@
       background: $cc-color-widget-more-background;
     }
   }
+  .cc-academics-semester-list {
+    .cc-widget-list-hover:not(tr):not(.cc-widget-list-hover-notriangle) {
+      &::before {
+        top: 20px;
+      }
+      &:hover, &:focus {
+        &::before {
+          top: 20px;
+        }
+      }
+    }
+  }
   .cc-academics-semester-title-link {
     margin-top: 7px;
   }

--- a/src/assets/templates/academics_plan.html
+++ b/src/assets/templates/academics_plan.html
@@ -1,0 +1,145 @@
+<div class="cc-widget">
+  <div class="cc-widget-title">
+    <h2 class="cc-left">Academic Plan</h2>
+  </div>
+  <div class="cc-widget-padding" data-ng-if="updatePlanUrl">
+    <h3>
+      <a class="cc-academics-semester-title-link" data-ng-href="{{updatePlanUrl}}">Update multi-year planner</a>
+    </h3>
+  </div>
+
+  <div class="cc-flex-space-between-vertical-15">
+    <ul class="cc-widget-list cc-widget-list-border-top">
+        <li
+          data-ng-repeat="semester in planSemesters"
+          class="cc-academics-semester-list cc-widget-list-hover cc-enrollment-card-section cc-table"
+          data-ng-class="{'cc-widget-list-hover-opened':(semester.show)}"
+          data-cc-accessible-focus-directive
+          data-ng-click="api.widget.toggleShow($event,  null, semester, 'Student Overview - Academic Plan')">
+          <div>
+            <h3 class="cc-left">
+              <span data-ng-bind="semester.name"></span> <span data-ng-bind="semester.notation" class="cc-text-red"></span>
+            </h3>
+            <br>
+            <div data-ng-show="semester.show">
+              <div class="cc-widget-text" data-ng-if="!semester.plannedClasses.length && !semester.hasEnrolledClasses && !semester.summaryFromTranscript">
+                No Plan Provided
+                <span data-ng-bind="semester.name"></span>.
+              </div>
+              <div data-ng-if="semester.plannedClasses.length">
+                <table>
+                  <thead>
+                    <tr>
+                      <th width="60%" scope="col">Planned</th>
+                      <th width="40%" scope="col" title="Units">Units</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr data-ng-repeat="class in semester.plannedClasses">
+                      <td data-ng-bind-template="{{class.subjectArea}} {{class.catalogNumber}}"></td>
+                      <td data-ng-bind="class.units | number:1"></td>
+                    </tr>
+                  </tbody>
+                </table>
+                <table>
+                  <tr>
+                      <td width="60%" scope="col" class="cc-table-right">Total Units: </td>
+                      <td width="25%" scope="col"><strong><span data-ng-bind="semester.plannedUnits | number:1"></span></strong></td>
+                      <td width="15%" scope="col"></td>
+                  </tr>
+                </table>
+                <br>
+              </div>
+              <div data-ng-if="semester.hasEnrolledClasses || semester.summaryFromTranscript">
+                <table data-ng-if="semester.summaryFromTranscript && semester.hasClassTranscript">
+                  <thead>
+                    <tr>
+                      <th width="60%" scope="col">Enrolled</th>
+                      <th width="25%" scope="col" title="Units">Units</th>
+                      <th data-ng-if="api.user.profile.canViewGrades" width="15%" scope="col" title="Grades">Grade</th>
+                    </tr>
+                  </thead>
+                  <tbody data-ng-repeat="class in semester.enrolledClasses">
+                    <tr data-ng-if="class.transcript" data-ng-repeat="transcript in class.transcript">
+                      <td data-ng-bind="class.course_code"></td>
+                      <td data-ng-bind="transcript.units | number:1"></td>
+                      <td data-ng-bind="transcript.grade" data-ng-if="api.user.profile.canViewGrades"></td>
+                    </tr>
+                  </tbody>
+                </table>
+                <table data-ng-if="semester.summaryFromTranscript && !semester.hasClassTranscript">
+                  <thead>
+                    <tr>
+                      <th width="60%" scope="col">Enrolled</th>
+                      <th width="25%" scope="col" title="Units">Units</th>
+                      <th data-ng-if="api.user.profile.canViewGrades" width="15%" scope="col"></th>
+                    </tr>
+                  </thead>
+                  <tbody data-ng-repeat="class in semester.enrolledClasses">
+                    <tr data-ng-if="!class.transcript && section.is_primary_section" data-ng-repeat="section in class.sections">
+                      <td data-ng-bind="class.course_code"></td>
+                      <td data-ng-bind="section.units | number:1" ></td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+                <table data-ng-if="!semester.summaryFromTranscript">
+                  <thead>
+                    <tr>
+                      <th width="60%" scope="col">Enrolled</th>
+                      <th width="25%" scope="col" title="Units">Units</th>
+                      <th data-ng-if="api.user.profile.canViewGrades" width="15%" scope="col"></th>
+                    </tr>
+                  </thead>
+                  <tbody data-ng-repeat="class in semester.enrolledClasses">
+                    <tr data-ng-repeat="section in class.sections" data-ng-if="section.is_primary_section && !section.waitlisted">
+                      <td data-ng-if="class.multiplePrimaries" data-ng-bind-template="{{class.course_code}} {{section.section_label}}"></td>
+                      <td data-ng-if="!class.multiplePrimaries" data-ng-bind="class.course_code"></td>
+                      <td data-ng-bind="section.units | number:1"></td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+                <table>
+                  <tr>
+                      <td width="60%" scope="col" class="cc-table-right">Total Units: </td>
+                      <td width="25%" scope="col"><strong><span data-ng-bind="semester.enrolledUnits | number:1"></strong></td>
+                      <td width="15%" scope="col"></td>
+                  </tr>
+                </table>
+                <br>
+              </div>
+              <div data-ng-if="semester.hasWaitlisted">
+                <table>
+                  <thead>
+                    <tr>
+                      <th width="60%" scope="col">Waitlisted</th>
+                      <th width="25%" scope="col" title="Units">Units</th>
+                      <th data-ng-if="api.user.profile.canViewGrades" width="15%" scope="col" title="Position">Position</th>
+                    </tr>
+                  </thead>
+                  <tbody data-ng-if="!semester.summaryFromTranscript" data-ng-repeat="class in semester.enrolledClasses">
+                    <tr data-ng-repeat="section in class.sections" data-ng-if="section.waitlisted">
+                      <td data-ng-if="class.multiplePrimaries" data-ng-bind-template="{{class.course_code}} {{section.section_label}}"></td>
+                      <td data-ng-if="!class.multiplePrimaries" data-ng-bind="class.course_code"></td>
+                      <td data-ng-bind="section.units | number:1"></td>
+                      <td data-ng-bind="section.waitlistPosition" class="cc-table-right"></td>
+                    </tr>
+                  </tbody>
+                </table>
+                <table>
+                  <tr>
+                      <td width="60%" scope="col" class="cc-table-right">Total Units: </td>
+                      <td width="25%" scope="col"><strong><span data-ng-bind="semester.waitlistedUnits | number:1"></strong></td>
+                      <td width="15%" scope="col"></td>
+                  </tr>
+                </table>
+                <br>
+              </div>
+            </div>
+          </div>
+        </li>
+      </div>
+    </ul>
+</div>
+

--- a/src/assets/templates/user_overview.html
+++ b/src/assets/templates/user_overview.html
@@ -8,16 +8,15 @@
     </div>
     <div class="medium-4 columns cc-column-2">
       <div data-ng-include="'widgets/student_success/student_success.html'" data-ng-if="api.user.profile.features.advisingStudentSuccess"></div>
-      <div data-ng-include src="'academics_semesters.html'" data-ng-if="semesters.length"></div>
       <div data-ng-include="'widgets/status_and_holds.html'"></div>
       <div data-ng-include src="'widgets/academics/degree_progress_graduate.html'" data-ng-if="api.user.profile.features.csDegreeProgressGradAdvising && (targetUser.roles.graduate || targetUser.roles.law)"></div>
       <div data-ng-include src="'widgets/academics/degree_progress_undergrad.html'" data-ng-if="api.user.profile.features.csDegreeProgressUgrdAdvising && targetUser.roles.undergrad"></div>
     </div>
     <div class="medium-4 columns cc-column-3">
       <div data-ng-include="'widgets/final_exam_schedule.html'" data-ng-if="examSchedule.length && api.user.profile.features.finalExamSchedule"></div>
-      <div data-ng-include="'widgets/enrollment_card.html'" data-ng-if="api.user.profile.features.csEnrollmentCard"></div>
       <div data-ng-include="'widgets/transfer_credit.html'"></div>
       <div data-ng-include="'widgets/my_advising.html'"></div>
+      <div data-ng-include src="'academics_plan.html'" data-ng-if="planSemesters.length"></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-25379

This a redo for PR https://github.com/ets-berkeley-edu/calcentral/pull/6083/

This is a brand new card "Academic Plan" for advisors and super users on the user_overview page. This card replaces the semesters and enrollments cards on this page.

There was enough refactoring after the last review that I decided not to reopen the old PR but create a new one with start from a zero review. 

* Add  academic plan feed as a merged feed under my academics filtered for advisor merged model.
* corrected some bugs found under the first review. 
* add missed UX features. 