### PR TITLE
SISRP-30527 - Filters inactive committee members from the student committees card

### DIFF
--- a/app/models/my_committees/student_committees.rb
+++ b/app/models/my_committees/student_committees.rb
@@ -25,9 +25,26 @@ module MyCommittees
       cs_committees.compact!
       committees_result = []
       cs_committees.try(:each) do |cs_committee|
+        remove_inactive_members(cs_committee)
         committees_result << parse_cs_committee(cs_committee)
       end
       committees_result.compact
+    end
+
+    def remove_inactive_members(cs_committee)
+      cs_committee[:committeeMembers].try(:reject!) do |member|
+        inactive?(member)
+      end
+    end
+
+    def inactive?(committee_member)
+      inactive = false;
+      begin
+        inactive = Time.zone.parse(committee_member[:memberEndDate].to_s).to_datetime.try(:past?)
+      rescue
+        logger.error "Bad Format for committee member end date; Class #{self.class.name} feed, uid = #{@uid}"
+      end
+      inactive
     end
 
   end

--- a/spec/models/my_committees/student_committees_spec.rb
+++ b/spec/models/my_committees/student_committees_spec.rb
@@ -46,6 +46,11 @@ describe MyCommittees::StudentCommittees do
       expect(committees[3][:statusMessage]).to eq 'Jan 01, 2024'
     end
 
+    it 'filters out committee members with end date in the past' do
+      members = feed[:studentCommittees][0][:committeeMembers]
+      expect(members[:chair].count).to eq 2
+    end
+
     it 'contains the expected student committee data for chairs' do
       members = feed[:studentCommittees][0][:committeeMembers]
       expect(members[:chair][0][:name]).to eq 'MEMBERFIRSTNAME1 MEMBERLASTNAME1'
@@ -84,6 +89,36 @@ describe MyCommittees::StudentCommittees do
       expect(members[:academicSenate][0][:name]).to eq 'MEMBERFIRSTNAME7 MEMBERLASTNAME7'
       expect(members[:academicSenate][0][:email]).to eq 'MEMBER@EMAIL.7'
       expect(members[:academicSenate][0][:primaryDepartment]).to eq 'MEMBERDEPTDESCR7'
+    end
+  end
+
+  describe '#inactive?' do
+    let(:committee_member) do
+      {
+        :memberEndDate => end_date
+      }
+    end
+    let(:result) { described_class.new(uid).inactive?(committee_member) }
+
+    context 'valid future date' do
+      let(:end_date) { '2999-01-01' }
+      it 'parses date and flags member as active' do
+        expect(result).to be false
+      end
+    end
+
+    context 'valid past date' do
+      let(:end_date) { '1999-01-01' }
+      it 'parses date and flags member as inactive' do
+        expect(result).to be true
+      end
+    end
+
+    context 'invalid date' do
+      let(:end_date) { 'bogus' }
+      it 'fails the date parsing but assumes member is active' do
+        expect(result).to be false
+      end
     end
   end
 end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-30527

Committee members who have been "reconned" (ended their term on the committee) will have a service end date in the past.  Faculty should see inactive members on the Committees card, but students should not.