### PR TITLE
SISRP-29026 Enable concurrent request handling in development mode

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,7 @@ development:
   adapter: postgresql
   database: <%= Settings.postgres.database %>
   encoding: unicode
-  pool: 3
+  pool: <%= Settings.postgres.pool %>
   timeout: 5000
   username: <%= Settings.postgres.username %>
   password: <%= Settings.postgres.password %>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -50,6 +50,7 @@ postgres:
   password: <%= ENV['DB_ENV_POSTGRESQL_PASS'] || 'secret' %>
   host: <%= ENV['DB_PORT_5432_TCP_ADDR'] || 'localhost' %>
   port: <%= ENV['DB_PORT_5432_TCP_PORT'] || '5432' %>
+  pool: 3
 
 campusdb:
   fake: true


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-29026

Just makes it easier to do more realistic testing when ``RAILS_ENV=development`` -- should be a no-op unless you change your settings.