### PR TITLE
CLC-6586 OEC: Remove one-year-ago cutoff for old instructor data

### DIFF
--- a/app/models/oec/merged_sheet_validation.rb
+++ b/app/models/oec/merged_sheet_validation.rb
@@ -23,19 +23,16 @@ module Oec
         course_supervisors = Oec::CourseSupervisors.new
       end
 
-      # Carry over course-instructor associations from the previous year, and note instructor UIDs to fill
+      # Carry over course-instructor associations from previous years, and note instructor UIDs to fill
       # any gaps in the this term's instructor data.
       previous_instructor_uids = Set.new
       if (previous_term_folder = find_previous_term_folder) && (previous_term_last_export = find_last_export previous_term_folder)
         previous_course_instructors = worksheet_from_folder(previous_term_last_export, Oec::CourseInstructors)
         previous_instructors = worksheet_from_folder(previous_term_last_export, Oec::Instructors)
         if previous_course_instructors && previous_instructors
-          cutoff_term = term_one_year_ago
           previous_course_instructors.each do |row|
-            if row['COURSE_ID'][0..5] > cutoff_term
-              validate_and_add(course_instructors, row, %w(LDAP_UID COURSE_ID))
-              previous_instructor_uids << row['LDAP_UID']
-            end
+            validate_and_add(course_instructors, row, %w(LDAP_UID COURSE_ID))
+            previous_instructor_uids << row['LDAP_UID']
           end
         end
       end
@@ -168,12 +165,6 @@ module Oec
         log_validation_errors
         nil
       end
-    end
-
-    def term_one_year_ago
-      # If this task's term is 2016-D, then 2015-D
-      term_yr = @term_code.to_i
-      @term_code.sub(term_yr.to_s, (term_yr - 1).to_s)
     end
 
     def validate_integrity(key, *worksheets)

--- a/spec/models/oec/publish_task_spec.rb
+++ b/spec/models/oec/publish_task_spec.rb
@@ -142,9 +142,9 @@ describe Oec::PublishTask do
         expect(instructors.find { |i| i['LDAP_UID'] == '77777'}).to be_present
       end
 
-      it 'should not include course-instructor pairings a year old or more' do
-        expect(course_instructors.find { |ci| ci['COURSE_ID'] == '2014-B-11111' && ci['LDAP_UID'] == '55555'}).not_to be_present
-        expect(instructors.find { |i| i['LDAP_UID'] == '55555'}).not_to be_present
+      it 'should also include course-instructor pairings from the distant past' do
+        expect(course_instructors.find { |ci| ci['COURSE_ID'] == '2014-B-11111' && ci['LDAP_UID'] == '55555'}).to be_present
+        expect(instructors.find { |i| i['LDAP_UID'] == '55555'}).to be_present
       end
 
       it 'should merge instructor data from previous terms when current-term data absent' do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6586

From this day forward, we wish to preserve instructor data for all time.