### PR TITLE
SISRP-29104 - CalCentral - Class Information page missing lecture date, time and location for Sp17 UGBA 118 (INC0367091 & INC0376337)

### DIFF
--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -162,8 +162,7 @@ module EdoOracle
         )
         WHERE
           sec."term-id" = '#{term_id}' AND
-          sec."id" = '#{section_id}' AND
-          mtg."location-code" IS NOT NULL
+          sec."id" = '#{section_id}'
         ORDER BY meeting_start_date, meeting_start_time
       SQL
     end

--- a/src/assets/templates/academics_classinfo.html
+++ b/src/assets/templates/academics_classinfo.html
@@ -101,7 +101,8 @@
               <div class="small-9 columns">
                 <div data-ng-repeat="schedule in section.schedules.recurring" data-ng-if="section.schedules.recurring" class="cc-academics-schedule-room">
                   <span data-ng-bind="schedule.schedule"></span> |
-                  <span data-ng-bind="schedule.roomNumber"></span> <span data-ng-bind="schedule.buildingName"></span> <br>
+                  <span data-ng-if="schedule.roomNumber" data-ng-bind="schedule.roomNumber"></span> <span data-ng-if="schedule.buildingName" data-ng-bind="schedule.buildingName"></span>
+                  <span data-ng-if="!schedule.roomNumber && !schedule.buildingName">Classroom Not Assigned</span> <br>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-29104

* Not shown here:  Updated EDODB query that should resolve existing CS data not being returned.
* The `IS NOT NULL` query parameter doesn't actually need to be there, even when the value is empty in CS, the query will return a value.  That is, there are no "`mtg."location-code" IS NOT NULL` rows.  I'm guessing they send us an empty string instead.