### PR TITLE
SISRP-26723 - Look for summer-2016 course data/enrollments in both legacy and EDO

### DIFF
--- a/app/models/berkeley/summer16_enrollment_terms.rb
+++ b/app/models/berkeley/summer16_enrollment_terms.rb
@@ -1,0 +1,29 @@
+module Berkeley
+  module Summer16EnrollmentTerms
+    extend self
+
+    # When fetching enrollments and sections from the EDO Oracle DB and the legacy Campus Oracle DB, we need to query
+    # for the summer-2016 term in both datasources.  This is because some students ("dual-citizens") have two SIDs, and
+    # their summer-2016 enrollments are stored under one ID in the EDO DB and under the other ID in the legacy DB.
+    #
+    # Including summer-2016 in both terms lists (legacy and non-legacy) allows these students to see their summer-2016
+    # data when logging in with either SID.
+
+    def legacy_terms
+      # Legacy terms are those before and including Settings.terms.legacy_cutoff.
+      Berkeley::Terms.fetch.campus.values.select &:legacy?
+    end
+
+    def non_legacy_terms
+      # Non-legacy terms are those after and including Settings.terms.legacy_cutoff.
+      Berkeley::Terms.fetch.campus.values.select do |term|
+        non_legacy_inclusive? term
+      end
+    end
+
+    def non_legacy_inclusive? term
+      term[:campus_solutions_id] >= TermCodes.slug_to_edo_id(Settings.terms.legacy_cutoff)
+    end
+
+  end
+end

--- a/app/models/campus_oracle/user_courses/base.rb
+++ b/app/models/campus_oracle/user_courses/base.rb
@@ -8,8 +8,7 @@ module CampusOracle
       def initialize(options = {})
         super(Settings.campusdb, options)
         @uid = @settings.fake_user_id if @fake
-        # Legacy terms are those before and including Settings.terms.legacy_cutoff.
-        @legacy_academic_terms = Berkeley::Terms.fetch.campus.values.select &:legacy?
+        @legacy_academic_terms = Berkeley::Summer16EnrollmentTerms.legacy_terms
       end
 
       def self.expires_in
@@ -23,8 +22,8 @@ module CampusOracle
       def merge_enrollments(campus_classes)
         return if @legacy_academic_terms.empty?
         previous_item = {}
-        enrollments = CampusOracle::Queries.get_enrolled_sections(@uid, @legacy_academic_terms)
-        enrollments.each do |row|
+
+        CampusOracle::Queries.get_enrolled_sections(@uid, @legacy_academic_terms).each do |row|
           if (item = row_to_feed_item(row, previous_item))
             item[:role] = 'Student'
             semester_key = "#{item[:term_yr]}-#{item[:term_cd]}"

--- a/app/models/edo_oracle/user_courses/base.rb
+++ b/app/models/edo_oracle/user_courses/base.rb
@@ -5,8 +5,7 @@ module EdoOracle
       def initialize(options = {})
         super(Settings.edodb, options)
         @uid = @settings.fake_user_id if @fake
-        # Non-legacy terms are those after Settings.terms.legacy_cutoff.
-        @non_legacy_academic_terms = Berkeley::Terms.fetch.campus.values.reject &:legacy?
+        @non_legacy_academic_terms = Berkeley::Summer16EnrollmentTerms.non_legacy_terms
       end
 
       def self.access_granted?(uid)
@@ -16,6 +15,7 @@ module EdoOracle
       def merge_enrollments(campus_classes)
         return if @non_legacy_academic_terms.empty?
         previous_item = {}
+
         EdoOracle::Queries.get_enrolled_sections(@uid, @non_legacy_academic_terms).each do |row|
           if (item = row_to_feed_item(row, previous_item))
             item[:role] = 'Student'
@@ -32,6 +32,7 @@ module EdoOracle
         return if @non_legacy_academic_terms.empty?
         previous_item = {}
         cross_listing_tracker = {}
+
         EdoOracle::Queries.get_instructing_sections(@uid, @non_legacy_academic_terms).each do |row|
           if (item = row_to_feed_item(row, previous_item, cross_listing_tracker))
             item[:role] = 'Instructor'

--- a/spec/models/edo_oracle/user_courses/base_spec.rb
+++ b/spec/models/edo_oracle/user_courses/base_spec.rb
@@ -1,15 +1,15 @@
 describe EdoOracle::UserCourses::Base do
 
-  RSpec::Matchers.define :terms_following_cutoff do |cutoff|
+  RSpec::Matchers.define :terms_following_and_including_cutoff do |cutoff|
     match do |terms|
       term_ids = terms.map &:campus_solutions_id
-      term_ids.present? && term_ids.all? { |term_id| term_id > cutoff }
+      term_ids.present? && term_ids.all? { |term_id| term_id >= cutoff }
     end
   end
 
   it 'should query non-legacy terms only' do
     allow(Settings.terms).to receive(:legacy_cutoff).and_return 'summer-2013'
-    expect(EdoOracle::Queries).to receive(:get_enrolled_sections).with(anything, terms_following_cutoff('2135')).and_return []
+    expect(EdoOracle::Queries).to receive(:get_enrolled_sections).with(anything, terms_following_and_including_cutoff('2135')).and_return []
     described_class.new(user_id: random_id).merge_enrollments({})
   end
 

--- a/spec/models/my_academics/semesters_spec.rb
+++ b/spec/models/my_academics/semesters_spec.rb
@@ -171,7 +171,7 @@ describe MyAcademics::Semesters do
   context 'legacy academic data' do
     before do
       allow(Settings.terms).to receive(:fake_now).and_return '2016-04-01'
-      allow(Settings.terms).to receive(:legacy_cutoff).and_return 'fall-2016'
+      allow(Settings.terms).to receive(:legacy_cutoff).and_return 'spring-2017'
       allow_any_instance_of(CampusOracle::UserCourses::All).to receive(:get_all_campus_courses).and_return enrollment_data
       expect(EdoOracle::Queries).not_to receive :get_enrolled_sections
     end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26723

Some students have two different SIDs on our system - they were issued one SID when they enrolled in summer courses, and a second SID when they came back the following fall.

These unlucky students have summer 2016 course enrollment data on the legacy Campus Oracle DB under the first SID, and the same data on EDO DB under the second SID.

The effect of this PR is to check in both datasources for summer 2016 enrollments.  That way, if a student logs in with the first SID they will see their summer 2016 enrollments, and if they log in with the second SID they will see those same summer 2016 enrollments as well as fall 2016 and later.