### PR TITLE
CLC-6522 Update font in local bCourses LTI tools to Lato

### DIFF
--- a/src/assets/stylesheets/_canvas_base.scss
+++ b/src/assets/stylesheets/_canvas_base.scss
@@ -1,5 +1,5 @@
 // Canvas Typography
-$bc-base-font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+$bc-base-font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
 .bc-canvas-base-typography,
 .bc-canvas-application,
@@ -71,13 +71,13 @@ $bc-base-font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   }
 
   h1 {
-    font-size: 30px;
-    font-weight: 300;
+    font-size: 28px;
+    font-weight: 400;
   }
 
   h2 {
     font-size: 25px;
-    font-weight: 300;
+    font-weight: 400;
   }
 
   h3 {
@@ -269,7 +269,7 @@ button.bc-button-link {
 // Headers
 .bc-header {
   color: $bc-color-off-black;
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: normal;
 }
 
@@ -407,7 +407,7 @@ button.bc-button-link {
 
   .bc-template-progress-bar-status {
     color: $bc-color-progressbar-status-color;
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
     font-size: 14px;
     font-style: normal;
     font-variant: normal;
@@ -545,6 +545,7 @@ button.bc-template-canvas-maintenance-notice-button {
 
 h3.bc-sections-course-title {
   display: inline;
+  font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 15px;
   font-weight: 500;
   width: 100%;

--- a/src/assets/stylesheets/_canvas_buttons.scss
+++ b/src/assets/stylesheets/_canvas_buttons.scss
@@ -6,7 +6,7 @@
   border: 1px solid $bc-color-button-border;
   border-radius: 3px;
   color: $bc-color-button-color;
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 14px;
   font-weight: 300;
   line-height: 20px;
@@ -71,7 +71,7 @@ a.bc-canvas-button {
     border-radius: 3px;
     color: $bc-color-off-black;
     display: inline-block;
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
     font-size: 14px;
     line-height: 20px;
     margin-bottom: 10px;

--- a/src/assets/stylesheets/_canvas_course_add_user.scss
+++ b/src/assets/stylesheets/_canvas_course_add_user.scss
@@ -8,8 +8,9 @@
 
   .bc-page-course-add-user-header {
     color: $bc-color-off-black;
+    font-family: $bc-base-font-family;
     font-size: 23px;
-    font-weight: 300;
+    font-weight: 400;
     line-height: 40px;
     margin: 8px 0;
   }

--- a/src/assets/stylesheets/_canvas_course_grade_export.scss
+++ b/src/assets/stylesheets/_canvas_course_grade_export.scss
@@ -15,12 +15,14 @@
   }
 
   .bc-page-course-grade-export-header {
+    font-family: $bc-base-font-family;
     font-size: 23px;
     font-weight: 400;
     padding: 12px 0 0;
   }
 
   .bc-page-course-grade-export-sub-header {
+    font-family: $bc-base-font-family;
     font-size: 20px;
     font-weight: 400;
     margin: 15px 0;

--- a/src/assets/stylesheets/_canvas_user_provision.scss
+++ b/src/assets/stylesheets/_canvas_user_provision.scss
@@ -6,6 +6,7 @@
   padding: 10px 20px;
 
   .cc-page-user-provision-heading {
+    font-family: $bc-base-font-family;
     font-size: 23px;
     font-weight: normal;
     margin: 10px 0;

--- a/src/base.html
+++ b/src/base.html
@@ -35,6 +35,10 @@
 
   <base href="/">
 
+  <link href="https://fonts.googleapis.com/css?family=Lato:300,300i,400&amp;subset=latin-ext"
+        rel="stylesheet" 
+        data-ng-if="isBcourses">
+
   <link href="/assets/stylesheets/application.css" rel="stylesheet">
   <script src="/assets/javascripts/application.js"></script>
 </head>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6522

Since Lato is a web font not shared across iframes, we need to fetch it from Google ourselves for bCourses pages only.

A couple of sizes and weights are tweaked to play better with the new font.

This should apply to all LTI tools except Roster Photos, which continues to use plain old CalCentral Arial for shared-template reasons.