### PR TITLE
CLC-6501, /api/oec/google/current_scope must use proper app_id in GoogleProxy call

### DIFF
--- a/app/models/google_apps/oauth2_tokens_grant.rb
+++ b/app/models/google_apps/oauth2_tokens_grant.rb
@@ -65,8 +65,8 @@ module GoogleApps
     end
 
     def scope_granted
-      return [] unless GoogleApps::Proxy.access_granted? @user_id
-      GoogleApps::Userinfo.new(user_id: @user_id).current_scope
+      return [] unless GoogleApps::Proxy.access_granted?(@user_id, @app_id)
+      GoogleApps::Userinfo.new(user_id: @user_id, app_id: @app_id).current_scope
     end
 
     def expire

--- a/spec/controllers/google_auth_controller_spec.rb
+++ b/spec/controllers/google_auth_controller_spec.rb
@@ -139,7 +139,7 @@ describe GoogleAuthController do
   describe '#current_scope' do
     let(:access_granted) { true }
     before do
-      expect(GoogleApps::Proxy).to receive(:access_granted?).with(user_id).and_return access_granted
+      expect(GoogleApps::Proxy).to receive(:access_granted?).with(user_id, GoogleApps::Proxy::APP_ID).and_return access_granted
     end
     subject {
       post :current_scope, { format: 'json' }
@@ -151,7 +151,7 @@ describe GoogleAuthController do
     context 'access granted' do
       let(:current_scope) { [ random_string(5), random_string(5) ] }
       before do
-        expect(GoogleApps::Userinfo).to receive(:new).with(user_id: user_id).and_return (user_info = double)
+        expect(GoogleApps::Userinfo).to receive(:new).with(user_id: user_id, app_id: GoogleApps::Proxy::APP_ID).and_return (user_info = double)
         expect(user_info).to receive(:current_scope).and_return current_scope
       end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6501

The call to get OEC `current_scope` (Google OAuth) had been using default app_id therefore finding no match in the db. Furthermore, OEC-mode is not compatible with the Google API call for 'self' so we ride the coattails of `can_administer_oec?` check. 
