### PR TITLE
SISRP-29961 - Ensure proper ordering of milestones - Reopened

### DIFF
--- a/app/models/berkeley/degree_progress_graduate.rb
+++ b/app/models/berkeley/degree_progress_graduate.rb
@@ -2,11 +2,15 @@ module Berkeley
   class DegreeProgressGraduate
 
     def self.get_status(status_code)
-      statuses[status_code.strip.upcase] unless status_code.blank?
+      statuses.try(:[], status_code.strip.upcase) unless status_code.blank?
     end
 
     def self.get_description(milestone_code)
-      milestones[milestone_code.strip.upcase] unless milestone_code.blank?
+      milestones.try(:[], milestone_code.strip.upcase).try(:[], :milestone) unless milestone_code.blank?
+    end
+
+    def self.get_order_number(milestone_code)
+      milestones.try(:[], milestone_code.strip.upcase).try(:[], :order) unless milestone_code.blank?
     end
 
     def self.get_merged_description
@@ -14,7 +18,7 @@ module Berkeley
     end
 
     def self.get_form_notification(milestone_code, status_code)
-      form_notifications[milestone_code.strip.upcase] unless (status_code === 'Y' || milestone_code.blank?)
+      form_notifications.try(:[], milestone_code.strip.upcase) unless (status_code === 'Y' || milestone_code.blank?)
     end
 
     def self.get_merged_form_notification
@@ -23,16 +27,42 @@ module Berkeley
 
     def self.milestones
       @milestones ||= {
-        'AAGADVMAS1' => 'Advancement to Candidacy Plan I',
-        'AAGADVMAS2' => 'Advancement to Candidacy Plan II',
-        'AAGFINALCK' => 'Department Final Recommendations',
-        'AAGACADP1' => 'Thesis File Date',
-        'AAGQEAPRV' => 'Approval for Qualifying Exam',
-        'AAGQERESLT' => 'Qualifying Exam Results',
-        'AAGADVPHD' => 'Advancement to Candidacy',
-        'AAGFINALCK' => 'Department Final Recommendations',
-        'AAGDISSERT' => 'Dissertation File Date',
-        'AAGACADP2' => 'Capstone'
+        'AAGADVMAS1' => {
+          :milestone => 'Advancement to Candidacy Plan I',
+          :order => 2
+        },
+        'AAGADVMAS2' => {
+          :milestone => 'Advancement to Candidacy Plan II',
+          :order => 3
+        },
+        'AAGFINALCK' => {
+          :milestone => 'Department Final Recommendations',
+          :order => 4
+        },
+        'AAGACADP1' => {
+          :milestone => 'Thesis File Date',
+          :order => 5
+        },
+        'AAGQEAPRV' => {
+          :milestone => 'Approval for Qualifying Exam',
+          :order => 1
+        },
+        'AAGQERESLT' => {
+          :milestone => 'Qualifying Exam Results',
+          :order => 2
+        },
+        'AAGADVPHD' => {
+          :milestone => 'Advancement to Candidacy',
+          :order => 3
+        },
+        'AAGDISSERT' => {
+          :milestone => 'Dissertation File Date',
+          :order => 5
+        },
+        'AAGACADP2' => {
+          :milestone => 'Capstone',
+          :order => 6
+        },
       }
     end
 

--- a/app/models/degree_progress/milestones_module.rb
+++ b/app/models/degree_progress/milestones_module.rb
@@ -42,6 +42,7 @@ module DegreeProgress
         if name
           requirement[:name] = name
           requirement[:status_descr] = Berkeley::DegreeProgressGraduate.get_status(requirement[:status])
+          requirement[:order_number] = Berkeley::DegreeProgressGraduate.get_order_number(requirement[:code])
           requirement[:date_formatted] = format_date(strptime_in_time_zone(requirement[:date], '%F'), '%m/%d/%Y') unless requirement[:date].blank?
           requirement[:form_notification] = Berkeley::DegreeProgressGraduate.get_form_notification(requirement[:code], requirement[:status])
           requirement

--- a/src/assets/templates/widgets/academics/degree_progress_graduate.html
+++ b/src/assets/templates/widgets/academics/degree_progress_graduate.html
@@ -22,7 +22,7 @@
     <ul>
       <li data-ng-repeat="plan in degreeProgress.graduate.progresses">
         <h3 data-ng-bind="plan.acadPlan ? plan.acadPlan + ' &mdash; Graduate Division Milestones' : 'Graduate Division Milestones'"></h3>
-        <div data-ng-repeat="requirement in plan.requirements | orderBy:'parseInt(number)'">
+        <div data-ng-repeat="requirement in plan.requirements | orderBy:'orderNumber'">
           <div class="cc-left cc-degree-progress-graduate-checkmark">
             <i class="fa fa-check cc-icon-green" data-ng-if="requirement.status === 'Y' || requirement.status === 'P'"></i>&nbsp;
           </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-29961

* Peppered in some `#try`'s in some unrelated methods just in case.
* The `order_number` definition is kind of weird because both Master and PhD tracks share a milestone, "Department Final Recommendations."  I was limited to assigning this milestone only one order number, despite it showing up in different places in each respective track.  I staggered the Masters track to start at 2 to make up for this.
* QA PR to come.