### PR TITLE
SISRP-28502 - Grading: UAT Feedback on Nov 30

### DIFF
--- a/app/models/my_academics/grading.rb
+++ b/app/models/my_academics/grading.rb
@@ -27,6 +27,12 @@ module MyAcademics
           inGradingPeriod: grading_link,
           afterGradingPeriod: grading_link,
           gradingPeriodNotSet: grading_link
+        },
+        APPR: {
+          beforeGradingPeriod: grading_link,
+          inGradingPeriod: grading_link,
+          afterGradingPeriod: grading_link,
+          gradingPeriodNotSet: grading_link
         }
       }
     end
@@ -46,10 +52,16 @@ module MyAcademics
           gradingPeriodNotSet: :periodStarted,
         },
         POST: {
-          beforeGradingPeriod:  :gradesSubmitted,
-          inGradingPeriod:  :gradesSubmitted,
-          afterGradingPeriod:  :gradesSubmitted,
-          gradingPeriodNotSet:  :gradesSubmitted,
+          beforeGradingPeriod:  :gradesPosted,
+          inGradingPeriod:  :gradesPosted,
+          afterGradingPeriod:  :gradesPosted,
+          gradingPeriodNotSet:  :gradesPosted,
+        },
+        APPR: {
+          beforeGradingPeriod:  :gradesApproved,
+          inGradingPeriod:  :gradesApproved,
+          afterGradingPeriod:  :gradesApproved,
+          gradingPeriodNotSet:  :gradesApproved,
         }
       }
     end
@@ -188,8 +200,10 @@ module MyAcademics
       case cs_grading_status
         when 'GRD', 'RDY'
           :GRD
-        when 'POST', 'APPR'
+        when 'POST'
           :POST
+        when 'APPR'
+          :APPR
         else
           :noCsData
       end

--- a/spec/models/my_academics/grading_spec.rb
+++ b/spec/models/my_academics/grading_spec.rb
@@ -197,7 +197,7 @@ describe MyAcademics::Grading do
     it 'it should return expected values merged into section' do
       subject.merge(feed)
       expect(feed[:teachingSemesters][0][:classes][0][:sections][0][:gradingLink]).to eq fake_grading_url
-      expect(feed[:teachingSemesters][0][:classes][0][:sections][0][:ccGradingStatus]).to eq :gradesSubmitted
+      expect(feed[:teachingSemesters][0][:classes][0][:sections][0][:ccGradingStatus]).to eq :gradesPosted
       expect(feed[:teachingSemesters][0][:classes][0][:sections][0][:csGradingStatus]).to eq :POST
 
       expect(feed[:teachingSemesters][0][:classes][0][:sections][1][:gradingLink]).to eq nil

--- a/src/assets/javascripts/angular/controllers/pages/academicsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicsController.js
@@ -7,12 +7,16 @@ var angular = require('angular');
 /**
  * Academics controller
  */
