### PR TITLE
SISRP-27722 - Standardizes <h*> styles sitewide for mac/win compatibility

### DIFF
--- a/src/assets/stylesheets/_academics.scss
+++ b/src/assets/stylesheets/_academics.scss
@@ -13,7 +13,6 @@
     }
   }
   h4 {
-    font-size: 14px;
     &:not(:first-of-type) {
       margin-top: 20px;
     }

--- a/src/assets/stylesheets/_base.scss
+++ b/src/assets/stylesheets/_base.scss
@@ -81,7 +81,12 @@ h2 {
   font-size: 18px;
 }
 h3 {
-  font-size: 16px;
+  font-size: 15px;
+  font-weight: 600;
+}
+h4 {
+  font-size: 13px;
+  font-weight: 600;
 }
 
 // Inset list items

--- a/src/assets/stylesheets/_student_success.scss
+++ b/src/assets/stylesheets/_student_success.scss
@@ -4,7 +4,7 @@
     margin: 15px 15px 12px;
     span {
       display: inline;
-      font-size: 16px;
+      font-size: 15px;
       font-weight: normal;
     }
   }


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-27722

After complaints that our headers looked wimpy on Windows 7, I updated the h3 and h4 styles* so that they appear similar on both Windows (Chrome) and Mac (Chrome).  I will continue spot-checking in other browsers as time permits.  Wanted to get this out first in case there are any concerns, since this affects the entire site.

If you want to see the before/after, view screenshots here:  https://drive.google.com/open?id=0BzCFJacXKzFBdGxWWWhBN2xQdmM

*I'm a little concerned about not being able to test every single header on the site.