### PR TITLE
SISRP-27699 - Implements strategy for identifying summer visiting students

### DIFF
--- a/app/controllers/advising_student_controller.rb
+++ b/app/controllers/advising_student_controller.rb
@@ -24,7 +24,7 @@ class AdvisingStudentController < ApplicationController
   end
 
   def academic_status
-    render json: HubEdos::AcademicStatus.new(user_id: student_uid_param).get
+    render json: HubEdos::MyAcademicStatus.new(student_uid_param).get_feed
   end
 
   def enrollment_instructions

--- a/app/controllers/hub_edo_controller.rb
+++ b/app/controllers/hub_edo_controller.rb
@@ -2,7 +2,7 @@ class HubEdoController < ApplicationController
   before_filter :api_authenticate_401
 
   def academic_status
-    json_proxy_passthrough HubEdos::AcademicStatus
+    json_passthrough HubEdos::MyAcademicStatus
   end
 
   def student

--- a/app/models/berkeley/academic_roles.rb
+++ b/app/models/berkeley/academic_roles.rb
@@ -1,0 +1,56 @@
+module Berkeley
+  module AcademicRoles
+    extend self
+
+    ACADEMIC_PLAN_ROLES = [
+      {role_code: 'fpf', match: ['25000FPFU'], types: [:enrollment]},
+      {role_code: 'haasFullTimeMba', match: ['70141MBAG'], types: []},
+      {role_code: 'haasEveningWeekendMba', match: ['701E1MBAG'], types: []},
+      {role_code: 'haasExecMba', match: ['70364MBAG'], types: []},
+      {role_code: 'haasMastersFinEng', match: ['701F1MFEG'], types: []},
+      {role_code: 'haasMbaPublicHealth', match: ['70141BAPHG'], types: []},
+      {role_code: 'haasMbaJurisDoctor', match: ['70141BAJDG'], types: []},
+      {role_code: 'ugrdUrbanStudies', match: ['19912U'], types: []},
+      {
+        role_code: 'summerVisitor',
+        match: %w(99000U 99000INTU 99000G 99000INTG 99V03U 99V04U 99V05U 99V09U 99V03G 99V05G 99V06G 99V07G 99V08G 99V10G 99V06U 99V07U 99V08U 99V10U 99V02G 99V04G 99V09G),
+        types: []
+      },
+    ]
+
+    ACADEMIC_CAREER_ROLES = [
+      {role_code: 'law', match: ['LAW'], types: [:enrollment]},
+      {role_code: 'concurrent', match: ['UCBX'], types: [:enrollment]}
+    ]
+
+    def get_academic_plan_role_code(plan_code, type = nil)
+      get_role_code(ACADEMIC_PLAN_ROLES, plan_code, type)
+    end
+
+    def get_academic_career_role_code(career_code, type = nil)
+      get_role_code(ACADEMIC_CAREER_ROLES, career_code, type)
+    end
+
+    def role_defaults
+      role_codes.inject({}) { |map, role_code| map[role_code] = false; map }
+    end
+
+    private
+
+    def get_role_code(roles, academic_code, type = nil)
+      role_codes = roles.select do |matcher|
+        is_match = matcher[:match].include?(academic_code)
+        is_type = type.blank? || matcher[:types].include?(type.to_sym)
+        is_match && is_type
+      end
+      role_codes.empty? ? nil : role_codes.first[:role_code]
+    end
+
+    def role_codes
+      (ACADEMIC_PLAN_ROLES | ACADEMIC_CAREER_ROLES).collect do |matcher|
+        matcher[:role_code]
+      end
+    end
+
+  end
+end

--- a/app/models/hub_edos/academic_status.rb
+++ b/app/models/hub_edos/academic_status.rb
@@ -1,7 +1,5 @@
 module HubEdos
   class AcademicStatus < Student
-    include HubEdos::CachedProxy
-    include Cache::UserCacheExpiry
 
     def url
       "#{@settings.base_url}/#{@campus_solutions_id}/academic-status"
@@ -14,6 +12,5 @@ module HubEdos
     def whitelist_fields
       %w(academicStatuses awardHonors degrees holds)
     end
