### PR TITLE
SISRP-25362 - 7.4 - Student Overview (Advisor) Degree Progress card for Grad and Law Careers

### DIFF
--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -56,10 +56,9 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
     showChart: true,
     isLoading: true
   };
-  $scope.degreeProgressGraduate = {
-    isLoading: true
-  };
-  $scope.degreeProgressUndergrad = {
+  $scope.degreeProgress = {
+    graduate: {},
+    undergraduate: {},
     isLoading: true
   };
 
@@ -238,25 +237,21 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
     });
   };
 
-  var loadDegreeProgressGraduate = function() {
+  var loadDegreeProgresses = function() {
     advisingFactory.getDegreeProgressGraduate({
       uid: $routeParams.uid
-    }).success(function(data) {
-      $scope.degreeProgressGraduate.progresses = _.get(data, 'feed.degreeProgress');
-      $scope.degreeProgressGraduate.errored = _.get(data, 'errored');
-    }).finally(function() {
-      $scope.degreeProgressGraduate.isLoading = false;
-    });
-  };
-
-  var loadDegreeProgressUndergrad = function() {
-    advisingFactory.getDegreeProgressUndergrad({
-      uid: $routeParams.uid
-    }).success(function(data) {
-      $scope.degreeProgressUndergrad.progresses = _.get(data, 'feed.degreeProgress.progresses');
-      $scope.degreeProgressUndergrad.errored = _.get(data, 'errored');
-    }).finally(function() {
-      $scope.degreeProgressUndergrad.isLoading = false;
+    }).then(function(data) {
+      $scope.degreeProgress.graduate.progresses = _.get(data, 'data.feed.degreeProgress');
+      $scope.degreeProgress.graduate.errored = _.get(data, 'errored');
+    }).then(function() {
+      advisingFactory.getDegreeProgressUndergrad({
+        uid: $routeParams.uid
+      }).then(function(data) {
+        $scope.degreeProgress.undergraduate.progresses = _.get(data, 'data.feed.degreeProgress.progresses');
+        $scope.degreeProgress.undergraduate.errored = _.get(data, 'errored');
+      }).finally(function() {
+        $scope.degreeProgress.isLoading = false;
+      });
     });
   };
 
@@ -319,8 +314,7 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
       .then(loadStudentSuccess)
       .then(loadHolds)
       .then(loadRegistrations)
-      .then(loadDegreeProgressGraduate)
-      .then(loadDegreeProgressUndergrad)
+      .then(loadDegreeProgresses)
       .then(getRegMessages);
     }
   });

--- a/src/assets/templates/user_overview.html
+++ b/src/assets/templates/user_overview.html
@@ -10,8 +10,10 @@
       <div data-ng-include="'widgets/student_success/student_success.html'" data-ng-if="api.user.profile.features.advisingStudentSuccess"></div>
       <div data-ng-include src="'academics_semesters.html'" data-ng-if="semesters.length && !api.user.profile.features.advisingAcademicPlanner"></div>
       <div data-ng-include="'widgets/status_and_holds.html'"></div>
-      <div data-ng-include src="'widgets/academics/degree_progress_graduate.html'" data-ng-if="api.user.profile.features.csDegreeProgressGradAdvising && (targetUser.roles.graduate || targetUser.roles.law)"></div>
-      <div data-ng-include src="'widgets/academics/degree_progress_undergrad.html'" data-ng-if="api.user.profile.features.csDegreeProgressUgrdAdvising && targetUser.roles.undergrad"></div>
+      <div data-cc-spinner-directive="degreeProgress.isLoading">
+        <div data-ng-include src="'widgets/academics/degree_progress_graduate.html'" data-ng-if="api.user.profile.features.csDegreeProgressGradAdvising && degreeProgress.graduate.progresses.length"></div>
+        <div data-ng-include src="'widgets/academics/degree_progress_undergrad.html'" data-ng-if="api.user.profile.features.csDegreeProgressUgrdAdvising && degreeProgress.undergraduate.progresses.length"></div>
+      </div>
     </div>
     <div class="medium-4 columns cc-column-3">
       <div data-ng-include="'widgets/final_exam_schedule.html'" data-ng-if="examSchedule.length && api.user.profile.features.finalExamSchedule"></div>

