### PR TITLE
SISRP-24076 - New data source for Concurrent Enrollment role

### DIFF
--- a/app/models/berkeley/user_roles.rb
+++ b/app/models/berkeley/user_roles.rb
@@ -12,8 +12,7 @@ module Berkeley
         :exStudent => (affiliations & ['STUDENT-STATUS-EXPIRED', 'FORMER-STUDENT', 'AFFILIATE-TYPE-ADVCON-ALUMNUS']).present?,
         :faculty => affiliations.include?('EMPLOYEE-TYPE-ACADEMIC'),
         :staff => affiliations.include?('EMPLOYEE-TYPE-STAFF'),
-        :guest => affiliations.include?('GUEST-TYPE-COLLABORATOR'),
-        :concurrentEnrollmentStudent => affiliations.include?('AFFILIATE-TYPE-CONCURR ENROLL')
+        :guest => affiliations.include?('GUEST-TYPE-COLLABORATOR')
       }
     end
 
@@ -95,6 +94,8 @@ module Berkeley
             result[:undergrad] = true
           when 'LAW'
             result[:law] = true
+          when 'EXTENSION'
+            result[:concurrentEnrollmentStudent] = true
         end
       end
       cs_affiliations.select { |a| a[:status][:code] == 'INA' }.each do |inactive_affiliation|

--- a/spec/models/berkeley/user_roles_spec.rb
+++ b/spec/models/berkeley/user_roles_spec.rb
@@ -10,6 +10,47 @@ describe Berkeley::UserRoles do
   describe '#roles_from_cs_affiliations' do
     subject { Berkeley::UserRoles.roles_from_cs_affiliations(affiliations) }
 
+    context 'concurrent enrollment student' do
+      let(:affiliations) do
+        [
+          {
+            :type => {
+              :code => 'STUDENT',
+              :description => ''
+            },
+            :status => {
+              :code =>'ACT',
+              :description => 'Active'
+            },
+            :fromDate => '2017-01-21'
+          },
+          {
+            :type => {
+              :code => 'EXTENSION',
+              :description => 'UCB Extension Student'
+            },
+            :status => {
+              :code => 'ACT',
+              :description => 'Active'
+            },
+            :fromDate => '2017-01-21'
+          },
+          {
+            :type => {
+              :code => 'UNDERGRAD',
+              :description => 'Undergraduate Student'
+            },
+            :status => {
+              :code =>'ACT',
+              :description => 'Active'
+            },
+            :fromDate => '2017-02-10'
+          }
+        ]
+      end
+      it_behaves_like 'a parser for roles', [:student, :undergrad, :concurrentEnrollmentStudent]
+    end
+
     context 'undergraduate student' do
       let(:affiliations) do
         [

--- a/spec/models/campus_oracle/user_attributes_spec.rb
+++ b/spec/models/campus_oracle/user_attributes_spec.rb
@@ -29,10 +29,6 @@ describe CampusOracle::UserAttributes do
           let(:uid) {19999969}
           it_behaves_like 'a parser for roles', [:guest]
         end
-        context 'concurrent enrollment student' do
-          let(:uid) {321703}
-          it_behaves_like 'a parser for roles', [:concurrentEnrollmentStudent]
-        end
         context 'user with expired CalNet account' do
           let(:uid) {6188989}
           it_behaves_like 'a parser for roles', [:student, :registered, :expiredAccount, :graduate]

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -448,7 +448,6 @@ describe User::Api do
           faculty: false,
           staff: false,
           guest: false,
-          concurrentEnrollmentStudent: false,
           expiredAccount: false
         }
       }
@@ -471,7 +470,6 @@ describe User::Api do
           faculty: true,
           staff: false,
           guest: false,
-          concurrentEnrollmentStudent: false,
           expiredAccount: false
         }
       }
@@ -491,8 +489,7 @@ describe User::Api do
               exStudent: true,
               faculty: true,
               staff: false,
-              guest: false,
-              concurrentEnrollmentStudent: false
+              guest: false
             },
             student_id: '17154428'
           }


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-24076

The 'AFFILIATE-TYPE-CONCURR ENROLL' affiliation has been [discontinued from use by CalNet LDAP](https://calnetweb.berkeley.edu/calnet-technologists/ldap-directory-service/how-ldap-organized/people-ou/people-ou-affiliations).

This updates CalCentral to use the 'EXTENSION' affiliation sourced from Campus Solutions.