-
   end
 end

--- a/app/models/hub_edos/my_academic_status.rb
+++ b/app/models/hub_edos/my_academic_status.rb
@@ -1,0 +1,59 @@
+module HubEdos
+  class MyAcademicStatus < UserSpecificModel
+    include Cache::CachedFeed
+    include Cache::UserCacheExpiry
+    include Berkeley::AcademicRoles
+
+    def get_feed_internal
+      feed = HubEdos::AcademicStatus.new({user_id: @uid}).get
+      if (academic_statuses = feed.try(:[], :feed).try(:[], 'student').try(:[], 'academicStatuses'))
+        feed[:feed]['student']['roles'] = roles(academic_statuses)
+      end
+      feed
+    end
+
+    def roles(statuses)
+      roles = role_defaults
+      assigned_roles = []
+
+      statuses.each do |status|
+        assign_roles(status)
+        assigned_roles.concat(collect_roles status)
+      end
+
+      assigned_roles.each do |role|
+        if roles.has_key?(role)
+          roles[role] = true
+        end
+      end
+      roles
+    end
+
+    def assign_roles(status)
+      career_code = status.try(:[], 'studentCareer').try(:[], 'academicCareer').try(:[], 'code')
+
+      status.try(:[], 'studentPlans').each do |plan|
+        if active? plan
+          plan_code = plan.try(:[], 'academicPlan').try(:[], 'plan').try(:[], 'code')
+          plan[:role] = find_role(plan_code, career_code)
+          plan[:enrollmentRole] = find_role(plan_code, career_code, :enrollment)
+        end
+      end
+    end
+
+    def active?(plan)
+      plan.try(:[], 'statusInPlan').try(:[], 'status').try(:[], 'code') == 'AC'
+    end
+
+    def find_role(plan_code, career_code, enrollment = nil)
+      role = get_academic_plan_role_code(plan_code, enrollment) || get_academic_career_role_code(career_code, enrollment)
+      role || 'default'
+    end
+
+    def collect_roles(status)
+      status.try(:[], 'studentPlans').collect do |plan|
+        plan[:role]
+      end
+    end
+  end
+end

--- a/app/models/my_academics/gpa_units.rb
+++ b/app/models/my_academics/gpa_units.rb
@@ -17,7 +17,7 @@ module MyAcademics
     end
 
     def hub_gpa_units
-      response = HubEdos::AcademicStatus.new(user_id: @uid).get
+      response = HubEdos::MyAcademicStatus.new(@uid).get_feed
       result = {}
       unit_total = 0
       unit_sum = 0

--- a/app/models/notifications/sis_expiry_processor.rb
+++ b/app/models/notifications/sis_expiry_processor.rb
@@ -63,7 +63,7 @@ module Notifications
       'sis:student:finaid' => CampusSolutions::FinancialAidExpiry,
       'sis:student:financials' => CampusSolutions::MyBilling,
       'sis:student:messages' => MyActivities::Merged,
-      'sis:student:serviceindicator' => HubEdos::AcademicStatus,
+      'sis:student:serviceindicator' => HubEdos::MyAcademicStatus,
       'sis:faculty:grade-roster' => CampusSolutions::SectionGradesExpiry
     }
   end

