### PR TITLE
SISRP-27748 - 7.3 Transfer Credit - Link to Student Overview (advisor)

### DIFF
--- a/app/models/campus_solutions/advising_resources.rb
+++ b/app/models/campus_solutions/advising_resources.rb
@@ -85,7 +85,6 @@ module CampusSolutions
           { feed_key: :student_service_indicators, cs_link_key: 'UC_CX_SERVICE_IND_STDNT', cs_link_params: { :EMPLID => student_empl_id, :ACAD_CAREER => '' } },
           { feed_key: :student_webnow_documents, cs_link_key: 'UC_CX_WEBNOW_STUDENT_URI', cs_link_params: { :EMPLID => student_empl_id } },
           { feed_key: :student_what_if_report, cs_link_key: 'UC_CX_WHIF_RPT_STDNT', cs_link_params: { :EMPLID => student_empl_id } },
-          { feed_key: :student_transfer_credit_report, cs_link_key: 'UC_CX_XFER_CREDIT_REPORT_STDNT', cs_link_params: { :EMPLID => student_empl_id } }
         ]
 
         advising_student_link_settings.each do |setting|

--- a/app/models/my_academics/transfer_credit.rb
+++ b/app/models/my_academics/transfer_credit.rb
@@ -14,7 +14,19 @@ module MyAcademics
         nonadjusted_units = credit[:unitsNonAdjusted].to_f
         response[:ucTransferCrseSch][:unitsTotal] = adjusted_units + nonadjusted_units
       end
+      response[:tcReportLink] = fetch_tc_report_link
       response
+    end
+
+    def fetch_tc_report_link
+      lookup_student_id
+      fetch_link('UC_CX_XFER_CREDIT_REPORT_STDNT', { :EMPLID => @campus_solutions_id })
+    end
+
+    def lookup_student_id
+      if @uid
+        @campus_solutions_id = CalnetCrosswalk::ByUid.new(user_id: @uid).lookup_campus_solutions_id
+      end
     end
 
   end

--- a/src/assets/templates/widgets/advisor/advising_links.html
+++ b/src/assets/templates/widgets/advisor/advising_links.html
@@ -53,12 +53,6 @@
         data-link="csLinks.ucAdministrativeTranscript"
       ></div>
     </li>
-    <li data-ng-if="csLinks.ucTransferCreditReport.url">
-      <div
-        data-cc-campus-solutions-link-item-directive
-        data-link="csLinks.ucTransferCreditReport"
-      ></div>
-    </li>
     <li data-ng-if="csLinks.ucMilestones.url">
       <div
         data-cc-campus-solutions-link-item-directive

--- a/src/assets/templates/widgets/transfer_credit.html
+++ b/src/assets/templates/widgets/transfer_credit.html
@@ -74,6 +74,14 @@
             </td>
           </tr>
         </tbody>
+        <tbody data-ng-if="transferCredit.tcReportLink.url">
+          <tr><td class="cc-transfer-credit-table-border" colspan="3"></td></tr>
+          <tr class="cc-transfer-credit-table-parent-row">
+            <td colspan="3">
+              <div data-cc-campus-solutions-link-item-directive data-link="transferCredit.tcReportLink"></div>
+            </td>
+          </tr>
+        </tbody>
       </table>
     </div>
   </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-27748
Design JIRA:  https://jira.berkeley.edu/browse/SISRP-27670

* There's actually a typo in the link being returned by the Link API, but that shouldn't stop us from moving on =) The typo (a space in the URL) can be addressed on Monday, and doesn't have an impact on the CalCentral code
* There's currently no documentation on JIRA that we want to remove the student-specific TC Report link from the Personal Summary card, but I got verbal confirmation from Chara earlier this week.  I'll ask her to update relevant JIRAs to include that.