### PR TITLE
SISRP-30579 - 8.0: Faculty - Current Roster (INC0305230)

### DIFF
--- a/app/models/canvas/course.rb
+++ b/app/models/canvas/course.rb
@@ -24,6 +24,10 @@ module Canvas
       }
     end
 
+    def to_s
+      "Canvas Course ID #{@canvas_course_id}"
+    end
+
     private
 
     def request_path

--- a/app/models/rosters/campus.rb
+++ b/app/models/rosters/campus.rb
@@ -2,122 +2,132 @@ module Rosters
   class Campus < Common
     include ClassLogger
 
-    def get_feed_internal
-      feed = {
-        campus_course: {
-          id: "#{@campus_course_id}"
-        },
-        sections: [],
-        students: []
-      }
-      all_courses = EdoOracle::UserCourses::All.new({user_id: @uid}).get_all_campus_courses
-      all_courses.merge!  CampusOracle::UserCourses::All.new(user_id: @uid).get_all_campus_courses if Settings.features.allow_legacy_fallback
+    def all_courses
+      worker = Proc.new do
+        all_courses = EdoOracle::UserCourses::All.new({user_id: @uid}).get_all_campus_courses
+        all_courses.merge! CampusOracle::UserCourses::All.new(user_id: @uid).get_all_campus_courses if Settings.features.allow_legacy_fallback
+        all_courses
+      end
+      @all_users_courses ||= worker.call
+    end
 
-      selected_term, selected_course = nil
+    def get_campus_course
+      matching_term, matching_course = nil
       all_courses.each do |term, courses|
         if (course = courses.find {|c| (c[:id] == @campus_course_id) && (c[:role] == 'Instructor') })
-          selected_term = term
-          selected_course = course
+          matching_term = term
+          matching_course = course
           break
         end
       end
+      {
+        course: matching_course,
+        term: matching_term
+      }
+    end
 
-      return feed if selected_course.nil?
-      term_yr, term_cd = selected_term.split '-'
-
-      feed[:campus_course].merge!(name: selected_course[:name])
-
+    # Obtains courses with matching crosslisted sections
+    def get_crosslisted_courses(selected_course, term_courses)
       crosslisted_courses = []
+      # if sections found with cross listing hash, find and include matching courses
       if (crosslisted_section = selected_course[:sections].find { |section| section[:cross_listing_hash].present? })
         crosslisting_hash = crosslisted_section[:cross_listing_hash]
-        crosslisted_courses = all_courses[selected_term].select do |course|
+        crosslisted_courses = term_courses.select do |course|
           course[:sections].find { |section| section[:cross_listing_hash] == crosslisting_hash }
         end
       else
         crosslisted_courses << selected_course
       end
+      crosslisted_courses
+    end
 
-      campus_enrollment_map = {}
-      ccns = crosslisted_courses.map { |course| course[:sections].map { |section| section[:ccn] } }.flatten
-      enrollments = get_enrollments(ccns, term_yr, term_cd)
+    def get_section_stats(section, section_enrollments)
+      section_enrolled_count, section_enrollments_open = 0, 0
+      section_waitlisted_count, section_waitlisted_open = 0, 0
+      section_enrollment_limit = section[:enroll_limit].to_i
+      section_waitlist_limit = section[:waitlist_limit].to_i
 
-      crosslisted_courses.each do |course|
-        course[:sections].each do |section|
-          recurring_schedules = section.try(:[], :schedules).try(:[], :recurring).to_a
-          section_locations, section_dates = [], []
+      if (section_enrollments)
+        section_enrollments_grouped = section_enrollments.group_by { |e| e[:enroll_status] != 'E' ? :waitlisted : :enrolled }
+        section_waitlisted_count = section_enrollments_grouped[:waitlisted].try(:length).to_i
+        section_enrolled_count = section_enrollments_grouped[:enrolled].try(:length).to_i
 
-          # calculate enrollment statistics
-          section_enrollment_limit = section[:enroll_limit].to_i
-          section_waitlist_limit = section[:waitlist_limit].to_i
+        section_enrollments_open = section_enrollment_limit - section_enrolled_count
+        section_waitlisted_open = section_waitlist_limit - section_waitlisted_count
+        if (section_enrollments_open < 0)
+          logger.debug "Section Enrollment limit exceeded in Section ID #{section[:ccn]}; Enrollment Count: #{section_enrolled_count}; Limit: #{section_enrollment_limit}"
+          section_enrollments_open = 0
+        end
+        if (section_waitlisted_open < 0)
+          logger.debug "Section Waitlist limit exceeded in Section ID #{section[:ccn]}; Waitlist Count: #{section_waitlisted_count}; Limit: #{section_waitlist_limit}"
+          section_waitlisted_open = 0
+        end
+      else
+        section_enrollments_open = section_enrollment_limit
+        section_waitlisted_open = section_waitlist_limit
+      end
+      {
+        enrolled: {
+          open: section_enrollments_open,
+          count: section_enrolled_count,
+          limit: section_enrollment_limit
+        },
+        waitlisted: {
+          open: section_waitlisted_open,
+          count: section_waitlisted_count,
+          limit: section_waitlist_limit
+        }
+      }
+    end
 
-          section_enrolled_count, section_waitlisted_count = 0, 0
-          if (section_enrollments = enrollments[section[:ccn]])
-            section_enrollments_grouped = section_enrollments.group_by { |e| e[:enroll_status] != 'E' ? :waitlisted : :enrolled }
-            section_waitlisted_count = section_enrollments_grouped[:waitlisted].try(:length).to_i
-            section_enrolled_count = section_enrollments_grouped[:enrolled].try(:length).to_i
+    def recurring_schedules(section)
+      section.try(:[], :schedules).try(:[], :recurring).to_a
+    end
 
-            section_enrollments_open = section_enrollment_limit - section_enrolled_count
-            section_waitlisted_open = section_waitlist_limit - section_waitlisted_count
-            if (section_enrollments_open < 0)
-              logger.debug "Section Enrollment limit exceeded in Section ID #{section[:ccn]}; Enrollment Count: #{section_enrolled_count}; Limit: #{section_enrollment_limit}"
-              section_enrollments_open = 0
-            end
-            if (section_waitlisted_open < 0)
-              logger.debug "Section Waitlist limit exceeded in Section ID #{section[:ccn]}; Waitlist Count: #{section_waitlisted_count}; Limit: #{section_waitlist_limit}"
-              section_waitlisted_open = 0
-            end
-          else
-            section_enrollments_open = section_enrollment_limit
-            section_enrolled_count = 0
-            section_waitlisted_open = section_waitlist_limit
-            section_waitlisted_count = 0
+    # Returns array of section locations
+    def section_locations(section)
+      schedules = recurring_schedules(section)
+      schedules.size > 0 ? schedules.map {|schedule| "#{schedule[:roomNumber]} #{schedule[:buildingName]}"} : []
+    end
+
+    # Returns array of section dates
+    def section_dates(section)
+      schedules = recurring_schedules(section)
+      schedules.size > 0 ? schedules.map {|schedule| schedule[:schedule]} : []
+    end
+
+    # Maps data from a sections enrollments to an enrollment map
+    # Required to apply special logic concerning enrollment status for waitlisted students
+    # Note: @campus_enrollment_map should be initialized before a course's sections are mapped
+    def apply_section_enrollments_to_enrollment_map(section, section_enrollments)
+      @campus_enrollment_map ||= {}
+      section_enrollments.try(:each) do |enrollment|
+        if (existing_entry = @campus_enrollment_map[enrollment[:ldap_uid]])
+          # We include waitlisted students in the roster. However, we do not show the official photo if the student
+          # is waitlisted in ALL sections.
+          if existing_entry[:enroll_status] == 'W' && enrollment[:enroll_status] == 'E'
+            existing_entry[:enroll_status] = 'E'
           end
