### PR TITLE
SISRP-28454 - CalCentral showing incorrect grade roster status in Faculty Grading - Confusing to users

### DIFF
--- a/src/assets/templates/academics_semester_classes.html
+++ b/src/assets/templates/academics_semester_classes.html
@@ -125,6 +125,9 @@
           <span class="cc-text-light">Final Grading Entry Period (Law):</span> Start: <strong>{{selectedTeachingSemester.gradingPeriodStartLaw}}</strong> | Due: <strong>{{selectedTeachingSemester.gradingPeriodEndLaw}}</strong>
         </span>
       </div>
+      <div>
+        <br>Please expect 15-20 minutes for Grading Status updates to be reflected below.
+      </div>
     </div>
     <div class="cc-widget-padding">
       <div class="cc-table">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-28454

* added comment in grading header to alert user of latency between CS and CC 