### PR TITLE
SISRP-30588 - CalCentral Code Fix: Transfer Credit Report Links

### DIFF
--- a/app/models/my_academics/academic_plan.rb
+++ b/app/models/my_academics/academic_plan.rb
@@ -5,8 +5,6 @@ module MyAcademics
 
     def merge(data)
       if is_feature_enabled
-        update_url_proxy = CampusSolutions::Link.new.get_url('UC_CX_PLANNER_ADV_STDNT', {:EMPLID => campus_solutions_id}).try(:[], :link)
-        data[:updatePlanUrl] = update_url_proxy
         data[:planSemesters] = get_plan_semesters(data[:semesters])
       end
     end

--- a/app/models/my_academics/academics_module.rb
+++ b/app/models/my_academics/academics_module.rb
@@ -230,5 +230,8 @@ module MyAcademics
       link
     end
 
+    def get_campus_solutions_id(uid)
+      CalnetCrosswalk::ByUid.new(user_id: uid).lookup_campus_solutions_id
+    end
   end
 end

--- a/app/models/my_academics/advisor_links.rb
+++ b/app/models/my_academics/advisor_links.rb
@@ -1,0 +1,18 @@
+module MyAcademics
+  class AdvisorLinks
+    include AcademicsModule
+    include ClassLogger
+
+    def merge(data)
+      data[:advisorLinks] = links
+    end
+
+    def links
+      campus_solutions_id = CalnetCrosswalk::ByUid.new(user_id: @uid).lookup_campus_solutions_id
+      tcReportLink = fetch_link('UC_CX_XFER_CREDIT_REPORT_ADVSR', { :EMPLID => campus_solutions_id })
+      {
+        tcReportLink: tcReportLink
+      }
+    end
+  end
+end

--- a/app/models/my_academics/advisor_links.rb
+++ b/app/models/my_academics/advisor_links.rb
@@ -8,10 +8,12 @@ module MyAcademics
     end
 
     def links
-      campus_solutions_id = CalnetCrosswalk::ByUid.new(user_id: @uid).lookup_campus_solutions_id
+      campus_solutions_id = get_campus_solutions_id(@uid)
       tcReportLink = fetch_link('UC_CX_XFER_CREDIT_REPORT_ADVSR', { :EMPLID => campus_solutions_id })
+      updatePlanUrl = fetch_link('UC_CX_PLANNER_ADV_STDNT', {:EMPLID => campus_solutions_id})
       {
-        tcReportLink: tcReportLink
+        tcReportLink: tcReportLink,
+        updatePlanUrl: updatePlanUrl
       }
     end
   end

--- a/app/models/my_academics/filtered_for_advisor.rb
+++ b/app/models/my_academics/filtered_for_advisor.rb
@@ -13,7 +13,8 @@ module MyAcademics
         Semesters,
         TransferCredit,
         Exams,
-        AcademicPlan
+        AcademicPlan,
+        AdvisorLinks
       ]
     end
 

--- a/app/models/my_academics/merged.rb
+++ b/app/models/my_academics/merged.rb
@@ -20,7 +20,8 @@ module MyAcademics
         Exams,
         CanvasSites,
         FacultyDelegate,
-        Grading
+        Grading,
+        StudentLinks
       ]
     end
 

--- a/app/models/my_academics/student_links.rb
+++ b/app/models/my_academics/student_links.rb
@@ -1,0 +1,17 @@
+module MyAcademics
+  class StudentLinks
+    include AcademicsModule
+    include ClassLogger
+
+    def merge(data)
+      data[:studentLinks] = links
+    end
+
+    def links
+      tcReportLink = fetch_link('UC_CX_XFER_CREDIT_REPORT_STDNT')
+      {
+        tcReportLink: tcReportLink
+      }
+    end
+  end
+end

--- a/app/models/my_academics/transfer_credit.rb
+++ b/app/models/my_academics/transfer_credit.rb
@@ -16,13 +16,7 @@ module MyAcademics
         nonadjusted_units = credit[:unitsNonAdjusted].to_f
         response[:ucTransferCrseSch][:unitsTotal] = adjusted_units + nonadjusted_units
       end
-      response.update({tcReportLink: fetch_tc_report_link}) if response
       response
-    end
-
-    def fetch_tc_report_link
-      campus_solutions_id = lookup_student_id
-      fetch_link('UC_CX_XFER_CREDIT_REPORT_STDNT', { :EMPLID => campus_solutions_id })
     end
 
   end

