### PR TITLE
SISRP-28970, webcast_spec: when fake=false use stubbed term data

### DIFF
--- a/spec/models/my_activities/webcasts_spec.rb
+++ b/spec/models/my_activities/webcasts_spec.rb
@@ -4,7 +4,9 @@ describe MyActivities::Webcasts do
 
   before {
     allow(Settings.terms).to receive(:fake_now).and_return '2017-01-18 04:20:00'
-    allow(Webcast::Recordings).to receive(:new).and_return recordings_proxy
+    allow(Berkeley::Terms).to receive(:fetch).and_return (terms = double)
+    allow(terms).to receive(:current).and_return double(year: 2017, code: 'B')
+    allow(terms).to receive(:campus).and_return({})
   }
 
   let(:activities) do
@@ -67,6 +69,7 @@ describe MyActivities::Webcasts do
     }
 
     before {
+      allow(Webcast::Recordings).to receive(:new).and_return recordings_proxy
       expect(EdoOracle::UserCourses::All).to receive(:new).with(user_id: uid).once.and_return (queries = double)
       expect(queries).to receive(:get_all_campus_courses).and_return(term => my_current_courses)
     }


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-28970

The `fake: false` spec is testing 'connection failure' and term data matters not to that test. (Personal Bamboo build is happy: https://bamboo.ets.berkeley.edu/bamboo/browse/MYB-TRC3-1)