### PR TITLE
CLC-6534, avoid duplicate section ids in eGrades export

### DIFF
--- a/spec/models/canvas_lti/egrades_spec.rb
+++ b/spec/models/canvas_lti/egrades_spec.rb
@@ -1,6 +1,7 @@
 describe CanvasLti::Egrades do
   let(:canvas_course_id)          { 1276293 }
   let(:canvas_course_section_id)  { 1312012 }
+
   subject { CanvasLti::Egrades.new(canvas_course_id: canvas_course_id) }
 
   let(:course_assignments) {
@@ -41,12 +42,17 @@ describe CanvasLti::Egrades do
       ]
     end
 
-    before { allow(subject).to receive(:official_student_grades).with('C', '2014', '7309').and_return(official_student_grades_list) }
-    it 'raises error when called with invalid type argument' do
-      expect { subject.official_student_grades_csv('C', '2014', '7309', 'finished') }.to raise_error(ArgumentError, 'type argument must be \'final\' or \'current\'')
+    before do
+      allow(subject).to receive(:official_student_grades).with('B', '2017', '7309').and_return official_student_grades_list
     end
 
-    let(:official_grades_csv_string) { subject.official_student_grades_csv('C', '2014', '7309', grade_type) }
+    it 'raises error when called with invalid type argument' do
+      expect {
+        subject.official_student_grades_csv('B', '2017', '7309', 'finished')
+      }.to raise_error(ArgumentError, 'type argument must be \'final\' or \'current\'')
+    end
+
+    let(:official_grades_csv_string) { subject.official_student_grades_csv('B', '2017', '7309', grade_type) }
     let(:official_grades_csv) { CSV.parse official_grades_csv_string.strip, headers: true }
 
     context 'current grades' do
@@ -111,9 +117,9 @@ describe CanvasLti::Egrades do
   context 'when serving official student grades' do
     let(:primary_section_enrollees) do
       [
-        {'ldap_uid'=>'872584', 'enroll_status'=>'E', 'pnp_flag' => 'N', 'student_id'=>'2004491', 'grading_basis' => 'GRD'},
-        {'ldap_uid'=>'872527', 'enroll_status'=>'E', 'pnp_flag' => 'N', 'student_id'=>'2004445', 'grading_basis' => 'GRD'},
-        {'ldap_uid'=>'872529', 'enroll_status'=>'E', 'pnp_flag' => 'Y', 'student_id'=>'2004421', 'grading_basis' => 'PNP'},
+        {'ldap_uid' => '872584', 'enroll_status' => 'E', 'pnp_flag' => 'N', 'student_id' => '2004491', 'grading_basis' => 'GRD'},
+        {'ldap_uid' => '872527', 'enroll_status' => 'E', 'pnp_flag' => 'N', 'student_id' => '2004445', 'grading_basis' => 'GRD'},
+        {'ldap_uid' => '872529', 'enroll_status' => 'E', 'pnp_flag' => 'Y', 'student_id' => '2004421', 'grading_basis' => 'PNP'},
       ]
     end
 
@@ -127,11 +133,11 @@ describe CanvasLti::Egrades do
     end
 
     before do
-      allow(CanvasLti::SisAdapter).to receive(:get_enrolled_students).with('7309', '2014', 'C').and_return(primary_section_enrollees)
-      allow(subject).to receive(:canvas_course_student_grades).and_return(canvas_course_student_grades_list)
+      allow(CanvasLti::SisAdapter).to receive(:get_enrolled_students).with('7309', '2017', 'B').and_return primary_section_enrollees
+      allow(subject).to receive(:canvas_course_student_grades).and_return canvas_course_student_grades_list
     end
     it 'only provides grades for official enrollees in section specified' do
-      result = subject.official_student_grades('C', '2014', '7309')
+      result = subject.official_student_grades('B', '2017', '7309')
       expect(result.count).to eq 3
       expect(result[0][:sis_login_id]).to eq '872584'
       expect(result[1][:sis_login_id]).to eq '872527'
@@ -139,7 +145,7 @@ describe CanvasLti::Egrades do
     end
 
     it 'includes pass/no-pass indicator' do