--- a/fixtures/xml/campus_solutions/link_api_multiple.xml
+++ b/fixtures/xml/campus_solutions/link_api_multiple.xml
@@ -22,6 +22,64 @@
     <COMMENTS>Apply to gain veteran's educational benefits.</COMMENTS>
   </Link>
   <Link>
+    <URL_ID>UC_CX_XFER_CREDIT_REPORT_STDNT</URL_ID>
+    <Description>Transfer Credit Report</Description>
+    <HOVER_OVER_TEXT>Detailed Transfer Credit Report</HOVER_OVER_TEXT>
+    <PROPERTIES type="array">
+      <PROPERTY>
+        <NAME>CALCENTRAL</NAME>
+        <value>ADVISOR</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>UCFROM</NAME>
+        <value>CalCentral</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>UCFROMLINK</NAME>
+        <value>https://calcentral-sis-dev-01.ist.berkeley.edu/</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>UCFROMTEXT</NAME>
+        <value>CalCentral</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>URI_TYPE</NAME>
+        <value>PL</value>
+      </PROPERTY>
+    </PROPERTIES>
+    <URL>https://bcswebqat.is.berkeley.edu/psp/bcsqat/EMPLOYEE/HRMS/c/CSU_DA_TRN_CDT_STD.CSU_DA_TRN_CDT_STD.GBL</URL>
+    <COMMENTS>This should take an advisor to a student's transfer credit report in CS.</COMMENTS>
+  </Link>
+  <Link>
+    <URL_ID>UC_CX_XFER_CREDIT_REPORT_ADVSR</URL_ID>
+    <Description>Transfer Credit Report</Description>
+    <HOVER_OVER_TEXT>Detailed Transfer Credit Report</HOVER_OVER_TEXT>
+    <PROPERTIES type="array">
+      <PROPERTY>
+        <NAME>CALCENTRAL</NAME>
+        <value>ADVISOR</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>UCFROM</NAME>
+        <value>CalCentral</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>UCFROMLINK</NAME>
+        <value>https://calcentral-sis-dev-01.ist.berkeley.edu/</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>UCFROMTEXT</NAME>
+        <value>CalCentral</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>URI_TYPE</NAME>
+        <value>PL</value>
+      </PROPERTY>
+    </PROPERTIES>
+    <URL>https://bcswebqat.is.berkeley.edu/psp/bcsqat/EMPLOYEE/HRMS/c/SSR_ADVISEE_OVRD.CSU_DA_TRN_CDT.GBL?EMPLID={EMPLID}</URL>
+    <COMMENTS>This should take an advisor to a student's transfer credit report in CS.</COMMENTS>
+  </Link>
+  <Link>
     <URL_ID>UC_CX_GT_CPPSTACK_ADD</URL_ID>
     <Description>Change of Academic Plan</Description>
     <HOVER_OVER_TEXT>Complete this form to change your academic plan.</HOVER_OVER_TEXT>

--- a/spec/models/my_academics/advisor_links_spec.rb
+++ b/spec/models/my_academics/advisor_links_spec.rb
@@ -1,0 +1,22 @@
+describe MyAcademics::AdvisorLinks do
+  let(:uid) { random_id }
+  let(:user_cs_id) { random_id }
+  let(:fake) { true }
+
+  before do
+    allow(CalnetCrosswalk::ByUid).to receive(:new).with(user_id: uid).and_return(
+      double(lookup_campus_solutions_id: user_cs_id)
+    )
+  end
+
+  subject do
+    {}.tap {|x| MyAcademics::AdvisorLinks.new(uid).merge(x)}
+  end
+
+  it 'merges student links into feed' do
+    expect(subject[:advisorLinks]).to be
+    expect(subject[:advisorLinks][:tcReportLink]).to be
+    expect(subject[:advisorLinks][:tcReportLink][:name]).to eq 'Transfer Credit Report'
+    expect(subject[:advisorLinks][:tcReportLink][:url]).to eq "https://bcswebqat.is.berkeley.edu/psp/bcsqat/EMPLOYEE/HRMS/c/SSR_ADVISEE_OVRD.CSU_DA_TRN_CDT.GBL?EMPLID=#{user_cs_id}"
+  end
+end

--- a/spec/models/my_academics/advisor_links_spec.rb
+++ b/spec/models/my_academics/advisor_links_spec.rb
@@ -1,11 +1,32 @@
 describe MyAcademics::AdvisorLinks do
   let(:uid) { random_id }
   let(:user_cs_id) { random_id }
