### PR TITLE
NOJIRA Fix Canvas::CourseUsers cache key

### DIFF
--- a/app/models/canvas/course_users.rb
+++ b/app/models/canvas/course_users.rb
@@ -9,7 +9,7 @@ module Canvas
     end
 
     def course_users(options = {})
-      optional_cache(options, key: "#{@course_id}/#{@user_id}", default: true) do
+      optional_cache(options, key: @course_id.to_s, default: true) do
         paged_get(request_path, include: %w(email enrollments)) do |response|
           if @paging_callback.present?
             parsed_link_header = LinkHeader.parse(response['link'])


### PR DESCRIPTION
A copy-and-paste in #4014 has this class referencing a nonexistent instance variable.