-      result = subject.official_student_grades('C', '2014', '7309')
+      result = subject.official_student_grades('B', '2017', '7309')
       expect(result.count).to eq 3
       expect(result[0][:pnp_flag]).to eq 'N'
       expect(result[1][:pnp_flag]).to eq 'N'
@@ -147,7 +153,7 @@ describe CanvasLti::Egrades do
     end
 
     it 'includes student IDs' do
-      result = subject.official_student_grades('C', '2014', '7309')
+      result = subject.official_student_grades('B', '2017', '7309')
       expect(result.count).to eq 3
       expect(result[0][:student_id]).to eq '2004491'
       expect(result[1][:student_id]).to eq '2004445'
@@ -157,34 +163,39 @@ describe CanvasLti::Egrades do
 
   context 'when resolving course state issues' do
     let(:course_settings) do
-      {statusCode: 200, body: {'id' => canvas_course_id} }
+      {
+        statusCode: 200,
+        body: {
+          'id' => canvas_course_id
+        }
+      }
     end
     let(:muted_assignments) { [] }
     before do
-      allow_any_instance_of(Canvas::CourseSettings).to receive(:set_grading_scheme).and_return(course_settings)
-      allow(subject).to receive(:unmute_course_assignments).and_return(muted_assignments)
+      allow_any_instance_of(Canvas::CourseSettings).to receive(:set_grading_scheme).and_return course_settings
+      allow(subject).to receive(:unmute_course_assignments).and_return muted_assignments
     end
 
     context 'when enabling grading scheme' do
       it 'enables the grading scheme' do
-        expect_any_instance_of(Canvas::CourseSettings).to receive(:set_grading_scheme).and_return(course_settings)
+        expect_any_instance_of(Canvas::CourseSettings).to receive(:set_grading_scheme).and_return course_settings
         subject.resolve_issues(true, false)
       end
 
       it 'does not unmute assignments' do
-        expect(subject).to_not receive(:unmute_course_assignments)
+        expect(subject).to_not receive :unmute_course_assignments
         subject.resolve_issues(true, false)
       end
     end
 
     context 'when unmuting assignments' do
       it 'unmutes assignments' do
-        expect(subject).to receive(:unmute_course_assignments).and_return(muted_assignments)
+        expect(subject).to receive(:unmute_course_assignments).and_return muted_assignments
         subject.resolve_issues(false, true)
       end
 
       it 'does not enable the grading scheme' do
-        expect_any_instance_of(Canvas::CourseSettings).to_not receive(:set_grading_scheme)
+        expect_any_instance_of(Canvas::CourseSettings).to_not receive :set_grading_scheme
         subject.resolve_issues(false, true)
       end
     end
@@ -200,15 +211,28 @@ describe CanvasLti::Egrades do
         {
           'sis_login_id' => u[0],
           'enrollments' => [
-            { 'type' => 'StudentEnrollment', 'grades' => {'current_score' => u[1], 'current_grade' => u[3], 'final_score' => u[2], 'final_grade' => u[4]} }
+            {
+              'type' => 'StudentEnrollment',
+              'grades' => {
+                'current_score' => u[1],
+                'final_score' => u[2],
+                'current_grade' => u[3],
+                'final_grade' => u[4]
+              }
+            }
           ]
         }
       end
     end
-    let(:course_users_response) { { :statusCode => 200, :body => course_users_array } }
+    let(:course_users_response) {
+      {
+        statusCode: 200,
+        body: course_users_array
+      }
+    }
 
     before do
-      allow_any_instance_of(Canvas::CourseUsers).to receive(:course_users).and_return(course_users_response)
+      allow_any_instance_of(Canvas::CourseUsers).to receive(:course_users).and_return course_users_response
       subject.background_job_initialize
     end
     it 'returns canvas course student grades' do
@@ -230,7 +254,7 @@ describe CanvasLti::Egrades do
     end
 
     it 'should not source data from cache' do
-      expect(Canvas::CourseUsers).to_not receive(:fetch_from_cache)
+      expect(Canvas::CourseUsers).to_not receive :fetch_from_cache
       subject.canvas_course_student_grades
     end
 