--- a/spec/models/berkeley/academic_roles_spec.rb
+++ b/spec/models/berkeley/academic_roles_spec.rb
@@ -1,0 +1,126 @@
+describe Berkeley::AcademicRoles do
+  let(:type) { nil }
+
+  shared_examples 'a map of academic status codes to roles' do
+    it 'includes plans and career matchers' do
+      expect(subject.count).to_not eq 0
+    end
+
+    it 'defines type code and match string for each matcher' do
+      subject.each do |matcher|
+        expect(matcher).to have_key(:role_code)
+        expect(matcher).to have_key(:match)
+      end
+    end
+
+    it 'includes types array' do
+      subject.each do |matcher|
+        expect(matcher).to have_key(:types)
+        expect(matcher[:types]).to be_an Array
+        matcher[:types].each do |type|
+          expect(type).to be_a Symbol
+        end
+      end
+    end
+  end
+
+  shared_examples 'a translator that returns the role corresponding to an academic status' do
+    context 'when code is nil' do
+      let(:code) { nil }
+      it { should be nil }
+    end
+
+    context 'when code is not mapped' do
+      let(:code) { 'BUNK' }
+      it { should be nil }
+    end
+  end
+
+  context 'when defining plan roles' do
+    subject { described_class::ACADEMIC_PLAN_ROLES }
+
+    it_behaves_like 'a map of academic status codes to roles'
+  end
+
+  context 'when defining career roles' do
+    subject { described_class::ACADEMIC_CAREER_ROLES }
+
+    it_behaves_like 'a map of academic status codes to roles'
+  end
+
+  describe '#get_academic_plan_role_code' do
+    subject { described_class.get_academic_plan_role_code(code, type) }
+
+    it_behaves_like 'a translator that returns the role corresponding to an academic status'
+
+    context 'when a match is found' do
+      let(:code) { '99V06G' }
+      it { should eq 'summerVisitor' }
+    end
+
+    context 'when looking for a type-specific role' do
+      let(:type) { :enrollment }
+
+      context 'when no type match is found for this code' do
+        let(:code) { '701F1MFEG' }
+        it { should be nil }
+      end
+
+      context 'when a match is found' do
+        let(:code) { '25000FPFU' }
+        it { should eq 'fpf' }
+      end
+
+      context 'when type is not mapped' do
+        let(:type) { :garbage }
+        let(:code) { '25000FPFU' }
+        it { should be nil }
+      end
+    end
+  end
+
+  describe '#get_academic_career_role_code' do
+    subject { described_class.get_academic_career_role_code(code, type) }
+
+    it_behaves_like 'a translator that returns the role corresponding to an academic status'
+
+    context 'when a match is found' do
+      let(:code) { 'LAW' }
+      it { should eq 'law' }
+    end
+
+    context 'when looking for a type-specific role' do
+      let(:type) { :enrollment }
+
+      context 'when a match is found' do
+        let(:code) { 'UCBX' }
+        it { should eq 'concurrent' }
+      end
+
+      context 'when type is not mapped' do
+        let(:type) { :garbage }
+        let(:code) { 'UCBX' }
+        it { should be nil }
+      end
+    end
+  end
+
+  describe '#role_defaults' do
+    subject { described_class.role_defaults }
+
+    it 'returns all possible roles set to false' do
+      expect(subject.keys.count).to eq (11)
+      expect(subject['fpf']).to eq false
+      expect(subject['law']).to eq false
+      expect(subject['concurrent']).to eq false
+      expect(subject['haasFullTimeMba']).to eq false
+      expect(subject['haasEveningWeekendMba']).to eq false
+      expect(subject['haasExecMba']).to eq false
+      expect(subject['haasMastersFinEng']).to eq false
+      expect(subject['haasMbaPublicHealth']).to eq false
+      expect(subject['haasMbaJurisDoctor']).to eq false
+      expect(subject['ugrdUrbanStudies']).to eq false
+      expect(subject['summerVisitor']).to eq false
+    end
+  end
+  end

