### PR TITLE
SISRP-28787 - Add Cache Expiration for Outgoing/Incoming Academic Plan Link

### DIFF
--- a/app/controllers/advising_student_controller.rb
+++ b/app/controllers/advising_student_controller.rb
@@ -68,6 +68,11 @@ class AdvisingStudentController < ApplicationController
     render json: HubEdos::StudentAttributes.new(user_id: student_uid_param).get
   end
 
+  def academics_cache_expiry
+    MyAcademics::FilteredForAdvisor.expire student_uid_param
+    render :nothing => true
+  end
+
   private
 
   def authorize_for_student

--- a/app/controllers/bootstrap_controller.rb
+++ b/app/controllers/bootstrap_controller.rb
@@ -46,6 +46,7 @@ class BootstrapController < ApplicationController
     # Sent from Campus Solutions Fluid UI when returning to CalCentral from
     # a Fluid activity that may have changed some data.
     flag = params['ucUpdateCache']
+    url = params['url']
     case flag
       when 'finaid'
         CampusSolutions::FinancialAidExpiry.expire current_user.user_id
@@ -53,6 +54,11 @@ class BootstrapController < ApplicationController
         CampusSolutions::PersonDataExpiry.expire current_user.user_id
       when 'enrollment'
         CampusSolutions::EnrollmentTermExpiry.expire current_user.user_id
+      when 'advisingAcademics'
+        # Since current_user does not know the student-overview UID the advisor is looking-up, we strip it from the URL
+        if (student_uid = url[/[0-9]+/])
+          MyAcademics::FilteredForAdvisor.expire student_uid
+        end
       else
         # no-op
     end

--- a/app/models/my_academics/academic_plan.rb
+++ b/app/models/my_academics/academic_plan.rb
@@ -1,11 +1,12 @@
 module MyAcademics
   class AcademicPlan < UserSpecificModel
     include AdvisingAcademicPlannerFeatureFlagged
+    include User::Student
 
     def merge(data)
       if is_feature_enabled
-        update_url_proxy = CampusSolutions::AcademicPlan.new(user_id: @uid).get
-        data[:updatePlanUrl] = update_url_proxy.try(:[], :feed).try(:[], :updateAcademicPlanner).try(:[], :url)
+        update_url_proxy = CampusSolutions::Link.new.get_url('UC_CX_PLANNER_ADV_STDNT', {:EMPLID => campus_solutions_id}).try(:[], :link)
+        data[:updatePlanUrl] = update_url_proxy
         data[:planSemesters] = get_plan_semesters(data[:semesters])
       end
     end

--- a/app/models/my_academics/filtered_for_advisor.rb
+++ b/app/models/my_academics/filtered_for_advisor.rb
@@ -2,6 +2,7 @@ module MyAcademics
   class FilteredForAdvisor < UserSpecificModel
     include Cache::CachedFeed
     include Cache::JsonifiedFeed
+    include Cache::UserCacheExpiry
     include MergedModel
 
     # Advisors do not see Teaching or Course Website (aka CanvasSites) data.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,6 +169,7 @@ Calcentral::Application.routes.draw do
   get '/api/advising/student_success/:student_uid' => 'advising_student#student_success', :defaults => { :format => 'json' }
   get '/api/advising/degree_progress/grad/:student_uid' => 'advising_student#degree_progress_graduate', :defaults => { :format => 'json' }
   get '/api/advising/degree_progress/ugrd/:student_uid' => 'advising_student#degree_progress_undergrad', :defaults => { :format => 'json' }
+  get '/api/advising/cache_expiry/academics/:student_uid' => 'advising_student#academics_cache_expiry', :defaults => { :format => 'json' }
   post '/advisor_act_as' => 'advisor_act_as#start'
   post '/stop_advisor_act_as' => 'advisor_act_as#stop'
 

--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -160,6 +160,9 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
           studentUid: $routeParams.uid
         };
       }
+      if (!!$scope.updatePlanUrl.url) {
+        linkService.addBackToTextToLink($scope.updatePlanUrl, backToText);
+      }
     }).error(function(data, status) {
       $scope.academics.error = errorReport(status, data.error);
     }).finally(function() {
@@ -295,6 +298,12 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
           _.merge($scope.regStatus.messages, statusHoldsService.getRegStatusMessages(messages));
         }
       });
