### PR TITLE
SISRP-30081 - Removes active/completed committee distinction

### DIFF
--- a/app/models/my_committees/faculty_committees.rb
+++ b/app/models/my_committees/faculty_committees.rb
@@ -11,8 +11,7 @@ module MyCommittees
     def get_feed
       result = {
         facultyCommittees: {
-          active: [],
-          completed: []
+          active: []
         }
       }
       feed = CampusSolutions::FacultyCommittees.new(user_id: @uid).get[:feed]
@@ -27,7 +26,7 @@ module MyCommittees
     def parse_cs_faculty_committees (cs_committees, committees_result)
       cs_committees.compact!
       cs_committees.try(:each) do |cs_committee|
-        faculty_committee = parse_cs_committee(cs_committee, is_committee_active(cs_committee))
+        faculty_committee = parse_cs_committee(cs_committee)
         if cs_committee.present?
           # Add additional pieces of data needed faculty committees
           cs_faculty_committee_svc = parse_cs_faculty_committee_svc(cs_committee)
@@ -37,14 +36,9 @@ module MyCommittees
             csMemberEndDate: cs_faculty_committee_svc[:memberEndDate],
             csMemberStartDate: cs_faculty_committee_svc[:memberStartDate]
           )
-          if is_committee_active cs_committee
-            committees_result[:active] << faculty_committee
-          else
-            committees_result[:completed] << faculty_committee
-          end
+          committees_result[:active] << faculty_committee
         end
       end
-      committees_result[:completed] = sort_committees_by_svc(committees_result[:completed])
       committees_result[:active] = sort_committees_by_svc(committees_result[:active])
       committees_result
     end
@@ -82,10 +76,5 @@ module MyCommittees
         format_date date
       end
     end
-
-    def is_committee_active(cs_committee)
-      cs_committee[:committeeStatus] === 'A'
-    end
-
   end
 end

--- a/app/models/my_committees/student_committees.rb
+++ b/app/models/my_committees/student_committees.rb
@@ -25,8 +25,7 @@ module MyCommittees
       cs_committees.compact!
       committees_result = []
       cs_committees.try(:each) do |cs_committee|
-        is_completed = cs_committee[:studentMilestoneCompleteDate].present?
-        committees_result << parse_cs_committee(cs_committee, is_completed)
+        committees_result << parse_cs_committee(cs_committee)
       end
       committees_result.compact
     end

--- a/spec/models/my_committees/faculty_committees_spec.rb
+++ b/spec/models/my_committees/faculty_committees_spec.rb
@@ -14,26 +14,25 @@ describe MyCommittees::FacultyCommittees do
         double(lookup_campus_solutions_id: user_cs_id))
     end
 
-    it 'sorts active and inactive committees into separate lists' do
-      expect(feed[:facultyCommittees][:active].count).to eq 1
-      expect(feed[:facultyCommittees][:completed].count).to eq 1
+    it 'dumps all committees into the "active" list' do
+      expect(feed[:facultyCommittees][:active].count).to eq 2
     end
     it 'contains the expected faculty data' do
       committees = feed[:facultyCommittees][:active]
-      expect(committees[0][:committeeType]).to eq 'Qualifying Exam Committee'
-      expect(committees[0][:program]).to eq 'Civil Environmental Eng MS'
-      expect(committees[0][:statusMessage]).to eq 'Pending'
-      expect(committees[0][:serviceRange]).to eq 'Aug 30, 2016 - Aug 30, 2017'
+      expect(committees[1][:committeeType]).to eq 'Qualifying Exam Committee'
+      expect(committees[1][:program]).to eq 'Civil Environmental Eng MS'
+      expect(committees[1][:statusMessage]).to eq 'Pending'
+      expect(committees[1][:serviceRange]).to eq 'Aug 30, 2016 - Aug 30, 2017'
     end
 
     it 'contains the expected faculty committee data' do
-      members = feed[:facultyCommittees][:active][0][:committeeMembers]
+      members = feed[:facultyCommittees][:active][1][:committeeMembers]
       expect(members[:additionalReps][0][:name]).to eq 'John Bear'
       expect(members[:additionalReps][1][:name]).to eq 'Bad Dog'
     end
 
     it 'replaces bogus dates with text' do
-      committees = feed[:facultyCommittees][:completed]
+      committees = feed[:facultyCommittees][:active]
       expect(committees[0][:serviceRange]).to eq 'Aug 30, 2016 - Present'
     end
   end

--- a/src/assets/javascripts/angular/controllers/widgets/academicsHigherDegreeCommitteesController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/academicsHigherDegreeCommitteesController.js
@@ -152,8 +152,7 @@ angular.module('calcentral.controllers').controller('AcademicsHigherDegreeCommit
       studentCommittees: studentCommittiees,
       facultyCommittees: {
         active: facultyActiveCommittiees,
-        completed: facultyCompletedCommittiees,
-        activeToggle: true
+        completed: facultyCompletedCommittiees
       }
     });
   };

