### PR TITLE
SISRP-28700 - Adds expiry handler for undergrad Degree Progress

### DIFF
--- a/app/models/campus_solutions/degree_progress/undergrad_requirements_expiry.rb
+++ b/app/models/campus_solutions/degree_progress/undergrad_requirements_expiry.rb
@@ -1,0 +1,13 @@
+module CampusSolutions
+  module DegreeProgress
+    module UndergradRequirementsExpiry
+      def self.expire(uids=[])
+        uids.each do |uid|
+          [::DegreeProgress::UndergradRequirements].each do |klass|
+            klass.expire uid
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/notifications/sis_expiry_single_student_provider.rb
+++ b/app/models/notifications/sis_expiry_single_student_provider.rb
@@ -1,0 +1,18 @@
+module Notifications
+  class SisExpirySingleStudentProvider
+    include ClassLogger
+
+    # This class is deprecated.  Eventually all event message payloads will be restructured to return a list of IDs, and
+    # SisExpiryStudentProvider will be phased out in favor of SisExpiryStudentsProvider.
+
+    def get_uids(event)
+      if (campus_solutions_id = event.try(:[], 'payload').try(:[], 'student').try(:[], 'StudentId'))
+        uid = CalnetCrosswalk::ByCsId.new(user_id: campus_solutions_id).lookup_ldap_uid
+        logger.error "No UID found for Campus Solutions ID #{campus_solutions_id}" unless uid
+      else
+        logger.error "Could not parse Campus Solutions ID from event #{event}"
+      end
+      uid
+    end
+  end
+end

--- a/app/models/notifications/sis_expiry_students_provider.rb
+++ b/app/models/notifications/sis_expiry_students_provider.rb
@@ -1,0 +1,21 @@
+module Notifications
+  class SisExpiryStudentsProvider
+    include ClassLogger
+
+    def get_uids(event)
+      if event && ids = event.try(:[], 'payload').try(:[], 'students')
+        uids = []
+        ids.each do |student_id|
+          if (uid = CalnetCrosswalk::ByCsId.new(user_id: student_id).lookup_ldap_uid)
+            uids << uid
+          else
+            logger.error "No UID found for Campus Solutions ID #{student_id}"
+          end
+        end
+        uids
+      else
+        logger.error "Could not parse Campus Solutions ID from event #{event}"
+      end
+    end
+  end
+end

--- a/spec/models/notifications/sis_expiry_student_provider_spec.rb
+++ b/spec/models/notifications/sis_expiry_student_provider_spec.rb
@@ -1,0 +1,65 @@
+describe Notifications::SisExpirySingleStudentProvider do
+
+  describe '#get_uids' do
+    subject { described_class.new }
+
+    context 'when given nil' do
+      let(:event) { nil }
+      it_behaves_like 'a provider receiving a malformed response'
+    end
+    context 'when given an empty event' do
+      let(:event) { {} }
+      it_behaves_like 'a provider receiving a malformed response'
+    end
+    context 'when given an empty payload' do
+      let(:event) do
+        {
+          'payload' => {}
+        }
+      end
+      it_behaves_like 'a provider receiving a malformed response'
+    end
+    context 'when given an empty ID' do
+      let(:event) do
+        {
+          'payload' => {
+            'StudentID' => id
+          }
+        }
+      end
+      let(:id) { nil }
+      it_behaves_like 'a provider receiving a malformed response'
+    end
+    context 'when given an ID' do
+      include_context 'when uid lookup is unsuccessful'
+      let(:event) do
+        {
+          'payload' => {
+            'student' => {
+              'StudentId' => id
+            }
+          }
+        }
+      end
+      let(:id) { '61889' }
+      it_behaves_like 'a provider receiving an empty response'
+    end
+    context 'when given an ID' do
+      include_context 'when uid lookup is successful'
+      let(:event) do
+        {
+          'payload' => {
+            'student' => {
+              'StudentId' => id
+            }
+          }
+        }
+      end
+      let(:id) { '61889' }
+      it 'returns a UID' do
+        uids = subject.get_uids(event)
+        expect(uids).to eq(uid)
+      end
+    end
+  end
+end

