### PR TITLE
SISRP-29841 - CalCentral/My Academics shows instructor names that should not print

### DIFF
--- a/app/models/edo_oracle/course_sections.rb
+++ b/app/models/edo_oracle/course_sections.rb
@@ -56,7 +56,8 @@ module EdoOracle
           name: instructor['person_name'],
           role: instructor['role_code'],
           gradeRosterAccess: instructor['grade_roster_access'],
-          uid: instructor['ldap_uid']
+          uid: instructor['ldap_uid'],
+          printInSchedule: instructor['print_in_schedule']
         }
       end
       instructors.uniq

--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -233,7 +233,8 @@ module EdoOracle
           instr."campus-uid" AS ldap_uid,
           instr."role-code" AS role_code,
           instr."role-descr" AS role_description,
-          instr."gradeRosterAccess" AS grade_roster_access
+          instr."gradeRosterAccess" AS grade_roster_access,
+          instr."printInScheduleOfClasses" AS print_in_schedule
         FROM
           SISEDO.ASSIGNEDINSTRUCTORV00_VW instr
         JOIN SISEDO.CLASSSECTIONV00_VW sec ON (

--- a/spec/models/edo_oracle/course_sections_spec.rb
+++ b/spec/models/edo_oracle/course_sections_spec.rb
@@ -178,13 +178,15 @@ describe EdoOracle::CourseSections do
             'ldap_uid' => '2040',
             'person_name' => 'Albertus Magnus',
             'grade_roster_access' => 'A',
-            'role_code' => 'PI'
+            'role_code' => 'PI',
+            'print_in_schedule' => 'Y'
           },
           {
             'ldap_uid' => '242881',
             'person_name' => 'Thomas Aquinas',
             'grade_roster_access' => 'A',
-            'role_code' => 'TNIC'
+            'role_code' => 'TNIC',
+            'print_in_schedule' => 'N'
           }
         ]
       end
@@ -196,13 +198,15 @@ describe EdoOracle::CourseSections do
             name: 'Albertus Magnus',
             role: 'PI',
             gradeRosterAccess: 'A',
-            uid: '2040'
+            uid: '2040',
+            printInSchedule: 'Y'
           },
           {
             name: 'Thomas Aquinas',
             role: 'TNIC',
             gradeRosterAccess: 'A',
-            uid: '242881'
+            uid: '242881',
+            printInSchedule: 'N'
           }
         ]
       end

--- a/src/assets/templates/academics_classinfo.html
+++ b/src/assets/templates/academics_classinfo.html
@@ -168,19 +168,19 @@
                   <th width="30%" class="cc-academics-instructors-grading-th">
                      <h3 data-ng-if="$index == 0">Role</h3>
                   </th>
-                  <th width="20%" data-ng-if="!api.user.profile.roles.student" class="cc-academics-instructors-grading-th">
+                  <th width="20%" data-ng-if="api.user.profile.roles.faculty" class="cc-academics-instructors-grading-th">
                      <h3 data-ng-if="$index == 0">Grading</h3>
                   </th>
                 </thead>
                 <tbody>
                   <tr data-ng-repeat="instructor in section.instructors | orderBy:'ccDelegateRoleOrder'">
-                    <td >
+                    <td data-ng-if="api.user.profile.roles.faculty || instructor.printInSchedule == 'Y'">
                       <a data-ng-href="http://www.berkeley.edu/directory/results?search-type=uid&search-base=all&search-term={{instructor.uid}}" data-ng-bind-template="&#9632; {{instructor.name}}"></a>
                     </td>
-                    <td>
+                    <td data-ng-if="api.user.profile.roles.faculty || instructor.printInSchedule == 'Y'">
                       <span data-ng-bind="instructor.ccDelegateRole">
                     </td>
-                    <td data-ng-if="!api.user.profile.roles.student" data-ng-switch="instructor.ccGradingAccess" class="cc-academics-instructors-grading-status">
+                    <td data-ng-if="api.user.profile.roles.faculty" data-ng-switch="instructor.ccGradingAccess" class="cc-academics-instructors-grading-status">
                       <i data-ng-switch-when="approveGrades" class="fa fa-check"></i>
                       <i data-ng-switch-when="enterGrades" class="fa fa-list-ul"></i>
                     </td>
@@ -189,7 +189,7 @@
               </table>
             </div>
           </div>
-           <div data-ng-if="!api.user.profile.roles.student" class="cc-academics-instructors-grading-header">
+           <div data-ng-if="api.user.profile.roles.faculty" class="cc-academics-instructors-grading-header">
             <h3>Grading Legend</h3>
             <span><i class="fa fa-list-ul"></i><span> Can enter grades</span></span>
             <span class="cc-academics-instructors-grading-header-legend"><i class="fa fa-check"></i><span> Can enter and approve grades</span></span>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-29841

* Consumed flag already in EDODB instructor view to hide instructors names from class info page if flag is not set to 'Y' and a student is viewing the page. 
* correct logic to allow GSI's to also see grading delegate information. 