@@ -241,27 +265,36 @@ describe CanvasLti::Egrades do
 
     it 'should specify forced cache write when specified' do
       expect(CanvasLti::Egrades).to receive(:fetch_from_cache).with("course-students-#{canvas_course_id}", true)
-      subject.canvas_course_student_grades(true)
+      subject.canvas_course_student_grades true
     end
   end
 
   context 'when extracting student grades from enrollments' do
     let(:student_enrollment) do
       {
-        'type'=>'StudentEnrollment',
-        'role'=>'StudentEnrollment',
-        'grades'=>{
-          'current_score'=>96.5,
-          'final_score'=>95.0,
-          'current_grade'=>'A+',
-          'final_grade'=>'A'
+        'type' => 'StudentEnrollment',
+        'role' => 'StudentEnrollment',
+        'grades' => {
+          'current_score' => 96.5,
+          'final_score' => 95.0,
+          'current_grade' => 'A+',
+          'final_grade' => 'A'
         }
       }
     end
-    let(:waitlist_student_enrollment) { student_enrollment.merge({'role' => 'Waitlist Student'}) }
-    let(:ta_enrollment) { {'type'=>'TaEnrollment', 'role'=>'TaEnrollment'} }
+    let(:waitlist_student_enrollment) {
+      student_enrollment.merge({
+          'role' => 'Waitlist Student'
+        })
+    }
+    let(:ta_enrollment) {
+      {
+        'type' => 'TaEnrollment',
+        'role' => 'TaEnrollment'
+      }
+    }
     it 'returns empty grade hash when enrollments are empty' do
-      result = subject.student_grade([])
+      result = subject.student_grade []
       expect(result[:current_score]).to eq nil
       expect(result[:current_grade]).to eq nil
       expect(result[:final_score]).to eq nil
@@ -269,8 +302,8 @@ describe CanvasLti::Egrades do
     end
 
     it 'returns empty grade when no student enrollments with grade are present' do
-      waitlist_student_enrollment.delete('grades')
-      result = subject.student_grade([ta_enrollment, waitlist_student_enrollment])
+      waitlist_student_enrollment.delete 'grades'
+      result = subject.student_grade [ta_enrollment, waitlist_student_enrollment]
       expect(result[:current_score]).to eq nil
       expect(result[:current_grade]).to eq nil
       expect(result[:final_score]).to eq nil
@@ -278,9 +311,9 @@ describe CanvasLti::Egrades do
     end
 
     it 'returns blank grade score when not present' do
-      student_enrollment['grades'].delete('current_score')
-      student_enrollment['grades'].delete('final_score')
-      result = subject.student_grade([student_enrollment])
+      student_enrollment['grades'].delete 'current_score'
+      student_enrollment['grades'].delete 'final_score'
+      result = subject.student_grade [student_enrollment]
       expect(result[:current_score]).to eq nil
       expect(result[:current_grade]).to eq 'A+'
       expect(result[:final_score]).to eq nil
@@ -288,9 +321,9 @@ describe CanvasLti::Egrades do
     end
 
     it 'returns blank letter grade when not present' do
-      student_enrollment['grades'].delete('current_grade')
-      student_enrollment['grades'].delete('final_grade')
-      result = subject.student_grade([student_enrollment])
+      student_enrollment['grades'].delete 'current_grade'
+      student_enrollment['grades'].delete 'final_grade'
+      result = subject.student_grade [student_enrollment]
       expect(result[:current_score]).to eq 96.5
       expect(result[:current_grade]).to eq nil
       expect(result[:final_score]).to eq 95.0
@@ -298,7 +331,7 @@ describe CanvasLti::Egrades do
     end
 
     it 'returns grade when student enrollment is present' do
-      result = subject.student_grade([ta_enrollment, waitlist_student_enrollment, student_enrollment])
+      result = subject.student_grade [ta_enrollment, waitlist_student_enrollment, student_enrollment]
       expect(result[:current_score]).to eq 96.5
       expect(result[:current_grade]).to eq 'A+'
       expect(result[:final_score]).to eq 95.0
@@ -310,43 +343,83 @@ describe CanvasLti::Egrades do
     let(:sections) do
       [
         {
-          'course_title'=>'Organic Chemistry Laboratory',
-          'course_title_short'=>'ORGANIC CHEM LAB',
-          'dept_name'=>'CHEM',
-          'catalog_id'=>'3BL',
-          'term_yr'=>'2014',
-          'term_cd'=>'C',
-          'course_cntl_num'=>'22280',
-          'primary_secondary_cd'=>'P',
-          'section_num'=>'001',
-          'instruction_format'=>'LEC',
-          'catalog_root'=>'3',
-          'catalog_prefix'=>nil,
-          'catalog_suffix_1'=>'B',
-          'catalog_suffix_2'=>'L'
+          'course_title' => 'General Biology Lecture',
+          'course_title_short' => 'GENERAL BIOLOGY LEC',
+          'dept_name' => 'BIOLOGY',
+          'catalog_id' => '1A',
+          'term_yr' => '2017',
+          'term_cd' => 'B',
+          'course_cntl_num' => '13234',
+          'primary_secondary_cd' => 'P',
+          'section_num' => '001',
+          'instruction_format' => 'LEC',
+          'catalog_root' => '1',
+          'catalog_prefix' => nil,
+          'catalog_suffix_1' => 'A',
+          'catalog_suffix_2' => nil
         },
         {
-          'course_title'=>'Organic Chemistry Laboratory',
-          'course_title_short'=>'ORGANIC CHEM LAB',
-          'dept_name'=>'CHEM',
-          'catalog_id'=>'3BL',
-          'term_yr'=>'2014',
-          'term_cd'=>'C',
-          'course_cntl_num'=>'22345',
-          'primary_secondary_cd'=>'S',
-          'section_num'=>'208',
-          'instruction_format'=>'LAB',
-          'catalog_root'=>'3',
-          'catalog_prefix'=>nil,
-          'catalog_suffix_1'=>'B',
-          'catalog_suffix_2'=>'L'
+          'course_title' => 'General Biology Lecture',
+          'course_title_short' => 'GENERAL BIOLOGY LEC',
+          'dept_name' => 'BIOLOGY',
+          'catalog_id' => '1A',
+          'term_yr' => '2017',
+          'term_cd' => 'B',
+          'course_cntl_num' => '13235',
+          'primary_secondary_cd' => 'P',
+          'section_num' => '002',
+          'instruction_format' => 'LEC',
+          'catalog_root' => '1',
+          'catalog_prefix' => nil,
+          'catalog_suffix_1' => 'A',
+          'catalog_suffix_2' => nil
+        },
+        # Secondary section
+        {
+          'course_title' => 'General Biology Discussion',
+          'course_title_short' => 'GENERAL BIOLOGY DIS',
+          'dept_name' => 'BIOLOGY',
+          'catalog_id' => '1A',
+          'term_yr' => '2017',
+          'term_cd' => 'B',
+          'course_cntl_num' => '13237',
+          # primaryAssociatedSectionId: 13234
+          'primary_secondary_cd' => 'S',
+          'section_num' => '301',
+          'instruction_format' => 'DIS',
+          'catalog_root' => '1',
+          'catalog_prefix' => nil,
+          'catalog_suffix_1' => 'A',
+          'catalog_suffix_2' => nil
+        },
+        # Below is an apparent DUPLICATE of the secondary section above. In the real world, our result-set might have
+        # duplicate section ids. If the course has multiple primary sections (as above) then you might find a secondary
+        # section with more than one parent; see column "primaryAssociatedSectionId" in SISEDO.CLASSSECTIONV00_VW. That
+        # might be useful info in other scenarios but the eGrades feature must filter out duplicates. This spec verifies
+        # de-duplication logic.
+        {
+          'course_title' => 'General Biology Discussion',
+          'course_title_short' => 'GENERAL BIOLOGY DIS',
+          'dept_name' => 'BIOLOGY',
+          'catalog_id' => '1A',
+          'term_yr' => '2017',
+          'term_cd' => 'B',
+          'course_cntl_num' => '13237',
+          # primaryAssociatedSectionId: 13235
+          'primary_secondary_cd' => 'S',
+          'section_num' => '301',
+          'instruction_format' => 'DIS',
+          'catalog_root' => '1',
+          'catalog_prefix' => nil,
+          'catalog_suffix_1' => 'A',
+          'catalog_suffix_2' => nil
         }
       ]
     end
 
     before do
-      allow_any_instance_of(CanvasLti::OfficialCourse).to receive(:official_section_identifiers).and_return(section_identifiers)
-      allow(CanvasLti::SisAdapter).to receive(:get_sections_by_ids).with(['22280','22345'], '2014', 'C').and_return(sections)
+      allow_any_instance_of(CanvasLti::OfficialCourse).to receive(:official_section_identifiers).and_return section_identifiers
+      allow(CanvasLti::SisAdapter).to receive(:get_sections_by_ids).with(%w(13234 13235 13237), '2017', 'B').and_return sections
     end
     context 'when official sections are not identified in course site' do
       let(:section_identifiers) { [] }
@@ -355,38 +428,71 @@ describe CanvasLti::Egrades do
       end
     end
     context 'when official sections are identified in course site' do
-      let(:section_identifiers) { [{:term_yr => '2014', :term_cd => 'C', :ccn => '22280'}, {:term_yr => '2014', :term_cd => 'C', :ccn => '22345'}] }
+      let(:section_identifiers) {
+        [
+          {
+            term_yr: '2017',
+            term_cd: 'B',
+            ccn: '13234'
+          },
+          {
+            term_yr: '2017',
+            term_cd: 'B',
+            ccn: '13235'
+          },
+          {
+            term_yr: '2017',
+            term_cd: 'B',
+            ccn: '13237'
+          }
+        ]
+      }
+
       it 'provides array of filtered section hashes' do
         result = subject.official_sections
-        expect(result.count).to eq 2
-        expect(result[0]['course_cntl_num']).to eq '22280'
-        expect(result[1]['course_cntl_num']).to eq '22345'
-        expect(result[0]['section_num']).to eq '001'
-        expect(result[1]['section_num']).to eq '208'
-        expect(result[0]['instruction_format']).to eq 'LEC'
-        expect(result[1]['instruction_format']).to eq 'LAB'
-        expect(result[0]['primary_secondary_cd']).to eq 'P'
-        expect(result[1]['primary_secondary_cd']).to eq 'S'
-        filtered_out_keys = ['course_title', 'course_title_short', 'catalog_root', 'catalog_prefix', 'catalog_suffix_1', 'catalog_suffix_2']
+        expect(result.count).to eq 3
+        # Primary
+        biology_lec_001 = result[0]
+        expect(biology_lec_001['course_cntl_num']).to eq '13234'
+        expect(biology_lec_001['section_num']).to eq '001'
+        expect(biology_lec_001['instruction_format']).to eq 'LEC'
+        expect(biology_lec_001['primary_secondary_cd']).to eq 'P'
+        # Primary
+        biology_lec_002 = result[1]
+        expect(biology_lec_002['course_cntl_num']).to eq '13235'
+        expect(biology_lec_002['section_num']).to eq '002'
+        expect(biology_lec_002['instruction_format']).to eq 'LEC'
+        expect(biology_lec_002['primary_secondary_cd']).to eq 'P'
+        # Secondary
+        biology_dis_301 = result[2]
+        expect(biology_dis_301['course_cntl_num']).to eq '13237'
+        expect(biology_dis_301['section_num']).to eq '301'
+        expect(biology_dis_301['instruction_format']).to eq 'DIS'
+        expect(biology_dis_301['primary_secondary_cd']).to eq 'S'
+
+        filtered_out_keys = %w(course_title course_title_short catalog_root catalog_prefix catalog_suffix_1 catalog_suffix_2)
         filtered_out_keys.each do |filtered_out_key|
           result.each do |section|
-            expect(section).to_not include(filtered_out_key)
+            expect(section).to_not include filtered_out_key
           end
         end
       end
 
-      it 'includes display name in each hash' do
+      it 'filters out rows with duplicate section ids' do
         result = subject.official_sections
-        expect(result.count).to eq 2
-        expect(result[0]['display_name']).to eq 'CHEM 3BL LEC 001'
-        expect(result[1]['display_name']).to eq 'CHEM 3BL LAB 208'
+        expect(result.count).to eq 3
+        expect(result[0]['display_name']).to eq 'BIOLOGY 1A LEC 001'
+        expect(result[1]['display_name']).to eq 'BIOLOGY 1A LEC 002'
+        expect(result[2]['display_name']).to eq 'BIOLOGY 1A DIS 301'
       end
     end
   end
 
   context 'when providing muted assignments' do
-    let(:muted_course_assignments) { [course_assignments[1]] }
-    before { allow_any_instance_of(Canvas::CourseAssignments).to receive(:muted_assignments).and_return(muted_course_assignments) }
+    let(:muted_course_assignments) { [ course_assignments[1] ] }
+    before do
+      allow_any_instance_of(Canvas::CourseAssignments).to receive(:muted_assignments).and_return muted_course_assignments
+    end
 
     it 'provides current muted assignments' do
       muted_assignments = subject.muted_assignments
@@ -403,13 +509,13 @@ describe CanvasLti::Egrades do
 
   context 'when unmuting all course assignments' do
     let(:muted_course_assignments) do
-      course_assignments.collect {|assignment| assignment['muted'] = true; assignment}
+      course_assignments.collect { |assignment| assignment['muted'] = true; assignment }
     end
     it 'unmutes all muted assignments for the course specified' do
       allow_any_instance_of(Canvas::CourseAssignments).to receive(:muted_assignments).and_return(muted_course_assignments)
-      expect_any_instance_of(Canvas::CourseAssignments).to receive(:unmute_assignment).exactly(1).times.with(19082)
-      expect_any_instance_of(Canvas::CourseAssignments).to receive(:unmute_assignment).exactly(1).times.with(19083)
-      expect_any_instance_of(Canvas::CourseAssignments).to receive(:unmute_assignment).exactly(1).times.with(19084)
+      expect_any_instance_of(Canvas::CourseAssignments).to receive(:unmute_assignment).exactly(1).times.with 19082
+      expect_any_instance_of(Canvas::CourseAssignments).to receive(:unmute_assignment).exactly(1).times.with 19083
+      expect_any_instance_of(Canvas::CourseAssignments).to receive(:unmute_assignment).exactly(1).times.with 19084
       subject.unmute_course_assignments
     end
   end
@@ -417,8 +523,36 @@ describe CanvasLti::Egrades do
   context 'when providing course states for grade export validation' do
     let(:official_course_sections) do
       [
-        {'dept_name'=>'CHEM', 'catalog_id'=>'3BL', 'term_yr'=>'2014', 'term_cd'=>'C', 'course_cntl_num'=>'22280', 'primary_secondary_cd'=>'P', 'section_num'=>'001', 'instruction_format'=>'LEC'},
-        {'dept_name'=>'CHEM', 'catalog_id'=>'3BL', 'term_yr'=>'2014', 'term_cd'=>'C', 'course_cntl_num'=>'22345', 'primary_secondary_cd'=>'S', 'section_num'=>'208', 'instruction_format'=>'LAB'}
+        {
+          'dept_name' => 'BIOLOGY',
+          'catalog_id' => '1A',
+          'term_yr' => '2017',
+          'term_cd' => 'B',
+          'course_cntl_num' => '13234',
+          'primary_secondary_cd' => 'P',
+          'section_num' => '001',
+          'instruction_format' => 'LEC'
+        },
+        {
+          'dept_name' => 'BIOLOGY',
+          'catalog_id' => '1A',
+          'term_yr' => '2017',
+          'term_cd' => 'B',
+          'course_cntl_num' => '13235',
+          'primary_secondary_cd' => 'P',
+          'section_num' => '002',
+          'instruction_format' => 'LEC'
+        },
+        {
+          'dept_name' => 'BIOLOGY',
+          'catalog_id' => '1A',
+          'term_yr' => '2017',
+          'term_cd' => 'B',
+          'course_cntl_num' => '13237',
+          'primary_secondary_cd' => 'S',
+          'section_num' => '301',
+          'instruction_format' => 'DIS'
+        },
       ]
     end
     let(:course_settings) do
@@ -436,22 +570,39 @@ describe CanvasLti::Egrades do
         {'name' => 'Assignment 7', 'due_at' => 'Oct 18, 2015 at 9:30am', 'points_possible' => 100},
       ]
     end
