### PR TITLE
CLC-6520, 'Create a Site' button after Canvas dashboard_sidebar renders

### DIFF
--- a/public/canvas/canvas-customization.js
+++ b/public/canvas/canvas-customization.js
@@ -111,7 +111,7 @@
               });
 
               // Add the 'Create a Site' button to the Dashboard page
-              waitUntilAvailable('#right-side .rs-margin-lr', false, function($container) {
+              waitUntilAvailable('#right-side div:nth-last-child(1)', false, function($container) {
                 $('#start_new_course').remove();
                 $container.prepend($createSiteButton);
               });


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6520

Info on jQuery selectors in play:
* http://api.jquery.com/nth-last-child-selector/
* http://api.jquery.com/prepend/

My initial solution (PR #6215) was faulty. We cannot rely on `waitUntilAvailable('#start_new_course', ...)` because that button does not always render (see default Canvas logic). Therefore, UC Berkeley's custom rules (e.g., staff can 'Create a Site') won't work; the replace logic will never fire.