--- a/src/assets/templates/widgets/higher_degree_faculty_committees.html
+++ b/src/assets/templates/widgets/higher_degree_faculty_committees.html
@@ -11,28 +11,15 @@
         </data-ng-pluralize>
       </h2>
     </div>
-    <div data-ng-switch="facultyCommittees.activeToggle">
-      <div data-ng-switch-when="true" >
-        <div class="cc-button-link cc-widget-padding cc-higher-degree-committee-toggle-link" data-ng-click="facultyCommittees.activeToggle = false">View Completed Committees
-        </div>
-        <div class="cc-widget-subtitle cc-higher-degree-committee-subtitle">Active Committees</div>
-        <div class="cc-widget-padding" data-ng-if="facultyCommittees.active.length == 0">You are not a member of any committee at this time.</div>
-      </div>
-      <div data-ng-switch-when="false">
-        <div class="cc-button-link cc-widget-padding cc-higher-degree-committee-toggle-link" data-ng-click="facultyCommittees.activeToggle = true">View Active Committees
-        </div>
-        <div class="cc-widget-subtitle cc-higher-degree-committee-subtitle">Completed Committees</div>
-        <div class="cc-widget-padding" data-ng-if="facultyCommittees.completed.length == 0">You have no completed committees.</div>
-      </div>
-    </div>
-    <div class="cc-widget-padding">
+    <div class="cc-widget-padding" data-ng-if="facultyCommittees.active.length == 0">You are not a member of any committee at this time.</div>
+    <div class="cc-widget-padding" data-ng-if="facultyCommittees.active.length > 0">
       <div class="cc-higher-degree-committees-section">
         <ul class="cc-higher-degree-committees-list">
-          <ng-repeat data-ng-repeat="committee in (facultyCommittees.activeToggle? facultyCommittees.active : facultyCommittees.completed) | limitTo: committeesLimit">
+          <ng-repeat data-ng-repeat="committee in facultyCommittees.active | limitTo: committeesLimit">
             <li class="cc-widget-list-hover " data-cc-accessible-focus-directive data-ng-class="{'cc-widget-list-hover-opened':(committee.show)}"
               data-ng-click="api.widget.toggleShow($event, null, committee, 'My Academics - Higher Degree Committee')">
               <div>
-                <div data-ng-if="facultyCommittees.activeToggle" class="cc-left cc-higher-degree-committees-picture">
+                <div class="cc-left cc-higher-degree-committees-picture">
                   <div>
                     <img data-cc-load-error-directive="committee" data-ng-if="committee.student.photo && !committee.loadError" data-ng-src="{{committee.student.photo}}"
                       data-ng-attr-alt="Photo of {{commitee.student.name}}">
@@ -42,15 +29,13 @@
                     </div>
                   </div>
                 </div>
-                <div data-ng-class="{true:'cc-higher-degree-committees-content', false:''}[facultyCommittees.activeToggle]">
+                <div data-ng-class="cc-higher-degree-committees-content">
                   <div><strong><span data-ng-bind="committee.student.name"></span></strong></div>
                   <div><strong class="cc-button-link"><span data-ng-bind="committee.student.email"></span></strong></div>
                   <div class="cc-text-light" data-ng-bind="committee.header.program"></div>
                   <div class="cc-text-light" data-ng-bind="committee.header.type"></div>
                   <div class="cc-higher-degree-committees-list-item">
-                    <span data-ng-if="facultyCommittees.activeToggle">
-                      <i data-ngclass="committees.header.statusIcon"></i>
-                    </span>
+                    <i data-ngclass="committees.header.statusIcon"></i>
                     <span class="cc-text-light">
                       <strong><span data-ng-bind="committee.header.statusTitle"></span></strong> <span data-ng-bind="committee.header.statusMessage"></span>
                     </span>
@@ -64,8 +49,7 @@
             </li>
           </ng-repeat>
         </ul>
-        <div data-cc-show-more-directive data-cc-show-more-list="(facultyCommittees.activeToggle? facultyCommittees.active: facultyCommittees.completed)"
-          data-cc-show-more-limit="committeesLimit">
+        <div data-cc-show-more-directive data-cc-show-more-list="facultyCommittees.active" data-cc-show-more-limit="committeesLimit">
         </div>
       </div>
     </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-30081

It came to light that the flag we were relying to distinguish an active committee from an inactive one is not being kept up-to-date in CS.  To avoid showing misleading info in 7.5, we are scrapping the "Active" and "Completed" committees lists and just showing them all in a single list.