### PR TITLE
SISRP-29725 - Implement deadline date configuration for concurrent enrollment 'decide' section

### DIFF
--- a/app/models/my_academics/class_enrollments.rb
+++ b/app/models/my_academics/class_enrollments.rb
@@ -120,9 +120,10 @@ module MyAcademics
 
     def get_enrollment_term_instructions
       instructions = {}
-      get_active_term_ids.collect do |term_id|
+      get_active_term_ids.each do |term_id|
         term_details = CampusSolutions::EnrollmentTerm.new(user_id: @uid, term_id: term_id).get
         instructions[term_id] = term_details.try(:[], :feed).try(:[], :enrollmentTerm)
+        instructions[term_id][:concurrentApplyDeadline] = get_concurrent_apply_deadline(term_id)
       end
       instructions
     end
@@ -178,6 +179,22 @@ module MyAcademics
       end
 
       cs_links
+    end
+
+    def get_concurrent_apply_deadline(term_id)
+      get_concurrent_apply_deadlines_hash[term_id.to_s].try(:deadline_date) || "TBD"
+    end
+
+    def get_concurrent_apply_deadlines_hash
+      deadlines_array = Settings.class_enrollment.try(:concurrent_apply_deadlines)
+      deadlines = {}
+      if deadlines_array.to_a.count > 0
+        deadlines = deadlines_array.inject({}) do |map, term_deadline|
+          map[term_deadline.term_code.to_s] = term_deadline
+          map
+        end
+      end
+      deadlines
     end
 
     private

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -436,6 +436,9 @@ calnet_crosswalk_proxy:
   password: secret
   http_timeout_seconds: 30
 
+class_enrollment:
+  concurrent_apply_deadlines: []
+
 final_exam_schedule: [
   {
     year: 2016,

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -90,6 +90,18 @@ grading_period:
     start: 2016-11-01 0:0:0
     end: 2017-01-06 23:59:59
 
+class_enrollment:
+  concurrent_apply_deadlines: [
+    {
+      term_code: '2165',
+      deadline_date: '05/01/2016'
+    },
+    {
+      term_code: '2168',
+      deadline_date: '09/23/2016'
+    }
+  ]
+
 features:
   advising: true
   advising_academic_planner: true

--- a/src/assets/templates/widgets/enrollment/decide_concurrent.html
+++ b/src/assets/templates/widgets/enrollment/decide_concurrent.html
@@ -19,7 +19,7 @@
           The deadline to apply
           <span data-ng-if="!enrollmentInstruction.isGradeBaseAvailable">is</span>
           <span data-ng-if="enrollmentInstruction.isGradeBaseAvailable">was</span>
-          09/23/2016
+          <span data-ng-bind="enrollmentInstruction.concurrentApplyDeadline"></span>
         </div>
       </div>
     </li>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-29725

Implements the ability to configure the deadline dates for the enrollment application process for the Class Enrollment card, within the 'Enroll' section of the 'Concurrent Enrollment' flavor of the card.