-    let(:grade_types) { {:number_grades_present => true, :letter_grades_present => false} }
-    let(:section_terms) { [{:term_cd => 'C', :term_yr => '2014'}, {:term_cd => 'D', :term_yr => '2015'}] }
+    let(:grade_types) {
+      {
+        number_grades_present: true,
+        letter_grades_present: false
+      }
+    }
+    let(:section_terms) {
+      [
+        {
+          term_cd: 'B',
+          term_yr: '2017'
+        },
+        {
+          term_cd: 'C',
+          term_yr: '2017'
+        }
+      ]
+    }
     before do
-      allow_any_instance_of(Canvas::CourseSettings).to receive(:settings).and_return(course_settings)
-      allow_any_instance_of(CanvasLti::OfficialCourse).to receive(:section_terms).and_return(section_terms)
-      allow(subject).to receive(:official_sections).and_return(official_course_sections)
-      allow(subject).to receive(:grade_types_present).and_return(grade_types)
-      allow(subject).to receive(:muted_assignments).and_return(muted_assignments)
+      allow_any_instance_of(Canvas::CourseSettings).to receive(:settings).and_return course_settings
+      allow_any_instance_of(CanvasLti::OfficialCourse).to receive(:section_terms).and_return section_terms
+      allow(subject).to receive(:official_sections).and_return official_course_sections
+      allow(subject).to receive(:grade_types_present).and_return grade_types
+      allow(subject).to receive(:muted_assignments).and_return muted_assignments
     end
 
     it 'provides official course sections' do
       result = subject.export_options
       official_sections = result[:officialSections]
