### PR TITLE
SISRP-29827 - Midpoint Status Column is missing on My Academics Tab

### DIFF
--- a/src/assets/javascripts/angular/controllers/pages/academicsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicsController.js
@@ -118,7 +118,7 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
     }
     $scope.selectedStudentSemester = selectedStudentSemester;
     $scope.selectedTeachingSemester = selectedTeachingSemester;
-    $scope.containsMidpointClass = academicsService.containsMidpointClass(selectedTeachingSemester);
+    $scope.containsMidpointClass = academicsService.containsMidpointClass($scope.selectedTeachingSemester);
 
     // Get selected course from URL params and extract data from selected semester schedule
     if ($routeParams.classSlug) {
@@ -191,6 +191,7 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
         // Show the current semester, or the most recent semester, since otherwise the instructor
         // landing page will be grimly bare.
         $scope.selectedTeachingSemester = academicsService.chooseDefaultSemester(data.teachingSemesters);
+        $scope.containsMidpointClass = academicsService.containsMidpointClass($scope.selectedTeachingSemester);
         $scope.widgetSemesterName = $scope.selectedTeachingSemester.name;
       }
     }


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-29827

* How I got caught:  The front-end academicsController has an `if` statement to show the most relevant semester on the My Academics tab for instructors, but only if `MyAcademics::Semesters` is empty.  If you're not tunneled to the CampusOracle DB, you'll never hit this part of the statement, because `fake` will always return data for you in `MyAcademics::Semesters`.