### PR TITLE
SISRP-30364 - Hides link on Committees card until the e-form is ready

### DIFF
--- a/app/models/my_committees/student_committees.rb
+++ b/app/models/my_committees/student_committees.rb
@@ -9,9 +9,10 @@ module MyCommittees
     end
 
     def get_feed
+      #TODO: un-comment the 'request change' link (see SISRP-30410)
       result = {
         studentCommittees: [],
-        committeeRequestChangeLink: fetch_link('UC_CX_GT_AAQEAPPLIC_ADD')
+        #committeeRequestChangeLink: fetch_link('UC_CX_GT_AAQEAPPLIC_ADD')
       }
       feed = CampusSolutions::StudentCommittees.new(user_id: @uid).get[:feed]
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-30364

Prevents the link URL from being handed to the front end, but leaves the code/markup to handle it in place since we expect to be able to surface this link in the next release.