### PR TITLE
SISRP-30618 - Authorization errors in CC Production logs related to committees

### DIFF
--- a/app/models/my_committees/committees_module.rb
+++ b/app/models/my_committees/committees_module.rb
@@ -98,7 +98,7 @@ module MyCommittees::CommitteesModule
   end
 
   def determine_qualifying_exam_status_message(cs_committee)
-    if cs_committee[:studentMilestoneAttempts].empty?
+    if cs_committee[:studentMilestoneAttempts].blank?
       proposed_exam_date = cs_committee.try(:[], :studentQeExamProposeDate)
       "Proposed Exam Date: #{format_date(proposed_exam_date)}" unless proposed_exam_date.blank?
     end

--- a/src/assets/templates/academics.html
+++ b/src/assets/templates/academics.html
@@ -33,8 +33,8 @@
         data-ng-controller="GraduateDegreeProgressController"
       ></div>
       <div data-ng-include src="'academics_teaching.html'" data-ng-if="!api.user.profile.delegateActingAsUid && hasTeachingClasses"></div>
-      <div data-ng-include src="'academics_higher_degree_committees.html'" data-ng-if="api.user.profile.features.csCommittees && (api.user.profile.roles.student || api.user.profile.roles.exStudent)"></div>
-      <div data-ng-include src="'academics_higher_degree_faculty_committees.html'" data-ng-if="api.user.profile.features.csCommittees && api.user.profile.roles.faculty"></div>
+      <div data-ng-include src="'academics_higher_degree_committees.html'" data-ng-if="api.user.profile.features.csCommittees && !api.user.profile.delegateActingAsUid && (api.user.profile.roles.student || api.user.profile.roles.exStudent)"></div>
+      <div data-ng-include src="'academics_higher_degree_faculty_committees.html'" data-ng-if="api.user.profile.features.csCommittees && !api.user.profile.delegateActingAsUid && api.user.profile.roles.faculty"></div>
     </div>
 
     <div class="medium-6 large-4 columns cc-column-3">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-30618

* Full disclosure, was not able to test this locally due to lack of test data, but we should have test cases in time for QA. 
* Removing the template from `academics.html` with a conditional should stop `AcademicsHigherDegreeCommitteesController` from instantiating, preventing the call to `api/my/committees`.
* If a delegate did manually hit the `api/my/comittees` endpoint, the `Pundit::NotAuthorizedError` will still be raised in the logs, notifying us of anything fishy.  For this reason, I did not add anything to the existing restrictions on `my_committees_controller.rb`.
* Changing `#empty?` to `#blank?` ensures no no error is raised if CS sends us `nil` for that particular field.