### PR TITLE
SISRP-27695 - Adds designated emphasis to Profile card

### DIFF
--- a/app/models/my_academics/college_and_level.rb
+++ b/app/models/my_academics/college_and_level.rb
@@ -118,6 +118,7 @@ module MyAcademics
       plan_set = {
         majors: [],
         minors: [],
+        designatedEmphases: [],
         plans: [],
         lastExpectedGraduationTerm: { code: nil, name: nil },
         roles: role_booleans
@@ -130,20 +131,7 @@ module MyAcademics
           flattened_plan = flatten_plan(plan)
           plan_set[:plans] << flattened_plan
 
-          # Catch Majors / Minors
-          college_plan = {college: flattened_plan[:college]}
-          case flattened_plan[:type].try(:[], :category)
-            when 'Major'
-              plan_set[:majors] << college_plan.merge({
-                major: flattened_plan[:plan].try(:[], :description),
-                subPlan: flattened_plan[:subPlan].try(:[], :description)
-              })
-            when 'Minor'
-              plan_set[:minors] << college_plan.merge({
-                minor: flattened_plan[:plan].try(:[], :description),
-                subPlan: flattened_plan[:subPlan].try(:[], :description)
-              })
-          end
+          group_plans_by_type(plan_set, flattened_plan)
 
           # Update Roles
           current_role = flattened_plan.try(:[], :role)
@@ -158,6 +146,27 @@ module MyAcademics
         end
       end
       plan_set
+    end
+
+    def group_plans_by_type(plan_set, plan)
+      college_plan = {college: plan[:college]}
+      case plan[:type].try(:[], :category)
+        when 'Major'
+          plan_set[:majors] << college_plan.merge({
+            major: plan[:plan].try(:[], :description),
+            subPlan: plan[:subPlan].try(:[], :description)
+          })
+        when 'Minor'
+          plan_set[:minors] << college_plan.merge({
+            minor: plan[:plan].try(:[], :description),
+            subPlan: plan[:subPlan].try(:[], :description)
+          })
+        when 'Designated Emphasis'
+          plan_set[:designatedEmphases] << college_plan.merge({
+            designatedEmphasis: plan[:plan].try(:[], :description),
+            subPlan: plan[:subPlan].try(:[], :description)
+          })
+      end
     end
 
     def filter_inactive_status_plans(statuses)
@@ -340,6 +349,8 @@ module MyAcademics
           category = 'Major'
         when 'MIN'
           category = 'Minor'
+        when 'DE'
+          category = 'Designated Emphasis'
       end
       {
         code: type['code'],

--- a/spec/models/my_academics/college_and_level_spec.rb
+++ b/spec/models/my_academics/college_and_level_spec.rb
@@ -76,7 +76,8 @@ describe MyAcademics::CollegeAndLevel do
   let(:student_plans) { [
     undergrad_student_plan_major,
     undergrad_student_plan_specialization,
-    undergrad_student_plan_minor
+    undergrad_student_plan_minor,
+    grad_student_plan_designated_emphasis
   ] }
   let(:undergrad_student_plan_major) do
     hub_edo_academic_status_student_plan({
@@ -117,6 +118,21 @@ describe MyAcademics::CollegeAndLevel do
       plan_description: 'Art BA',
       type_code: 'MIN',
       type_description: 'Major - UG Specialization',
+      admin_owners: [{org_code: 'MCELLBI', org_description: 'Molecular & Cell Biology', percentage: 100}],
+      is_primary: false
+    })
+  end
+
+  let(:grad_student_plan_designated_emphasis) do
+    hub_edo_academic_status_student_plan({
+      career_code: 'GRAD',
+      career_description: 'Graduate',
+      program_code: 'GACAD',
+      program_description: 'Graduate Academic Programs',
+      plan_code: '00E017G',
+      plan_description: 'Women, Gender and Sexuality DE',
+      type_code: 'DE',
+      type_description: 'Designated Emphasis',
       admin_owners: [{org_code: 'MCELLBI', org_description: 'Molecular & Cell Biology', percentage: 100}],
       is_primary: false
     })
@@ -340,7 +356,7 @@ describe MyAcademics::CollegeAndLevel do
       end
 
       it 'translates plans' do
-        expect(feed[:collegeAndLevel][:plans].count).to eq 3
+        expect(feed[:collegeAndLevel][:plans].count).to eq 4
 
         expect(feed[:collegeAndLevel][:plans][0][:career][:code]).to eq 'UGRD'
         expect(feed[:collegeAndLevel][:plans][0][:program][:code]).to eq 'UCLS'
@@ -375,6 +391,17 @@ describe MyAcademics::CollegeAndLevel do
         expect(feed[:collegeAndLevel][:plans][2][:type][:code]).to eq 'MIN'
         expect(feed[:collegeAndLevel][:plans][2][:type][:category]).to eq 'Minor'
         expect(feed[:collegeAndLevel][:plans][2][:college]).to eq 'Undergrad Letters & Science'
+
+        expect(feed[:collegeAndLevel][:plans][3][:career][:code]).to eq 'GRAD'
+        expect(feed[:collegeAndLevel][:plans][3][:program][:code]).to eq 'GACAD'
+        expect(feed[:collegeAndLevel][:plans][3][:plan][:code]).to eq '00E017G'
+        expect(feed[:collegeAndLevel][:plans][3][:expectedGraduationTerm]).to eq nil
+        expect(feed[:collegeAndLevel][:plans][3][:role]).to eq 'default'
+        expect(feed[:collegeAndLevel][:plans][3][:enrollmentRole]).to eq 'default'
+        expect(feed[:collegeAndLevel][:plans][3][:primary]).to eq false
+        expect(feed[:collegeAndLevel][:plans][3][:type][:code]).to eq 'DE'
+        expect(feed[:collegeAndLevel][:plans][3][:type][:category]).to eq 'Designated Emphasis'
+        expect(feed[:collegeAndLevel][:plans][3][:college]).to eq 'Graduate Academic Programs'
       end
 
       it 'translates sub-plans' do
@@ -746,11 +773,13 @@ describe MyAcademics::CollegeAndLevel do
     context 'when filtering out inactive plans from statuses' do
       let(:filtered_academic_statuses) { subject.filter_inactive_status_plans(hub_academic_statuses) }
       it 'removes inactive plans from each status' do
-        expect(filtered_academic_statuses[0]['studentPlans'].count).to eq 2
+        expect(filtered_academic_statuses[0]['studentPlans'].count).to eq 3
         expect(filtered_academic_statuses[0]['studentPlans'][0]['statusInPlan']['status']['code']).to eq 'AC'
         expect(filtered_academic_statuses[0]['studentPlans'][1]['statusInPlan']['status']['code']).to eq 'AC'
+        expect(filtered_academic_statuses[0]['studentPlans'][2]['statusInPlan']['status']['code']).to eq 'AC'
         expect(filtered_academic_statuses[0]['studentPlans'][0]['academicPlan']['plan']['code']).to eq '25345U'
         expect(filtered_academic_statuses[0]['studentPlans'][1]['academicPlan']['plan']['code']).to eq '25090U'
+        expect(filtered_academic_statuses[0]['studentPlans'][2]['academicPlan']['plan']['code']).to eq '00E017G'
       end
     end
   end

--- a/src/assets/javascripts/angular/directives/academicPlansDirective.js
+++ b/src/assets/javascripts/angular/directives/academicPlansDirective.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var angular = require('angular');
+
+angular.module('calcentral.directives').directive('ccAcademicPlansDirective', [function() {
+  return {
+    templateUrl: 'directives/academic_plans.html',
+    scope: {
+      plans: '=',
+      options: '=',
+      type: '@'
+    }
+  };
+}]);

--- a/src/assets/templates/directives/academic_plans.html
+++ b/src/assets/templates/directives/academic_plans.html
@@ -1,0 +1,16 @@
+<div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="plans.length">
+  <table class="cc-widget-profile-table">
+    <tbody>
+    <tr>
+      <th data-ng-pluralize count="plans.length" when="options.labels"></th>
+      <td>
+        <div data-ng-repeat="plan in plans">
+          <div class="cc-text-light" data-ng-if="plan.college" data-ng-bind="plan.college"></div>
+          <div><strong data-ng-bind="plan.{{type}}"></strong></div>
+          <div class="cc-widget-profile-indent" data-ng-bind="plan.subPlan"></div>
+        </div>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+</div>

--- a/src/assets/templates/widgets/academics/college_and_level.html
+++ b/src/assets/templates/widgets/academics/college_and_level.html
@@ -1,37 +1,6 @@
-
-<div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="collegeAndLevel.majors.length">
-  <table class="cc-widget-profile-table">
-    <tbody>
-    <tr>
-      <th data-ng-pluralize count="collegeAndLevel.majors.length" when="{'1': 'Major', 'other': 'Majors'}"></th>
-      <td>
-        <div data-ng-repeat="major in collegeAndLevel.majors">
-          <div class="cc-text-light" data-ng-if="major.college" data-ng-bind="major.college"></div>
-          <div><strong data-ng-bind="major.major"></strong></div>
-          <div class="cc-widget-profile-indent" data-ng-bind="major.subPlan"></div>
-        </div>
-      </td>
-    </tr>
-    </tbody>
-  </table>
-</div>
-
-<div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="collegeAndLevel.minors.length">
-  <table class="cc-widget-profile-table">
-    <tbody>
-    <tr>
-      <th data-ng-pluralize count="collegeAndLevel.minors.length" when="{'1': 'Minor', 'other': 'Minors'}"></th>
-      <td>
-        <div data-ng-repeat="minor in collegeAndLevel.minors">
-          <div class="cc-text-light" data-ng-if="minor.college" data-ng-bind="minor.college"></div>
-          <div><strong data-ng-bind="minor.minor"></strong></div>
-          <div class="cc-widget-profile-indent" data-ng-bind="minor.subPlan"></div>
-        </div>
-      </td>
-    </tr>
-    </tbody>
-  </table>
-</div>
+<div data-cc-academic-plans-directive data-plans="collegeAndLevel.majors" data-options="{labels: {'1': 'Major', 'other': 'Majors'}}" data-type="major"> </div>
+<div data-cc-academic-plans-directive data-plans="collegeAndLevel.minors" data-options="{labels: {'1': Minor', 'other': 'Minors'}}" data-type="minors"> </div>
+<div data-cc-academic-plans-directive data-plans="collegeAndLevel.designatedEmphases" data-options="{labels: {'1': 'Designated Emphasis', 'other': 'Designated Emphases'}}" data-type="designatedEmphasis"> </div>
 
 <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="collegeAndLevel.careers.length">
   <table class="cc-widget-profile-table">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-27695

Designated emphasis is to grad students as a minor is to undergrads.  

We'll display it alongside majors and minors.  Following the "rule of 3", since we're now repeating the same code three times in the template I moved it into a directive.  We'll likely be adding a fourth type (certificates) in the future.