### PR TITLE
CLC-6588 OEC: Highlight salient differences in diff report

### DIFF
--- a/app/models/oec/diff_report.rb
+++ b/app/models/oec/diff_report.rb
@@ -3,7 +3,7 @@ module Oec
 
     def headers
       %w(
-        +/-
+        REASON
         DEPT_CODE
         KEY
         LDAP_UID


### PR DESCRIPTION
Per requirements in https://jira.ets.berkeley.edu/jira/browse/CLC-6588:
- The symbolic '+/-' column is replaced with a more verbose 'REASON' column.
- Rows with multiple discrepancies will appear multiple times in the diff, each time with a different value in the 'REASON' column.
- Values without discrepancies are omitted from the report, apart from 'COURSE_NAME', which enables identification.