### PR TITLE
SISRP-29795 - Create Enrollment API Proxy

### DIFF
--- a/app/models/hub_enrollments/current_enrollments.rb
+++ b/app/models/hub_enrollments/current_enrollments.rb
@@ -1,0 +1,24 @@
+module HubEnrollments
+  class CurrentEnrollments < Proxy
+
+    def initialize (options = {})
+      @term_id = options[:term_id]
+      super(options)
+    end
+
+    def json_filename
+      'hub_current_enrollments.json'
+    end
+
+    # Returns only current enrollments in primary class sections.  This response is limited to 50
+    # enrollments.  If more is needed, a loop will be required.
+    def url
+      "#{@settings.base_url}/#{@campus_solutions_id}?term-id=#{@term_id}&primary-only=true&page-size=50"
+    end
+
+    def wrapper_keys
+      %w(apiResponse response studentEnrollments)
+    end
+
+  end
+end

--- a/app/models/hub_enrollments/my_current_enrollments.rb
+++ b/app/models/hub_enrollments/my_current_enrollments.rb
@@ -1,0 +1,22 @@
+module HubEnrollments
+  class MyCurrentEnrollments < UserSpecificModel
+    include Cache::CachedFeed
+    include Cache::FeedExceptionsHandled
+    include Cache::UserCacheExpiry
+    include Cache::JsonifiedFeed
+
+    def initialize (options = {})
+      @uid = options[:user_id]
+      @term_id = options[:term_id]
+    end
+
+    def get_feed_internal
+      current_enrollments = HubEnrollments::CurrentEnrollments.new(user_id: @uid, term_id: @term_id).get
+      if (enrollments = current_enrollments.try(:[], :feed))
+        logger.warn("Maximum enrollment size of #{enrollments.length} from Enrollments API reached, additional enrollments not being shown.") if enrollments.length == 50
+      end
+      current_enrollments
+    end
+
+  end
+end

--- a/app/models/hub_enrollments/proxy.rb
+++ b/app/models/hub_enrollments/proxy.rb
@@ -1,0 +1,132 @@
+module HubEnrollments
+  class Proxy < BaseProxy
+    include ClassLogger
+    include Proxies::Mockable
+    include User::Student
+    include SafeJsonParser
+
+    def initialize(options = {})
+      super(Settings.hub_enrollments_proxy, options)
+      if @fake
+        @campus_solutions_id = lookup_campus_solutions_id
+        initialize_mocks
+      end
+    end
+
+    def instance_key
+      @uid
+    end
+
+    def json_filename
+      ''
+    end
+
+    def mock_json
+      read_file('fixtures', 'json', json_filename)
+    end
+
+    def mock_request
+      super.merge(uriMating: url)
+    end
+
+    def get
+      wrapped_response = self.class.handling_exceptions(instance_key) do
+        get_internal
+      end
+      internal_response = wrapped_response ? wrapped_response[:response] : {}
+      process_response_after_caching internal_response
+    end
+
+    def process_response_after_caching(internal_response)
+      if internal_response[:noStudentId] || internal_response[:studentNotFound] || internal_response[:statusCode] < 400
+        internal_response
+      else
+        internal_response.merge({
+          errored: true
+        })
+      end
+    end
+
+    def get_internal(opts = {})
+      @campus_solutions_id ||= lookup_campus_solutions_id
+      if @campus_solutions_id.nil?
+        logger.warn "Lookup of campus_solutions_id for uid #{@uid} failed, cannot call Campus Solutions API"
+        {
+          feed: empty_feed,
+          noStudentId: true
+        }
+      else
+        logger.info "Fake = #{@fake}; Making request to #{url} on behalf of user #{@uid}; cache expiration #{self.class.expires_in}"
+        opts = opts.merge(request_options)
+        response = get_response(url, opts)
+        logger.debug "Remote server status #{response.code}, Body = #{response.body.force_encoding('UTF-8')}"
+        if response.code == 404
+          if response.try(:[], 'apiResponse').try(:[], 'httpStatus').try(:[], 'description') == 'Not Found'
+            logger.warn "Response '#{response['apiResponse']['httpStatus']['description']}' for UID #{@uid}, Campus Solutions ID #{@campus_solutions_id}"
+            feed = build_feed response
+            student_not_found = true
+          else
+            logger.error "Unexpected 404 response for UID #{@uid}, Campus Solutions ID #{@campus_solutions_id}: #{response}"
+            feed = empty_feed
+          end
+        else
+          feed = build_feed response
+        end
+        {
+          statusCode: response.code,
+          feed: feed,
+          studentNotFound: student_not_found
+        }
+      end
+    end
+
+    def url
+      @settings.base_url
+    end
+
+    def request_options
+      opts = {
+        headers: {
+          'Accept' => 'application/json'
+        },
+        on_error: {
+          rescue_status: 404
+        }
+      }
+      if @settings.app_id.present? && @settings.app_key.present?
+        # app ID and token are used on the prod/staging Hub servers
+        opts[:headers]['app_id'] = @settings.app_id
+        opts[:headers]['app_key'] = @settings.app_key
+      else
+        opts[:basic_auth] = {
+          username: @settings.username,
+          password: @settings.password
+        }
+      end
+      opts
+    end
+
+    def unwrap_response(response)
+      return [] unless response.is_a? Hash
+      unwrapped = wrapper_keys.inject(response) { |feed, key| (feed.is_a?(Hash) && feed[key]) || [] }
+      unwrapped.respond_to?(:each) ? unwrapped : []
+    end
+
+    def wrapper_keys
+      %w(apiResponse response)
+    end
+
+    def parse_response(response)
+      safe_json response.body.force_encoding('UTF-8')
+    end
+
+    def build_feed(response)
+      unwrap_response parse_response(response)
+    end
+
+    def empty_feed
+      {}
+    end
+
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -432,6 +432,13 @@ hub_edos_proxy:
   password: secret
   http_timeout_seconds: 30
 