--- a/spec/models/hub_edos/my_academic_status_spec.rb
+++ b/spec/models/hub_edos/my_academic_status_spec.rb
@@ -1,0 +1,161 @@
+describe HubEdos::MyAcademicStatus do
+
+  subject { described_class.new(random_id).get_feed_internal }
+
+  context 'when calling a mock proxy' do
+    it 'should successfully return a response' do
+      expect(subject[:statusCode]).to eq 200
+    end
+  end
+
+  context 'when calling a stubbed proxy' do
+    shared_examples 'a translator that maps academic status to roles' do
+      it 'translates roles' do
+        roles = subject[:feed]['student']['roles']
+        expect(roles).to be
+        expect(roles.keys.count).to eq 11
+        expect(roles['fpf']).to eq false
+        expect(roles['law']).to eq has_law_role
+        expect(roles['concurrent']).to eq false
+        expect(roles['haasFullTimeMba']).to eq false
+        expect(roles['haasEveningWeekendMba']).to eq false
+        expect(roles['haasExecMba']).to eq false
+        expect(roles['haasMastersFinEng']).to eq false
+        expect(roles['haasMbaPublicHealth']).to eq false
+        expect(roles['haasMbaJurisDoctor']).to eq false
+        expect(roles['ugrdUrbanStudies']).to eq false
+        expect(roles['summerVisitor']).to eq has_summer_visitor_role
+      end
+    end
+
+    before do
+      allow_any_instance_of(HubEdos::AcademicStatus).to receive(:get).and_return academic_status_response
+    end
+
+    let(:academic_status_response) do
+      {
+        'statusCode' => 200,
+        :feed => {
+          'student' => {
+            'academicStatuses' => [
+              {
+                'studentCareer' => {
+                  'academicCareer' => academic_career,
+                  'fromDate' => '2011-05-23'
+                },
+                'studentPlans' => academic_plans,
+                'currentRegistration' => {
+                  'term' => {
+                    'id' => '2115',
+                    'name' => '2011 Summer'
+                  },
+                  'academicCareer' => {
+                    'code' => 'UGRD',
+                    'description' => 'Undergraduate'
+                  },
+                  'eligibleToRegister' => false,
+                  'registered' => false,
+                  'disabled' => false,
+                  'athlete' => false,
+                  'intendsToGraduate' => false,
+                  'academicLevel' => {
+                    'type' => {
+                      'code' => 'Self Reported'
+                    },
+                    'level' => {
+                      'code' => '',
+                      'description' => ''
+                    }
+                  },
+                  'termUnits' => [],
+                  'termGPA' => {},
+                  'new' => true
+                }
+              }
+            ],
+            'holds' => [],
+            'awardHonors' => [],
+            'degrees' => []
+          }
+        },
+        'studentNotFound' => nil
+      }
+    end
+    let(:academic_plans) {
+      []
+    }
+    let(:academic_career) {
+      nil
+    }
+    let(:academic_plan_generic) {
+      {
+        'academicPlan' => {
+          'plan' => {
+            'code' => '12345AB',
+            'description' => 'Plan Not Tied To Any Role',
+            'fromDate' => '2011-05-23'
+          }
+        },
+        'statusInPlan' => {
+          'status' => {
+            'code' => 'AC',
+            'description' => 'Active in Program'
+          }
+        },
+      }
+    }
+    let(:academic_plan_summer_visitor) {
+      {
+        'academicPlan' => {
+          'plan' => {
+            'code' => '99000U',
+            'description' => 'Summer Domestic Visitor UG',
+            'fromDate' => '2011-05-23'
+          }
+        },
+        'statusInPlan' => {
+          'status' => {
+            'code' => 'AC',
+            'description' => 'Active in Program'
+          }
+        }
+      }
+    }
+
+    let(:has_summer_visitor_role) { false }
+    let(:has_law_role) { false }
+
+    context 'when student has no career and no plans' do
+      it_behaves_like 'a translator that maps academic status to roles'
+    end
+
+    context 'when student has a law career' do
+      let(:academic_career) {
+        {
+          'code' => 'LAW',
+          'description' => 'Bob Loblaw\'s Law Blog'
+        }
+      }
+      context 'when student has no plans' do
+        it_behaves_like 'a translator that maps academic status to roles'
+      end
+
+      context 'when student has a plan' do
+        let(:has_law_role) { true }
+        let(:academic_plans) {
+          [academic_plan_generic]
+        }
+        it_behaves_like 'a translator that maps academic status to roles'
+      end
+    end
+
+    context 'when student has a summer visitor plan' do
+      let(:has_summer_visitor_role) { true }
+      let(:academic_plans) {
+        [academic_plan_summer_visitor]
+      }
+      it_behaves_like 'a translator that maps academic status to roles'
+    end
+
+  end
+end

