### PR TITLE
SISRP-30636 - Adds APR link to UGRD Degree Progress card for advisor only

### DIFF
--- a/app/models/degree_progress/my_graduate_milestones.rb
+++ b/app/models/degree_progress/my_graduate_milestones.rb
@@ -37,7 +37,7 @@ module DegreeProgress
       if (link_feed = CampusSolutions::Link.new.get_url link_key)
         link = link_feed.try(:[], :link)
       end
-      logger.error "Could not retrieve CS link #{link_key} for Degree Progress feed, uid = #{@uid}" unless link
+      logger.error "Could not retrieve CS link #{link_key} for #{self.class.name} feed, uid = #{@uid}" unless link
       link
     end
 

--- a/app/models/degree_progress/undergrad_requirements.rb
+++ b/app/models/degree_progress/undergrad_requirements.rb
@@ -7,6 +7,10 @@ module DegreeProgress
     include Cache::UserCacheExpiry
     include RequirementsModule
 
+    LINKS_CONFIG = [
+      { feed_key: :academic_progress_report, cs_link_key: 'UC_CX_APR_RPT_STDNT' }
+    ]
+
     def get_feed_internal
       return {} unless is_feature_enabled?
       response = CampusSolutions::DegreeProgress::UndergradRequirements.new(user_id: @uid).get
@@ -15,12 +19,30 @@ module DegreeProgress
       else
         response[:feed] = HashConverter.camelize({
           degree_progress: process(response),
+          links: get_links
         })
       end
       response
     end
 
     private
+
+    def get_links
+      links = {}
+      LINKS_CONFIG.each do |setting|
+        link = fetch_link setting[:cs_link_key]
+        links[setting[:feed_key]] = link unless link.blank?
+      end
+      links
+    end
+
+    def fetch_link(link_key)
+      if (link_feed = CampusSolutions::Link.new.get_url link_key)
+        link = link_feed.try(:[], :link)
+      end
+      logger.error "Could not retrieve CS link #{link_key} for #{self.class.name} feed, uid = #{@uid}" unless link
+      link
+    end
 
     def is_feature_enabled?
       Settings.features.cs_degree_progress_ugrd_advising

--- a/spec/models/degree_progress/my_undergrad_requirements_spec.rb
+++ b/spec/models/degree_progress/my_undergrad_requirements_spec.rb
@@ -9,5 +9,9 @@ describe DegreeProgress::MyUndergradRequirements do
 
     it_behaves_like 'a proxy that observes a feature flag'
     it_behaves_like 'a proxy that returns undergraduate milestone data'
+
+    it 'does not include the Academic Progress Report link in the response' do
+      expect(subject[:feed][:links]).not_to be
+    end
   end
 end

--- a/spec/models/degree_progress/undergrad_requirements_spec.rb
+++ b/spec/models/degree_progress/undergrad_requirements_spec.rb
@@ -9,5 +9,10 @@ describe DegreeProgress::UndergradRequirements do
 
     it_behaves_like 'a proxy that observes a feature flag'
     it_behaves_like 'a proxy that returns undergraduate milestone data'
+
+    it 'includes the Academic Progress Report link in the response' do
+      expect(subject[:feed][:links]).to be
+      expect(subject[:feed][:links][:academicProgressReport]).to be
+    end
   end
 end

--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -245,6 +245,7 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
         uid: $routeParams.uid
       }).then(function(data) {
         $scope.degreeProgress.undergraduate.progresses = _.get(data, 'data.feed.degreeProgress.progresses');
+        $scope.degreeProgress.undergraduate.links = _.get(data, 'data.feed.links');
         $scope.degreeProgress.undergraduate.errored = _.get(data, 'errored');
       }).finally(function() {
         $scope.degreeProgress.undergraduate.showCard = apiService.user.profile.features.csDegreeProgressUgrdAdvising && $scope.degreeProgress.undergraduate.progresses.length;

--- a/src/assets/stylesheets/_degree_progress.scss
+++ b/src/assets/stylesheets/_degree_progress.scss
@@ -4,6 +4,10 @@
     font-size: 13px;
     margin-bottom: 10px;
   }
+
+  .cc-degree-progress-footer {
+    margin: 15px 0 0;
+  }
 }
 
 .cc-degree-progress-card ul.cc-graduate-milestones>li {

--- a/src/assets/templates/widgets/academics/degree_progress_undergrad.html
+++ b/src/assets/templates/widgets/academics/degree_progress_undergrad.html
@@ -10,14 +10,14 @@
     <div data-ng-if="!degreeProgress.undergraduate.errored && degreeProgress.undergraduate.progresses.length">
       <ul>
         <li data-ng-repeat="plan in degreeProgress.undergraduate.progresses">
-          <div class="cc-degree-progress-report-date">
+          <div data-ng-if="plan.reportDate" class="cc-degree-progress-report-date">
             Degree Progress as of <span data-ng-bind="plan.reportDate"></span>
           </div>
           <div class="cc-table">
             <table>
               <thead>
                 <tr>
-                  <th>University Requirement</th>
+                  <th>University Requirement</th>r
                   <th>Status</th>
                 </tr>
               </thead>
@@ -34,6 +34,19 @@
           </div>
         </li>
       </ul>
+    </div>
+    <div data-ng-if="api.user.profile.roles.advisor" class="cc-degree-progress-footer">
+      Run the
+      <a data-ng-if="degreeProgress.undergraduate.links.academicProgressReport.url"
+        data-cc-campus-solutions-link-directive="degreeProgress.undergraduate.links.academicProgressReport"
+        data-cc-campus-solutions-link-directive-cc-page-name="currentPage.name"
+        data-cc-campus-solutions-link-directive-cc-page-url="currentPage.url"
+      ></a>
+      <span data-ng-if="!degreeProgress.undergraduate.links.academicProgressReport.url">Academic Progress Report</span>
+      to refresh this data. Updates may take up to 24 hours.
+    </div>
+    <div data-ng-if="!api.user.profile.roles.advisor" class="cc-degree-progress-footer">
+      If this information is out of date, please contact your advisor.
     </div>
   </div>
 </div>


### PR DESCRIPTION
Parent:  https://jira.berkeley.edu/browse/SISRP-30580

Advisors will see a message with a link to run the APR.  Students will see a message with no link. (https://jira.berkeley.edu/browse/SISRP-30636)

I also wrapped the report run date and label in `ngIf` because it seems the API is not sending that date.  I will investigate that further, but at least wanted to make sure we don't ever display the label with the date missing.