-angular.module('calcentral.controllers').controller('AcademicsController', function(academicsFactory, academicsService, academicStatusFactory, apiService, badgesFactory, registrationsFactory, userService, $q, $routeParams, $scope) {
+angular.module('calcentral.controllers').controller('AcademicsController', function(academicsFactory, academicsService, academicStatusFactory, apiService, badgesFactory, registrationsFactory, userService, $q, $routeParams, $scope, $location) {
   var title = 'My Academics';
   apiService.util.setTitle(title);
   $scope.backToText = title;
   $scope.academics = {
     isLoading: true
+  };
+
+  $scope.gotoGrading = function(slug) {
+    $location.path('/academics/semester/' + slug);
   };
 
   var checkPageExists = function(page) {

--- a/src/assets/stylesheets/_academics.scss
+++ b/src/assets/stylesheets/_academics.scss
@@ -138,6 +138,11 @@
   .cc-academics-class-info-grading {
     border-top: 1px solid $cc-color-widget-background;
   }
+  .cc-academics-class-info-grading-button-text {
+    font-size: 16px;
+    font-weight: normal;
+    margin: 5px;
+  }
   .cc-academics-class-primary-row {
     font-weight: bold;
   }
@@ -201,9 +206,9 @@
     }
   }
   .cc-academics-instructors-grading-header {
-    border-bottom: 1px solid $cc-color-widget-background;
-    margin-bottom: 10px;
-    padding-bottom: 10px;
+    border-top: 1px solid $cc-color-widget-background;
+    margin-top: 15px;
+    padding-top: 10px;
   }
   .cc-academics-instructors-grading-header-legend {
     float: right;

--- a/src/assets/templates/academics_classinfo.html
+++ b/src/assets/templates/academics_classinfo.html
@@ -153,11 +153,6 @@
           <h2 data-ng-pluralize count="selectedCourseCountInstructors" when="{'1': 'Instructor', 'other': 'Instructors'}">Instructors</h2>
         </div>
         <div class="cc-widget-padding">
-          <div data-ng-if="!api.user.profile.roles.student" class="cc-academics-instructors-grading-header">
-            <h3>Grading Legend</h3>
-            <span><i class="fa fa-list-ul"></i><span> Enter Grades</span></span>
-            <span class="cc-academics-instructors-grading-header-legend"><i class="fa fa-check"></i><span> Enter and approve grades</span></span>
-          </div>
           <div data-ng-repeat="section in selectedCourse.sections" data-ng-if="!section.scheduledWithCcn">
             <div class="cc-table">
               <table width="100%">
@@ -188,6 +183,11 @@
                 </tbody>
               </table>
             </div>
+          </div>
+           <div data-ng-if="!api.user.profile.roles.student" class="cc-academics-instructors-grading-header">
+            <h3>Grading Legend</h3>
+            <span><i class="fa fa-list-ul"></i><span> Can enter grades</span></span>
+            <span class="cc-academics-instructors-grading-header-legend"><i class="fa fa-check"></i><span> Can enter and approve grades</span></span>
           </div>
         </div>
       </div>
@@ -327,15 +327,25 @@
         <h2>Grading</h2>
       </div>
       <div class="cc-widget-padding">
+        <div>
+          <span><h2>Entering Final Grades</h2></span>
+          <span>For {{selectedSemester.name}}, final grades will be entered via the new <strong>Course Grades</strong> on the <strong>{{selectedSemester.name}}</strong> page.</span>
+        </div>
+        <br>
+        <div>
+          <button class="cc-button cc-button-blue" data-ng-click="gotoGrading(selectedSemester.slug)">
+            <span class="cc-academics-class-info-grading-button-text">Goto Grading Links</span>
+          </button>
+        </div>
+      </div>
+      <div class="cc-widget-padding cc-academics-class-info-grading">
+         <span><h2>More Info</h2></span>
         <div data-ng-if="selectedTeachingSemester.gradingAssistanceLink">
           <span><a data-ng-href="{{selectedTeachingSemester.gradingAssistanceLink}}">&#9632; Assistance with Grading: General</a></span>
         </div>
         <div data-ng-if="selectedTeachingSemester.gradingAssistanceLinkLaw">
           <span><a data-ng-href="{{selectedTeachingSemester.gradingAssistanceLinkLaw}}">&#9632; Assistance with Grading: Law</a></span>
         </div>
-      </div>
-      <div class="cc-widget-padding cc-academics-class-info-grading">
-          Links for final grades are on the <a data-ng-href="/academics/semester/{{selectedSemester.slug}}"><span data-ng-bind-template="{{selectedSemester.name}} page"></span></a>
       </div>
     </div>
   </div>

--- a/src/assets/templates/academics_semester_classes.html
+++ b/src/assets/templates/academics_semester_classes.html
@@ -65,49 +65,6 @@
       </div>
     </div>
   </div>
-  <div data-ng-if="selectedTeachingSemester">
-    <div class="cc-academics-subtitle">
-      <h3>Teaching</h3>
-    </div>
-    <div class="cc-widget-padding">
-      <div class="cc-table">
-        <table>
-          <thead>
-            <th scope="col" class="cc-table-right-spacing">Course</th>
-            <th scope="col" class="show-for-medium-up">Class Number</th>
-            <th scope="col">Title</th>
-            <th scope="col" class="show-for-medium-up">Sections</th>
-          </thead>
-          <tbody data-ng-if="selectedTeachingSemester.classes.length" data-ng-repeat="course in selectedTeachingSemester.classes">
-            <tr data-ng-class-even="'cc-academics-even'">
-              <td class="cc-table-right-spacing cc-academics-course-number">
-                <div data-ng-repeat="listing in course.listings">
-                  <a data-ng-href="{{course.url}}"
-                     data-ng-bind="listing.course_code">
-                  </a>
-                </div>
-                <div class="show-for-small-only">
-                  <span data-ng-bind="course.scheduledSectionCount"></span>
-                  <span data-ng-pluralize count="course.scheduledSectionCount" when="{'1': 'section', 'other': 'sections'}">sections</span>
-                </div>
-              </td>
-              <td class="show-for-medium-up">
-                <div data-ng-if="!course.multiplePrimaries" data-ng-bind="course.sections[0].ccn"></div>
-                <div data-ng-if="course.multiplePrimaries">Multiple</div>
-              </td>
-              <td data-ng-bind="course.title"></td>
-              <td class="show-for-medium-up">
-                <div data-ng-repeat="scheduledSection in course.scheduledSections">
-                  <span data-ng-bind="scheduledSection.count"></span> <span data-ng-bind="scheduledSection.format"></span>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-
   <div data-ng-if="selectedTeachingSemester && (selectedTeachingSemester.gradingAssistanceLink || selectedTeachingSemester.gradingAssistanceLinkLaw)">
     <div class="cc-academics-subtitle">
       <h3>Grading</h3>
@@ -172,7 +129,7 @@
                   data-cc-outbound-enabled="false"
                   data-ng-disabled="!section.gradingLink.url"
                   data-ng-attr-title="{{section.gradingLink.title}}">
-                  Course Grades
+                  Enter Grades
                 </a>
               </td>
               <td data-ng-if="section.is_primary_section && !section.gradingLink.url" class="show-for-medium-up cc-academics-course-grading-link">
@@ -181,7 +138,8 @@
               <td data-ng-if="section.is_primary_section" class="show-for-medium-up cc-academics-course-grading-icon" data-ng-switch="section.ccGradingStatus" >
                 <i data-ng-switch-when="periodNotStarted" class="fa fa-ban"></i>
                 <i data-ng-switch-when="periodStarted" class="fa fa-file-o"></i>
-                <i data-ng-switch-when="gradesSubmitted" class="fa fa-check cc-icon-green"></i>
+                <i data-ng-switch-when="gradesApproved" class="fa fa-check cc-icon-green"></i>
+                <i data-ng-switch-when="gradesPosted" class="fa fa-check-circle cc-icon-green"></i>
                 <i data-ng-switch-when="gradesOverdue" class="fa fa-exclamation-circle cc-icon-red"></i>
                 <i data-ng-switch-default class="fa fa-ban"></i>
               </td>
@@ -211,7 +169,9 @@
             </td>
             <td>
               <span><i class="fa fa-check cc-icon-green"></i></span>
-              <span>Grades approved</span>
+              <span>Grades approved</span><br>
+              <span><i class="fa fa-check-circle cc-icon-green"></i></span>
+              <span> Grades posted</span>
             </td>
             <td>
               <span><i class="fa fa-exclamation-circle cc-icon-red"></i></span>
@@ -222,3 +182,46 @@
       </div>
     </div>
   </div>
+  <div data-ng-if="selectedTeachingSemester">
+    <div class="cc-academics-subtitle">
+      <h3>Teaching</h3>
+    </div>
+    <div class="cc-widget-padding">
+      <div class="cc-table">
+        <table>
+          <thead>
+            <th scope="col" class="cc-table-right-spacing">Course</th>
+            <th scope="col" class="show-for-medium-up">Class Number</th>
+            <th scope="col">Title</th>
+            <th scope="col" class="show-for-medium-up">Sections</th>
+          </thead>
+          <tbody data-ng-if="selectedTeachingSemester.classes.length" data-ng-repeat="course in selectedTeachingSemester.classes">
+            <tr data-ng-class-even="'cc-academics-even'">
+              <td class="cc-table-right-spacing cc-academics-course-number">
+                <div data-ng-repeat="listing in course.listings">
+                  <a data-ng-href="{{course.url}}"
+                     data-ng-bind="listing.course_code">
+                  </a>
+                </div>
+                <div class="show-for-small-only">
+                  <span data-ng-bind="course.scheduledSectionCount"></span>
+                  <span data-ng-pluralize count="course.scheduledSectionCount" when="{'1': 'section', 'other': 'sections'}">sections</span>
+                </div>
+              </td>
+              <td class="show-for-medium-up">
+                <div data-ng-if="!course.multiplePrimaries" data-ng-bind="course.sections[0].ccn"></div>
+                <div data-ng-if="course.multiplePrimaries">Multiple</div>
+              </td>
+              <td data-ng-bind="course.title"></td>
+              <td class="show-for-medium-up">
+                <div data-ng-repeat="scheduledSection in course.scheduledSections">
+                  <span data-ng-bind="scheduledSection.count"></span> <span data-ng-bind="scheduledSection.format"></span>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-28502
Multiple areas for dramatic improvement via minor changes to language and placement:

Changes to Instructor Card:
* Move "Grading Legend" to appear beneath the courses
* Rename "Enter Grades" to "Can enter grades"
* Rename "Enter and approve grades" to "Can enter and approve grades"

Changes to Grade Tab:
* Switch the order of the 2 links on this page
* Rename "Links for final grades are on the Fall 2016 page" to "Fall 2016 Final Grades"
* Make "Fall 2016 Final Grades" larger and more prominent
* Make "Assistance with Grading: General" less prominent, smaller and lower on the page

Changes to Grading Card:
* Reorder Teaching section with Grading section - Grading appears before Teaching
* Rename "Course Grades" link to "Enter Grades"
* Create 1 new status: "Posted", use GRADE_ROSTER_STAT = Posted