### PR TITLE
SISRP-28750 - Downgrade AngularJS from 1.6.0 to 1.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   "license": "ECL-2.0",
   "devDependencies": {
     "add-stream": "^1.0.0",
-    "angular": "^1.4.3",
-    "angular-route": "^1.4.3",
-    "angular-sanitize": "^1.4.3",
+    "angular": "1.5.8",
+    "angular-route": "1.5.8",
+    "angular-sanitize": "1.5.8",
     "browser-sync": "^2.12.3",
     "browserify": "^13.0.0",
     "bulkify": "^1.2.0",


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-28750

Forces AngularJS to v1.5.8 instead of v1.6.0 with [broken calls](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#160-rainbow-tsunami-2016-12-08) to $http.get(...).success / error