### PR TITLE
SISRP-27695 - Adds sub-plan to the Profile card

### DIFF
--- a/app/models/my_academics/college_and_level.rb
+++ b/app/models/my_academics/college_and_level.rb
@@ -135,11 +135,13 @@ module MyAcademics
           case flattened_plan[:type].try(:[], :category)
             when 'Major'
               plan_set[:majors] << college_plan.merge({
-                major: flattened_plan[:plan].try(:[], :description)
+                major: flattened_plan[:plan].try(:[], :description),
+                subPlan: flattened_plan[:subPlan].try(:[], :description)
               })
             when 'Minor'
               plan_set[:minors] << college_plan.merge({
-                minor: flattened_plan[:plan].try(:[], :description)
+                minor: flattened_plan[:plan].try(:[], :description),
+                subPlan: flattened_plan[:subPlan].try(:[], :description)
               })
           end
 
@@ -265,6 +267,7 @@ module MyAcademics
         career: {},
         program: {},
         plan: {},
+        subPlan: {}
       }
       if (academic_plan = hub_plan['academicPlan'])
         # Get CPP
@@ -286,6 +289,14 @@ module MyAcademics
           code: plan.try(:[], 'code'),
           description: plan.try(:[], 'description')
         })
+
+        if (academic_sub_plan = hub_plan['academicSubPlan'])
+          sub_plan = academic_sub_plan.try(:[], 'subPlan')
+          flat_plan[:subPlan].merge!({
+            code: sub_plan.try(:[], 'code'),
+            description: sub_plan.try(:[], 'description')
+          })
+        end
 
         if (hub_plan['expectedGraduationTerm'])
           expected_grad_term_name = hub_plan['expectedGraduationTerm'].try(:[], 'name')

--- a/spec/models/my_academics/college_and_level_spec.rb
+++ b/spec/models/my_academics/college_and_level_spec.rb
@@ -101,6 +101,8 @@ describe MyAcademics::CollegeAndLevel do
       plan_description: 'MCB-Cell & Dev Biology BA',
       type_code: 'SP',
       type_description: 'Major - UG Specialization',
+      sub_plan_code: '25966SA02U',
+      sub_plan_description: 'Biological Chemistry',
       admin_owners: [{org_code: 'MCELLBI', org_description: 'Molecular & Cell Biology', percentage: 100}],
       is_primary: false
     })
@@ -319,18 +321,21 @@ describe MyAcademics::CollegeAndLevel do
       it 'translates minors' do
         expect(feed[:collegeAndLevel][:minors].first).to eq({
           college: 'Undergrad Letters & Science',
-          minor: 'Art BA'
+          minor: 'Art BA',
+          subPlan: nil
         })
       end
 
       it 'translates majors' do
         expect(feed[:collegeAndLevel][:majors][0]).to eq({
           college: 'Undergrad Letters & Science',
-          major: 'English BA'
+          major: 'English BA',
+          subPlan: nil
         })
         expect(feed[:collegeAndLevel][:majors][1]).to eq({
           college: 'Undergrad Letters & Science',
-          major: 'MCB-Cell & Dev Biology BA'
+          major: 'MCB-Cell & Dev Biology BA',
+          subPlan: 'Biological Chemistry'
         })
       end
 
@@ -370,6 +375,12 @@ describe MyAcademics::CollegeAndLevel do
         expect(feed[:collegeAndLevel][:plans][2][:type][:code]).to eq 'MIN'
         expect(feed[:collegeAndLevel][:plans][2][:type][:category]).to eq 'Minor'
         expect(feed[:collegeAndLevel][:plans][2][:college]).to eq 'Undergrad Letters & Science'
+      end
+
+      it 'translates sub-plans' do
+        expect(feed[:collegeAndLevel][:plans][1][:subPlan]).to be
+        expect(feed[:collegeAndLevel][:plans][1][:subPlan][:code]).to eq '25966SA02U'
+        expect(feed[:collegeAndLevel][:plans][1][:subPlan][:description]).to eq 'Biological Chemistry'
       end
 
       it 'translates roles' do
@@ -448,11 +459,13 @@ describe MyAcademics::CollegeAndLevel do
       it 'translates majors' do
         expect(feed[:collegeAndLevel][:majors][0]).to eq({
           college: 'Law Professional Programs',
-          major: 'Law JD-MPP CDP'
+          major: 'Law JD-MPP CDP',
+          subPlan: nil
         })
         expect(feed[:collegeAndLevel][:majors][1]).to eq({
           college: 'Graduate Professional Programs',
-          major: 'Public Policy MPP-JD CDP'
+          major: 'Public Policy MPP-JD CDP',
+          subPlan: nil
         })
       end
 

--- a/spec/support/spec_helper_module.rb
+++ b/spec/support/spec_helper_module.rb
@@ -63,6 +63,12 @@ module SpecHelperModule
           "administrativeOwners" => adminOwners
         },
       },
+      "academicSubPlan" => {
+        "subPlan" => {
+          "code" => cpp_hash[:sub_plan_code],
+          "description" => cpp_hash[:sub_plan_description]
+        }
+      },
       "primary" => cpp_hash[:is_primary],
       "statusInPlan" => {
         "action" => {

--- a/src/assets/stylesheets/_profile.scss
+++ b/src/assets/stylesheets/_profile.scss
@@ -22,6 +22,9 @@
       width: 92px;
     }
   }
+  .cc-widget-profile-indent {
+    margin-left: 10px;
+  }
   .cc-widget-profile-content-fullname {
     font-size: 16px;
   }

--- a/src/assets/templates/widgets/academics/college_and_level.html
+++ b/src/assets/templates/widgets/academics/college_and_level.html
@@ -8,6 +8,7 @@
         <div data-ng-repeat="major in collegeAndLevel.majors">
           <div class="cc-text-light" data-ng-if="major.college" data-ng-bind="major.college"></div>
           <div><strong data-ng-bind="major.major"></strong></div>
+          <div class="cc-widget-profile-indent" data-ng-bind="major.subPlan"></div>
         </div>
       </td>
     </tr>
@@ -24,6 +25,7 @@
         <div data-ng-repeat="minor in collegeAndLevel.minors">
           <div class="cc-text-light" data-ng-if="minor.college" data-ng-bind="minor.college"></div>
           <div><strong data-ng-bind="minor.minor"></strong></div>
+          <div class="cc-widget-profile-indent" data-ng-bind="minor.subPlan"></div>
         </div>
       </td>
     </tr>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-27695

Students can have a sub-plan associated with their plan (major or minor) which will now display on the Profile card.

So far it looks like there will be a 1-1 relationship between plan and sub-plan.  I'm checking to see if we'll ever have to handle a list of sub-plans and will make changes accordingly if that's the case.

![ideal](https://cloud.githubusercontent.com/assets/12432859/20405509/3c77112e-acbe-11e6-9a7d-dfc6bd1ea87a.png)
