### PR TITLE
SISRP-30297 - Midpoint Status column is missing when the Grading card has Law and Non Law classes

### DIFF
--- a/src/assets/javascripts/angular/services/academicsService.js
+++ b/src/assets/javascripts/angular/services/academicsService.js
@@ -294,8 +294,8 @@ angular.module('calcentral.services').service('academicsService', function() {
   var containsMidpointClass = function(selectedTeachingSemester) {
     var classes = _.get(selectedTeachingSemester, 'classes');
     if (classes && classes.length) {
-      return _.every(classes, function(klass) {
-        if (_.get(klass, 'dept') !== 'LAW') {
+      return !_.every(classes, function(klass) {
+        if (_.get(klass, 'dept') === 'LAW') {
           return true;
         } else {
           return false;


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-30297

* QA PR to come.
* This bug surfaced due to my initial misunderstanding of Lodash's `_.every`, which returns `true` only if all iterations return `true`.   