### PR TITLE
CLC-6579, proper ID of tab on Add People

### DIFF
--- a/public/canvas/canvas-customization.js
+++ b/public/canvas/canvas-customization.js
@@ -429,7 +429,7 @@
       // First, give active tab an icon linked to ETS help page
       var modifiedMarker = 'calcentral-modified';
 
-      waitUntilAvailable('#ui-id-1:visible:not(.' + modifiedMarker + ')', true, function($activeTab) {
+      waitUntilAvailable('#group_categories_tabs ul li a:first:not(.' + modifiedMarker + ')', true, function($activeTab) {
         $activeTab.after([
           '<a href="http://ets.berkeley.edu/bcourses/faq/adding-people" id="add-people-help" target="_blank">',
           '  <i class="icon-question" aria-hidden="true"></i>',


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6579

In case you're interested, verify the ID on both UIs:
* old: https://ucberkeley.test.instructure.com/courses/1452646/users
* new: https://ucberkeley.beta.instructure.com/courses/1460916/users

Steps per URL above:
1. open console
1. find DOM element with `$('#group_categories_tabs ul li a:first')`
1. verify that anchor tag on "Everyone" (tab) is selected
 
I'll put steps above to the Jira, too.