-
-          if (recurring_schedules.size > 0)
-            section_dates = recurring_schedules.map {|schedule| schedule[:schedule]}
-            section_locations = recurring_schedules.map {|schedule| "#{schedule[:roomNumber]} #{schedule[:buildingName]}"}
-          end
-          feed[:sections] << {
-            ccn: section[:ccn],
-            name: "#{course[:dept]} #{course[:catid]} #{section[:section_label]}",
-            section_label: section[:section_label].to_s,
-            locations: section_locations,
-            dates: section_dates,
-            is_primary: section[:is_primary_section],
-            enroll_limit: section_enrollment_limit,
-            enroll_count: section_enrolled_count,
-            enroll_open: section_enrollments_open,
-            waitlist_limit: section_waitlist_limit,
-            waitlist_count: section_waitlisted_count,
-            waitlist_open: section_waitlisted_open
-          }
-          enrollments[section[:ccn]].try(:each) do |enr|
-            if (existing_entry = campus_enrollment_map[enr[:ldap_uid]])
-              # We include waitlisted students in the roster. However, we do not show the official photo if the student
-              # is waitlisted in ALL sections.
-              if existing_entry[:enroll_status] == 'W' && enr[:enroll_status] == 'E'
-                existing_entry[:enroll_status] = 'E'
-              end
-              campus_enrollment_map[enr[:ldap_uid]][:section_ccns] |= [section[:ccn]]
-            else
-              campus_enrollment_map[enr[:ldap_uid]] = enr.slice(:student_id, :first_name, :last_name, :email, :enroll_status, :majors, :terms_in_attendance, :academic_career).merge({
-                section_ccns: [section[:ccn]]
-              })
-            end
-            # Grading and waitlist information in the enrollment summary view should apply to the graded component.
-            if enr[:grade_option].present? && enr[:units].to_f.nonzero?
-              campus_enrollment_map[enr[:ldap_uid]].merge! enr.slice(:grade_option, :units, :waitlist_position)
-            end
-          end
+          @campus_enrollment_map[enrollment[:ldap_uid]][:section_ccns] |= [section[:ccn]]
+        else
+          @campus_enrollment_map[enrollment[:ldap_uid]] = enrollment.slice(:student_id, :first_name, :last_name, :email, :enroll_status, :majors, :terms_in_attendance, :academic_career).merge({
+            section_ccns: [section[:ccn]]
+          })
+        end
+        # Grading and waitlist information in the enrollment summary view should apply to the graded component.
+        if enrollment[:grade_option].present? && enrollment[:units].to_f.nonzero?
+          @campus_enrollment_map[enrollment[:ldap_uid]].merge! enrollment.slice(:grade_option, :units, :waitlist_position)
         end
       end
+      @campus_enrollment_map
+    end
 
+    def get_mapped_students(sections)
       # Create sections hash indexed by CCN
-      sections_index = index_by_attribute(feed[:sections], :ccn)
-
-      return feed if campus_enrollment_map.empty?
-      campus_enrollment_map.keys.each do |id|
-        campus_student = campus_enrollment_map[id]
+      sections_index = index_by_attribute(sections, :ccn)
+      mapped_students = []
+      @campus_enrollment_map.keys.each do |id|
+        campus_student = @campus_enrollment_map[id]
         campus_student[:id] = id
         campus_student[:login_id] = id
         campus_student[:profile_url] = 'http://www.berkeley.edu/directory/results?search-type=uid&search-base=all&search-term=' + id
@@ -125,11 +135,72 @@ module Rosters
         campus_student[:section_ccns].each do |section_ccn|
           campus_student[:sections].push(sections_index[section_ccn])
         end
+
         if campus_student[:enroll_status] == 'E'
           campus_student[:photo] = "/campus/#{@campus_course_id}/photo/#{id}"
         end
-        feed[:students] << campus_student
+        mapped_students << campus_student
       end
+      mapped_students
+    end
+
+    def get_feed_internal
+      # init enrollment map, see #apply_section_enrollments_to_enrollment_map
+      @campus_enrollment_map = {}
+
+      feed = {
+        campus_course: {
+          id: "#{@campus_course_id}"
+        },
+        sections: [],
+        students: []
+      }
+
+      campus_course = get_campus_course
+      selected_course = campus_course[:course]
+      selected_term = campus_course[:term]
+
+      return feed if selected_course.nil?
+      feed[:campus_course].merge!(name: selected_course[:name])
+      term_yr, term_cd = selected_term.split '-'
+
+      crosslisted_courses = get_crosslisted_courses(selected_course, all_courses[selected_term])
+      ccns = crosslisted_courses.map { |course| course[:sections].map { |section| section[:ccn] } }.flatten
+
+      enrollments = get_enrollments(ccns, term_yr, term_cd)
+
+      crosslisted_courses.each do |course|
+        course[:sections].each do |section|
+
+          # Process Section
+          section_enrollments = enrollments[section[:ccn]]
+          section_stats = get_section_stats(section, section_enrollments)
+          feed[:sections] << {
+            ccn: section[:ccn],
+            name: "#{course[:dept]} #{course[:catid]} #{section[:section_label]}",
+            section_label: section[:section_label].to_s,
+            section_number: section[:section_number].to_s,
+            instruction_format: section[:instruction_format].to_s,
+            locations: section_locations(section),
+            dates: section_dates(section),
+            is_primary: section[:is_primary_section],
+            enroll_limit: section_stats[:enrolled][:limit],
+            enroll_count: section_stats[:enrolled][:count],
+            enroll_open: section_stats[:enrolled][:open],
+            waitlist_limit: section_stats[:waitlisted][:limit],
+            waitlist_count: section_stats[:waitlisted][:count],
+            waitlist_open: section_stats[:waitlisted][:open]
+          }
+
+          # apply section enrollments to map
+          apply_section_enrollments_to_enrollment_map(section, section_enrollments)
+        end
+      end
+
+      feed[:students] = get_mapped_students(feed[:sections]) unless @campus_enrollment_map.empty?
+      student_columns_and_headers = TableColumns.get_students_with_columns_and_headers(feed[:students])
+      feed[:students] = student_columns_and_headers[:students]
+      feed[:columnHeaders] = student_columns_and_headers[:headers]
       feed
     end
 

--- a/app/models/rosters/table_columns.rb
+++ b/app/models/rosters/table_columns.rb
@@ -1,0 +1,120 @@
+module Rosters
+  module TableColumns
+    extend self
+
+    def get_students_with_columns_and_headers(students)
+      student_section_columns = get_student_section_columns(students)
+      student_columns = student_section_columns[:student_columns]
+      students.each do |student|
+        student[:columns] = student_columns[student[:student_id]]
+      end
+      {
+        headers: student_section_columns[:headers],
+        students: students
+      }
+    end
+
+    def get_student_section_columns(students)
+      students_with_columns_hash = get_student_section_columns_hash(students)
+      section_headers_prototype = get_section_headers_prototype(students_with_columns_hash)
+      section_headers = get_section_headers(section_headers_prototype)
+      student_columns = get_student_columns(section_headers_prototype, students_with_columns_hash)
+      {
+        headers: section_headers,
+        student_columns: student_columns
+      }
+    end
+
+    def get_student_columns(section_headers_prototype, students_with_columns_hash)
+      student_columns = {}
+      students_with_columns_hash.each do |student_id, student_columns_hash|
+        student_columns[student_id] = []
+        section_headers_prototype_iterator(section_headers_prototype) do |header_column_hash, index|
+          instruction_format = header_column_hash[:instruction_format]
+          primary_group_key = header_column_hash[:primary_group_key]
+          sections = student_columns_hash.try(:[], primary_group_key).try(:[], instruction_format).to_a
+          ordered_sections = sections.collect {|sec| sec[:section_number]}.sort
+          student_column = header_column_hash.merge({section_number: ordered_sections[index]})
+          student_columns[student_id].push(student_column)
+        end
+      end
+      student_columns
+    end
+
+    def get_section_headers(section_headers_prototype)
+      section_headers = []
+      section_headers_prototype_iterator(section_headers_prototype) do |header_column_hash|
+        section_headers.push(header_column_hash)
+      end
+      section_headers
+    end
+
+    # Used to iterate over columns hash
+    def section_headers_prototype_iterator(section_headers_prototype, &block)
+      section_headers_prototype.each do |header_column_config|
+        header_column_config[:columns].times do |index|
+          yield(header_column_config.slice(:instruction_format, :primary_group_key), index)
+        end
+      end
+    end
+
+    def get_section_headers_prototype(students_with_columns_hash)
+      headers_prototype = []
+      max_column_count_hash = {}
+
+      students_with_columns_hash.keys.each do |sid|
+        columns_hash = students_with_columns_hash[sid]
+        # sort automatically makes primary before secondary
+        columns_hash.keys.sort.each do |primary_group_key|
+          instruction_format_groups = columns_hash[primary_group_key]
+          instruction_format_groups.keys.sort.each do |instruction_format_code|
+            sections = instruction_format_groups[instruction_format_code]
+
+            column_key = {if: instruction_format_code, pgk: primary_group_key}
+            max_column_count_hash[column_key] ||= 0
+
+            current_value = max_column_count_hash[column_key]
+            max_column_count_hash[column_key] = sections.count > current_value ? sections.count : current_value
+          end
+        end
+      end
+
+      max_column_count_hash.each do |key, value|
+        column = {
+          :instruction_format => key[:if],
+          :primary_group_key => key[:pgk],
+          :columns => value
+        }
+        headers_prototype.push(column)
+      end
+      headers_prototype
+    end
+
+    # Provides hash representing students and enrolled sections
+    def get_student_section_columns_hash(students)
+      students.inject({}) do |map, student|
+        map[student[:student_id]] = section_columns_hash(student[:sections])
+        map
+      end
+    end
+
+    # Converts student sections into data structure used to build column data sets
+    # Returns hash representing sections categorized by primary/secondary status and instructional format
+    def section_columns_hash(sections)
+      section_property_filter = [:instruction_format, :is_primary, :section_number]
+      columns_hash = {}
+      primary_groups = sections.group_by { |section| section.try(:[], :is_primary) ? :primary : :secondary }
+      primary_groups.keys.each do |primary_group_key|
+        columns_hash[primary_group_key] = {}
+        primary_group = primary_groups[primary_group_key]
+        instructional_format_groups = primary_group.group_by { |sec| sec[:instruction_format] }
+        instructional_format_groups.keys.each do |instruction_format_code|
+          if_sections = instructional_format_groups[instruction_format_code]
+          columns_hash[primary_group_key][instruction_format_code] = if_sections.collect {|sec| sec.slice(*section_property_filter)}
+        end
+      end
+      columns_hash
+    end
+
+  end
+end

