### PR TITLE
SISRP-28251 - Student Overview Academic Plan Card shows wrong total unit count

### DIFF
--- a/app/models/my_academics/academic_plan.rb
+++ b/app/models/my_academics/academic_plan.rb
@@ -97,7 +97,7 @@ module MyAcademics
         cls.try(:[], :sections).try(:each) do |section|
           if section[:waitlisted] && section[:is_primary_section]
             waitlisted_units += section[:units].to_f
-          elsif section[:is_primary_section]
+          elsif section[:is_primary_section] && !semester[:summaryFromTranscript]
             enrolled_units += section[:units].to_f
           end
         end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-28251

* fix for double counting units for classes with transcript data. 