### PR TITLE
SISRP-28781 Check Alumni & Expired-account LDAP populations if needed

### DIFF
--- a/app/models/calnet_ldap/client.rb
+++ b/app/models/calnet_ldap/client.rb
@@ -7,6 +7,8 @@ module CalnetLdap
 
     PEOPLE_DN = 'ou=people,dc=berkeley,dc=edu'
     GUEST_DN = 'ou=guests,dc=berkeley,dc=edu'
+    ADVCON_DN = 'ou=advcon people,dc=berkeley,dc=edu'
+    EXPIRED_DN = 'ou=expired people,dc=berkeley,dc=edu'
     TIMESTAMP_FORMAT = '%Y%m%d%H%M%SZ'
 
     # TODO Ask CalNet for suggested maximum number of search values.
@@ -64,9 +66,9 @@ module CalnetLdap
     def search_by_uid(uid)
       filter = uids_filter([uid])
       results = search(base: PEOPLE_DN, filter: filter)
-      if results.empty?
-        results = search(base: GUEST_DN, filter: filter)
-      end
+      results = search(base: GUEST_DN, filter: filter) if results.empty?
+      results = search(base: ADVCON_DN, filter: filter) if results.empty?
+      results = search(base: EXPIRED_DN, filter: filter) if results.empty?
       results.first
     end
 

--- a/spec/models/calnet_ldap/client_spec.rb
+++ b/spec/models/calnet_ldap/client_spec.rb
@@ -94,6 +94,16 @@ describe CalnetLdap::Client do
     expect(results).to eq nil
   end
 
+  it 'tries to find a specific UID in all population groups' do
+    uid = random_id
+    expect(subject).to receive(:search).exactly(1).times.with(hash_including base: CalnetLdap::Client::PEOPLE_DN).and_return []
+    expect(subject).to receive(:search).exactly(1).times.with(hash_including base: CalnetLdap::Client::GUEST_DN).and_return []
+    expect(subject).to receive(:search).exactly(1).times.with(hash_including base: CalnetLdap::Client::ADVCON_DN).and_return []
+    expect(subject).to receive(:search).exactly(1).times.with(hash_including base: CalnetLdap::Client::EXPIRED_DN).and_return [{uid: [uid]}]
+    result = subject.search_by_uid uid
+    expect(result[:uid]).to eq([uid])
+  end
+
   context 'search by name with mock LDAP' do
     let(:expected_ldap_searches) { nil }
     before do


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-28781

This will ensure up-to-date personal attributes in the user's own view, in advisor Student Overview, and in View-As.

Bulk attributes (such as shown in class rosters) may continue to be out-of-date for non-active campus accounts until follow-up task SISRP-28908 is addressed.