### PR TITLE
SISRP-29263 - CalCentral missing summer 2016 classes for Fall 2016 

### DIFF
--- a/app/models/my_academics/semesters.rb
+++ b/app/models/my_academics/semesters.rb
@@ -155,7 +155,8 @@ module MyAcademics
     end
 
     def use_enrollment_grades?(semester)
-      semester[:timeBucket] == 'current' || semester[:gradingInProgress] || semester[:campusSolutionsTerm]
+      return true unless Settings.features.allow_legacy_fallback
+      semester[:timeBucket] == 'current' || semester[:gradingInProgress] || semester[:campusSolutionsTerm] ||  semester[:slug] == Settings.terms.legacy_cutoff
     end
 
     def use_transcript_grades?(semester)


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-29263 

* force semesters to pull grades from CS for summer-2016 and when allow_legacy_fallback is false