### PR TITLE
CLC-6571 Add Torquebox links to ETS service jobs; increase concurrency

### DIFF
--- a/app/controllers/canvas_course_grade_export_controller.rb
+++ b/app/controllers/canvas_course_grade_export_controller.rb
@@ -18,8 +18,7 @@ class CanvasCourseGradeExportController < ApplicationController
 
   # POST /api/academics/canvas/egrade_export/prepare/:canvas_course_id.json
   def prepare_grades_cache
-    egrades.background_job_initialize
-    egrades.background.canvas_course_student_grades(true)
+    egrades.bg_canvas_course_student_grades(true)
     render json: { jobRequestStatus: 'Success', jobId: egrades.background_job_id }.to_json
   end
 

--- a/app/controllers/torquebox_controller.rb
+++ b/app/controllers/torquebox_controller.rb
@@ -34,15 +34,15 @@ class TorqueboxController < ApplicationController
   end
 
   def test_no_wait
-    times = params['times'] || 5
-    pauses = params['pauses'] || 5
+    times = params['times'].present? ? params['times'].to_i : 5
+    pauses = params['pauses'].present? ? params['pauses'].to_i : 5
     result = TorqueboxTester.new.start_background_and_return(times, pauses)
     render json: {result: result.to_s}.to_json
   end
 
   def test_wait
-    times = params['times'] || 5
-    pauses = params['pauses'] || 5
+    times = params['times'].present? ? params['times'].to_i : 5
+    pauses = params['pauses'].present? ? params['pauses'].to_i : 5
     result = TorqueboxTester.new.start_background_and_wait(times, pauses)
     render json: {result: result.to_s}.to_json
   end

--- a/app/models/canvas_csv/provide_course_site.rb
+++ b/app/models/canvas_csv/provide_course_site.rb
@@ -19,7 +19,7 @@ module CanvasCsv
     end
 
     def create_course_site(site_name, site_course_code, term_slug, ccns, is_admin_by_ccns = false)
-      logger.info "Course provisioning job started. Job state updated in cache key #{background_job_id}"
+      logger.warn "Course provisioning job started. Job state updated in cache key #{background_job_id}"
       @import_data['site_name'] = site_name
       @import_data['site_course_code'] = site_course_code
       @import_data['term_slug'] = term_slug
@@ -64,9 +64,9 @@ module CanvasCsv
     end
 
     def edit_sections(canvas_course_info, ccns_to_remove, ccns_to_add)
+      logger.warn "Edit course site sections job started. Job state updated in cache key #{background_job_id}"
       canvas_course_id = canvas_course_info[:canvasCourseId]
       @import_data['sis_course_id'] = canvas_course_info[:sisCourseId]
-      logger.info "Edit course site sections job started. Job state updated in cache key #{background_job_id}"
       @import_data['term'] = find_term(yr: canvas_course_info[:term][:term_yr], cd: canvas_course_info[:term][:term_cd])
       raise RuntimeError, "Course site #{canvas_course_id} does not match a current term" if @import_data['term'].nil?
       @import_data['term_slug'] = @import_data['term'][:slug]
@@ -229,6 +229,7 @@ module CanvasCsv
     end
 
     def import_enrollments(sis_course_id, canvas_section_rows, into_canvas_course_id)