--- a/spec/models/canvas/course_spec.rb
+++ b/spec/models/canvas/course_spec.rb
@@ -6,6 +6,10 @@ describe Canvas::Course do
 
   context 'when requesting course from canvas' do
     context 'if course exists in canvas' do
+      it 'returns a string representation of itself' do
+        expect(subject.to_s).to eq 'Canvas Course ID 1121'
+      end
+
       it 'returns course hash' do
         course = subject.course[:body]
         expect(course['id']).to eq 1121

--- a/spec/models/rosters/campus_spec.rb
+++ b/spec/models/rosters/campus_spec.rb
@@ -7,6 +7,8 @@ describe Rosters::Campus do
   let(:student_user_id) {rand(99999).to_s}
   let(:ccn1) {rand(9999)}
   let(:ccn2) {rand(9999)}
+  let(:ccn3) {rand(9999)}
+  let(:ccn4) {rand(9999)}
   let(:enrolled_student_login_id) {rand(99999).to_s}
   let(:enrolled_student_student_id) {rand(99999).to_s}
   let(:waitlisted_student_login_id) {rand(99999).to_s}
@@ -17,54 +19,80 @@ describe Rosters::Campus do
   let(:campus_course_id) {"info-#{catid}-#{term_slug}"}
   let(:fake_campus) do
     {
-      "#{term_slug}" => [{
-        id: campus_course_id,
-        term_yr: term_yr,
-        term_cd: term_cd,
-        catid: catid,
-        dept: 'INFO',
-        course_code: "INFO #{catid}",
-        emitter: 'Campus',
-        name: 'Data Rules Everything Around Me',
-        role: 'Instructor',
-        sections: [{
-          ccn: ccn1,
-          section_label: 'LEC 001',
-          is_primary_section: true,
-          enroll_limit: 650,
-          waitlist_limit: 110,
-          schedules: {
-            recurring: [
-              {
-                buildingName: 'Soda',
-                roomNumber: '100',
-                schedule: 'TuTh 3:00P-3:59P'
-              },
-              {
-                buildingName: 'Soda',
-                roomNumber: '102',
-                schedule: 'Fr 11:00A-11:59A'
-              }
-            ]
-          }
-        },
+      "#{term_slug}" => [
         {
-          ccn: ccn2,
-          section_label: 'LAB 001',
-          is_primary_section: false,
-          enroll_limit: 2,
-          waitlist_limit: 1,
-          schedules: {
-            recurring: [
-              {
-                buildingName: 'Hertz',
-                roomNumber: '320',
-                schedule: 'MoFr 1:00P-1:59P'
+          id: campus_course_id,
+          term_yr: term_yr,
+          term_cd: term_cd,
+          catid: catid,
+          dept: 'INFO',
+          course_code: "INFO #{catid}",
+          emitter: 'Campus',
+          name: 'Data Rules Everything Around Me',
+          role: 'Instructor',
+          sections: [
+            {
+              ccn: ccn1,
+              section_label: 'LEC 001',
+              section_number: '001',
+              instruction_format: 'LEC',
+              is_primary_section: true,
+              enroll_limit: 650,
+              waitlist_limit: 110,
+              schedules: {
+                recurring: [
+                  {
+                    buildingName: 'Soda',
+                    roomNumber: '100',
+                    schedule: 'TuTh 3:00P-3:59P'
+                  },
+                  {
+                    buildingName: 'Soda',
+                    roomNumber: '102',
+                    schedule: 'Fr 11:00A-11:59A'
+                  }
+                ]
               }
-            ]
-          }
-        }]
-      }]
+            },
+            {
+              ccn: ccn2,
+              section_label: 'LAB 001',
+              section_number: '001',
+              instruction_format: 'LAB',
+              is_primary_section: false,
+              enroll_limit: 4,
+              waitlist_limit: 2,
+              schedules: {
+                recurring: [
+                  {
+                    buildingName: 'Hertz',
+                    roomNumber: '320',
+                    schedule: 'MoFr 1:00P-1:59P'
+                  }
+                ]
+              }
+            },
+            {
+              ccn: ccn3,
+              section_label: 'LAB 002',
+              section_number: '003',
+              instruction_format: 'LAB',
+              is_primary_section: false,
+              enroll_limit: 3,
+              waitlist_limit: 2,
+              schedules: {
+                recurring: [
+                  {
+                    buildingName: 'Hertz',
+                    roomNumber: '450',
+                    schedule: 'MoFr 1:00P-1:59P'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
     }
   end
 
@@ -78,10 +106,12 @@ describe Rosters::Campus do
     end
 
     it 'should include section statistics' do
-      expect(feed[:sections].length).to eq 2
+      expect(feed[:sections].length).to eq 3
       expect(feed[:sections][0][:ccn]).to eq ccn1
       expect(feed[:sections][0][:name]).to eq "INFO #{catid} LEC 001"
       expect(feed[:sections][0][:section_label]).to eq "LEC 001"
+      expect(feed[:sections][0][:section_number]).to eq "001"
+      expect(feed[:sections][0][:instruction_format]).to eq "LEC"
       expect(feed[:sections][0][:dates]).to eq ['TuTh 3:00P-3:59P', 'Fr 11:00A-11:59A']
       expect(feed[:sections][0][:locations]).to eq ['100 Soda', '102 Soda']
       expect(feed[:sections][0][:is_primary]).to eq true
@@ -94,14 +124,16 @@ describe Rosters::Campus do
       expect(feed[:sections][1][:ccn]).to eq ccn2
       expect(feed[:sections][1][:name]).to eq "INFO #{catid} LAB 001"
       expect(feed[:sections][1][:section_label]).to eq "LAB 001"
+      expect(feed[:sections][1][:section_number]).to eq "001"
+      expect(feed[:sections][1][:instruction_format]).to eq "LAB"
       expect(feed[:sections][1][:dates]).to eq ['MoFr 1:00P-1:59P']
       expect(feed[:sections][1][:locations]).to eq ['320 Hertz']
       expect(feed[:sections][1][:is_primary]).to eq false
-      expect(feed[:sections][1][:enroll_limit]).to eq 2
-      expect(feed[:sections][1][:enroll_open]).to eq 0
+      expect(feed[:sections][1][:enroll_limit]).to eq 4
+      expect(feed[:sections][1][:enroll_open]).to eq 2
       expect(feed[:sections][1][:enroll_count]).to eq 2
-      expect(feed[:sections][1][:waitlist_limit]).to eq 1
-      expect(feed[:sections][1][:waitlist_open]).to eq 0
+      expect(feed[:sections][1][:waitlist_limit]).to eq 2
+      expect(feed[:sections][1][:waitlist_open]).to eq 1
       expect(feed[:sections][1][:waitlist_count]).to eq 1
     end
 
@@ -122,7 +154,7 @@ describe Rosters::Campus do
     end
 
     it 'should show official photo links for students who are not waitlisted in all sections' do
-      expect(feed[:sections].length).to eq 2
+      expect(feed[:sections].length).to eq 3
       expect(feed[:students].length).to eq 3
       expect(feed[:students].index {|student| student[:id] == waitlisted_student_login_id &&
         student[:photo].nil?
@@ -142,7 +174,7 @@ describe Rosters::Campus do
       let(:fake_oracle) { fake_campus }
       let(:fake_edo) { {} }
       before do
-        expect(CampusOracle::Queries).to receive(:get_enrolled_students_for_ccns).with([ccn1, ccn2], term_yr, term_cd).and_return(fake_enrollments)
+        expect(CampusOracle::Queries).to receive(:get_enrolled_students_for_ccns).with([ccn1, ccn2, ccn3], term_yr, term_cd).and_return(fake_enrollments)
       end
       let(:fake_enrollments) do
         [
@@ -214,7 +246,7 @@ describe Rosters::Campus do
 
       context 'when enrollments are present' do
         before do
-          expect(EdoOracle::Queries).to receive(:get_rosters).with([ccn1, ccn2], term_id).and_return enrollments
+          expect(EdoOracle::Queries).to receive(:get_rosters).with([ccn1, ccn2, ccn3], term_id).and_return enrollments
           # A method rather than a let so that modifications during a test don't persist.
           def attributes
             [

--- a/spec/models/rosters/table_columns_spec.rb
+++ b/spec/models/rosters/table_columns_spec.rb
@@ -1,0 +1,212 @@
+describe Rosters::TableColumns do
+  let(:lec_section1) do
+    {
+      :name=>"COMPSCI 849 LEC 001",
+      :instruction_format => 'LEC',
+      :is_primary => true,
+      :section_number => '001'
+    }
+  end
+  let(:lec_section2) do
+    {
+      :name=>"COMPSCI 849 LEC 002",
+      :instruction_format => 'LEC',
+      :is_primary => true,
+      :section_number => '002'
+    }
+  end
+  let(:lec_section3) do
+    {
+      :name=>"COMPSCI 849 LEC 401",
+      :instruction_format => 'LEC',
+      :is_primary => false,
+      :section_number => '401'
+    }
+  end
+  let(:lab_section1) do
+    {
+      :name=>"COMPSCI 849 LAB 101",
+      :instruction_format => 'LAB',
+      :is_primary => false,
+      :section_number => '101'
+    }
+  end
+  let(:lab_section2) do
+    {
+      :name=>"COMPSCI 849 LAB 102",
+      :instruction_format => 'LAB',
+      :is_primary => false,
+      :section_number => '102'
+    }
+  end
+  let(:dis_section1) do
+    {
+      :name=>"COMPSCI 849 DIS 201",
+      :instruction_format => 'DIS',
+      :is_primary => false,
+      :section_number => '001',
+    }
+  end
+  let(:dis_section2) do
+    {
+      :name=>"COMPSCI 849 DIS 202",
+      :instruction_format => 'DIS',
+      :is_primary => false,
+      :section_number => '002'
+    }
+  end
+  let(:student1) { {:student_id => '10001', :sections => [lec_section1, lab_section1]} }
+  let(:student2) { {:student_id => '10002', :sections => [lec_section2, lab_section2, dis_section2]} }
+  let(:student3) { {:student_id => '10003', :sections => [lab_section2, lec_section1, dis_section2, lec_section2, lab_section1, lec_section3]} }
+  let(:student4) { {:student_id => '10004', :sections => [dis_section2, lab_section2, lab_section1]} }
+  let(:students) { [student1, student2, student3, student4] }
+
+  let(:section_headers_prototype) do
+    [
+      {:instruction_format => 'LEC', :primary_group_key => :primary, :columns => 2},
+      {:instruction_format => 'DIS', :primary_group_key => :secondary, :columns => 1},
+      {:instruction_format => 'LAB', :primary_group_key => :secondary, :columns => 2},
+      {:instruction_format => 'LEC', :primary_group_key => :secondary, :columns => 1}
+    ]
+  end
+  let(:students_columns_hash) do
+    {
+      student3[:student_id]=>{
+        :secondary=>{
+          "LAB"=>[
+            {:instruction_format=>"LAB", :is_primary=>false, :section_number=>"201"}
+          ],
+          "DIS"=>[{:instruction_format=>"DIS", :is_primary=>false, :section_number=>"102"}],
+          "LEC"=>[
+            {:instruction_format=>"LEC", :is_primary=>false, :section_number=>"401"}
+          ]
+        },
+        :primary=>{
+          "LEC"=>[
+            {:instruction_format=>"LEC", :is_primary=>true, :section_number=>"002"},
+            {:instruction_format=>"LEC", :is_primary=>true, :section_number=>"001"}
+          ]
+        }
+      },
+      student4[:student_id]=>{
+        :secondary=>{
+          "DIS"=>[{:instruction_format=>"DIS", :is_primary=>false, :section_number=>"101"}],
+          "LAB"=>[
+            {:instruction_format=>"LAB", :is_primary=>false, :section_number=>"202"},
+            {:instruction_format=>"LAB", :is_primary=>false, :section_number=>"201"}
+          ]
+        }
+      }
+    }
+  end
+
+  describe '#get_students_with_columns_and_headers' do
+    let(:section_columns_and_headers) { subject.get_students_with_columns_and_headers(students) }
+    it 'returns students with columns and headers' do
+      expect(section_columns_and_headers[:headers].count).to eq 6
+      expect(section_columns_and_headers[:students].count).to eq 4
+      section_columns_and_headers[:students].each do |student|
+        expect(student[:columns].count).to eq 6
+      end
+    end
+  end
+
+  describe '#get_student_section_columns' do
+    let(:student_section_columns) { subject.get_student_section_columns(students) }
+    it 'returns student section columns and headers with same column count' do
+      expect(student_section_columns[:headers].count).to eq 6
+      expect(student_section_columns[:student_columns].count).to eq 4
+      student_section_columns[:student_columns].each do |student_id, columns|
+        expect(columns.count).to eq student_section_columns[:headers].count
+      end
+    end
+  end
+
+  describe '#get_student_columns' do
+    let(:student_columns) { subject.get_student_columns(section_headers_prototype, students_columns_hash) }
+    it 'returns student section columns based on header prototype' do
+      expect(student_columns.keys.count).to eq 2
+      student_ids = student_columns.keys
+      student1_section_numbers = student_columns[student_ids[0]].collect {|col| col[:section_number]}
+      student2_section_numbers = student_columns[student_ids[1]].collect {|col| col[:section_number]}
+      expect(student1_section_numbers).to eq ['001', '002', '102', '201', nil, '401']
+      expect(student2_section_numbers).to eq [nil, nil, '101', '201', '202', nil]
+    end
+  end
+
+  describe '#get_section_headers' do
+    let(:section_headers) { subject.get_section_headers(section_headers_prototype) }
+    it 'returns section headers array' do
+      expect(section_headers.count).to eq 6
+      expect(section_headers[0][:instruction_format]).to eq 'LEC'
+      expect(section_headers[0][:primary_group_key]).to eq :primary
+      expect(section_headers[1][:instruction_format]).to eq 'LEC'
+      expect(section_headers[1][:primary_group_key]).to eq :primary
+      expect(section_headers[2][:instruction_format]).to eq 'DIS'
+      expect(section_headers[2][:primary_group_key]).to eq :secondary
+      expect(section_headers[3][:instruction_format]).to eq 'LAB'
+      expect(section_headers[3][:primary_group_key]).to eq :secondary
+      expect(section_headers[4][:instruction_format]).to eq 'LAB'
+      expect(section_headers[4][:primary_group_key]).to eq :secondary
+      expect(section_headers[5][:instruction_format]).to eq 'LEC'
+      expect(section_headers[5][:primary_group_key]).to eq :secondary
+    end
+  end
+
+  describe '#get_section_headers_prototype' do
+    let(:section_headers_prototype) { subject.get_section_headers_prototype(students_columns_hash) }
+    it 'returns section headers prototype' do
+      expect(section_headers_prototype.count).to eq 4
+      expect(section_headers_prototype[0][:instruction_format]).to eq 'LEC'
+      expect(section_headers_prototype[0][:primary_group_key]).to eq :primary
+      expect(section_headers_prototype[0][:columns]).to eq 2
+      expect(section_headers_prototype[1][:instruction_format]).to eq 'DIS'
+      expect(section_headers_prototype[1][:primary_group_key]).to eq :secondary
+      expect(section_headers_prototype[1][:columns]).to eq 1
+      expect(section_headers_prototype[2][:instruction_format]).to eq 'LAB'
+      expect(section_headers_prototype[2][:primary_group_key]).to eq :secondary
+      expect(section_headers_prototype[2][:columns]).to eq 2
+      expect(section_headers_prototype[3][:instruction_format]).to eq 'LEC'
+      expect(section_headers_prototype[3][:primary_group_key]).to eq :secondary
+      expect(section_headers_prototype[3][:columns]).to eq 1
+    end
+  end
+
+  describe '#get_student_section_columns_hash' do
+    let(:students) { [student3, student4] }
+    it 'returns hash with students by sid' do
+      student_columns = subject.get_student_section_columns_hash(students)
+      expect(student_columns[students[0][:student_id]]).to be_an_instance_of Hash
+      expect(student_columns[students[1][:student_id]]).to be_an_instance_of Hash
+    end
+  end
+
+  describe '#section_columns_hash' do
+    let(:student_sections) { student3[:sections] }
+    let(:columns_hash) { subject.section_columns_hash(student_sections) }
+    it 'converts sections into section columns hash' do
+      unwanted_keys = [:name, :section_label, :dates, :locations, :enroll_limit, :enroll_count, :enroll_open, :waitlist_limit, :waitlist_count, :waitlist_open]
+      expect(columns_hash[:primary].keys).to eq ['LEC']
+      expect(columns_hash[:secondary].keys.sort).to eq ['DIS', 'LAB', 'LEC']
+      expect(columns_hash[:primary]['DIS']).to_not be
+      expect(columns_hash[:primary]['LAB']).to_not be
+      expect(columns_hash[:primary]['LEC'].count).to eq 2
+      expect(columns_hash[:primary]['LEC'][0][:is_primary]).to eq true
+      expect(columns_hash[:secondary]['DIS'].count).to eq 1
+      expect(columns_hash[:secondary]['LAB'].count).to eq 2
+      expect(columns_hash[:secondary]['LEC'].count).to eq 1
+      expect(columns_hash[:secondary]['LEC'][0][:is_primary]).to eq false
+      columns_hash.values.each do |primary_hash|
+        primary_hash.values.each do |instruction_format_section_set|
+          instruction_format_section_set.each do |section|
+            expect(section).to have_key(:instruction_format)
+            expect(section).to have_key(:is_primary)
+            expect(section).to have_key(:section_number)
+            expect(section).to_not have_keys(unwanted_keys)
+          end
+        end
+      end
+    end
+  end
+
+end

--- a/src/assets/javascripts/angular/controllers/pages/rosterController.js
+++ b/src/assets/javascripts/angular/controllers/pages/rosterController.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var angular = require('angular');
-var _ = require('lodash');
 
 /**
  * Canvas roster photos LTI app controller
@@ -13,31 +12,20 @@ angular.module('calcentral.controllers').controller('RosterController', function
   }
   $scope.accessibilityAnnounce = apiService.util.accessibilityAnnounce;
   $scope.bmailLink = rosterService.bmailLink;
+  $scope.currentRosterViewType = 'photos';
   $scope.searchOptions = {
     text: '',
     section: null,
-    type: 'all'
+    enrollStatus: 'all'
+  };
+  $scope.tableSort = {
+    'column': ['last_name', 'first_name'],
+    'reverse': false
   };
 
-  $scope.rosterTypeFilter = function(student) {
-    switch ($scope.searchOptions.type) {
-      case 'enrolled': {
-        return (!_.get(student, 'waitlist_position'));
-      }
-      case 'waitlist': {
-        return (_.get(student, 'waitlist_position'));
-      }
-      default: {
-        return true;
-      }
-    }
-  };
-
-  $scope.studentInSectionFilter = function(student) {
-    if (!$scope.searchOptions.section) {
-      return true;
-    }
-    return (student.section_ccns.indexOf($scope.searchOptions.section.ccn) !== -1);
+  $scope.sectionChangeActions = function(filterType) {
+    $scope.accessibilityAnnounce('Rosters filtered by ' + filterType);
+    refreshFilteredStudents();
   };
 
   var getRoster = function() {
@@ -49,10 +37,15 @@ angular.module('calcentral.controllers').controller('RosterController', function
       angular.extend($scope, data);
       $scope.course = $scope[$scope.context + '_course'];
       apiService.util.iframeUpdateHeight();
+      refreshFilteredStudents();
     }).error(function(data, status) {
       angular.extend($scope, data);
       $scope.errorStatus = status;
     });
+  };
+
+  var refreshFilteredStudents = function() {
+    $scope.filteredStudents = rosterService.getFilteredStudents($scope.students, $scope.sections, $scope.searchOptions, false);
   };
 
   getRoster();

--- a/src/assets/javascripts/angular/services/rosterService.js
+++ b/src/assets/javascripts/angular/services/rosterService.js
@@ -1,8 +1,10 @@
+/* jshint camelcase: false */
 'use strict';
 
 var angular = require('angular');
+var _ = require('lodash');
 
-angular.module('calcentral.services').factory('rosterService', function() {
+angular.module('calcentral.services').factory('rosterService', function($filter) {
   /**
    * Returns link to gMail compose with TO address specified
    * @param {String} toAddress 'TO' address string
@@ -12,8 +14,144 @@ angular.module('calcentral.services').factory('rosterService', function() {
     return 'https://mail.google.com/mail/u/0/?view=cm&fs=1&tf=1&source=mailto&to=' + urlEncodedToAddress;
   };
 
+  /**
+   * Returns array with AngularJS text filter applied
+   * Must use this to maintain parity with template based filter
+   * Template Filter Example:
+   *   <input data-ng-model="searchOptions.text.$">
+   *   <li data-ng-repeat="item in list | filter:searchOptions.text">
+   *
+   * @param  {Array}  array             Any array of objects
+   * @param  {String} textFilterString  text used for search
+   * @return {Array}                    Array of filtered results
+   */
+  var textFilter = function(array, textFilterString) {
+    if (_.isEmpty(textFilterString)) {
+      return array;
+    } else {
+      return $filter('filter')(array, {
+        $: textFilterString
+      });
+    }
+  };
+
+  /**
+   * Returns count if object is an array, otherwise returns 0
+   */
+  var getCount = function(array) {
+    return Array.isArray(array) ? array.length : 0;
+  };
+
+  /**
+   * Returns array of students from selected section, including statistics
+   * @param  {Array}    students            All students in course
+   * @param  {Array}    sections            All sections for the course
+   * @param  {Object}   searchOptions       Object containing search filtering arguments
+   * @param  {Boolean}  useWaitlistCounts   Stats based on waitlist counts when true
+   * @return {Object}                       Object containing current student view with statistics
+   */
+  var getFilteredStudents = function(students, sections, searchOptions, useWaitlistCounts) {
+    // apply filters
+    var filteredStudents = filterStudents(students, searchOptions);
+
+    // calculate stats
+    var openSeatsCount = getOpenSeatCount(sections, searchOptions.section, useWaitlistCounts);
+    var shownStudentCount = getCount(filteredStudents);
+    var totalStudentCount = getCount(students);
+    return {
+      shownStudents: filteredStudents,
+      shownStudentCount: shownStudentCount,
+      totalStudentCount: totalStudentCount,
+      openSeatsCount: openSeatsCount
+    };
+  };
+
+  var filterStudents = function(students, searchOptions) {
+    if (students) {
+      if (!searchOptions) {
+        return students;
+      } else {
+        var filteredStudents = failsafeArrayFilter(students, isStudentInSection, _.get(searchOptions, 'section'));
+        filteredStudents = failsafeArrayFilter(filteredStudents, doesStudentMatchEnrollStatus, _.get(searchOptions, 'enrollStatus'));
+        filteredStudents = textFilter(filteredStudents, _.get(searchOptions, 'text'));
+        return filteredStudents;
+      }
+    } else {
+      return [];
+    }
+  };
+
+  /**
+   * Indicates if the student matches the enrollment status
+   * @param  {Object} student       student object
+   * @param  {String} enrollStatus  enrollment status (e.g. 'all', enrolled', 'waitlisted')
+   * @return {Boolean}              true or false
+   */
+  var doesStudentMatchEnrollStatus = function(student, enrollStatus) {
+    switch (enrollStatus) {
+      case 'enrolled': {
+        return (!_.get(student, 'waitlist_position'));
+      }
+      case 'waitlisted': {
+        return (_.get(student, 'waitlist_position'));
+      }
+      default: {
+        return true;
+      }
+    }
+  };
+
+  /**
+   * Fail Safe Array Filter
+   * @param  {Array}    array         collection being filtered
+   * @param  {Function} callback      function used to determine if the item should be included in the array (boolean return)
+   * @param  {mixed}    callbackArg   argument sent to the callback with the array item
+   * @return {Array}                  filtered array result
+   */
+  var failsafeArrayFilter = function(array, callback, callbackArg) {
+    if (array) {
+      if (!callbackArg) {
+        return array;
+      }
+      return _.filter(array, function(arrayItem) {
+        return callback(arrayItem, callbackArg);
+      });
+    } else {
+      return [];
+    }
+  };
+
+  /**
+   * Returns the number of available seats for the course, for the specified enrollment status
+   * @param  {Array}   sections           all sections for the course
+   * @param  {Object}  selectedSection    current selected section
+   * @param  {Boolean} useWaitlistCounts  calculates open seat count based on waitlist positions open when true,
+   *                                      rather than on enrollment positions open. Defaults to false
+   * @return {Number}                     Number of open enrollment or waitlist seats in entire course or selected section
+   */
+  var getOpenSeatCount = function(sections, selectedSection, useWaitlistCounts) {
+    var selectedSectionId = _.get(selectedSection, 'ccn');
+    return _.reduce(sections, function(count, section) {
+      if (!selectedSectionId || selectedSectionId === _.get(section, 'ccn')) {
+        count += !!useWaitlistCounts ? section.waitlist_open : section.enroll_open;
+      }
+      return count;
+    }, 0);
+  };
+
+  /**
+   * Indicates if student is in a section
+   * @param  {Object} student   student object containing array of section CCNs / IDs
+   * @param  {Object} section   class section
+   * @return {Boolean}          true or false
+   */
+  var isStudentInSection = function(student, section) {
+    return (!section) ? true : (student.section_ccns.indexOf(section.ccn) !== -1);
+  };
+
   return {
-    bmailLink: bmailLink
+    bmailLink: bmailLink,
+    getFilteredStudents: getFilteredStudents
   };
 });
 

--- a/src/assets/stylesheets/_print.scss
+++ b/src/assets/stylesheets/_print.scss
@@ -19,6 +19,11 @@
       content: " (" attr(href) ")";
     }
   }
+  .cc-heading-page-title {
+    a[href]::after {
+      content: none;
+    }
+  }
   abbr[title]::after {
     content: " (" attr(title) ")";
   }

--- a/src/assets/stylesheets/_roster.scss
+++ b/src/assets/stylesheets/_roster.scss
@@ -1,18 +1,21 @@
-// Canvas Embedded Overrides
-.bc-canvas-embedded {
+// Canvas Application Overrides
+.bc-canvas-application {
   .cc-page-roster .cc-roster-search .cc-right {
     margin-top: 8px;
-  }
-  .cc-page-roster .cc-roster-search .cc-roster-search-type-filter {
-    display: none;
   }
   .cc-page-roster .cc-inline-select {
     height: auto;
   }
-  .cc-page-roster-list {
+  .cc-page-roster .cc-page-roster-photos-list {
     li {
       height: auto;
     }
+  }
+  .cc-page-roster div.cc-roster-view-mode {
+    display: none;
+  }
+  .cc-page-roster div.cc-roster-search-enroll-status {
+    display: none;
   }
 }
 
@@ -21,7 +24,6 @@
   border: 1px solid $cc-color-button-border;
   border-radius: 5px;
   font-size: 12px;
-  margin: 0 10px 0 0;
   padding: 4px 10px 5px 8px;
   width: 200px;
 }
@@ -44,7 +46,19 @@
     }
 
     .cc-inline-select {
+      height: 26px;
       width: 200px;
+    }
+
+    .cc-roster-search-option {
+      padding-right: 10px;
+      .cc-button-group {
+        margin-top: 2px;
+        li a {
+          line-height: 2;
+          padding: 6px 20px;
+        }
+      }
     }
 
     .cc-roster-search-row {
@@ -58,7 +72,14 @@
     }
   }
 
-  .cc-page-roster-list {
+  .cc-page-roster-image-unavailable {
+    background-image: url('../images/svg/photo_unavailable_official_72x96.svg');
+    height: 96px;
+    margin: 0 auto;
+    max-width: 72px;
+  }
+
+  .cc-page-roster-photos-list {
     li {
       display: block;
       float: left;
@@ -74,13 +95,6 @@
     }
   }
 
-  .cc-page-roster-image-unavailable {
-    background-image: url('../images/svg/photo_unavailable_official_72x96.svg');
-    height: 96px;
-    margin: 0 auto;
-    max-width: 72px;
-  }
-
   .cc-page-roster-student-name {
     display: block;
     overflow: hidden;
@@ -88,18 +102,32 @@
     white-space: nowrap;
   }
 
+  .cc-page-roster-table-list-description {
+    margin-bottom: 10px;
+  }
+
   @media print {
     overflow: visible;
     padding: 0;
 
-    .cc-page-roster-image-unavailable::before {
-      content: url('../images/svg/photo_unavailable_official_72x96.svg');
+    a[href]::after {
+      content: none;
     }
 
-    .cc-page-roster-list {
-      a[href]::after {
-        content: "";
+    .cc-academics-class-enrollment-table {
+      table tr th {
+        padding: 2px;
+        vertical-align: top;
       }
+      table tr td {
+        font-size: 10px;
+        line-height: normal;
+        padding: 2px;
+      }
+    }
+
+    .cc-page-roster-image-unavailable::before {
+      content: url('../images/svg/photo_unavailable_official_72x96.svg');
     }
 
     .cc-page-roster-student-name {
@@ -109,7 +137,7 @@
       white-space: normal;
     }
 
-    .cc-page-roster-list {
+    .cc-page-roster-photos-list {
       li {
         height: auto;
         margin-top: 15px;

--- a/src/assets/stylesheets/calcentral.scss
+++ b/src/assets/stylesheets/calcentral.scss
@@ -61,6 +61,7 @@
 @import "enrollment_verification";
 @import "degree_progress";
 @import "higher_degree_committees";
+@import "roster";
 
 // Textbooks
 @import "textbooks";
@@ -85,6 +86,7 @@
 @import "campus";
 
 // Canvas external apps
+// See also 'roster' above for shared CalCentral/Canvas Roster
 @import "canvas_colors";
 @import "canvas_base";
 @import "canvas_embedded";
@@ -95,7 +97,6 @@
 @import "canvas_create_course_site";
 @import "canvas_create_project_site";
 @import "canvas_user_provision";
-@import "canvas_roster";
 @import "canvas_site_creation";
 @import "canvas_site_mailing_list";
 

--- a/src/assets/templates/academics_classinfo.html
+++ b/src/assets/templates/academics_classinfo.html
@@ -10,7 +10,7 @@
       <a data-ng-href="/academics/semester/{{selectedSemester.slug}}"><span data-ng-bind="selectedSemester.name"></span></a> &raquo;
       <span data-ng-bind="selectedCourse.course_code"></span>
       <span data-ng-if="selectedSection" data-ng-bind-template=" &raquo; {{selectedSection.section_label}}"></span>
-      <div class="cc-academics-teaching-button-group" data-ng-if="isInstructorOrGsi">
+      <div class="cc-academics-teaching-button-group cc-print-hide" data-ng-if="isInstructorOrGsi">
         <ul class="cc-button-group cc-even-{{classInfoCategories.length}}" role="tablist">
           <li data-ng-repeat="classInfoCategory in classInfoCategories">
             <a class="cc-button cc-academics-class-info-category-button"
@@ -299,6 +299,7 @@
          data-cc-academics-class-info-enrollment-directive
          data-class-department="selectedCourse.dept"
          data-class-name="selectedCourse.course_code"
+         data-enrollment-status="waitlisted"
          data-instructor-name="api.user.profile.preferredName"
          data-semester-name="selectedSemester.name"
          data-show-position="true"
@@ -309,6 +310,7 @@
          data-cc-academics-class-info-enrollment-directive
          data-class-department="selectedCourse.dept"
          data-class-name="selectedCourse.course_code"
+         data-enrollment-status="enrolled"
          data-instructor-name="api.user.profile.preferredName"
          data-semester-name="selectedSemester.name"
          data-show-position="false"
@@ -322,7 +324,7 @@
       <div class="cc-widget-title">
         <h2>Roster</h2>
       </div>
-      <div data-ng-include src="'canvas_embedded/roster.html'"></div>
+      <div data-ng-include src="'widgets/roster.html'"></div>
     </div>
   </div>
 

--- a/src/assets/templates/canvas_embedded/roster.html
+++ b/src/assets/templates/canvas_embedded/roster.html
@@ -1,1 +1,1 @@
-<div data-ng-include src="'widgets/roster.html'"></div>
+<div data-ng-include src="'widgets/roster.html'" class="bc-canvas-application"></div>

--- a/src/assets/templates/directives/academics_class_info_enrollment.html
+++ b/src/assets/templates/directives/academics_class_info_enrollment.html
@@ -11,7 +11,7 @@
       <label for="section-select" class="cc-visuallyhidden">Filter by Section</label>
       <select id="section-select" class="cc-inline-select bc-canvas-embedded-roster-select"
               data-ng-options="section as section.name for section in sections track by section.ccn"
-              data-ng-model="selectedSection"
+              data-ng-model="searchFilters.section"
               data-ng-change="sectionChangeActions()">
         <option value="">All Sections</option>
       </select>
@@ -21,8 +21,9 @@
 
     <div class="cc-academics-class-enrollment-text">
       <span class="cc-academics-class-enrollment-stats">
-        On List: <strong data-ng-bind="seatsFilled"></strong> |
-        Available: <strong data-ng-bind="seatsAvailable"></strong>
+        On List: <strong data-ng-bind="filteredStudents.totalStudentCount"></strong> |
+        Available: <strong data-ng-bind="filteredStudents.openSeatsCount"></strong> |
+        Shown: <strong data-ng-bind="filteredStudents.shownStudentCount"></strong>
       </span>
 
       <div class="visible-for-small-only cc-academics-class-enrollment-mobile-button-spacer"></div>
@@ -35,28 +36,28 @@
       </a>
 
       <a class="cc-button cc-class-enrollment-formatted-content-show-button"
-          data-ng-if="studentRole === 'waitlisted' && !isLaw"
+          data-ng-if="searchFilters.enrollStatus === 'waitlisted' && !isLaw"
           data-ng-disabled="displayedSection === 'promote' || noStudentsSelected()"
           data-ng-click="displaySection('promote')">
         <span class="hidden-for-small-only">Request to</span> Promote
       </a>
 
       <a class="cc-button cc-class-enrollment-formatted-content-show-button"
-          data-ng-if="studentRole === 'waitlisted' && !isLaw"
+          data-ng-if="searchFilters.enrollStatus === 'waitlisted' && !isLaw"
           data-ng-disabled="displayedSection === 'enroll' || noStudentsSelected()"
           data-ng-click="displaySection('enroll')">
         <span class="hidden-for-small-only">Request to</span> Enroll
       </a>
 
       <a class="cc-button cc-class-enrollment-formatted-content-show-button"
-          data-ng-if="studentRole === 'waitlisted' && !isLaw"
+          data-ng-if="searchFilters.enrollStatus === 'waitlisted' && !isLaw"
           data-ng-disabled="displayedSection === 'remove' || noStudentsSelected()"
           data-ng-click="displaySection('remove')">
         <span class="hidden-for-small-only">Request to</span> Remove
       </a>
 
       <a class="cc-button cc-class-enrollment-formatted-content-show-button"
-          data-ng-if="studentRole !== 'waitlisted' && !isLaw"
+          data-ng-if="searchFilters.enrollStatus !== 'waitlisted' && !isLaw"
           data-ng-disabled="displayedSection === 'drop' || noStudentsSelected()"
           data-ng-click="displaySection('drop')">
         <span class="hidden-for-small-only">Request to</span> Drop
@@ -128,19 +129,19 @@
             <th data-cc-sortable-column-directive="grade_option" data-column-heading="Grade" class="show-for-large-up"></th>
             <th data-cc-sortable-column-directive="student_id" data-column-heading="SID" class="show-for-large-up"></th>
           </thead>
-          <tbody data-ng-repeat="student in filteredStudents = (studentsInSection | orderBy:tableSort.column:tableSort.reverse)"
+          <tbody data-ng-repeat="student in sortedStudents = (filteredStudents.shownStudents | orderBy:tableSort.column:tableSort.reverse)"
                  data-ng-class-even="'cc-academics-even'"
                  data-ng-if="students.length">
             <tr class="cc-academics-class-enrollment-table-row">
               <td>
-                <input id="cc-academics-class-enrollment-{{studentRole}}-{{$index}}"
+                <input id="cc-academics-class-enrollment-{{searchFilters.enrollStatus}}-{{$index}}"
                   type="checkbox" name="student_id" data-ng-model="student.selected">
               </td>
               <td data-ng-if="showPosition">
                 <strong data-ng-bind="student.waitlist_position"></strong>
               </td>
               <td>
-                <label for="cc-academics-class-enrollment-{{studentRole}}-{{$index}}">
+                <label for="cc-academics-class-enrollment-{{searchFilters.enrollStatus}}-{{$index}}">
                   <span data-ng-bind="student.last_name"></span>,
                   <span data-ng-bind="student.first_name"></span>
                 </label>
@@ -165,10 +166,10 @@
         </div>
         <div data-ng-if="!errorStatus">
           <div class="cc-academics-class-enrollment-table-notice" data-ng-if="!students.length">
-            No students are currently <span data-ng-bind="studentRole"></span> in this class.
+            No students are currently <span data-ng-bind="searchFilters.enrollStatus"></span> in this class.
           </div>
-          <div class="cc-academics-class-enrollment-table-notice" data-ng-if="students.length && !filteredStudents.length">
-            No students are currently <span data-ng-bind="studentRole"></span> in this section.
+          <div class="cc-academics-class-enrollment-table-notice" data-ng-if="students.length && !sortedStudents.length">
+            No students are currently <span data-ng-bind="searchFilters.enrollStatus"></span> in this section.
           </div>
         </div>
       </div>

--- a/src/assets/templates/widgets/roster.html
+++ b/src/assets/templates/widgets/roster.html
@@ -9,17 +9,48 @@
     <form class="cc-roster-search" data-ng-hide="errorStatus">
       <div class="cc-roster-search-row">
         <div>
-          <label for="roster-search" class="cc-visuallyhidden">Filter by Text</label>
-          <input id="roster-search" class="cc-roster-input cc-left bc-canvas-embedded-roster-input" placeholder="Search People"
-            data-ng-model="searchOptions.text.$" data-ng-change="accessibilityAnnounce('Rosters filtered by text')">
+          <div class="cc-left cc-roster-search-option">
+            <label for="roster-search" class="cc-visuallyhidden">Filter by Text</label>
+            <input id="roster-search" class="cc-roster-input bc-canvas-embedded-roster-input" placeholder="Search People"
+              data-ng-model="searchOptions.text"
+              data-ng-change="sectionChangeActions('text')">
+          </div>
 
-          <label for="section-select" class="cc-visuallyhidden">Filter by Section</label>
-          <select id="section-select" class="cc-inline-select bc-canvas-embedded-roster-select"
-            data-ng-options="section as section.name for section in sections track by section.ccn"
-            data-ng-model="searchOptions.section"
-            data-ng-change="accessibilityAnnounce('Rosters filtered by section')">
-            <option value="">All Sections</option>
-          </select>
+          <div class="cc-left cc-roster-search-option">
+            <label for="section-select" class="cc-visuallyhidden">Filter by Section</label>
+            <select id="section-select" class="cc-inline-select bc-canvas-embedded-roster-select"
+              data-ng-options="section as section.name for section in sections track by section.ccn"
+              data-ng-model="searchOptions.section"
+              data-ng-change="sectionChangeActions('section')">
+              <option value="">All Sections</option>
+            </select>
+          </div>
+
+          <div class="cc-roster-view-mode cc-left cc-roster-search-option">
+            <ul class="cc-button-group" role="tablist">
+              <li>
+                <a class="cc-button"
+                  aria-selected="{{currentRosterViewType === 'photos'}}"
+                  role="tab"
+                  data-ng-click="currentRosterViewType = 'photos'"
+                  data-ng-class="{'cc-button-selected cc-button-selected-roster':(currentRosterViewType === 'photos')}"
+                >
+                  <i class="fa fa-user"></i> Photos
+                </a>
+              </li>
+              <li>
+                <a class="cc-button"
+                  aria-selected="{{currentRosterViewType === 'list'}}"
+                  role="tab"
+                  data-ng-click="currentRosterViewType = 'list'"
+                  data-ng-class="{'cc-button-selected cc-button-selected-roster':(currentRosterViewType === 'list')}"
+                >
+                  <i class="fa fa-list"></i> List
+                </a>
+              </li>
+            </ul>
+          </div>
+
         </div>
         <div>
           <a class="cc-button cc-button-spaced" target="_self"
@@ -32,23 +63,23 @@
           </a>
         </div>
       </div>
-      <div class="cc-roster-search-type-filter cc-roster-search-row">
+      <div class="cc-roster-search-enroll-status cc-roster-search-row">
         <div class="cc-roster-search-horizontal-radio">
           <strong>Include:</strong>
-          <label for="searchOptionType">
-            <input type="radio" name="searchOptionType" value="all"
-              data-ng-model="searchOptions.type"
-              data-ng-change="accessibilityAnnounce('All roster types shown')">All
+          <label for="searchOptionEnrollStatus">
+            <input type="radio" name="searchOptionEnrollStatus" value="all"
+              data-ng-model="searchOptions.enrollStatus"
+              data-ng-change="sectionChangeActions('enrollment status')">All
           </label>
-          <label for="searchOptionType">
-            <input type="radio" name="searchOptionType" value="enrolled"
-              data-ng-model="searchOptions.type"
-              data-ng-change="accessibilityAnnounce('Only enrollments shown')">Enrolled Only
+          <label for="searchOptionEnrollStatus">
+            <input type="radio" name="searchOptionEnrollStatus" value="enrolled"
+              data-ng-model="searchOptions.enrollStatus"
+              data-ng-change="sectionChangeActions('enrollment status')">Enrolled Only
           </label>
-          <label for="searchOptionType">
-            <input type="radio" name="searchOptionType" value="waitlist"
-              data-ng-model="searchOptions.type"
-              data-ng-change="accessibilityAnnounce('Only waitlisted shown')">Waitlisted Only
+          <label for="searchOptionEnrollStatus">
+            <input type="radio" name="searchOptionEnrollStatus" value="waitlisted"
+              data-ng-model="searchOptions.enrollStatus"
+              data-ng-change="sectionChangeActions('enrollment status')">Waitlisted Only
           </label>
         </div>
       </div>
@@ -69,50 +100,126 @@
     <span data-ng-bind="course.name"></span> -
     <span data-ng-if="searchOptions.section.name" data-ng-bind="searchOptions.section.name"></span>
     <span data-ng-if="!searchOptions.section.name">All Sections</span>
-    <span data-ng-if="searchOptions.text.$" data-ng-bind-template=" - Matching '{{searchOptions.text.$}}'"></span>
+    <span data-ng-if="searchOptions.text" data-ng-bind-template=" - Matching '{{searchOptions.text}}'"></span>
   </h2>
 
-  <ul class="cc-page-roster-list">
-    <li data-ng-repeat="student in students | filter:searchOptions.text | filter:studentInSectionFilter | filter:rosterTypeFilter | orderBy:['last_name', 'first_name']">
-      <div data-ng-if="student.profile_url">
-        <a data-ng-href="{{student.profile_url}}" target="_top">
-          <div data-ng-include="'widgets/roster_photo.html'"></div>
-        </a>
-      </div>
-      <div data-ng-if="!student.profile_url">
-        <a data-ng-href="{{origin}}/{{context}}/{{courseId}}/profile/{{student.login_id}}" target="_top">
-          <div data-ng-include="'widgets/roster_photo.html'"></div>
-        </a>
-      </div>
-      <div data-ng-if="!student.email">
-        <div class="cc-page-roster-student-name" data-ng-bind="student.first_name"></div>
-        <div class="cc-page-roster-student-name">
-          <strong data-ng-bind="student.last_name"></strong>
-        </div>
-      </div>
-      <div data-ng-if="student.email">
-        <div class="cc-page-roster-student-name">
-          <a data-ng-href="{{bmailLink(student.email)}}">
-            <span data-ng-bind="student.first_name"></span>
+  <div data-ng-show="currentRosterViewType === 'photos'">
+    <ul class="cc-page-roster-photos-list">
+      <li data-ng-repeat="student in sortedStudents = (filteredStudents.shownStudents | orderBy:tableSort.column:tableSort.reverse)">
+        <div data-ng-if="student.profile_url">
+          <a data-ng-href="{{student.profile_url}}" target="_top">
+            <div data-ng-include="'widgets/roster_photo.html'"></div>
           </a>
         </div>
-        <div class="cc-page-roster-student-name">
-          <a data-ng-href="{{bmailLink(student.email)}}">
+        <div data-ng-if="!student.profile_url">
+          <a data-ng-href="{{origin}}/{{context}}/{{courseId}}/profile/{{student.login_id}}" target="_top">
+            <div data-ng-include="'widgets/roster_photo.html'"></div>
+          </a>
+        </div>
+        <div data-ng-if="!student.email">
+          <div class="cc-page-roster-student-name" data-ng-bind="student.first_name"></div>
+          <div class="cc-page-roster-student-name">
             <strong data-ng-bind="student.last_name"></strong>
-          </a>
+          </div>
+        </div>
+        <div data-ng-if="student.email">
+          <div class="cc-page-roster-student-name">
+            <a data-ng-href="{{bmailLink(student.email)}}">
+              <span data-ng-bind="student.first_name"></span>
+            </a>
+          </div>
+          <div class="cc-page-roster-student-name">
+            <a data-ng-href="{{bmailLink(student.email)}}">
+              <strong data-ng-bind="student.last_name"></strong>
+            </a>
+          </div>
+        </div>
+        <div class="cc-print-hide">
+          <span class="cc-visuallyhidden">Student ID: </span>
+          <span data-ng-bind="student.student_id"></span>
+        </div>
+        <div class="cc-page-roster-student-terms cc-print-hide"
+            data-ng-if="student.terms_in_attendance"
+            data-ng-bind-template="Terms: {{student.terms_in_attendance}}"></div>
+        <div class="cc-page-roster-student-majors cc-print-hide">
+          <span data-ng-bind="student.majors.join(', ') | limitTo:50"></span>
+        </div>
+      </li>
+    </ul>
+  </div>
+
+  <div data-ng-show="currentRosterViewType === 'list'">
+    <div class="cc-page-roster-table-list-description">
+      <strong>Primary Section:</strong>
+      On List: <strong data-ng-bind="filteredStudents.totalStudentCount"></strong> |
+      Available: <strong data-ng-bind="filteredStudents.openSeatsCount"></strong> |
+      Shown: <strong data-ng-bind="filteredStudents.shownStudentCount"></strong>
+    </div>
+    <div class="cc-page-roster-table-list-description">
+      <strong>Notes:</strong>
+      Use headers to sort columns. For email links, have bMail open in the same browser as CalCentral.
+      Only waitlisted students have "Pos" position numbers.
+    </div>
+    <div class="cc-table cc-academics-class-enrollment-table">
+      <table>
+        <thead class="cc-academics-class-enrollment-table-head">
+          <th data-cc-sortable-column-directive="waitlist_position" data-column-heading="Pos" data-ng-if="showPosition"></th>
+          <th data-cc-sortable-column-directive="last_name" data-column-heading="Name"></th>
+          <th data-cc-sortable-column-directive="email" data-column-heading="Email"></th>
+          <th data-cc-sortable-column-directive="majors" data-column-heading="Majors" class="show-for-medium-up"></th>
+          <th class="show-for-medium-up"
+            data-ng-repeat="column in columnHeaders"
+            data-cc-sortable-column-directive="{{column.instruction_format}}"
+            data-column-heading="{{column.instruction_format}}"></th>
+          <th data-cc-sortable-column-directive="terms_in_attendance" data-column-heading="Terms" class="show-for-large-up"></th>
+          <th data-cc-sortable-column-directive="student_id" data-column-heading="SID" class="show-for-large-up cc-print-hide"></th>
+          <th data-cc-sortable-column-directive="units" data-column-heading="Units" class="show-for-large-up"></th>
+          <th data-cc-sortable-column-directive="grade_option" data-column-heading="Grade" class="show-for-large-up"></th>
+        </thead>
+        <tbody
+          data-ng-repeat="student in sortedStudents = (filteredStudents.shownStudents | orderBy:tableSort.column:tableSort.reverse)"
+          data-ng-class-even="'cc-academics-even'"
+          data-ng-if="students.length"
+        >
+          <tr class="cc-academics-class-enrollment-table-row">
+            <td data-ng-if="showPosition">
+              <strong data-ng-bind="student.waitlist_position"></strong>
+            </td>
+            <td>
+              <label for="cc-academics-class-enrollment-{{studentRole}}-{{$index}}">
+                <span data-ng-bind="student.last_name"></span>,
+                <span data-ng-bind="student.first_name"></span>
+              </label>
+            </td>
+            <td>
+              <a data-ng-if="student.email" data-ng-bind="student.email" data-ng-href="{{bmailLink(student.email)}}"></a>
+            </td>
+            <td class="show-for-medium-up">
+              <span data-ng-repeat="major in student.majors">
+                <span data-ng-bind="major"></span><br>
+              </span>
+            </td>
+            <td data-ng-bind="column.section_number" data-ng-repeat="column in student.columns" class="show-for-medium-up"></td>
+            <td data-ng-bind="student.terms_in_attendance" class="show-for-large-up"></td>
+            <td data-ng-bind="student.student_id" class="show-for-large-up cc-print-hide"></td>
+            <td data-ng-bind="student.units" class="show-for-large-up"></td>
+            <td data-ng-bind="student.grade_option" class="show-for-large-up"></td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="cc-academics-class-enrollment-table-notice" data-ng-if="errorStatus">
+        There was an error retrieving roster data.
+      </div>
+      <div data-ng-if="!errorStatus">
+        <div class="cc-academics-class-enrollment-table-notice" data-ng-if="!students.length">
+          No students are currently enrolled or waitlisted in this class.
+        </div>
+        <div class="cc-academics-class-enrollment-table-notice" data-ng-if="students.length && !sortedStudents.length">
+          No students found matching the above search criteria.
         </div>
       </div>
-      <div class="cc-print-hide">
-        <span class="cc-visuallyhidden">Student ID: </span>
-        <span data-ng-bind="student.student_id"></span>
-      </div>
-      <div class="cc-page-roster-student-terms cc-print-hide"
-          data-ng-if="student.terms_in_attendance"
-          data-ng-bind-template="Terms: {{student.terms_in_attendance}}"></div>
-      <div class="cc-page-roster-student-majors cc-print-hide">
-        <span data-ng-bind="student.majors.join(', ') | limitTo:50"></span>
-      </div>
-    </li>
-  </ul>
+    </div>
+
+  </div>
 
 </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-30579

* Adds Rosters::TableColumns module
* Merges prepared column data and headers into Rosters::Campus data feed
* Updated rosters template to hide new search options from bCourses (Canvas) LTI tool
* Refactors Rosters::Campus
* Adds instructional format code and section number to Rosters::Campus feed
* Adds list view, migrates roster filtering to shared rosterService methods
* Moves logic for viewing selected section of students and statistics to rosterService
* Updates Canvas::Course object to represent as `Canvas Course ID 1234` instead of `#<Canvas::Course:0x2aadf2a9>`