+  let(:tcReportLink) do
+    {
+      link: {
+        name: 'Transfer Credit Report',
+        url: "https://bcswebqat.is.berkeley.edu/psp/bcsqat/EMPLOYEE/HRMS/c/SSR_ADVISEE_OVRD.CSU_DA_TRN_CDT.GBL?EMPLID=#{user_cs_id}"
+      }
+    }
+  end
+  let(:updatePlanUrl) do
+    {
+      link: {
+        name: 'Update Multi-Year Planner',
+        url: "https://bcswebqat.is.berkeley.edu/psp/bcsqat/EMPLOYEE/HRMS/c/SCI_PLNR_ADMIN.SCI_PLNR_FL.GBL?&EMPLID=#{user_cs_id}"
+      }
+    }
+  end
 
   before do
-    allow(CalnetCrosswalk::ByUid).to receive(:new).with(user_id: uid).and_return(
-      double(lookup_campus_solutions_id: user_cs_id)
-    )
+    crosswalk_double = double(lookup_campus_solutions_id: user_cs_id)
+    allow(CalnetCrosswalk::ByUid).to receive(:new).with(user_id: uid).and_return(crosswalk_double)
+
+    # stub CS Link proxy responses
+    fake_cs_link_proxy = double
+    allow(fake_cs_link_proxy).to receive(:get_url).with('UC_CX_XFER_CREDIT_REPORT_ADVSR', {:EMPLID => user_cs_id}).and_return(tcReportLink)
+    allow(fake_cs_link_proxy).to receive(:get_url).with('UC_CX_PLANNER_ADV_STDNT', {:EMPLID => user_cs_id}).and_return(updatePlanUrl)
+    allow(CampusSolutions::Link).to receive(:new).and_return(fake_cs_link_proxy)
   end
 
   subject do
@@ -17,5 +38,8 @@ describe MyAcademics::AdvisorLinks do
     expect(subject[:advisorLinks][:tcReportLink]).to be
     expect(subject[:advisorLinks][:tcReportLink][:name]).to eq 'Transfer Credit Report'
     expect(subject[:advisorLinks][:tcReportLink][:url]).to eq "https://bcswebqat.is.berkeley.edu/psp/bcsqat/EMPLOYEE/HRMS/c/SSR_ADVISEE_OVRD.CSU_DA_TRN_CDT.GBL?EMPLID=#{user_cs_id}"
+    expect(subject[:advisorLinks][:updatePlanUrl]).to be
+    expect(subject[:advisorLinks][:updatePlanUrl][:name]).to eq 'Update Multi-Year Planner'
+    expect(subject[:advisorLinks][:updatePlanUrl][:url]).to eq "https://bcswebqat.is.berkeley.edu/psp/bcsqat/EMPLOYEE/HRMS/c/SCI_PLNR_ADMIN.SCI_PLNR_FL.GBL?&EMPLID=#{user_cs_id}"
   end
 end

--- a/spec/models/my_academics/advisor_links_spec.rb
+++ b/spec/models/my_academics/advisor_links_spec.rb
@@ -1,7 +1,6 @@
 describe MyAcademics::AdvisorLinks do
   let(:uid) { random_id }
   let(:user_cs_id) { random_id }
