### PR TITLE
CLC-6520, select #right-side child w/o class for prepend 'Create a Site'

### DIFF
--- a/public/canvas/canvas-customization.js
+++ b/public/canvas/canvas-customization.js
@@ -111,7 +111,7 @@
               });
 
               // Add the 'Create a Site' button to the Dashboard page
-              waitUntilAvailable('#right-side div:nth-last-child(1)', false, function($container) {
+              waitUntilAvailable('#right-side > div:not([class])', false, function($container) {
                 $('#start_new_course').remove();
                 $container.prepend($createSiteButton);
               });


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6520

PR #6217 did not do the job. See Steven Williams comments in Jira above about unwanted buttons in "To Do" and "Recent Activity" items. This PR targets the no-class `<div>` within immediate children of `#right-side`.

DO NOT MERGE until Steven Williams does initial validation at https://ucberkeley.beta.instructure.com  