### PR TITLE
SISRP-28333 - MyAcademics feed taking over 90 sec to load for faculty user in CC-QA

### DIFF
--- a/app/models/campus_solutions/faculty_delegate.rb
+++ b/app/models/campus_solutions/faculty_delegate.rb
@@ -1,5 +1,5 @@
 module CampusSolutions
-  class FacultyDelegate < Proxy
+  class FacultyDelegate < CachedProxy
 
     def initialize(options = {})
       super options

--- a/app/models/my_academics/faculty_delegate.rb
+++ b/app/models/my_academics/faculty_delegate.rb
@@ -2,14 +2,15 @@ module MyAcademics
   class FacultyDelegate < UserSpecificModel
 
     def merge(data)
-      teaching_semesters = data[:teachingSemesters]
-      if teaching_semesters
-        add_grd_access_to_semesters(teaching_semesters)
-      end
-      semesters = data[:semesters]
+      semesters = is_user_student? ? data[:semesters] : data[:teachingSemesters]
       if semesters
         add_grd_access_to_semesters(semesters)
       end
+    end
+
+
+    def is_user_student?
+      User::SearchUsersByUid.new(id: @uid, roles: [:student]).search_users_by_uid.present?
     end
 
     def add_grd_access_to_semesters(teaching_semesters)

--- a/app/models/my_academics/grading.rb
+++ b/app/models/my_academics/grading.rb
@@ -155,11 +155,15 @@ module MyAcademics
 
     def get_cs_status(ccn, term_code)
       cnn_status = nil
-      if (grading_feed = CampusSolutions::Grading.new(user_id: @uid).get)
+      if (grading_feed = get_grading_data)
         grading_statuses = grading_feed[:feed].try(:[],:ucSrClassGrading).try(:[],:classGradingStatuses)
         cnn_status = find_ccn_grading_statuses(grading_statuses, ccn, term_code)
       end
       cnn_status
+    end
+
+    def get_grading_data
+      @grading_feed ||= CampusSolutions::Grading.new(user_id: @uid).get
     end
 
     def find_ccn_grading_statuses(grading_statuses, ccn, term_code)

--- a/spec/models/my_academics/faculty_delegate_spec.rb
+++ b/spec/models/my_academics/faculty_delegate_spec.rb
@@ -90,6 +90,7 @@ describe MyAcademics::FacultyDelegate do
 
     before do
       allow(CampusSolutions::FacultyDelegate).to receive(:new).and_return(delegate_proxy)
+      allow_any_instance_of(MyAcademics::FacultyDelegate).to receive(:is_user_student?).and_return(false)
       allow(CalnetCrosswalk::ByUid).to receive(:new).with(user_id: uid).and_return(
         double(lookup_campus_solutions_id: '25738808'))
       allow(CalnetCrosswalk::ByUid).to receive(:new).with(user_id: '904715').and_return(


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-28333

* Added instance level variable for grading log issue. 
* used cached proxy from FacultyDelegate API calls, this will help for instructors with the same set of sections
* added logic to only apply FacultyDelegate to semester for student users and only teaching semesters for non-student users, this should improve performance by at least 50%