-  let(:fake) { true }
 
   before do
     allow(CalnetCrosswalk::ByUid).to receive(:new).with(user_id: uid).and_return(

--- a/spec/models/my_academics/student_links_spec.rb
+++ b/spec/models/my_academics/student_links_spec.rb
@@ -1,7 +1,21 @@
 describe MyAcademics::StudentLinks do
   let(:uid) { random_id }
   let(:user_cs_id) { random_id }
-  let(:fake) { true }
+  let(:tcReportLink) do
+    {
+      link: {
+        name: 'Transfer Credit Report',
+        url: 'https://bcswebqat.is.berkeley.edu/psp/bcsqat/EMPLOYEE/HRMS/c/CSU_DA_TRN_CDT_STD.CSU_DA_TRN_CDT_STD.GBL'
+      }
+    }
+  end
+
+  before do
+    # stub CS Link proxy responses
+    fake_cs_link_proxy = double
+    allow(fake_cs_link_proxy).to receive(:get_url).with('UC_CX_XFER_CREDIT_REPORT_STDNT', {}).and_return(tcReportLink)
+    allow(CampusSolutions::Link).to receive(:new).and_return(fake_cs_link_proxy)
+  end
 
   subject do
     {}.tap {|x| MyAcademics::StudentLinks.new(uid).merge(x)}

--- a/spec/models/my_academics/student_links_spec.rb
+++ b/spec/models/my_academics/student_links_spec.rb
@@ -1,0 +1,16 @@
+describe MyAcademics::StudentLinks do
+  let(:uid) { random_id }
+  let(:user_cs_id) { random_id }
+  let(:fake) { true }
+
+  subject do
+    {}.tap {|x| MyAcademics::StudentLinks.new(uid).merge(x)}
+  end
+
+  it 'merges student links into feed' do
+    expect(subject[:studentLinks]).to be
+    expect(subject[:studentLinks][:tcReportLink]).to be
+    expect(subject[:studentLinks][:tcReportLink][:name]).to eq 'Transfer Credit Report'
+    expect(subject[:studentLinks][:tcReportLink][:url]).to eq 'https://bcswebqat.is.berkeley.edu/psp/bcsqat/EMPLOYEE/HRMS/c/CSU_DA_TRN_CDT_STD.CSU_DA_TRN_CDT_STD.GBL'
+  end
+end

--- a/src/assets/templates/widgets/academic_plan.html
+++ b/src/assets/templates/widgets/academic_plan.html
@@ -2,9 +2,9 @@
   <div class="cc-widget-title">
     <h2 class="cc-left">Academic Plan</h2>
   </div>
-  <div class="cc-widget-padding" data-ng-if="updatePlanUrl.url">
+  <div class="cc-widget-padding" data-ng-if="advisorLinks.updatePlanUrl.url">
     <h3>
-      <a data-cc-campus-solutions-link-directive="updatePlanUrl"
+      <a data-cc-campus-solutions-link-directive="advisorLinks.updatePlanUrl"
         data-cc-campus-solutions-link-directive-cc-page-name="currentPage.name"
         data-cc-campus-solutions-link-directive-cc-page-url="currentPage.url"
         data-cc-campus-solutions-link-directive-cc-cache="advisingAcademics"

--- a/src/assets/templates/widgets/transfer_credit.html
+++ b/src/assets/templates/widgets/transfer_credit.html
@@ -74,12 +74,24 @@
             </td>
           </tr>
         </tbody>
-        <tbody data-ng-if="transferCredit.tcReportLink.url">
+        <tbody data-ng-if="studentLinks.tcReportLink.url && api.user.profile.roles.student">
           <tr><td class="cc-transfer-credit-table-border" colspan="3"></td></tr>
           <tr class="cc-transfer-credit-table-parent-row">
             <td colspan="3">
               <a
-                data-cc-campus-solutions-link-directive="transferCredit.tcReportLink"
+                data-cc-campus-solutions-link-directive="studentLinks.tcReportLink"
+                data-cc-campus-solutions-link-directive-cc-page-name="currentPage.name"
+                data-cc-campus-solutions-link-directive-cc-page-url="currentPage.url"
+              ></a>
+            </td>
+          </tr>
+        </tbody>
+        <tbody data-ng-if="advisorLinks.tcReportLink.url && api.user.profile.roles.advisor">
+          <tr><td class="cc-transfer-credit-table-border" colspan="3"></td></tr>
+          <tr class="cc-transfer-credit-table-parent-row">
+            <td colspan="3">
+              <a
+                data-cc-campus-solutions-link-directive="advisorLinks.tcReportLink"
                 data-cc-campus-solutions-link-directive-cc-page-name="currentPage.name"
                 data-cc-campus-solutions-link-directive-cc-page-url="currentPage.url"
               ></a>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-30588

A conflict arose where a link intended only for student was embedded in the students Transfer Credits model. Passing links down the chain to the model to determine if it should provide the 'Student' links, or the 'Advisor' links would be inappropriate.

After some analysis I see that the Student Overview page is sharing a filtered version of the My Academics feed, which doesn't include links intended for Advisors. It's pure student data, yet only the data Advisors should see for the student.

The trend thus far has been to retrieve links for Advisors from the Advising Resources feed shared between the 'Advising Resources' card on the My Dashboard page, and the Personal Summary card on the Student Overview (containing student specific links that include the EMPLID).

Because this is the first time that we are placing a student specific link in a card, intended only for an Advisor, I've decided to implement two new My Academics modules specifically for Advisor Links and Student Links, each merged into the data feed respectively based on which type of user is viewing the data.

Moving forward we should add CS links to these models if they're going to be shown on the My Academics page (MyAcademics::StudentLinks) or Student Overview page (MyAcademics::AdvisorLinks).