### PR TITLE
SISRP-29777 - Show Degree Progress card to GRAD/LAW students with no milestones

### DIFF
--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -261,7 +261,7 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
         $scope.degreeProgress.undergraduate.errored = _.get(data, 'errored');
       }).finally(function() {
         $scope.degreeProgress.undergraduate.showCard = apiService.user.profile.features.csDegreeProgressUgrdAdvising && $scope.degreeProgress.undergraduate.progresses.length;
-        $scope.degreeProgress.graduate.showCard = apiService.user.profile.features.csDegreeProgressGradAdvising && $scope.degreeProgress.graduate.progresses.length;
+        $scope.degreeProgress.graduate.showCard = apiService.user.profile.features.csDegreeProgressGradAdvising && ($scope.degreeProgress.graduate.progresses.length || $scope.targetUser.roles.graduate || $scope.targetUser.roles.law);
         $scope.degreeProgress.isLoading = false;
       });
     });


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-29777

Fixes the logic around displaying the Graduate Degree Progress card due to these funny cases:

- Student may have UGRD and GRAD degree progress, and need to see both cards
- GRAD and LAW students with milestones need to see the card
- GRAD and LAW students with no milestones need to see the card with a message
- Ex-students should see the card as long as they still have milestones

QA PR forthcoming