+hub_enrollments_proxy:
+  fake: true
+  base_url: 'https://sis-integration.berkeley.edu/dev/apis/sis/v2/enrollments/students'
+  username: secret
+  password: secret
+  http_timeout_seconds: 30
+
 calnet_crosswalk_proxy:
   fake: true
   base_url: 'https://registry-d1.calnet.1918.berkeley.edu:8453/registry-service/api/v1/identifiers'

--- a/fixtures/json/hub_current_enrollments.json
+++ b/fixtures/json/hub_current_enrollments.json
@@ -1,0 +1,727 @@
+{
+    "apiResponse": {
+        "httpStatus": {
+            "code": "200",
+            "description": "OK"
+        },
+        "responseType": "namespaceURI=\"http://bmeta.berkeley.edu/student/enrollmentV0.xsd\" element=\"enrollmentsByStudent\"",
+        "response": {
+            "student": {
+                "identifiers": [
+                    {
+                        "type": "student-id",
+                        "id": "12345678",
+                        "disclose": false
+                    },
+                    {
+                        "type": "campus-uid",
+                        "id": "1234567",
+                        "disclose": true
+                    },
+                    {
+                        "type": "Social Security Number",
+                        "id": "000-00-0000",
+                        "disclose": false
+                    },
+                    {
+                        "type": "DB2",
+                        "id": "12345678",
+                        "disclose": false
+                    }
+                ],
+                "names": [
+                    {
+                        "type": {
+                            "code": "PRF",
+                            "description": "Preferred"
+                        },
+                        "familyName": "Duck",
+                        "givenName": "TheDonald",
+                        "formattedName": "TheDonald Duck",
+                        "disclose": false,
+                        "uiControl": {
+                            "code": "U",
+                            "description": "Edit - No Delete"
+                        },
+                        "fromDate": "1902-02-01"
+                    },
+                    {
+                        "type": {
+                            "code": "PRI",
+                            "description": "Primary"
+                        },
+                        "familyName": "Duck",
+                        "givenName": "TheDonald",
+                        "formattedName": "TheDonald Duck",
+                        "disclose": false,
+                        "uiControl": {
+                            "code": "D",
+                            "description": "Display Only"
+                        },
+                        "fromDate": "1902-02-01"
+                    }
+                ],
+                "emails": [
+                    {
+                        "type": {
+                            "code": "CAMP",
+                            "description": "Campus"
+                        },
+                        "emailAddress": "daffyduck@berkeley.edu",
+                        "primary": true,
+                        "disclose": false,
+                        "uiControl": {
+                            "code": "D",
+                            "description": "Display Only"
+                        }
+                    },
+                    {
+                        "type": {
+                            "code": "OTHR",
+                            "description": "Other"
+                        },
+                        "emailAddress": "daffyduck@berkeley.edu",
+                        "primary": false,
+                        "disclose": false,
+                        "uiControl": {
+                            "code": "F",
+                            "description": "Full Edit"
+                        }
+                    }
+                ],
+                "confidential": false
+            },
+            "studentEnrollments": [
+                {
+                    "enrollmentStatus": {
+                        "status": {
+                            "code": "E",
+                            "description": "Enrolled"
+                        },
+                        "reason": {
+                            "code": "EWAT",
+                            "description": "Enrolled from Wait List"
+                        },
+                        "fromDate": "2016-10-20"
+                    },
+                    "enrolledUnits": {
+                        "taken": 3,
+                        "forAcademicProgress": 3,
+                        "forFinancialAid": 3,
+                        "forBilling": 3
+                    },
+                    "gradingBasis": {
+                        "code": "GRD",
+                        "description": "Standard Grading Basis"
+                    },
+                    "grades": [
+                        {
+                            "type": {
+                                "code": "MID",
+                                "description": "Mid-Term Grade"
+                            },
+                            "mark": "F",
+                            "status": {},
+                            "uiControl": {}
+                        }
+                    ],
+                    "classSection": {
+                        "id": 10633,
+                        "number": "001",
+                        "component": {
+                            "code": "LEC",
+                            "description": "Lecture"
+                        },
+                        "displayName": "2017 Spring UGBA 102B 001 LEC 001",
+                        "association": {
+                            "primary": false,
+                            "primaryAssociatedComponent": {}
+                        },
+                        "enrollmentStatus": {
+                            "status": {}
+                        },
+                        "printInScheduleOfClasses": false,
+                        "addConsentRequired": {
+                            "code": "N",
+                            "description": "No Special Consent Required"
+                        },
+                        "dropConsentRequired": {
+                            "code": "N",
+                            "description": "No Special Consent Required"
+                        },
+                        "meetings": [
+                            {
+                                "number": 1,
+                                "meetsDays": "TuTh",
+                                "meetsMonday": false,
+                                "meetsTuesday": true,
+                                "meetsWednesday": false,
+                                "meetsThursday": true,
+                                "meetsFriday": false,
+                                "meetsSaturday": false,
+                                "meetsSunday": false,
+                                "startTime": "11:00:00",
+                                "endTime": "12:29:00",
+                                "location": {
+                                    "code": "CHEIC230",
+                                    "description": "Cheit C230"
+                                },
+                                "building": {
+                                    "code": "1233",
+                                    "description": "Cheit"
+                                },
+                                "assignedInstructors": [
+                                    {
+                                        "assignmentNumber": 1,
+                                        "instructor": {
+                                            "identifiers": [
+                                                {
+                                                    "type": "student-id",
+                                                    "id": "13764941",
+                                                    "disclose": false
+                                                },
+                                                {
+                                                    "type": "campus-uid",
+                                                    "id": "92860",
+                                                    "disclose": true
+                                                },
+                                                {
+                                                    "type": "Social Security Number",
+                                                    "id": "000-00-0000",
+                                                    "disclose": false
+                                                },
+                                                {
+                                                    "type": "DB2",
+                                                    "id": "13764941",
+                                                    "disclose": false
+                                                },
+                                                {
+                                                    "type": "HCM System",
+                                                    "id": "011186083",
+                                                    "disclose": false
+                                                }
+                                            ],
+                                            "names": [
+                                                {
+                                                    "type": {
+                                                        "code": "PRF",
+                                                        "description": "Preferred"
+                                                    },
+                                                    "familyName": "Briginshaw",
+                                                    "givenName": "John",
+                                                    "formattedName": "John  Briginshaw",
+                                                    "disclose": false,
+                                                    "uiControl": {
+                                                        "code": "U",
+                                                        "description": "Edit - No Delete"
+                                                    },
+                                                    "fromDate": "1998-04-01"
+                                                },
+                                                {
+                                                    "type": {
+                                                        "code": "PRI",
+                                                        "description": "Primary"
+                                                    },
+                                                    "familyName": "Briginshaw",
+                                                    "givenName": "John",
+                                                    "formattedName": "John  Briginshaw",
+                                                    "disclose": false,
+                                                    "uiControl": {
+                                                        "code": "D",
+                                                        "description": "Display Only"
+                                                    },
+                                                    "fromDate": "1998-04-01"
+                                                }
+                                            ],
+                                            "emails": [
+                                                {
+                                                    "type": {
+                                                        "code": "CAMP",
+                                                        "description": "Campus"
+                                                    },
+                                                    "emailAddress": "john_briginshaw@haas.berkeley.edu",
+                                                    "primary": true,
+                                                    "disclose": false,
+                                                    "uiControl": {
+                                                        "code": "D",
+                                                        "description": "Display Only"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "role": {
+                                            "code": "PI",
+                                            "description": "1-TIC",
+                                            "formalDescription": "Teaching and In Charge"
+                                        },
+                                        "printInScheduleOfClasses": true,
+                                        "gradeRosterAccess": {}
+                                    }
+                                ],
+                                "startDate": "2017-01-17",
+                                "endDate": "2017-05-05",
+                                "meetingTopic": {}
+                            }
+                        ],
+                        "class": {
+                            "course": {
+                                "identifiers": [
+                                    {
+                                        "type": "cs-course-id",
+                                        "id": "122485"
+                                    }
+                                ],
+                                "subjectArea": {
+                                    "code": "UGBA",
+                                    "description": "Business Admin-Undergrad"
+                                },
+                                "catalogNumber": {
+                                    "number": "102",
+                                    "suffix": "B",
+                                    "formatted": "102B"
+                                },
+                                "displayName": "UGBA 102B",
+                                "title": "Introduction to Managerial Accounting",
+                                "transcriptTitle": "INTRO MANAGER ACCT"
+                            },
+                            "offeringNumber": 1,
+                            "session": {
+                                "term": {
+                                    "id": "2172",
+                                    "name": "2017 Spring"
+                                },
+                                "id": "1",
+                                "name": "Regular Academic Session"
+                            },
+                            "number": "001",
+                            "displayName": "2017 Spring UGBA 102B 001",
+                            "allowedUnits": {
+                                "minimum": 3,
+                                "maximum": 3,
+                                "forAcademicProgress": 3,
+                                "forFinancialAid": 3
+                            }
+                        }
+                    }
+                },
+                {
+                    "enrollmentStatus": {
+                        "status": {
+                            "code": "E",
+                            "description": "Enrolled"
+                        },
+                        "reason": {
+                            "code": "ENRL",
+                            "description": "Enrolled"
+                        },
+                        "fromDate": "2016-10-19"
+                    },
+                    "enrolledUnits": {
+                        "taken": 3,
+                        "forAcademicProgress": 3,
+                        "forFinancialAid": 3,
+                        "forBilling": 3
+                    },
+                    "gradingBasis": {
+                        "code": "GRD",
+                        "description": "Standard Grading Basis"
+                    },
+                    "grades": [
+                        {
+                            "type": {
+                                "code": "MID",
+                                "description": "Mid-Term Grade"
+                            },
+                            "mark": "D",
+                            "status": {},
+                            "uiControl": {}
+                        }
+                    ],
+                    "classSection": {
+                        "id": 10665,
+                        "number": "001",
+                        "component": {
+                            "code": "LEC",
+                            "description": "Lecture"
+                        },
+                        "displayName": "2017 Spring UGBA 106 001 LEC 001",
+                        "association": {
+                            "primary": false,
+                            "primaryAssociatedComponent": {}
+                        },
+                        "enrollmentStatus": {
+                            "status": {}
+                        },
+                        "printInScheduleOfClasses": false,
+                        "addConsentRequired": {
+                            "code": "N",
+                            "description": "No Special Consent Required"
+                        },
+                        "dropConsentRequired": {
+                            "code": "N",
+                            "description": "No Special Consent Required"
+                        },
+                        "meetings": [
+                            {
+                                "number": 1,
+                                "meetsDays": "Mo",
+                                "meetsMonday": true,
+                                "meetsTuesday": false,
+                                "meetsWednesday": false,
+                                "meetsThursday": false,
+                                "meetsFriday": false,
+                                "meetsSaturday": false,
+                                "meetsSunday": false,
+                                "startTime": "12:30:00",
+                                "endTime": "13:59:00",
+                                "location": {
+                                    "code": "HAASF295",
+                                    "description": "Haas Faculty Wing F295"
+                                },
+                                "building": {
+                                    "code": "1236",
+                                    "description": "Haas"
+                                },
+                                "assignedInstructors": [
+                                    {
+                                        "assignmentNumber": 1,
+                                        "instructor": {
+                                            "identifiers": [
+                                                {
+                                                    "type": "student-id",
+                                                    "id": "3030367705",
+                                                    "disclose": true
+                                                },
+                                                {
+                                                    "type": "campus-uid",
+                                                    "id": "264867",
+                                                    "disclose": true
+                                                },
+                                                {
+                                                    "type": "Social Security Number",
+                                                    "id": "000-00-0000",
+                                                    "disclose": false
+                                                },
+                                                {
+                                                    "type": "HCM System",
+                                                    "id": "011772648",
+                                                    "disclose": false
+                                                }
+                                            ],
+                                            "names": [
+                                                {
+                                                    "type": {
+                                                        "code": "PRF",
+                                                        "description": "Preferred"
+                                                    },
+                                                    "familyName": "Azhar",
+                                                    "givenName": "Wasim",
+                                                    "formattedName": "Wasim  Azhar",
+                                                    "disclose": true,
+                                                    "uiControl": {
+                                                        "code": "U",
+                                                        "description": "Edit - No Delete"
+                                                    },
+                                                    "fromDate": "1902-02-01"
+                                                },
+                                                {
+                                                    "type": {
+                                                        "code": "PRI",
+                                                        "description": "Primary"
+                                                    },
+                                                    "familyName": "Azhar",
+                                                    "givenName": "Wasim",
+                                                    "formattedName": "Wasim  Azhar",
+                                                    "disclose": true,
+                                                    "uiControl": {
+                                                        "code": "D",
+                                                        "description": "Display Only"
+                                                    },
+                                                    "fromDate": "2005-08-01"
+                                                }
+                                            ],
+                                            "emails": [
+                                                {
+                                                    "type": {
+                                                        "code": "CAMP",
+                                                        "description": "Campus"
+                                                    },
+                                                    "emailAddress": "azhar@berkeley.edu",
+                                                    "primary": true,
+                                                    "disclose": true,
+                                                    "uiControl": {
+                                                        "code": "D",
+                                                        "description": "Display Only"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "role": {
+                                            "code": "PI",
+                                            "description": "1-TIC",
+                                            "formalDescription": "Teaching and In Charge"
+                                        },
+                                        "printInScheduleOfClasses": true,
+                                        "gradeRosterAccess": {}
+                                    }
+                                ],
+                                "startDate": "2017-01-17",
+                                "endDate": "2017-05-05",
+                                "meetingTopic": {}
+                            }
+                        ],
+                        "class": {
+                            "course": {
+                                "identifiers": [
+                                    {
+                                        "type": "cs-course-id",
+                                        "id": "122489"
+                                    }
+                                ],
+                                "subjectArea": {
+                                    "code": "UGBA",
+                                    "description": "Business Admin-Undergrad"
+                                },
+                                "catalogNumber": {
+                                    "number": "106",
+                                    "formatted": "106"
+                                },
+                                "displayName": "UGBA 106",
+                                "title": "Marketing",
+                                "transcriptTitle": "MARKETING"
+                            },
+                            "offeringNumber": 1,
+                            "session": {
+                                "term": {
+                                    "id": "2172",
+                                    "name": "2017 Spring"
+                                },
+                                "id": "1",
+                                "name": "Regular Academic Session"
+                            },
+                            "number": "001",
+                            "displayName": "2017 Spring UGBA 106 001",
+                            "allowedUnits": {
+                                "minimum": 3,
+                                "maximum": 3,
+                                "forAcademicProgress": 3,
+                                "forFinancialAid": 3
+                            }
+                        }
+                    }
+                },
+                {
+                    "enrollmentStatus": {
+                        "status": {
+                            "code": "E",
+                            "description": "Enrolled"
+                        },
+                        "reason": {
+                            "code": "ENRL",
+                            "description": "Enrolled"
+                        },
+                        "fromDate": "2016-10-19"
+                    },
+                    "enrolledUnits": {
+                        "taken": 3,
+                        "forAcademicProgress": 3,
+                        "forFinancialAid": 3,
+                        "forBilling": 3
+                    },
+                    "gradingBasis": {
+                        "code": "GRD",
+                        "description": "Standard Grading Basis"
+                    },
+                    "grades": [
+                        {
+                            "type": {
+                                "code": "MID",
+                                "description": "Mid-Term Grade"
+                            },
+                            "mark": "F",
+                            "status": {},
+                            "uiControl": {}
+                        }
+                    ],
+                    "classSection": {
+                        "id": 10729,
+                        "number": "001",
+                        "component": {
+                            "code": "LEC",
+                            "description": "Lecture"
+                        },
+                        "displayName": "2017 Spring UGBA 179 001 LEC 001",
+                        "association": {
+                            "primary": false,
+                            "primaryAssociatedComponent": {}
+                        },
+                        "enrollmentStatus": {
+                            "status": {}
+                        },
+                        "printInScheduleOfClasses": false,
+                        "addConsentRequired": {
+                            "code": "N",
+                            "description": "No Special Consent Required"
+                        },
+                        "dropConsentRequired": {
+                            "code": "N",
+                            "description": "No Special Consent Required"
+                        },
+                        "meetings": [
+                            {
+                                "number": 1,
+                                "meetsDays": "TuTh",
+                                "meetsMonday": false,
+                                "meetsTuesday": true,
+                                "meetsWednesday": false,
+                                "meetsThursday": true,
+                                "meetsFriday": false,
+                                "meetsSaturday": false,
+                                "meetsSunday": false,
+                                "startTime": "09:30:00",
+                                "endTime": "10:59:00",
+                                "location": {
+                                    "code": "CHEIC330",
+                                    "description": "Cheit C330"
+                                },
+                                "building": {
+                                    "code": "1233",
+                                    "description": "Cheit"
+                                },
+                                "assignedInstructors": [
+                                    {
+                                        "assignmentNumber": 1,
+                                        "instructor": {
+                                            "identifiers": [
+                                                {
+                                                    "type": "student-id",
+                                                    "id": "82056430",
+                                                    "disclose": false
+                                                },
+                                                {
+                                                    "type": "campus-uid",
+                                                    "id": "632242",
+                                                    "disclose": true
+                                                },
+                                                {
+                                                    "type": "Social Security Number",
+                                                    "id": "000-00-0000",
+                                                    "disclose": false
+                                                },
+                                                {
+                                                    "type": "DB2",
+                                                    "id": "82056430",
+                                                    "disclose": false
+                                                },
+                                                {
+                                                    "type": "HCM System",
+                                                    "id": "011205891",
+                                                    "disclose": false
+                                                }
+                                            ],
+                                            "names": [
+                                                {
+                                                    "type": {
+                                                        "code": "PRF",
+                                                        "description": "Preferred"
+                                                    },
+                                                    "familyName": "Himelstein",
+                                                    "givenName": "Daniel",
+                                                    "formattedName": "Daniel A Himelstein",
+                                                    "disclose": false,
+                                                    "uiControl": {
+                                                        "code": "U",
+                                                        "description": "Edit - No Delete"
+                                                    },
+                                                    "fromDate": "1998-07-01"
+                                                },
+                                                {
+                                                    "type": {
+                                                        "code": "PRI",
+                                                        "description": "Primary"
+                                                    },
+                                                    "familyName": "Himelstein",
+                                                    "givenName": "Daniel",
+                                                    "formattedName": "Daniel Alan Himelstein",
+                                                    "disclose": false,
+                                                    "uiControl": {
+                                                        "code": "D",
+                                                        "description": "Display Only"
+                                                    },
+                                                    "fromDate": "2004-02-23"
+                                                }
+                                            ],
+                                            "emails": [
+                                                {
+                                                    "type": {
+                                                        "code": "CAMP",
+                                                        "description": "Campus"
+                                                    },
+                                                    "emailAddress": "dhimel@berkeley.edu",
+                                                    "primary": false,
+                                                    "disclose": false,
+                                                    "uiControl": {
+                                                        "code": "D",
+                                                        "description": "Display Only"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "role": {
+                                            "code": "PI",
+                                            "description": "1-TIC",
+                                            "formalDescription": "Teaching and In Charge"
+                                        },
+                                        "printInScheduleOfClasses": true,
+                                        "gradeRosterAccess": {}
+                                    }
+                                ],
+                                "startDate": "2017-01-17",
+                                "endDate": "2017-05-05",
+                                "meetingTopic": {}
+                            }
+                        ],
+                        "class": {
+                            "course": {
+                                "identifiers": [
+                                    {
+                                        "type": "cs-course-id",
+                                        "id": "122540"
+                                    }
+                                ],
+                                "subjectArea": {
+                                    "code": "UGBA",
+                                    "description": "Business Admin-Undergrad"
+                                },
+                                "catalogNumber": {
+                                    "number": "179",
+                                    "formatted": "179"
+                                },
+                                "displayName": "UGBA 179",
+                                "title": "International Consulting for Small and Medium-Sized Enterprises",
+                                "transcriptTitle": "INTL CONSULTING SME"
+                            },
+                            "offeringNumber": 1,
+                            "session": {
+                                "term": {
+                                    "id": "2172",
+                                    "name": "2017 Spring"
+                                },
+                                "id": "1",
+                                "name": "Regular Academic Session"
+                            },
+                            "number": "001",
+                            "displayName": "2017 Spring UGBA 179 001",
+                            "allowedUnits": {
+                                "minimum": 3,
+                                "maximum": 3,
+                                "forAcademicProgress": 3,
+                                "forFinancialAid": 3
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/script/sis/verify_sis_api_endpoints.sh
+++ b/script/sis/verify_sis_api_endpoints.sh
@@ -309,6 +309,13 @@ export HUB_APP_KEY="${yml_hub_term_proxy_app_key//\'}"
 verify_hub 'hub_term_api' "${yml_features_hub_term_api}" \
   "${yml_hub_term_proxy_base_url//\'}?temporal-position=Next"
 
+# Custom credentials are needed for the Hub's Enrollment API
+export HUB_APP_ID="${yml_hub_enrollments_proxy_app_id//\'}"
+export HUB_APP_KEY="${yml_hub_enrollments_proxy_app_key//\'}"
+
+verify_hub 'hub_enrollments_api' true \
+  "${yml_hub_enrollments_proxy_base_url//\'}/${CAMPUS_SOLUTIONS_ID}?page-size=1"
+
 echo; echo "----------------------------------------------------------------------------------------------------"; echo
 echo "Results can be found in the directory:"
 echo "  ${LOG_DIRECTORY}/${LOG_RELATIVE_PATH}"; echo;

--- a/spec/models/hub_enrollments/current_enrollments_spec.rb
+++ b/spec/models/hub_enrollments/current_enrollments_spec.rb
@@ -1,0 +1,17 @@
+describe HubEnrollments::CurrentEnrollments do
+
+  context 'mock proxy' do
+    let(:proxy) { HubEnrollments::CurrentEnrollments.new(fake: true, user_id: '61889', term_id: 2172) }
+    subject { proxy.get }
+
+    it_should_behave_like 'a simple proxy that returns errors'
+
+    it 'returns data with the expected structure' do
+      expect(subject[:feed][0]["enrollmentStatus"]).to be
+      expect(subject[:feed][0]["enrollmentStatus"]["status"]).to be
+      expect(subject[:feed][0]["grades"][0]["type"]["code"]).to eq 'MID'
+      expect(subject[:feed][0]["gradingBasis"]["code"]).to eq 'GRD'
+      expect(subject[:feed][0]["classSection"]["id"]).to eq 10633
+    end
+  end
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-29795
Some more good information on why I chose to create a "CurrentEnrollments" class instead of a more general, catch-all "Enrollments" class here:
https://jira.berkeley.edu/browse/SISRP-29571

* The Enrollments Proxy portion of the `verify_sis_endpoints` script *WILL* fail for the time being, until v2 of the Enrollments API proxy gets migrated to Hub UAT.