### PR TITLE
SISRP-29434 - Makes link handling null-safe on Student Overview

### DIFF
--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -160,7 +160,7 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
           studentUid: $routeParams.uid
         };
       }
-      if (!!$scope.updatePlanUrl.url) {
+      if (!!_.get($scope, 'updatePlanUrl.url')) {
         linkService.addBackToTextToLink($scope.updatePlanUrl, backToText);
       }
     }).error(function(data, status) {


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-29434

While smoke-testing the 7.4 release we noticed a JS error on Student Overview.  Seems pretty minor and doesn't impact functionality, and it is only occurring when the advising_academic_planner feature flag is set to false.