### PR TITLE
SISRP-28736 TEMPORARY reversion of jruby-openssl back to 0.9.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,9 @@ gem 'active_attr', '~> 0.8.5'
 gem 'jruby-activemq', '~> 5.13.0', git: 'https://github.com/ets-berkeley-edu/jruby-activemq.git'
 
 # To support SSL TLSv1.2.
-gem 'jruby-openssl', '0.9.17'
+# jruby-openssl versions 0.9.8 through 0.9.16 trigger runaway memory consumption in CalCentral.
+# Track progress at https://github.com/jruby/jruby-openssl/issues/86 and SISRP-18781.
+gem 'jruby-openssl', '0.9.7'
 
 # Addressable is a replacement for the URI implementation that is part of Ruby's standard library.
 # https://github.com/sporkmonger/addressable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.0)
       railties (>= 3.2.16)
-    jruby-openssl (0.9.17-java)
+    jruby-openssl (0.9.7-java)
     json (1.8.3-java)
     jwt (1.5.4)
     kaminari (0.16.1)
@@ -484,7 +484,7 @@ DEPENDENCIES
   icalendar (~> 2.2.2)
   ims-lti!
   jruby-activemq (~> 5.13.0)!
-  jruby-openssl (= 0.9.17)
+  jruby-openssl (= 0.9.7)
   json (~> 1.8.0)
   link_header (~> 0.0.7)
   log4r (~> 1.1)

--- a/app/models/calnet_crosswalk/proxy.rb
+++ b/app/models/calnet_crosswalk/proxy.rb
@@ -3,6 +3,7 @@ module CalnetCrosswalk
 
     include ClassLogger
     include Proxies::Mockable
+    include Proxies::Tls12
 
     APP_ID = 'calnetcrosswalk'
     APP_NAME = 'Calnet Crosswalk'
@@ -68,11 +69,11 @@ module CalnetCrosswalk
       internal_response
     end
 
-    def request_options
-      {
+    def request_options(opts = {})
+      super(opts).merge({
         digest_auth: {username: @settings.username, password: @settings.password},
         on_error: {rescue_status: 404}
-      }
+      })
     end
 
     def lookup_campus_solutions_id


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-28736

This reverts commit 152173c97d1bee4567e1f236959b8aa950c80046.

The reversion is already in the QA branch for a prospective v85.2 release. However, since our post-0.9.7 stability problems  are very unlikely to be resolved in time for GL7.4, it seems safest to get it into the master branch now.

SISRP-29026 is a critical-priority task to undo the undoing.