### PR TITLE
SISRP-28730 - Fall 2016 Grades need to be pulled from CS into Calcentral

### DIFF
--- a/app/models/my_academics/semesters.rb
+++ b/app/models/my_academics/semesters.rb
@@ -126,11 +126,11 @@ module MyAcademics
     end
 
     def use_enrollment_grades?(semester)
-      semester[:timeBucket] == 'current' || semester[:gradingInProgress]
+      semester[:timeBucket] == 'current' || semester[:gradingInProgress] || semester[:campusSolutionsTerm]
     end
 
     def use_transcript_grades?(semester)
-      semester[:timeBucket] == 'past' && !semester[:gradingInProgress]
+      semester[:timeBucket] == 'past' && !semester[:gradingInProgress] && !semester[:campusSolutionsTerm]
     end
 
   end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-28730

* updated the semesters feed parsing to include grades from enrollments for all non-legacy terms even if not current term or grading in progress conditions. 

moving forward the new CS will keep official grades in enrollments and does not have a transcript records table. legacy terms will continue to pull from transcripts until data migration is complete and code can be stripped out to only point to CS enrollments. 