-      expect(official_sections.count).to eq 2
-      expect(official_sections[0]['course_cntl_num']).to eq '22280'
-      expect(official_sections[1]['course_cntl_num']).to eq '22345'
+      expect(official_sections.count).to eq 3
+      expect(official_sections[0]['course_cntl_num']).to eq '13234'
+      expect(official_sections[1]['course_cntl_num']).to eq '13235'
+      expect(official_sections[2]['course_cntl_num']).to eq '13237'
     end
 
     it 'provides grading standard enabled boolean' do
@@ -463,10 +614,10 @@ describe CanvasLti::Egrades do
       export_options = subject.export_options
       section_terms = export_options[:sectionTerms]
       expect(section_terms.count).to eq 2
-      expect(section_terms[0][:term_cd]).to eq 'C'
-      expect(section_terms[0][:term_yr]).to eq '2014'
-      expect(section_terms[1][:term_cd]).to eq 'D'
-      expect(section_terms[1][:term_yr]).to eq '2015'
+      expect(section_terms[0][:term_cd]).to eq 'B'
+      expect(section_terms[0][:term_yr]).to eq '2017'
+      expect(section_terms[1][:term_cd]).to eq 'C'
+      expect(section_terms[1][:term_yr]).to eq '2017'
     end
 
     it 'provides muted assignments existing within course' do
@@ -477,6 +628,4 @@ describe CanvasLti::Egrades do
       expect(muted_assignments[1]['name']).to eq 'Assignment 7'
     end
   end
-
 end
-


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6534

See screenshot attached to Jira above.

Duplicates in the eGrades dropdown happen when the course has:
* multiple primary sections
* secondary section has multiple parents/primaries. I.e., duplicate rows, per section id, in `SISEDO.CLASSSECTIONV00_VW` with differing `primaryAssociatedSectionId` values.

This multiple parent info might be useful in other scenarios but the eGrades feature doesn't care. So, we put de-dupe logic at level of the model.

*Note:* overhaul of spec and up-to-date test data.