--- a/spec/models/my_academics/college_and_level_spec.rb
+++ b/spec/models/my_academics/college_and_level_spec.rb
@@ -21,7 +21,20 @@ describe MyAcademics::CollegeAndLevel do
       "student" => {
         "academicStatuses" => hub_academic_statuses,
         "holds" => hub_holds,
-        "degrees" => hub_degrees
+        "degrees" => hub_degrees,
+        "roles" => {
+          'fpf' => false,
+          'law' => false,
+          'concurrent' => false,
+          'haasFullTimeMba' => false,
+          'haasEveningWeekendMba' => false,
+          'haasExecMba' => false,
+          'haasMastersFinEng' => false,
+          'haasMbaPublicHealth' => false,
+          'haasMbaJurisDoctor' => false,
+          'ugrdUrbanStudies' => false,
+          'summerVisitor' => false
+        }
       }
     }
   end
@@ -152,6 +165,8 @@ describe MyAcademics::CollegeAndLevel do
       program_description: 'Undergrad Letters & Science',
       plan_code: '25345U',
       plan_description: 'English BA',
+      role: 'default',
+      enrollmentRole: 'default',
       admin_owners: [{org_code: 'ENGLISH', org_description: 'English', percentage: 100}],
       expected_grad_term_id: '2202',
       expected_grad_term_name: '2020 Spring'
@@ -165,6 +180,8 @@ describe MyAcademics::CollegeAndLevel do
       program_description: 'Undergrad Letters & Science',
       plan_code: '25971U',
       plan_description: 'MCB-Cell & Dev Biology BA',
+      role: 'default',
+      enrollmentRole: 'default',
       type_code: 'SP',
       type_description: 'Major - UG Specialization',
       sub_plan_code: '25966SA02U',
@@ -181,6 +198,8 @@ describe MyAcademics::CollegeAndLevel do
       program_description: 'Undergrad Letters & Science',
       plan_code: '25090U',
       plan_description: 'Art BA',
+      role: 'default',
+      enrollmentRole: 'default',
       type_code: 'MIN',
       type_description: 'Major - UG Specialization',
       admin_owners: [{org_code: 'MCELLBI', org_description: 'Molecular & Cell Biology', percentage: 100}],
@@ -196,6 +215,8 @@ describe MyAcademics::CollegeAndLevel do
       program_description: 'Graduate Academic Programs',
       plan_code: '00E017G',
       plan_description: 'Women, Gender and Sexuality DE',
+      role: 'default',
+      enrollmentRole: 'default',
       type_code: 'DE',
       type_description: 'Designated Emphasis',
       admin_owners: [{org_code: 'MCELLBI', org_description: 'Molecular & Cell Biology', percentage: 100}],
@@ -210,6 +231,8 @@ describe MyAcademics::CollegeAndLevel do
       program_description: 'Graduate Professional Programs',
       plan_code: '82790PPJDG',
       plan_description: 'Public Policy MPP-JD CDP',