--- a/src/assets/templates/widgets/academics/degree_progress_graduate.html
+++ b/src/assets/templates/widgets/academics/degree_progress_graduate.html
@@ -2,25 +2,24 @@
   <div class="cc-widget-title">
     <h2>Degree Progress</h2>
   </div>
-  <div class="cc-widget-padding" data-cc-spinner-directive="degreeProgressGraduate.isLoading">
-    <div data-ng-if="degreeProgressGraduate.errored">There was an error retrieving degree progress data.</div>
-    <div data-ng-if="!degreeProgressGraduate.errored && !degreeProgressGraduate.progresses.length">No degree progress data is available.</div>
-    <ul data-ng-if="!degreeProgressGraduate.errored && degreeProgressGraduate.progresses" class="cc-list-links">
-      <li data-ng-if="degreeProgressGraduate.links.advancementFormSubmit.url">
+  <div class="cc-widget-padding">
+    <div data-ng-if="degreeProgress.graduate.errored">There was an error retrieving graduate degree progress data.</div>
+    <ul data-ng-if="!degreeProgress.graduate.errored && degreeProgress.graduate.progresses" class="cc-list-links">
+      <li data-ng-if="degreeProgress.graduate.links.advancementFormSubmit.url">
         <div
           data-cc-campus-solutions-link-item-directive
-          data-link="degreeProgressGraduate.links.advancementFormSubmit"
+          data-link="degreeProgress.graduate.links.advancementFormSubmit"
         ></div>
       </li>
-      <li data-ng-if="degreeProgressGraduate.links.advancementFormView.url">
+      <li data-ng-if="degreeProgress.graduate.links.advancementFormView.url">
         <div
           data-cc-campus-solutions-link-item-directive
-          data-link="degreeProgressGraduate.links.advancementFormView"
+          data-link="degreeProgress.graduate.links.advancementFormView"
         ></div>
       </li>
     </ul>
     <ul>
-      <li data-ng-repeat="plan in degreeProgressGraduate.progresses">
+      <li data-ng-repeat="plan in degreeProgress.graduate.progresses">
         <h3 data-ng-bind="plan.acadPlan ? plan.acadPlan + ' &mdash; Graduate Division Milestones' : 'Graduate Division Milestones'"></h3>
         <div data-ng-repeat="requirement in plan.requirements">
           <h4 data-ng-bind="requirement.name"></h4>

--- a/src/assets/templates/widgets/academics/degree_progress_undergrad.html
+++ b/src/assets/templates/widgets/academics/degree_progress_undergrad.html
@@ -2,11 +2,10 @@
   <div class="cc-widget-title">
     <h2>Degree Progress</h2>
   </div>
-  <div class="cc-widget-padding" data-cc-spinner-directive="degreeProgressUndergrad.isLoading">
-    <div data-ng-if="degreeProgressUndergrad.errored">There was an error retrieving degree progress data.</div>
-    <div data-ng-if="!degreeProgressUndergrad.errored && !degreeProgressUndergrad.progresses.length">No degree progress data is available.</div>
-    <ul data-ng-if="!degreeProgressUndergrad.errored && degreeProgressUndergrad.progresses">
-      <li data-ng-repeat="plan in degreeProgressUndergrad.progresses">
+  <div class="cc-widget-padding">
+    <div data-ng-if="degreeProgress.undergraduate.errored">There was an error retrieving undergraduate degree progress data.</div>
+    <ul data-ng-if="!degreeProgress.undergraduate.errored && degreeProgress.undergraduate.progresses">
+      <li data-ng-repeat="plan in degreeProgress.undergraduate.progresses">
         <h3>University Requirements</h3>
         <div class="cc-table">
           <table>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-25362

* Biggest change on our end (lot of stuff going on in that ticket) is opening this up to students who have *any* Degree Progress data - not just current students.
* Also reformatted front-end to use one spinner for both graduate and undergraduate data.  There's a small population who might have both a graduate and an undergraduate Degree Progress card, but for the most part, people will only have one.
* This brought up a design question though - as we are introducing yet another spinner to the User Overview page.  Do we go the My Academics (Student) route and use one spinner for everything?  But that would delay user's views of ready-to-go data.  I discussed this with @lyttam and Chara and while it is a larger question that should include both designers and developers, I think we are getting to the point  where the data we are gathering from different sources is becoming so large and fractured that we need to start looking for a solution.  The open-endedness of this question is ultimately why we decided not to have this merged with `MyAcademics::FilteredForAdvisors` at this time.