### PR TITLE
SISRP-27699 - Refactors academic roles and holds handling

### DIFF
--- a/src/assets/javascripts/angular/controllers/pages/academicsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicsController.js
@@ -163,7 +163,7 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
   var loadNumberOfHolds = function() {
     return academicStatusFactory.getHolds()
       .then(function(data) {
-        $scope.numberOfHolds = data.holds.length;
+        $scope.numberOfHolds = _.get(data, 'holds.length');
       });
   };
 
@@ -229,7 +229,7 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
   var loadAcademicRoles = function() {
     return academicStatusFactory.getAcademicRoles()
       .then(function(data) {
-        $scope.academicStatus.roles = data.roles;
+        $scope.academicStatus.roles = _.get(data, 'roles');
       });
   };
 

--- a/src/assets/javascripts/angular/controllers/pages/academicsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicsController.js
@@ -11,6 +11,9 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
   var title = 'My Academics';
   apiService.util.setTitle(title);
   $scope.backToText = title;
+  $scope.academicStatus = {
+    roles: {}
+  };
   $scope.academics = {
     isLoading: true
   };
@@ -157,8 +160,11 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
     }
   };
 
-  var loadNumberOfHolds = function(data) {
-    $scope.numberOfHolds = _.get(data, 'feed.student.holds.length');
+  var loadNumberOfHolds = function() {
+    return academicStatusFactory.getHolds()
+      .then(function(data) {
+        $scope.numberOfHolds = data.holds.length;
+      });
   };
 
   var loadRegistrations = function(data) {
@@ -172,7 +178,7 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
     $scope.isLSStudent = academicsService.isLSStudent($scope.collegeAndLevel);
     $scope.isUndergraduate = _.includes(_.get($scope.collegeAndLevel, 'careers'), 'Undergraduate');
     $scope.hasTeachingClasses = academicsService.hasTeachingClasses(data.teachingSemesters);
-    $scope.canViewFinalExamSchedule = $scope.api.user.profile.roles.student && !$scope.api.user.profile.delegateActingAsUid && !$scope.collegeAndLevel.roles.summerVisitor;
+    $scope.canViewFinalExamSchedule = $scope.api.user.profile.roles.student && !$scope.api.user.profile.delegateActingAsUid && !$scope.academicStatus.roles.summerVisitor;
 
     // Get selected semester from URL params and extract data from semesters array
     var semesterSlug = ($routeParams.semesterSlug || $routeParams.teachingSemesterSlug);
@@ -202,7 +208,7 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
     $scope.showLegacyAdvising = !$scope.filteredForDelegate && $scope.api.user.profile.features.legacyAdvising && $scope.isLSStudent;
     $scope.showAdvising = !$scope.filteredForDelegate && apiService.user.profile.features.advising && apiService.user.profile.roles.student && isMbaJdOrNotLaw();
     $scope.showProfileMessage = (!$scope.isAcademicInfoAvailable || !$scope.collegeAndLevel || _.isEmpty($scope.collegeAndLevel.careers));
-    $scope.showResidency = apiService.user.profile.roles.student && !$scope.collegeAndLevel.roles.summerVisitor && hasResidency();
+    $scope.showResidency = apiService.user.profile.roles.student && !$scope.academicStatus.roles.summerVisitor && hasResidency();
   };
 
   /**
@@ -210,14 +216,21 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
    * @return {Boolean} Returns true when student is MBA/JD or Not a Law Student
    */
   var isMbaJdOrNotLaw = function() {
-    if (!$scope.collegeAndLevel.roles.law || ($scope.collegeAndLevel.roles.law && $scope.collegeAndLevel.roles.haasMbaJurisDoctor)) {
+    if (!$scope.academicStatus.roles.law || ($scope.academicStatus.roles.law && $scope.academicStatus.roles.haasMbaJurisDoctor)) {
       return true;
     }
     return false;
   };
 
   var hasResidency = function() {
-    return (!$scope.collegeAndLevel.roles.haasMastersFinEng && !$scope.collegeAndLevel.roles.haasExecMba && !$scope.collegeAndLevel.roles.haasEveningWeekendMba);
+    return (!$scope.academicStatus.roles.haasMastersFinEng && !$scope.academicStatus.roles.haasExecMba && !$scope.academicStatus.roles.haasEveningWeekendMba);
+  };
+
+  var loadAcademicRoles = function() {
+    return academicStatusFactory.getAcademicRoles()
+      .then(function(data) {
+        $scope.academicStatus.roles = data.roles;
+      });
   };
 
   // Wait until user profile is fully loaded before hitting academics data
@@ -226,13 +239,11 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
       $scope.canViewAcademics = $scope.api.user.profile.hasAcademicsTab;
       var getAcademics = academicsFactory.getAcademics().success(parseAcademics);
       var getRegistrations = registrationsFactory.getRegistrations().success(loadRegistrations);
-      var requests = [getAcademics, getRegistrations];
-      var getNumberOfHolds;
+      var requests = [loadAcademicRoles(), getAcademics, getRegistrations];
 
       if ($scope.api.user.profile.features.csHolds &&
         ($scope.api.user.profile.roles.student || $scope.api.user.profile.roles.applicant)) {
-        getNumberOfHolds = academicStatusFactory.getAcademicStatus().success(loadNumberOfHolds);
-        requests.push(getNumberOfHolds);
+        requests.push(loadNumberOfHolds());
       }
       $q.all(requests).then(filterWidgets);
     }

--- a/src/assets/javascripts/angular/controllers/pages/myFinancesController.js
+++ b/src/assets/javascripts/angular/controllers/pages/myFinancesController.js
@@ -1,30 +1,27 @@
 'use strict';
 
-var _ = require('lodash');
 var angular = require('angular');
 
 /**
  * My Finances controller
  */
-angular.module('calcentral.controllers').controller('MyFinancesController', function($scope, apiService) {
+angular.module('calcentral.controllers').controller('MyFinancesController', function($scope, apiService, academicStatusFactory) {
   apiService.util.setTitle('My Finances');
 
   $scope.academicStatus = {
     roles: {}
   };
 
-  var parseAcademicStatusRoles = function() {
-    _.extend($scope.academicStatus.roles, apiService.academics.roles);
-  };
-
-  var getAcademics = function() {
-    return apiService.academics.fetch();
+  var loadAcademicRoles = function() {
+    return academicStatusFactory.getAcademicRoles()
+      .then(function(data) {
+        $scope.academicStatus.roles = data.roles;
+      });
   };
 
   $scope.$on('calcentral.api.user.isAuthenticated', function(event, isAuthenticated) {
     if (isAuthenticated && apiService.user.profile.hasFinancialsTab) {
-      getAcademics()
-        .then(parseAcademicStatusRoles);
+      loadAcademicRoles();
     }
   });
 });

--- a/src/assets/javascripts/angular/controllers/pages/myFinancesController.js
+++ b/src/assets/javascripts/angular/controllers/pages/myFinancesController.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var angular = require('angular');
+var _ = require('lodash');
 
 /**
  * My Finances controller
@@ -15,7 +16,7 @@ angular.module('calcentral.controllers').controller('MyFinancesController', func
   var loadAcademicRoles = function() {
     return academicStatusFactory.getAcademicRoles()
       .then(function(data) {
-        $scope.academicStatus.roles = data.roles;
+        $scope.academicStatus.roles = _.get(data, 'roles');
       });
   };
 

--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -177,7 +177,7 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
     };
     return academicStatusFactory.getHolds(options)
       .then(function(data) {
-        $scope.holds = data.holds;
+        $scope.holds = _.get(data, 'holds');
       })
       .finally(function() {
         $scope.holdsInfo.isLoading = false;

--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -172,13 +172,16 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
   };
 
   var loadHolds = function() {
-    academicStatusFactory.getAcademicStatus({
+    var options = {
       uid: $routeParams.uid
-    }).success(function(data) {
-      $scope.holds = _.get(data, 'data.feed.student.holds');
-    }).finally(function() {
-      $scope.holdsInfo.isLoading = false;
-    });
+    };
+    return academicStatusFactory.getHolds(options)
+      .then(function(data) {
+        $scope.holds = data.holds;
+      })
+      .finally(function() {
+        $scope.holdsInfo.isLoading = false;
+      });
   };
 
   var loadRegistrations = function() {

--- a/src/assets/javascripts/angular/controllers/widgets/holdsController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/holdsController.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var angular = require('angular');
-var _ = require('lodash');
 
 /**
  * Holds controller
@@ -11,15 +10,22 @@ angular.module('calcentral.controllers').controller('HoldsController', function(
     isLoading: true
   };
 
-  var init = function(options) {
-    academicStatusFactory.getAcademicStatus(options).then(function(data) {
-      $scope.holdsInfo.isLoading = false;
-      $scope.holds = _.get(data, 'data.feed.student.holds');
-    });
+  var loadHolds = function() {
+    return academicStatusFactory.getHolds()
+      .then(function(data) {
+        $scope.holds = data.holds;
+      })
+      .finally(function() {
+        $scope.holdsInfo.isLoading = false;
+      });
+  };
 
+  var init = function() {
     if ($route.current.isAdvisingStudentLookup) {
       $scope.holds = $scope.$parent.holds;
       $scope.holdsInfo = $scope.$parent.holdsInfo;
+    } else {
+      loadHolds();
     }
   };
 

--- a/src/assets/javascripts/angular/controllers/widgets/holdsController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/holdsController.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var angular = require('angular');
+var _ = require('lodash');
 
 /**
  * Holds controller
@@ -13,7 +14,7 @@ angular.module('calcentral.controllers').controller('HoldsController', function(
   var loadHolds = function() {
     return academicStatusFactory.getHolds()
       .then(function(data) {
-        $scope.holds = data.holds;
+        $scope.holds = _.get(data, 'holds');
       })
       .finally(function() {
         $scope.holdsInfo.isLoading = false;

--- a/src/assets/javascripts/angular/controllers/widgets/statusController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/statusController.js
@@ -157,8 +157,8 @@ angular.module('calcentral.controllers').controller('StatusController', function
           $scope.count++;
           $scope.hasWarnings = true;
         } else {
-          $scope.holds = data.holds;
-          $scope.count += data.holds.length;
+          $scope.holds = _.get(data, 'holds');
+          $scope.count += _.get(data, 'holds.length');
           $scope.hasAlerts = true;
         }
       });

--- a/src/assets/javascripts/angular/controllers/widgets/statusController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/statusController.js
@@ -139,23 +139,29 @@ angular.module('calcentral.controllers').controller('StatusController', function
     });
   };
 
-  var loadHolds = function(data) {
+  var loadHolds = function() {
+    var deferred;
+
     if (!apiService.user.profile.features.csHolds ||
       !(apiService.user.profile.roles.student || apiService.user.profile.roles.applicant)) {
-      return;
+      deferred = $q.defer();
+      deferred.resolve();
+      return deferred.promise;
     }
-    $scope.holds = _.get(data, 'data.feed.student.holds');
-    var numberOfHolds = _.get($scope, 'holds.length');
-    if (numberOfHolds) {
-      $scope.count += numberOfHolds;
-      $scope.hasAlerts = true;
-    } else if (_.get(data, 'data.errored')) {
-      $scope.holds = {
-        errored: true
-      };
-      $scope.count++;
-      $scope.hasWarnings = true;
-    }
+    return academicStatusFactory.getHolds()
+      .then(function(data) {
+        if (data.isError) {
+          $scope.holds = {
+            errored: true
+          };
+          $scope.count++;
+          $scope.hasWarnings = true;
+        } else {
+          $scope.holds = data.holds;
+          $scope.count += data.holds.length;
+          $scope.hasAlerts = true;
+        }
+      });
   };
 
   var finishLoading = function() {
@@ -192,10 +198,9 @@ angular.module('calcentral.controllers').controller('StatusController', function
       $scope.photo = {};
 
       // Get all the necessary data from the different factories
-      var getHolds = academicStatusFactory.getAcademicStatus().then(loadHolds);
       var getRegistrations = registrationsFactory.getRegistrations().then(parseRegistrations);
       var getStudentAttributes = studentAttributesFactory.getStudentAttributes().then(parseStudentAttributes);
-      var statusGets = [getHolds, getRegistrations, getStudentAttributes];
+      var statusGets = [loadHolds(), getRegistrations, getStudentAttributes];
 
       // Only fetch financial data for delegates who have been given explicit permssion.
       var includeFinancial = (!apiService.user.profile.delegateActingAsUid || apiService.user.profile.delegateViewAsPrivileges.financial);

--- a/src/assets/javascripts/angular/controllers/widgets/studentResourcesController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/studentResourcesController.js
@@ -3,7 +3,7 @@
 var angular = require('angular');
 var _ = require('lodash');
 
-angular.module('calcentral.controllers').controller('StudentResourcesController', function(apiService, linkService, studentResourcesFactory, $scope) {
+angular.module('calcentral.controllers').controller('StudentResourcesController', function(apiService, linkService, academicStatusFactory, studentResourcesFactory, $scope) {
   $scope.isLoading = true;
 
   var backToText = 'My Dashboard';
@@ -23,21 +23,23 @@ angular.module('calcentral.controllers').controller('StudentResourcesController'
     $scope.isLawStudent = apiService.user.profile.roles.law;
     $scope.isGraduateStudent = apiService.user.profile.roles.graduate;
     $scope.isUndergraduate = apiService.user.profile.roles.undergrad;
-    $scope.isSummerVisitor = apiService.academics.roles.summerVisitor;
   };
 
-  var getAcademics = function() {
-    return apiService.academics.fetch();
+  var loadAcademicRoles = function() {
+    return academicStatusFactory.getAcademicRoles()
+      .then(function(data) {
+        $scope.isSummerVisitor = data.roles.summerVisitor;
+      });
   };
 
   var loadInformation = function() {
-    getAcademics()
-    .then(loadStudentResources)
-    .then(parseStudentResources)
-    .then(setStudentRole)
-    .then(function() {
-      $scope.isLoading = false;
-    });
+    loadAcademicRoles()
+      .then(loadStudentResources)
+      .then(parseStudentResources)
+      .then(setStudentRole)
+      .then(function() {
+        $scope.isLoading = false;
+      });
   };
 
   loadInformation();

--- a/src/assets/javascripts/angular/controllers/widgets/studentResourcesController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/studentResourcesController.js
@@ -28,7 +28,7 @@ angular.module('calcentral.controllers').controller('StudentResourcesController'
   var loadAcademicRoles = function() {
     return academicStatusFactory.getAcademicRoles()
       .then(function(data) {
-        $scope.isSummerVisitor = data.roles.summerVisitor;
+        $scope.isSummerVisitor = _.get(data, 'roles.summerVisitor');
       });
   };
 

--- a/src/assets/javascripts/angular/factories/academicStatusFactory.js
+++ b/src/assets/javascripts/angular/factories/academicStatusFactory.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var _ = require('lodash');
 var angular = require('angular');
 
 /**
@@ -10,12 +11,41 @@ angular.module('calcentral.factories').factory('academicStatusFactory', function
   var urlAcademicStatus = '/api/edos/academic_status';
   var urlAdvisingAcademicStatus = '/api/advising/academic_status/';
 
-  var getAcademicStatus = function(options) {
+  var parseAcademicRoles = function(data) {
+    var roles = _.get(data, 'data.feed.student.roles');
+    var isError = _.get(data, 'data.errored');
+    return {
+      roles: roles || {},
+      isError: isError
+    };
+  };
+
+  var parseHolds = function(data) {
+    var holds = _.get(data, 'data.feed.student.holds');
+    var isError = _.get(data, 'data.errored');
+    return {
+      holds: holds || [],
+      isError: isError
+    };
+  };
+
+  var fetch = function(options) {
     var url = $route.current.isAdvisingStudentLookup ? urlAdvisingAcademicStatus + $routeParams.uid : urlAcademicStatus;
     return apiService.http.request(options, url);
   };
 
+  var getAcademicRoles = function(options) {
+    return fetch(options)
+      .then(parseAcademicRoles);
+  };
+
+  var getHolds = function(options) {
+    return fetch(options)
+      .then(parseHolds);
+  };
+
   return {
-    getAcademicStatus: getAcademicStatus
+    getAcademicRoles: getAcademicRoles,
+    getHolds: getHolds
   };
 });

--- a/src/assets/javascripts/angular/factories/campusLinksFactory.js
+++ b/src/assets/javascripts/angular/factories/campusLinksFactory.js
@@ -6,9 +6,10 @@ var angular = require('angular');
 /**
  * Campus Links Factory
  */
-angular.module('calcentral.factories').factory('campusLinksFactory', function(apiService, $http) {
+angular.module('calcentral.factories').factory('campusLinksFactory', function(apiService, academicStatusFactory, $http) {
   // Data contains "links" and "navigation"
   var linkDataUrl = '/api/my/campuslinks';
+  var academicRoles = {};
 
   /**
    * Add to the subcategories list if it doesn't exist yet
@@ -40,7 +41,6 @@ angular.module('calcentral.factories').factory('campusLinksFactory', function(ap
   };
 
   var hasBlacklistedRole = function(linkRoles) {
-    var academicRoles = apiService.academics.roles;
     return _.some(academicRoles, function(hasRole, role) {
       return hasRole && linkRoles[role] === false;
     });
@@ -138,8 +138,11 @@ angular.module('calcentral.factories').factory('campusLinksFactory', function(ap
     });
   };
 
-  var getAcademicStatusRoles = function() {
-    return apiService.academics.fetch();
+  var loadAcademicRoles = function() {
+    return academicStatusFactory.getAcademicRoles()
+      .then(function(data) {
+        academicRoles = data.roles;
+      });
   };
 
   var getUserRoles = function() {
@@ -150,7 +153,7 @@ angular.module('calcentral.factories').factory('campusLinksFactory', function(ap
     apiService.http.clearCache(options, linkDataUrl);
 
     return getUserRoles()
-      .then(getAcademicStatusRoles)
+      .then(loadAcademicRoles)
       .then(getCampusLinks)
       .then(function(response) {
         return parseCampusLinks(response, options.category);

--- a/src/assets/javascripts/angular/factories/campusLinksFactory.js
+++ b/src/assets/javascripts/angular/factories/campusLinksFactory.js
@@ -141,7 +141,7 @@ angular.module('calcentral.factories').factory('campusLinksFactory', function(ap
   var loadAcademicRoles = function() {
     return academicStatusFactory.getAcademicRoles()
       .then(function(data) {
-        academicRoles = data.roles;
+        academicRoles = _.get(data, 'roles');
       });
   };
 

--- a/src/assets/javascripts/angular/services/academicsService.js
+++ b/src/assets/javascripts/angular/services/academicsService.js
@@ -4,11 +4,7 @@
 var _ = require('lodash');
 var angular = require('angular');
 
-angular.module('calcentral.services').service('academicsService', function($http, $route, $routeParams) {
-  // var urlAcademicStatus = '/dummy/json/hub_academic_status.json';
-  var urlAcademicStatus = '/api/edos/academic_status';
-  var urlAdvisingAcademicStatus = '/api/advising/academic_status/';
-  var roles = {};
+angular.module('calcentral.services').service('academicsService', function() {
 
   // Selects the semester of most pressing interest. Choose the current semester if available.
   // Otherwise choose the next semester in the future, if available.
@@ -295,23 +291,8 @@ angular.module('calcentral.services').service('academicsService', function($http
     }
   };
 
-  var handleAcademicStatus = function(data) {
-    angular.extend(roles, data.feed.student.roles);
-  };
-
-  var fetch = function() {
-    var url = $route.current.isAdvisingStudentLookup ? urlAdvisingAcademicStatus + $routeParams.uid : urlAcademicStatus;
-    return $http.get(url, {
-      cache: true
-    }).then(function(xhr) {
-      return handleAcademicStatus(xhr.data);
-    });
-  };
-
   // Expose methods
   return {
-    fetch: fetch,
-    roles: roles,
     chooseDefaultSemester: chooseDefaultSemester,
     countSectionItem: countSectionItem,
     expectedGradTerm: expectedGradTerm,

--- a/src/assets/javascripts/angular/services/apiService.js
+++ b/src/assets/javascripts/angular/services/apiService.js
@@ -3,7 +3,6 @@
 var angular = require('angular');
 
 angular.module('calcentral.services').service('apiService', function(
-  academicsService,
   analyticsService,
   authService,
   apiEventService,
@@ -21,7 +20,6 @@ angular.module('calcentral.services').service('apiService', function(
   widgetService) {
   // API
   var api = {
-    academics: academicsService,
     analytics: analyticsService,
     auth: authService,
     events: apiEventService,

--- a/src/assets/javascripts/angular/services/profileMenuService.js
+++ b/src/assets/javascripts/angular/services/profileMenuService.js
@@ -244,7 +244,7 @@ angular.module('calcentral.services').factory('profileMenuService', function(api
   var loadAcademicRoles = function() {
     return academicStatusFactory.getAcademicRoles()
       .then(function(data) {
-        academicRoles = data.roles;
+        academicRoles = _.get(data, 'roles');
       });
   };
 

--- a/src/assets/javascripts/angular/services/profileMenuService.js
+++ b/src/assets/javascripts/angular/services/profileMenuService.js
@@ -6,7 +6,7 @@ var angular = require('angular');
 /**
  * Profile Menu Serives - provide all the information for the profile menu
  */
-angular.module('calcentral.services').factory('profileMenuService', function(apiService, $q) {
+angular.module('calcentral.services').factory('profileMenuService', function(apiService, academicStatusFactory, $q) {
   var navigation = [
     {
       label: 'Profile',
@@ -119,6 +119,7 @@ angular.module('calcentral.services').factory('profileMenuService', function(api
       ]
     }
   ];
+  var academicRoles = {};
 
   /**
    * Wrap callbacks into a promise
@@ -150,7 +151,6 @@ angular.module('calcentral.services').factory('profileMenuService', function(api
   };
 
   var hasBlacklistedRole = function(categoryRoles) {
-    var academicRoles = apiService.academics.roles;
     return _.some(academicRoles, function(hasRole, role) {
       return hasRole && categoryRoles[role] === false;
     });
@@ -241,13 +241,16 @@ angular.module('calcentral.services').factory('profileMenuService', function(api
     });
   };
 
-  var getAcademics = function() {
-    return apiService.academics.fetch();
+  var loadAcademicRoles = function() {
+    return academicStatusFactory.getAcademicRoles()
+      .then(function(data) {
+        academicRoles = data.roles;
+      });
   };
 
   var getNavigation = function() {
     return apiService.user.fetch()
-      .then(getAcademics)
+      .then(loadAcademicRoles)
       .then(initialNavigation)
       .then(filterRoles)
       .then(filterFeatureFlags)


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-27699

Per discussion on #6299, I moved the fetching of academic status from `academicsService` back into `academicStatusFactory`, and moved the finagling of holds data from the various controllers that use it into the factory level for increased DRYness.

`academicStatusFactory` now exposes two functions:  `getHolds` and `getAcademicRoles`, which are used in a standard way by all the calling controllers.  Thoughts/critiques on this approach are appreciated!