+      logger.warn "Enrollments import job started. Job state updated in cache key #{background_job_id}"
       added_sections = canvas_section_rows.select {|row| row['status'] == 'active'}
       CanvasCsv::SiteMembershipsMaintainer.import_memberships(sis_course_id,
         added_sections.collect {|row| row['section_id']}, "#{csv_filename_prefix}-enrollments.csv",

--- a/app/models/canvas_csv/provide_course_site.rb
+++ b/app/models/canvas_csv/provide_course_site.rb
@@ -11,12 +11,14 @@ module CanvasCsv
       @uid = uid
       @import_data = {}
       @section_definitions = []
-      background_job_initialize
+    end
+
+    def bg_create_course_site(site_name, site_course_code, term_slug, ccns, is_admin_by_ccns = false)
+      background_job_initialize(job_type: 'course_creation', total_steps: 10)
+      background_correlate(background.create_course_site(site_name, site_course_code, term_slug, ccns, is_admin_by_ccns))
     end
 
     def create_course_site(site_name, site_course_code, term_slug, ccns, is_admin_by_ccns = false)
-      background_job_set_type 'course_creation'
-      background_job_set_total_steps 10
       logger.info "Course provisioning job started. Job state updated in cache key #{background_job_id}"
       @import_data['site_name'] = site_name
       @import_data['site_course_code'] = site_course_code
@@ -53,13 +55,17 @@ module CanvasCsv
       raise error
     end
 
+    def bg_edit_sections(canvas_course_info, ccns_to_remove, ccns_to_add)
+      total_steps = 3 # Section CSV import, clearing course site cache
+      total_steps += 2 if ccns_to_add.present?
+      total_steps += 1 if ccns_to_remove.present?
+      background_job_initialize(job_type: 'edit_sections', total_steps: total_steps)
+      background_correlate(background.edit_sections(canvas_course_info, ccns_to_remove, ccns_to_add))
+    end
+
     def edit_sections(canvas_course_info, ccns_to_remove, ccns_to_add)
       canvas_course_id = canvas_course_info[:canvasCourseId]
       @import_data['sis_course_id'] = canvas_course_info[:sisCourseId]
-      background_job_set_total_steps(3) # Section CSV import, clearing course site cache
-      @background_job_total_steps += 2.0 if ccns_to_add.present?
-      @background_job_total_steps += 1.0 if ccns_to_remove.present?
-      background_job_set_type('edit_sections')
       logger.info "Edit course site sections job started. Job state updated in cache key #{background_job_id}"
       @import_data['term'] = find_term(yr: canvas_course_info[:term][:term_yr], cd: canvas_course_info[:term][:term_cd])
       raise RuntimeError, "Course site #{canvas_course_id} does not match a current term" if @import_data['term'].nil?
@@ -77,7 +83,7 @@ module CanvasCsv
       # Add section enrollments.
       refresh_sections_cache(canvas_course_id)
 
-      # Start a background job to add students and instructors to the new sections in the site.
+      # Start a background job from a new instance to add students and instructors to the new sections in the site.
       import_enrollments_in_background(@import_data['sis_course_id'], section_definitions, canvas_course_id)
     rescue StandardError => error
       logger.error("ERROR: #{error.message}; Completed steps: #{@background_job_completed_steps.inspect}; Import Data: #{@import_data.inspect}; UID: #{@uid}")
@@ -213,12 +219,22 @@ module CanvasCsv
     end
 
     def import_enrollments_in_background(sis_course_id, canvas_section_rows, into_canvas_course_id = nil)
+      CanvasCsv::ProvideCourseSite.new(@uid).bg_import_enrollments(sis_course_id, canvas_section_rows, into_canvas_course_id)
+      background_job_complete_step 'Started enrollments import in background'
+    end
+
+    def bg_import_enrollments(sis_course_id, canvas_section_rows, into_canvas_course_id)
+      background_job_initialize(job_type: 'import_enrollments', total_steps: 1)
+      background_correlate(background.import_enrollments(sis_course_id, canvas_section_rows, into_canvas_course_id))
+    end
+
+    def import_enrollments(sis_course_id, canvas_section_rows, into_canvas_course_id)
       added_sections = canvas_section_rows.select {|row| row['status'] == 'active'}
-      CanvasCsv::SiteMembershipsMaintainer.background.import_memberships(sis_course_id,
+      CanvasCsv::SiteMembershipsMaintainer.import_memberships(sis_course_id,
         added_sections.collect {|row| row['section_id']}, "#{csv_filename_prefix}-enrollments.csv",
         into_canvas_course_id
       )
-      background_job_complete_step 'Started enrollments import in background'
+      background_job_complete_step 'Finished enrollments import'
     end
 
     def csv_filename_prefix

--- a/app/models/canvas_csv/site_memberships_maintainer.rb
+++ b/app/models/canvas_csv/site_memberships_maintainer.rb
@@ -1,6 +1,5 @@
 module CanvasCsv
   class SiteMembershipsMaintainer < Base
-    include TorqueBox::Messaging::Backgroundable
 
     # Roles indicated by Canvas Enrollments API
     ENROLL_STATUS_TO_CANVAS_API_ROLE = {
@@ -23,7 +22,7 @@ module CanvasCsv
       worker.refresh_sections_in_course
     end
 
-    # Self-contained method suitable for running as a background job.
+    # Self-contained method suitable for running in a background job.
     def self.import_memberships(sis_course_id, sis_section_ids, enrollments_csv_filename, into_canvas_course_id = nil)
       enrollments_rows = []
       users_rows = []

--- a/app/models/canvas_lti/course_provision.rb
+++ b/app/models/canvas_lti/course_provision.rb
@@ -57,8 +57,7 @@ module CanvasLti
 
     def create_course_site(site_name, site_course_code, term_slug, ccns)
       cpcs = CanvasCsv::ProvideCourseSite.new(working_uid)
-      cpcs.background_job_save
-      cpcs.background.create_course_site(site_name, site_course_code, term_slug, ccns, @admin_by_ccns.present?)
+      cpcs.bg_create_course_site(site_name, site_course_code, term_slug, ccns, @admin_by_ccns.present?)
       self.class.expire instance_key unless @admin_by_ccns
       cpcs.background_job_id
     end
@@ -66,8 +65,7 @@ module CanvasLti
     def edit_sections(ccns_to_remove, ccns_to_add)
       raise RuntimeError, 'canvas_course_id option not present' if @canvas_course_id.blank?
       cpcs = CanvasCsv::ProvideCourseSite.new(working_uid)
-      cpcs.background_job_save
-      cpcs.background.edit_sections(get_course_info, ccns_to_remove, ccns_to_add)
+      cpcs.bg_edit_sections(get_course_info, ccns_to_remove, ccns_to_add)
       self.class.expire instance_key unless @admin_by_ccns
       cpcs.background_job_id
     end

--- a/app/models/canvas_lti/egrades.rb
+++ b/app/models/canvas_lti/egrades.rb
@@ -58,7 +58,13 @@ module CanvasLti
       end
     end
 
+    def bg_canvas_course_student_grades(force = false)
+      background_job_initialize
+      background_correlate(background.canvas_course_student_grades(force))
+    end
+
     def canvas_course_student_grades(force = false)
+      logger.warn "Course student grades job started. Job state updated in cache key #{background_job_id}"
       self.class.fetch_from_cache("course-students-#{@canvas_course_id}", force) do
         proxy = Canvas::CourseUsers.new(course_id: @canvas_course_id, paging_callback: self)
         course_users = proxy.course_users(cache: false)[:body] || []

--- a/app/models/oec/api_task_wrapper.rb
+++ b/app/models/oec/api_task_wrapper.rb
@@ -1,6 +1,7 @@
 module Oec
   class ApiTaskWrapper
     include TorqueBox::Messaging::Backgroundable
+    include ClassLogger
 
     TASK_LIST = [
       {
@@ -75,7 +76,13 @@ module Oec
 
     def start_in_background
       task_id = self.class.generate_task_id
-      self.background.run task_id
+      # Ensure that a Task Status entry will be found in the cache even before the queued
+      # background job starts.
+      @task_class.write_cache(
+        {status: 'In progress', log: []},
+        task_id
+      )
+      background_correlate(self.background(future_ttl: 5000).run(task_id), task_id)
       {
         id: task_id,
         status: 'In progress'
@@ -83,6 +90,12 @@ module Oec
     end
 
     private
+
+    def background_correlate(backgroundable_future, task_id)
+      torquebox_correlation_id = backgroundable_future.correlation_id
+      logger.warn "#{@task_class.name} task_id = #{task_id}, Torquebox correlation_id = #{torquebox_correlation_id}"
+      backgroundable_future
+    end
 
     def translate_params(params)
       term_code = Berkeley::TermCodes.from_english params['term']

--- a/app/models/oec/task.rb
+++ b/app/models/oec/task.rb
@@ -62,6 +62,7 @@ module Oec
     end
 
     def run
+      logger.warn "OEC job started. Job state updated in cache key #{@api_task_id}"
       return if @status == 'Error'
       begin
         log :info, "Starting #{self.class.name}"

--- a/config/torquebox.rb
+++ b/config/torquebox.rb
@@ -6,8 +6,8 @@ TorqueBox.configure do
 
   # By default, Backgroundable tasks are durable (queued tasks will persist between
   # server restarts) and processing has a concurrency of 1 (single-threaded).
-  # The next line would make them double-threadable and discardable at shutdown:
-  # options_for Backgroundable, :concurrency => 2, :durable => false
+  # Increasing concurrency keeps a single slow job from blocking on all other apps.
+  options_for Backgroundable, :concurrency => 3
 
   # process incoming JMS messages from activeMQ
   # CALCENTRAL-ONLY

--- a/lib/background_job.rb
+++ b/lib/background_job.rb
@@ -101,6 +101,7 @@ module BackgroundJob
 
   def background_correlate(backgroundable_future)
     torquebox_correlation_id = backgroundable_future.correlation_id
+    logger.warn "background_job_id = #{@background_job_id}, Torquebox correlation_id = #{torquebox_correlation_id}"
     Rails.cache.write(correlation_cache_key, torquebox_correlation_id, expires_in: Settings.cache.expiration.CanvasBackgroundJobs)
     backgroundable_future
   end

--- a/lib/torquebox_tester.rb
+++ b/lib/torquebox_tester.rb
@@ -10,7 +10,7 @@ class TorqueboxTester
   # Start a time-consuming background task and wait for it to complete,
   # reporting its progress.
   def start_background_and_wait(times, pauses)
-    logger.warn "#{@background_job_id} About to start twiddling and will not return until done"
+    logger.warn "#{@background_job_id} About to start twiddling #{times} times with #{pauses}-second waits and will not return until done"
     background_job_set_total_steps times
     tracker = background_correlate(background.twiddle_thumbs(@background_job_id, times, pauses))
     logger.warn "#{@background_job_id} wait tracker = #{tracker}, correlation_id = #{tracker.correlation_id}"
@@ -29,7 +29,7 @@ class TorqueboxTester
 
   # Start a time-consuming background job and return immediately.
   def start_background_and_return(times, pauses)
-    logger.warn "#{@background_job_id} About to start twiddling and will return immediately afterward"
+    logger.warn "#{@background_job_id} About to start twiddling #{times} times with #{pauses}-second waits and will return immediately afterward"
     background_job_set_total_steps times
     tracker = background_correlate(background.twiddle_thumbs(@background_job_id, times, pauses))
     logger.warn "#{@background_job_id} twiddle tracker = #{tracker}, correlation_id = #{tracker.correlation_id}, started = #{tracker.started?}, error = #{tracker.error?}, complete = #{tracker.complete?}, status = #{tracker.status}"

--- a/spec/controllers/canvas_course_grade_export_controller_spec.rb
+++ b/spec/controllers/canvas_course_grade_export_controller_spec.rb
@@ -42,6 +42,7 @@ describe CanvasCourseGradeExportController do
     it 'makes call to load canvas course student grades with forced cacheing' do
       expect(torquebox_fake_background_proxy).to receive(:canvas_course_student_grades).with(true).and_return(nil)
       allow_any_instance_of(CanvasLti::Egrades).to receive(:background).and_return(torquebox_fake_background_proxy)
+      allow_any_instance_of(CanvasLti::Egrades).to receive(:background_correlate).and_return(true)
       post :prepare_grades_cache, :canvas_course_id => canvas_course_id, :format => :csv
       expect(response.status).to eq(200)
       json_response = JSON.parse(response.body)
@@ -51,6 +52,7 @@ describe CanvasCourseGradeExportController do
 
     it 'returns background job id' do
       allow_any_instance_of(CanvasLti::Egrades).to receive(:background).and_return(torquebox_fake_background_proxy)
+      allow_any_instance_of(CanvasLti::Egrades).to receive(:background_correlate).and_return(true)
       post :prepare_grades_cache, :canvas_course_id => canvas_course_id, :format => :csv
       expect(response.status).to eq(200)
       json_response = JSON.parse(response.body)

--- a/spec/controllers/canvas_course_provision_controller_spec.rb
+++ b/spec/controllers/canvas_course_provision_controller_spec.rb
@@ -180,6 +180,7 @@ describe CanvasCourseProvisionController do
 
     it 'returns status of canvas course provisioning job' do
       cpcs = CanvasCsv::ProvideCourseSite.new '1234'
+      cpcs.background_job_initialize(job_type: 'course_creation', total_steps: 10)
       cpcs.instance_eval { @background_job_status = 'processing'; @background_job_completed_steps = ['Prepared courses list', 'Identified department sub-account'] }
       cpcs.background_job_save
 

--- a/spec/models/canvas_lti/course_provision_spec.rb
+++ b/spec/models/canvas_lti/course_provision_spec.rb
@@ -202,9 +202,7 @@ describe CanvasLti::CourseProvision do
     subject     { CanvasLti::CourseProvision.new(instructor_id) }
     let(:cpcs)  { instance_double CanvasCsv::ProvideCourseSite }
     before do
-      allow(cpcs).to receive(:background).and_return(cpcs)
-      allow(cpcs).to receive(:background_job_save).and_return(true)
-      allow(cpcs).to receive(:create_course_site).and_return(true)
+      allow(cpcs).to receive(:bg_create_course_site).and_return(true)
       allow(cpcs).to receive(:background_job_id).and_return('canvas.courseprovision.1234.1383330151057')
       allow(CanvasCsv::ProvideCourseSite).to receive(:new).and_return(cpcs)
     end
@@ -215,8 +213,7 @@ describe CanvasLti::CourseProvision do
     end
 
     it 'saves state of job before sending to bg job queue' do
-      expect(cpcs).to receive(:background_job_save).ordered.and_return(true)
-      expect(cpcs).to receive(:background).ordered.and_return(cpcs)
+      expect(cpcs).to receive(:bg_create_course_site).ordered.and_return(true)
       expect(cpcs).to receive(:background_job_id).ordered.and_return('canvas.courseprovision.1234.1383330151057')
       subject.create_course_site('Intro to Biomedicine', 'BIOENG 101 LEC', 'fall-2013', ['1136', '1204'])
     end
@@ -233,9 +230,7 @@ describe CanvasLti::CourseProvision do
       before do
         expect(subject).to receive(:get_course_info).and_return(course_info)
         expect(CanvasCsv::ProvideCourseSite).to receive(:new).and_return(cpcs)
-        expect(cpcs).to receive(:background_job_save).ordered
-        expect(cpcs).to receive(:background).ordered.and_return(cpcs)
-        expect(cpcs).to receive(:edit_sections).ordered
+        expect(cpcs).to receive(:bg_edit_sections).ordered
         expect(cpcs).to receive(:background_job_id).ordered.and_return(background_job_id)
       end
       it 'saves the state of the job' do

--- a/spec/models/oec/api_task_wrapper_spec.rb
+++ b/spec/models/oec/api_task_wrapper_spec.rb
@@ -31,6 +31,7 @@ describe Oec::ApiTaskWrapper do
     before do
       allow(Oec::RemoteDrive).to receive(:new).and_return double
       allow(wrapper).to receive(:background).and_return wrapper
+      allow(wrapper).to receive(:background_correlate).and_return(true)
       allow_any_instance_of(Oec::TermSetupTask).to receive(:run)
     end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6571

The changes mostly aim to help diagnose problems by linking Torquebox background job Correlation IDs to Junction task status IDs, but two bugs are fixed as well:

* Stop throwing 400 errors when an OEC task starts (as noted in CLC-6570).
* Do not let a single unusually long-running task block tools like bCourses Course Site creation.