+  };
+
+  $scope.expireAcademicsCache = function() {
+    advisingFactory.expireAcademicsCache({
+      uid: $routeParams.uid
+    });
   };
 
   $scope.showCNP = function(registration) {

--- a/src/assets/javascripts/angular/directives/campusSolutionsLinkDirective.js
+++ b/src/assets/javascripts/angular/directives/campusSolutionsLinkDirective.js
@@ -11,7 +11,7 @@ var angular = require('angular');
  *   data-cc-campus-solutions-link-directive="testUrl" // CS URL
  *   data-cc-campus-solutions-link-directive-enabled="{{item.isCsLink}}" // Default is true, if set to false, we don't execute this directive
  *   data-cc-campus-solutions-link-directive-text="backToText" // For the 'Back to ...'' text in CS
- *   data-cc-campus-solutions-link-directive-cache="'finaid'" // Will add an addition querystring to the back to link to expire the cache (e.g. 'finaid' or 'profile')
+ *   data-cc-campus-solutions-link-directive-cache="finaid" // Will add an addition querystring to the back to link to expire the cache (e.g. 'finaid' or 'profile' - see bootsrap_controller.rb)
  */
 angular.module('calcentral.directives').directive('ccCampusSolutionsLinkDirective', function($compile, $location, $parse) {
   /**
@@ -90,4 +90,3 @@ angular.module('calcentral.directives').directive('ccCampusSolutionsLinkDirectiv
     }
   };
 });
-

--- a/src/assets/javascripts/angular/factories/advisingFactory.js
+++ b/src/assets/javascripts/angular/factories/advisingFactory.js
@@ -12,6 +12,7 @@ angular.module('calcentral.factories').factory('advisingFactory', function(apiSe
   // var urlAdvisingStudent = '/dummy/json/advising_student_academics.json';
   var urlAdvisingAcademics = '/api/advising/academics/';
   // var urlAdvisingAcademics = '/dummy/json/advising_student_academics.json?';
+  var urlAdvisingAcademicsCacheExpiry = '/api/advising/cache_expiry/academics/';
   var urlAdvisingResources = '/api/advising/resources/';
   // var urlAdvisingResources = '/dummy/json/advising_resources.json';
   var urlAdvisingRegistrations = '/api/advising/registrations/';
@@ -55,6 +56,10 @@ angular.module('calcentral.factories').factory('advisingFactory', function(apiSe
     return apiService.http.request(options, urlAdvisingDegreeProgressUndergrad + options.uid);
   };
 
+  var expireAcademicsCache = function(options) {
+    return apiService.http.request(options, urlAdvisingAcademicsCacheExpiry + options.uid);
+  };
+
   return {
     getAdvisingResources: getAdvisingResources,
     getResources: getResources,
@@ -63,6 +68,7 @@ angular.module('calcentral.factories').factory('advisingFactory', function(apiSe
     getStudentRegistrations: getStudentRegistrations,
     getStudentSuccess: getStudentSuccess,
     getDegreeProgressGraduate: getDegreeProgressGraduate,
-    getDegreeProgressUndergrad: getDegreeProgressUndergrad
+    getDegreeProgressUndergrad: getDegreeProgressUndergrad,
+    expireAcademicsCache: expireAcademicsCache
   };
 });

--- a/src/assets/templates/widgets/academic_plan.html
+++ b/src/assets/templates/widgets/academic_plan.html
@@ -2,9 +2,13 @@
   <div class="cc-widget-title">
     <h2 class="cc-left">Academic Plan</h2>
   </div>
-  <div class="cc-widget-padding" data-ng-if="updatePlanUrl">
+  <div class="cc-widget-padding" data-ng-if="updatePlanUrl.url">
     <h3>
-      <a class="cc-academics-semester-title-link" data-ng-href="{{updatePlanUrl}}">Update multi-year planner</a>
+      <div data-cc-campus-solutions-link-item-directive
+        data-link="updatePlanUrl"
+        data-text="Update Multi-Year Planner"
+        data-cache="advisingAcademics"
+        data-ng-click="expireAcademicsCache()"></div>
     </h3>
   </div>
 
@@ -154,4 +158,3 @@
       </div>
     </ul>
 </div>
-

--- a/src/assets/templates/widgets/toolbox/user_preview.html
+++ b/src/assets/templates/widgets/toolbox/user_preview.html
@@ -131,6 +131,8 @@
                   <div
                     data-cc-campus-solutions-link-item-directive
                     data-link="ucAdvisingResources.csLinks.studentMultiYearAcademicPlanner"
+                    data-cache="advisingAcademics"
+                    data-ng-click="expireAcademicsCache()"
                   ></div>
                 </div>
                 <div data-ng-if="ucAdvisingResources.csLinks.studentAdvisorNotes.url">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-28787

* Adds a cache expiry function when user clicks the Multi-Year Planner link, and another cache expiry function when the user clicks "Return to Student Overview" while in CS.
* Also added to the Multi-Year Planner link in `user_preview.html`.  If we're showing the same link in two different places on the same page, we should have them behave the same way.
* This PR is a bit larger than I expected to be - so feel free to ping me on any questions.  I do intend to open a QA PR for this as well.