### PR TITLE
SISRP-27698 - re-styles <hr> to make it visible

### DIFF
--- a/src/assets/stylesheets/_finaid_summary.scss
+++ b/src/assets/stylesheets/_finaid_summary.scss
@@ -24,6 +24,10 @@
   border: 1px solid $cc-color-light-grey;
   margin: 20px 0;
   padding: 5px 10px;
+
+  hr {
+    border-bottom: 1px solid $cc-color-light-grey;
+  }
 }
 .cc-widget-finaid-summary-funding-offered {
   .cc-padded {

--- a/src/assets/templates/widgets/finaid_summary_netcost.html
+++ b/src/assets/templates/widgets/finaid_summary_netcost.html
@@ -5,6 +5,6 @@
   <div data-ng-repeat="item in finaidSummaryData.netCost.items">
     <div data-cc-finaid-summary-item-directive data-item="item"></div>
   </div>
-  <hr class="cc-hr-spacing-5" aria-hidden="true">
+  <hr class="cc-hr-spacing-5" aria-hidden="true" />
   <div data-cc-finaid-summary-item-directive data-item="finaidSummaryData.netCost.total"></div>
 </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-27698

The testing team pointed out that the horizontal separator was missing from the "Net Cost" section on the Financial Aid and Scholarships card.  In fact, it was just blending into its surroundings as we changed the background color of the section.  I overrode the sitewide \<hr\> style to make this one darker so it stands out.

QA PR forthcoming.