### PR TITLE
SISRP-29459 - CalCentral CUM Units is only displaying UC Berkeley Units total

### DIFF
--- a/app/models/my_academics/gpa_units.rb
+++ b/app/models/my_academics/gpa_units.rb
@@ -57,7 +57,7 @@ module MyAcademics
     def parse_hub_total_units(status)
       if (units = status['cumulativeUnits']) && (total_units = units.find { |u| u['type'] && u['type']['code'] == 'Total'})
         {
-          totalUnits: total_units['unitsPassed'].to_f,
+          totalUnits: total_units['unitsCumulative'].to_f,
           transferUnitsAccepted: total_units['unitsTransferAccepted'].to_f,
           testingUnits: total_units['unitsTest'].to_f
         }

--- a/fixtures/json/hub_academic_status.json
+++ b/fixtures/json/hub_academic_status.json
@@ -21,6 +21,7 @@
                     },
                     "unitsOther": 0,
                     "unitsPassed": 73,
+                    "unitsCumulative": 73,
                     "unitsTaken": 8,
                     "unitsTest": 0,
                     "unitsTransferAccepted": 65,


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-29459

lots of analysis for the smallest change :) 
* fix put in to source cumulative units for new field added to academic status API
