### PR TITLE
CLC-6547, Course Capture related notifications will expire after 2 days

### DIFF
--- a/app/models/my_activities/merged.rb
+++ b/app/models/my_activities/merged.rb
@@ -15,8 +15,9 @@ module MyActivities
       ]
     end
 
-    def self.cutoff_date
-      @cutoff_date ||= (Settings.terms.fake_now || Time.zone.today.in_time_zone).to_datetime.advance(days: -10).to_time.to_i
+    def self.cutoff_date(offset = 10)
+      today = Settings.terms.fake_now || Time.zone.today.in_time_zone
+      today.to_datetime.advance(days: -offset).to_time.to_i
     end
 
     def get_feed_internal

--- a/app/models/my_activities/notification_activities.rb
+++ b/app/models/my_activities/notification_activities.rb
@@ -10,7 +10,8 @@ module MyActivities
     def self.append!(uid, activities)
       result = []
       use_pooled_connection {
-        result = Notifications::Notification.where(:uid => uid.to_s, :occurred_at => Time.at(MyActivities::Merged.cutoff_date)..Time.now) || []
+        cutoff_time = Time.at MyActivities::Merged.cutoff_date
+        result = Notifications::Notification.where(:uid => uid.to_s, :occurred_at => cutoff_time..Time.now) || []
       }
       result.each do |notification|
         translator = (self.translators[notification.translator] ||= "Notifications::#{notification.translator}".constantize.new)

--- a/app/models/my_activities/webcasts.rb
+++ b/app/models/my_activities/webcasts.rb
@@ -2,6 +2,9 @@ module MyActivities
   class Webcasts
     include DatedFeed
 
+    # Custom cutoff date for Course Capture related notifications
+    CUTOFF_DAY_COUNT = 2
+
     def self.append!(uid, activities)
       term_code = get_current_term_code
       courses_by_ccn = get_courses_by_ccn(uid, term_code)
@@ -39,7 +42,7 @@ module MyActivities
     def self.each_recent_recording(webcast_course)
       webcast_course[:recordings].each do |recording|
         next unless recording['recordingStartUTC'].present? && (start_time = DateTime.parse recording['recordingStartUTC'])
-        if start_time.to_i >= MyActivities::Merged.cutoff_date
+        if start_time.to_i >= MyActivities::Merged.cutoff_date(CUTOFF_DAY_COUNT)
           yield recording.merge('startTime' => start_time)
         end
       end

--- a/spec/models/my_activities/webcasts_spec.rb
+++ b/spec/models/my_activities/webcasts_spec.rb
@@ -48,7 +48,9 @@ describe MyActivities::Webcasts do
     end
 
     it 'should only include webcasts after cutoff date' do
-      expect(activities.collect { |a| a[:date][:epoch] }).to all be > MyActivities::Merged.cutoff_date
+      today = (Settings.terms.fake_now || Time.zone.today.in_time_zone).to_datetime
+      cutoff_date = MyActivities::Merged.cutoff_date MyActivities::Webcasts::CUTOFF_DAY_COUNT
+      expect(activities.collect { |a| a[:date][:epoch] }).to all be > cutoff_date
     end
   end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6547

Default `cutoff` is 10 days. Course Capture is 2 days.