+      role: 'default',
+      enrollmentRole: 'default',
       admin_owners: [
         {org_code: 'LAW', org_description: 'School of Law', percentage: 50},
         {org_code: 'PUBPOL', org_description: 'Goldman School Public Policy', percentage: 50},
@@ -224,6 +247,8 @@ describe MyAcademics::CollegeAndLevel do
       program_description: 'Law Professional Programs',
       plan_code: '84501JDPPG',
       plan_description: 'Law JD-MPP CDP',
+      role: 'law',
+      enrollmentRole: 'law',
       admin_owners: [
         {org_code: 'LAW', org_description: 'School of Law', percentage: 50},
         {org_code: 'PUBPOL', org_description: 'Goldman School Public Policy', percentage: 50},
@@ -252,6 +277,8 @@ describe MyAcademics::CollegeAndLevel do
       program_description: 'Graduate Professional Programs',
       plan_code: '70141BAPHG',
       plan_description: 'Business Admin MBA-MPH CDP',
+      role: 'haasMbaPublicHealth',
+      enrollmentRole: 'default',
       admin_owners: [
         {org_code: 'BUS', org_description: 'Haas School of Business', percentage: 50},
         {org_code: 'PUBHEALTH', org_description: 'School of Public Health', percentage: 50},
@@ -261,48 +288,7 @@ describe MyAcademics::CollegeAndLevel do
 
   before do
     allow_any_instance_of(CalnetCrosswalk::ByUid).to receive(:lookup_campus_solutions_id).and_return campus_solutions_id
-    allow_any_instance_of(HubEdos::AcademicStatus).to receive(:get).and_return hub_academic_status_response
-  end
-
-  context 'when defining student plan roles' do
-    it 'includes plans and career matchers' do
-      expect(subject.class::STUDENT_PLAN_ROLES[:plan].count).to_not eq 0
-      expect(subject.class::STUDENT_PLAN_ROLES[:career].count).to_not eq 0
-    end
-
-    it 'defines type code and match string for each matcher' do
-      subject.class::STUDENT_PLAN_ROLES.values_at(:plan, :career).flatten.each do |matcher|
-        expect(matcher).to have_key(:student_plan_role_code)
-        expect(matcher).to have_key(:match)
-      end
-    end
-
-    it 'includes types array' do
-      subject.class::STUDENT_PLAN_ROLES.values_at(:plan, :career).flatten.each do |matcher|
-        expect(matcher).to have_key(:types)
-        expect(matcher[:types]).to be_an Array
-        matcher[:types].each do |type|
-          expect(type).to be_a Symbol
-        end
-      end
-    end
-  end
-
-  context 'when providing student plan role codes' do
-    it 'returns all possible student plan role codes' do
-      role_codes = subject.class.student_plan_role_codes
-      expect(role_codes.count).to eq 10
-      expect(role_codes).to include('fpf')
-      expect(role_codes).to include('law')
-      expect(role_codes).to include('concurrent')
-      expect(role_codes).to include('haasFullTimeMba')
-      expect(role_codes).to include('haasEveningWeekendMba')
-      expect(role_codes).to include('haasExecMba')
-      expect(role_codes).to include('haasMastersFinEng')
-      expect(role_codes).to include('haasMbaPublicHealth')
-      expect(role_codes).to include('haasMbaJurisDoctor')
-      expect(role_codes).to include('ugrdUrbanStudies')
-    end
+    allow_any_instance_of(HubEdos::MyAcademicStatus).to receive(:get_feed).and_return hub_academic_status_response
   end
 
   context 'data sourcing' do
@@ -364,7 +350,7 @@ describe MyAcademics::CollegeAndLevel do
     context 'failed response' do
       let(:failure_response) { {:errored=>true, :statusCode=>503, :body=>"An unknown server error occurred"} }
       before do
-        allow_any_instance_of(HubEdos::AcademicStatus).to receive(:get).and_return(failure_response)
+        allow_any_instance_of(HubEdos::MyAcademicStatus).to receive(:get_feed).and_return(failure_response)
       end
       it 'reports failure' do
         expect(feed[:collegeAndLevel][:statusCode]).to eq 503
@@ -374,6 +360,8 @@ describe MyAcademics::CollegeAndLevel do
       end
     end
     context 'undergrad with single academic status' do
+      let(:has_law_role) { false }
+
       it 'reports success' do
         expect(feed[:collegeAndLevel][:statusCode]).to eq 200
       end
@@ -482,17 +470,7 @@ describe MyAcademics::CollegeAndLevel do
       end
 
       it 'translates roles' do
-        expect(feed[:collegeAndLevel][:roles].keys.count).to eq 10
-        expect(feed[:collegeAndLevel][:roles]['fpf']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['law']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['concurrent']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['haasFullTimeMba']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['haasEveningWeekendMba']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['haasExecMba']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['haasMastersFinEng']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['haasMbaPublicHealth']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['haasMbaJurisDoctor']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['ugrdUrbanStudies']).to eq false
+        expect(feed[:collegeAndLevel][:roles]).to be
       end
 
       it 'translates holds' do
@@ -568,6 +546,8 @@ describe MyAcademics::CollegeAndLevel do
       let(:student_plans) { [law_jd_mpp_cdp_plan] }
       let(:student_plans_secondary) { [graduate_master_public_policy_plan] }
 
+      let(:has_law_role) { true }
+
       it 'reports success' do
         expect(feed[:collegeAndLevel][:statusCode]).to eq 200
       end
@@ -613,6 +593,7 @@ describe MyAcademics::CollegeAndLevel do
         expect(feed[:collegeAndLevel][:plans][0][:type][:code]).to eq 'MAJ'
         expect(feed[:collegeAndLevel][:plans][0][:type][:category]).to eq 'Major'
         expect(feed[:collegeAndLevel][:plans][0][:college]).to eq 'Law Professional Programs'
+
         expect(feed[:collegeAndLevel][:plans][1][:career][:code]).to eq 'GRAD'
         expect(feed[:collegeAndLevel][:plans][1][:program][:code]).to eq 'GPRFL'
         expect(feed[:collegeAndLevel][:plans][1][:plan][:code]).to eq '82790PPJDG'
@@ -626,17 +607,7 @@ describe MyAcademics::CollegeAndLevel do
       end
 
       it 'translates roles' do
-        expect(feed[:collegeAndLevel][:roles].keys.count).to eq 10
-        expect(feed[:collegeAndLevel][:roles]['fpf']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['law']).to eq true
-        expect(feed[:collegeAndLevel][:roles]['concurrent']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['haasFullTimeMba']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['haasEveningWeekendMba']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['haasExecMba']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['haasMastersFinEng']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['haasMbaPublicHealth']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['haasMbaJurisDoctor']).to eq false
-        expect(feed[:collegeAndLevel][:roles]['ugrdUrbanStudies']).to eq false
+        expect(feed[:collegeAndLevel][:roles]).to be
       end
     end
 
@@ -676,7 +647,7 @@ describe MyAcademics::CollegeAndLevel do
   context 'when sourced from Bearfacts' do
     let(:campus_solutions_id) { legacy_campus_solutions_id }
     before do
-      allow_any_instance_of(HubEdos::AcademicStatus).to receive(:get).and_return({})
+      allow_any_instance_of(HubEdos::MyAcademicStatus).to receive(:get_feed).and_return({})
       allow(subject).to receive(:current_term).and_return(fake_spring_term)
     end
 
@@ -871,6 +842,8 @@ describe MyAcademics::CollegeAndLevel do
         program_description: 'Undergrad Letters & Science',
         plan_code: '25971U',
         plan_description: 'MCB-Cell & Dev Biology BA',
+        role: 'default',
+        enrollmentRole: 'default',
         is_primary: false,
         status_in_plan_status_code: 'X',
         status_in_plan_status_description: 'Invalid Status'
@@ -887,93 +860,6 @@ describe MyAcademics::CollegeAndLevel do
         expect(filtered_academic_statuses[0]['studentPlans'][0]['academicPlan']['plan']['code']).to eq '25345U'
         expect(filtered_academic_statuses[0]['studentPlans'][1]['academicPlan']['plan']['code']).to eq '25090U'
         expect(filtered_academic_statuses[0]['studentPlans'][2]['academicPlan']['plan']['code']).to eq '00E017G'
-      end
-    end
-  end
-
-  context 'when determining the student plan role code' do
-    let(:plan) { { career: { code: 'GRAD' }, plan: { code: '70141MBAG' } } }
-
-    context 'when role type not specified' do
-      let(:plan_role_code) { subject.get_student_plan_role_code(plan) }
-
-      it 'identifies a default plan in undergrad career' do
-        plan[:career][:code] = 'UGRD'
-        plan[:plan][:code] = '25699U'
-        expect(plan_role_code).to eq 'default'
-      end
-
-      it 'identifies a default plan in graduate career' do
-        plan[:career][:code] = 'GRAD'
-        plan[:plan][:code] = '16290PHDG'
-        expect(plan_role_code).to eq 'default'
-      end
-
-      it 'identifies a berkeley law career plan' do
-        plan[:career][:code] = 'LAW'
-        plan[:plan][:code] = '842C1JSDG'
-        expect(plan_role_code).to eq 'law'
-      end
-
-      it 'identifies a concurrent enrollment plan' do
-        plan[:career][:code] = 'UCBX'
-        plan[:plan][:code] = '30XCECCENX'
-        expect(plan_role_code).to eq 'concurrent'
-      end
-
-      it 'identifies a fall program for freshmen plan' do
-        plan[:career][:code] = 'UGRD'
-        plan[:plan][:code] = '25000FPFU'
-        expect(plan_role_code).to eq 'fpf'
-      end
-
-      it 'identifies a Haas Business School Fulltime MBA plan' do
-        plan[:career][:code] = 'GRAD'
-        plan[:plan][:code] = '70141MBAG'
-        expect(plan_role_code).to eq 'haasFullTimeMba'
-      end
-
-      it 'identifies a Haas Business School Evening and Weekend MBA plan' do
-        plan[:career][:code] = 'GRAD'
-        plan[:plan][:code] = '701E1MBAG'
-        expect(plan_role_code).to eq 'haasEveningWeekendMba'
-      end
-
-      it 'identifies a Haas Business School Executive MBA plan' do
-        plan[:career][:code] = 'GRAD'
-        plan[:plan][:code] = '70364MBAG'
-        expect(plan_role_code).to eq 'haasExecMba'
-      end
-
-      it 'identifies a Haas Business School Masters of Financial Engineering plan' do
-        plan[:career][:code] = 'GRAD'
-        plan[:plan][:code] = '701F1MFEG'
-        expect(plan_role_code).to eq 'haasMastersFinEng'
-      end
-
-      it 'identifies a Haas Business School Business Admin MBA-MPH plan' do
-        plan[:career][:code] = 'GRAD'
-        plan[:plan][:code] = '70141BAPHG'
-        expect(plan_role_code).to eq 'haasMbaPublicHealth'
-      end
-
-      it 'identifies a Haas Business School Business Admin MBA-JD plan' do
-        plan[:career][:code] = 'GRAD'
-        plan[:plan][:code] = '70141BAJDG'
-        expect(plan_role_code).to eq 'haasMbaJurisDoctor'
-      end
-    end
-
-    context 'when enrollment role type specified' do
-      let(:role_type) { :enrollment }
-      let(:plan_role_code) { subject.get_student_plan_role_code(plan, role_type) }
-
-      it 'identifies Haas Business School plans as default' do
-        haas_plan_codes = ['70141MBAG', '701E1MBAG', '70364MBAG', '701F1MFEG', '70141BAPHG', '70141BAJDG']
-        haas_plan_codes.each do |haas_plan_code|
-          plan_hash = { career: { code: 'GRAD' }, plan: { code: haas_plan_code } }
-          expect(plan_role_code).to eq 'default'
-        end
       end
     end
   end

--- a/spec/support/spec_helper_module.rb
+++ b/spec/support/spec_helper_module.rb
@@ -83,7 +83,9 @@ module SpecHelperModule
           "code" => cpp_hash[:status_in_plan_status_code],
           "description" => cpp_hash[:status_in_plan_status_description]
         }
-      }
+      },
+      "role" => cpp_hash[:role],
+      "enrollmentRole" => cpp_hash[:enrollmentRole]
     }
     if (cpp_hash[:expected_grad_term_id] && cpp_hash[:expected_grad_term_name])
       plan.merge!({


### PR DESCRIPTION
This is the backend work required to support https://jira.berkeley.edu/browse/SISRP-27699.

We needed a way for every page in calcentral to be aware of the roles that are assigned to a student based on their academic status (plan or career).  Prior to this, that information was added to the feed in `CollegeAndLevel` and only available on the My Academics page.

I refactored the roles logic into a new model called `MyAcademicStatus`, which takes the feed from `AcademicStatus` and inserts the roles into it.  The roles will now be included in the `CollegeAndLevel` feed and in `HubEdoController#academic_status`.  `GpaUnits` and `AdvisingStudentController` are still calling `AcademicStatus` directly unless anyone sees a reason to switch those over too.

I also added a new role that will be assigned to students in a "summer visitor" plan (there are a number of plans that have this designation).