### PR TITLE
CLC-6533 OEC: return preferred name from enrollments query

### DIFF
--- a/app/models/edo_oracle/oec.rb
+++ b/app/models/edo_oracle/oec.rb
@@ -108,7 +108,7 @@ module EdoOracle
               email."EMAIL_TYPE_CODE" = 'CAMP')
             LEFT OUTER JOIN SISEDO.PERSON_NAMEV00_VW name ON (
               name."PERSON_KEY" = enroll."STUDENT_ID" AND
-              name."NAME_TYPE_CODE" = 'PRI')
+              name."NAME_TYPE_CODE" = 'PRF')
             WHERE
               enroll."TERM_ID" = '#{term_id}'
               AND (enroll."STDNT_ENRL_STATUS_CODE" = 'E')

--- a/app/models/oec/queries.rb
+++ b/app/models/oec/queries.rb
@@ -48,7 +48,7 @@ module Oec
         batch += 1
       end
 
-      EdoOracle::Adapters::Oec.supplement_email_addresses(rows, columns)
+      EdoOracle::Adapters::Oec.supplement_user_attributes(rows, columns)
 
       {
         rows: rows,

--- a/spec/models/edo_oracle/adapters/oec_spec.rb
+++ b/spec/models/edo_oracle/adapters/oec_spec.rb
@@ -124,6 +124,7 @@ describe EdoOracle::Adapters::Oec do
     context 'missing email address' do
       before { row['email_address'] = nil }
       it 'fills in email address from attributes query' do
+        allow(User::BasicAttributes).to receive(:attributes_for_uids).and_call_original
         expect(User::BasicAttributes).to receive(:attributes_for_uids).with(['12345']).and_return([{
           ldap_uid: '12345',
           email_address: 'kaymcnulty@arl.army.mil'
@@ -161,12 +162,31 @@ describe EdoOracle::Adapters::Oec do
     context 'missing email address' do
       before { row[5] = nil }
       it 'fills in email address from attributes query' do
+        allow(User::BasicAttributes).to receive(:attributes_for_uids).and_call_original
         expect(User::BasicAttributes).to receive(:attributes_for_uids).with(['12345678']).and_return([{
           ldap_uid: '12345678',
           email_address: 'hedy@gmail.com'
         }])
-        EdoOracle::Adapters::Oec.supplement_email_addresses([row], columns)
+        EdoOracle::Adapters::Oec.supplement_user_attributes([row], columns)
         expect(enrollment['EMAIL_ADDRESS']).to eq 'hedy@gmail.com'
+      end
+    end
+
+    context 'missing name' do
+      before do
+        row[3] = nil
+        row[4] = nil
+      end
+      it 'fills in email address from attributes query' do
+        allow(User::BasicAttributes).to receive(:attributes_for_uids).and_call_original
+        expect(User::BasicAttributes).to receive(:attributes_for_uids).with(['12345678']).and_return([{
+          ldap_uid: '12345678',
+          first_name: 'Hedwig Eva Maria',
+          last_name: 'Kiesler'
+        }])
+        EdoOracle::Adapters::Oec.supplement_user_attributes([row], columns)
+        expect(enrollment['FIRST_NAME']).to eq 'Hedwig Eva Maria'
+        expect(enrollment['LAST_NAME']).to eq 'Kiesler'
       end
     end
   end

--- a/spec/models/oec/queries_spec.rb
+++ b/spec/models/oec/queries_spec.rb
@@ -40,6 +40,7 @@ describe Oec::Queries do
     context 'missing email address' do
       before { edo_oracle_rows[0][5] = nil }
       it 'fills in email address from attributes query' do
+        allow(User::BasicAttributes).to receive(:attributes_for_uids).and_call_original
         expect(User::BasicAttributes).to receive(:attributes_for_uids).with(['1234567']).and_return([{
           ldap_uid: '1234567',
           email_address: 'buck@tcd.ie'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6533

In cases where a preferred name is not present, we fill in from User::BasicAttributes, as we do for missing email addresses.