### PR TITLE
SISRP-28447 Add new service_alerts column to developer-seed-data

### DIFF
--- a/db/developer-seed-data.sql
+++ b/db/developer-seed-data.sql
@@ -311,6 +311,7 @@ CREATE TABLE service_alerts (
   body text NOT NULL,
   publication_date timestamp without time zone NOT NULL,
   display boolean DEFAULT false NOT NULL,
+  splash boolean DEFAULT false NOT NULL,
   created_at timestamp without time zone,
   updated_at timestamp without time zone
 );


### PR DESCRIPTION
Fix for https://github.com/ets-berkeley-edu/calcentral/pull/6483

I'd used normal Rails migration to test locally, but Bamboo relies on developer-seed-data.sql to start from a fresh DB.