--- a/spec/models/notifications/sis_expiry_students_provider_spec.rb
+++ b/spec/models/notifications/sis_expiry_students_provider_spec.rb
@@ -1,0 +1,65 @@
+describe Notifications::SisExpiryStudentsProvider do
+
+  describe '#get_uids' do
+    subject { described_class.new }
+
+    context 'when given nil' do
+      let(:event) { nil }
+      it_behaves_like 'a provider receiving a malformed response'
+    end
+    context 'when given an empty event' do
+      let(:event) { {} }
+      it_behaves_like 'a provider receiving a malformed response'
+    end
+    context 'when given an empty payload' do
+      let(:event) do
+        {
+          'payload' => {}
+        }
+      end
+      it_behaves_like 'a provider receiving a malformed response'
+    end
+    context 'when given an empty array' do
+      let(:event) do
+        {
+          'payload' => {
+            'students' => ids
+          }
+        }
+      end
+      let(:ids) { [] }
+      it 'returns an empty array' do
+        uids = subject.get_uids(event)
+        expect(uids).to eq([])
+      end
+    end
+    context 'when given an array of IDs' do
+      include_context 'when uid lookup is unsuccessful'
+      let(:event) do
+        {
+          'payload' => {
+            'students' => ids
+          }
+        }
+      end
+      let(:ids) { ['61889'] }
+      it_behaves_like 'a provider receiving an empty response'
+    end
+    context 'when given an array of IDs' do
+      include_context 'when uid lookup is successful'
+      let(:event) do
+        {
+          'payload' => {
+            'students' => ids
+          }
+        }
+      end
+      let(:ids) { ['61889'] }
+      it 'returns an array of UIDs' do
+        uids = subject.get_uids(event)
+        expect(uids).to eq([uid])
+      end
+    end
+  end
+
+end

--- a/spec/support/sis_expiry_shared_examples.rb
+++ b/spec/support/sis_expiry_shared_examples.rb
@@ -1,0 +1,28 @@
+shared_context 'when uid lookup is successful' do
+  before do
+    allow_any_instance_of(CalnetCrosswalk::ByCsId).to receive(:lookup_ldap_uid).and_return uid
+  end
+  let(:uid) { '123' }
+end
+
+shared_context 'when uid lookup is unsuccessful' do
+  before do
+    allow_any_instance_of(CalnetCrosswalk::ByCsId).to receive(:lookup_ldap_uid).and_return nil
+  end
+end
+
+shared_examples 'a provider receiving a malformed response' do
+  it 'logs an error' do
+    expect(CalnetCrosswalk::ByCsId).not_to receive(:lookup_ldap_uid)
+    expect(Rails.logger).to receive(:error).with /Could not parse Campus Solutions ID from event/
+    subject.get_uids(event)
+  end
+end
+
+shared_examples 'a provider receiving an empty response' do
+  it 'logs an error' do
+    expect(CalnetCrosswalk::ByCsId).not_to receive(:lookup_ldap_uid)
+    expect(Rails.logger).to receive(:error).with /No UID found for Campus Solutions ID/
+    subject.get_uids(event)
+  end
+end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-28700

The Degree Progress card for undergrads gets its data from the Academic Progress Report.  Advisors want to be able to run the APR, which generates a new set of data, and see that data reflected in CalCentral right away rather than wait for the cache to expire.

An event will fire when the APR is run for a single student.  The event notification allows for an array of student IDs in case we want to have the event fire when the APR is run in batch (for many students).

Payload for the event notification is detailed here:  https://docs.google.com/document/d/10uOE80vkeDXpf-7jv_I0vfnIlSpZUsUTvKIa1zLkZ1k/edit#heading=h.qa4txi13e9gh