### PR TITLE
SISRP-30252 - 'Request Official Verification' - Google form link showing in addition to CS link

### DIFF
--- a/src/assets/javascripts/angular/controllers/pages/enrollmentVerificationController.js
+++ b/src/assets/javascripts/angular/controllers/pages/enrollmentVerificationController.js
@@ -10,9 +10,6 @@ angular.module('calcentral.controllers').controller('EnrollmentVerificationContr
   linkService.addCurrentRouteSettings($scope);
   apiService.util.setTitle($scope.currentPage.name);
 
-  $scope.enrollmentCsDeeplink = {
-    title: 'Request Other Verifications'
-  };
   $scope.enrollmentGoogleLink = {
     url: 'http://goo.gl/forms/xcYYehIBFDbDE92y1',
     title: 'Request Other Verifications'

--- a/src/assets/templates/widgets/academics/enrollment_verification.html
+++ b/src/assets/templates/widgets/academics/enrollment_verification.html
@@ -40,15 +40,16 @@
           </div>
           <div class="cc-enrollment-verification-link">
             <div data-ng-if="api.user.profile.isDirectlyAuthenticated">
-              <div data-ng-if="!api.user.profile.features.enrollmentVerificationDeeplink">
-                <strong><a data-ng-href="{{enrollmentGoogleLink.url}}" data-ng-attr-title="{{enrollmentGoogleLink.title}}">Request Official Verification</a></strong>
-              </div>
+              <strong data-ng-if="!requestOfficialVerificationLink.url">
+                <a data-ng-href="{{enrollmentGoogleLink.url}}" data-ng-attr-title="{{enrollmentGoogleLink.title}}">Request Official Verification</a>
+              </strong>
               <strong data-ng-if="requestOfficialVerificationLink.url">
                 <a data-cc-campus-solutions-link-directive="requestOfficialVerificationLink"
                   data-cc-campus-solutions-link-directive-cc-page-name="currentPage.name"
                   data-cc-campus-solutions-link-directive-cc-page-url="currentPage.url"
                 ></a>
               </strong>
+
             </div>
             <div data-ng-if="!api.user.profile.isDirectlyAuthenticated">
               <p class="cc-enrollment-verification-link-disabled">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-30252

In [SISRP-29535](https://jira.berkeley.edu/browse/SISRP-29535) a CS link that was configured in the application YAML was migrated to the CS Link API, and the `enrollment_verification_deeplink` feature flag was removed. A static link (Google form) was left in as a fallback, displayed when the previously configured link was not present, resulting in two links shown.

This update retains the original logic, however clarification is still being requested from the SR team (and may result in a follow up PR).

* Updates logic for fallback to static Google link for Enrollment Verification.
* Removes unused scope settings.