### PR TITLE
SISRP-29225 - Bookstore - not returning books with 2-part dept name (SOC WEL, COGSCI, etc)

### DIFF
--- a/app/models/edo_oracle/adapters/common.rb
+++ b/app/models/edo_oracle/adapters/common.rb
@@ -8,9 +8,10 @@ module EdoOracle
       end
 
       def adapt_dept_name_and_catalog_id(row, user_courses)
-        dept_name, catalog_id = user_courses.parse_course_code row
+        dept_name, dept_code, catalog_id = user_courses.parse_course_code row
         row.merge!({
           'dept_name' => dept_name,
+          'dept_code' => dept_code,
           'catalog_id' => catalog_id
         })
       end

--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -18,6 +18,7 @@ module EdoOracle
       TRIM(crs."title") AS course_title,
       TRIM(crs."transcriptTitle") AS course_title_short,
       crs."subjectArea" AS dept_name,
+      crs."classSubjectArea" AS dept_code,
       sec."primary" AS primary,
       sec."sectionNumber" AS section_num,
       sec."component-code" as instruction_format,

--- a/app/models/my_academics/academics_module.rb
+++ b/app/models/my_academics/academics_module.rb
@@ -49,7 +49,7 @@ module MyAcademics
     end
 
     def course_listing(campus_course)
-      campus_course.slice(:course_code, :dept, :dept_desc).merge({
+      campus_course.slice(:course_code, :dept, :dept_code, :dept_desc).merge({
         courseCatalog: campus_course[:course_catalog],
         course_id: campus_course[:id]
       })

--- a/spec/models/edo_oracle/user_courses/base_spec.rb
+++ b/spec/models/edo_oracle/user_courses/base_spec.rb
@@ -439,6 +439,8 @@ describe EdoOracle::UserCourses::Base do
       its([:slug]) { should eq 'mec_eng_i_res-0109al' }
       its([:id])  {should eq 'mec_eng_i_res-0109al-2016-D' }
       its([:course_code]) { should eq 'MEC ENG/I,RES 0109AL' }
+      its([:dept]) { should eq 'MEC ENG/I,RES' }
+      its([:dept_code]) { should eq 'MECENGIRES' }
     end
     let(:subject_areas) { ['MEC ENG/I,RES', 'MUSIC'] }
     context 'dept_name and catalog_id available' do
@@ -446,6 +448,7 @@ describe EdoOracle::UserCourses::Base do
         'catalog_id' => '0109AL',
         'course_display_name' => 'MEC ENG/I,RES 0109AL',
         'dept_name' => 'MEC ENG/I,RES',
+        'dept_code' => 'MECENGIRES',
         'section_display_name' => 'MECENGIRES 0109AL',
         'term_id' => '2168'
       }}
@@ -456,6 +459,7 @@ describe EdoOracle::UserCourses::Base do
         'catalog_id' => nil,
         'course_display_name' => 'MEC ENG/I,RES 0109AL',
         'dept_name' => nil,
+        'dept_code' => 'MECENGIRES',
         'section_display_name' => 'MECENGIRES 0109AL',
         'term_id' => '2168'
       }}
@@ -466,6 +470,7 @@ describe EdoOracle::UserCourses::Base do
         'catalog_id' => nil,
         'course_display_name' => nil,
         'dept_name' => nil,
+        'dept_code' => 'MECENGIRES',
         'section_display_name' => 'MECENGIRES 0109AL',
         'term_id' => '2168'
       }}
@@ -476,6 +481,7 @@ describe EdoOracle::UserCourses::Base do
         'catalog_id' => '0109AL',
         'course_display_name' => 'MECENGIRES 0109AL',
         'dept_name' => 'MECENGIRES',
+        'dept_code' => 'MECENGIRES',
         'section_display_name' => 'MECENGIRES 0109AL',
         'term_id' => '2168'
       }}
@@ -487,6 +493,7 @@ describe EdoOracle::UserCourses::Base do
     let(:row) {{
       'catalog_id' => '0109AL',
       'dept_name' => 'MEC ENG/I,RES',
+      'dept_code' => 'MECENGIRES',
       'term_id' => '2168',
       'course_title' => course_title,
       'course_title_short' => 'KOLLAPS',

--- a/src/assets/javascripts/angular/services/academicsService.js
+++ b/src/assets/javascripts/angular/services/academicsService.js
@@ -281,7 +281,7 @@ angular.module('calcentral.services').service('academicsService', function() {
     if (sectionNumbers.length) {
       var courseInfo = {
         'sectionNumbers[]': sectionNumbers,
-        'department': course.dept,
+        'department': course.dept_code,
         'courseCatalog': course.courseCatalog,
         'slug': semester.slug
       };


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-29225

* Adds department code to course/section related EDO DB queries
* Adds `dept_code` to MyAcademics::Semesters feed within classes
* Updates BookListsController to pass `dept_code` instead of department name field for Textbooks API request
