### PR TITLE
SISRP-28441 - Advising dashboard - advising resources card missing links

### DIFF
--- a/app/models/campus_solutions/advising_resources.rb
+++ b/app/models/campus_solutions/advising_resources.rb
@@ -40,6 +40,7 @@ module CampusSolutions
 
       advising_link_settings = [
         # advisors see these on advisor-specific views
+        { feed_key: :uc_academic_progress_report, cs_link_key: 'UC_CX_APR_RPT'},
         { feed_key: :web_now_documents, cs_link_key: 'UC_CX_WEBNOW_ADVISOR_URI' },
         { feed_key: :uc_administrative_transcript, cs_link_key: 'UC_CX_ADM_TRANSCRIPT' },
         { feed_key: :uc_advising_assignments, cs_link_key: 'UC_CX_STUDENT_ADVISOR' },
@@ -51,7 +52,8 @@ module CampusSolutions
         { feed_key: :uc_multi_year_academic_planner_generic, cs_link_key: 'UC_CX_PLANNER_ADV' },
         { feed_key: :uc_reporting_center, cs_link_key: 'UC_CX_REPORTING_CENTER' },
         { feed_key: :uc_service_indicators, cs_link_key: 'UC_CX_SERVICE_IND_DATA' },
-        { feed_key: :uc_transfer_credit_report, cs_link_key: 'UC_CX_CSU_DA_TRN_CDT' }
+        { feed_key: :uc_transfer_credit_report, cs_link_key: 'UC_CX_CSU_DA_TRN_CDT' },
+        { feed_key: :uc_what_if_reports, cs_link_key: 'UC_CX_WHIF_RPT'}
       ]
 
       advising_link_settings.each do |setting|

--- a/src/assets/templates/widgets/advisor/advising_links.html
+++ b/src/assets/templates/widgets/advisor/advising_links.html
@@ -53,6 +53,18 @@
         data-link="csLinks.ucAdministrativeTranscript"
       ></div>
     </li>
+    <li data-ng-if="csLinks.ucAcademicProgressReport.url">
+      <div
+        data-cc-campus-solutions-link-item-directive
+        data-link="csLinks.ucAcademicProgressReport"
+      ></div>
+    </li>
+    <li data-ng-if="csLinks.ucWhatIfReports.url">
+      <div
+        data-cc-campus-solutions-link-item-directive
+        data-link="csLinks.ucWhatIfReports"
+      ></div>
+    </li>
     <li data-ng-if="csLinks.ucTransferCreditReport.url">
       <div
         data-cc-campus-solutions-link-item-directive


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-28441

* Adding back the What-If Report and Academic Progress Report links I ripped out in #6124.
* Links have been unit tested in BCSDEV, will hit BCSQAT later today.
* QA PR to come.