### PR TITLE
SISRP-31364 - Allows ex-student to see GRAD Degree Progress

### DIFF
--- a/app/models/degree_progress/my_graduate_milestones.rb
+++ b/app/models/degree_progress/my_graduate_milestones.rb
@@ -44,7 +44,7 @@ module DegreeProgress
     private
 
     def target_audience?
-      User::SearchUsersByUid.new(id: @uid, roles: [:graduate, :law]).search_users_by_uid.present?
+      User::SearchUsersByUid.new(id: @uid, roles: [:graduate, :law, :exStudent]).search_users_by_uid.present?
     end
 
     def is_feature_enabled?

--- a/src/assets/javascripts/angular/controllers/widgets/academics/graduateDegreeProgressController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/academics/graduateDegreeProgressController.js
@@ -3,7 +3,7 @@
 var angular = require('angular');
 var _ = require('lodash');
 
-angular.module('calcentral.controllers').controller('GraduateDegreeProgressController', function(degreeProgressFactory, $scope) {
+angular.module('calcentral.controllers').controller('GraduateDegreeProgressController', function(degreeProgressFactory, apiService, $scope) {
 
   $scope.degreeProgress = {
     graduate: {
@@ -19,6 +19,9 @@ angular.module('calcentral.controllers').controller('GraduateDegreeProgressContr
         $scope.degreeProgress.graduate.errored = _.get(data, 'errored');
       })
       .finally(function() {
+        var isHigherDegreeStudent = apiService.user.profile.roles.graduate || apiService.user.profile.roles.law;
+        var isExStudentWithMilestones = apiService.user.profile.roles.exStudent && $scope.degreeProgress.graduate.progresses.length;
+        $scope.degreeProgress.graduate.showCard = apiService.user.profile.features.csDegreeProgressGradStudent && (isHigherDegreeStudent || isExStudentWithMilestones);
         $scope.degreeProgress.graduate.isLoading = false;
       });
   };

--- a/src/assets/templates/academics.html
+++ b/src/assets/templates/academics.html
@@ -28,7 +28,6 @@
         data-ng-controller="UndergraduateDegreeProgressController"
       ></div>
       <div
-        data-ng-if="api.user.profile.features.csDegreeProgressGradStudent && (api.user.profile.roles.graduate || api.user.profile.roles.law)"
         data-ng-include src="'widgets/academics/degree_progress_graduate.html'"
         data-ng-controller="GraduateDegreeProgressController"
       ></div>

--- a/src/assets/templates/widgets/academics/degree_progress_graduate.html
+++ b/src/assets/templates/widgets/academics/degree_progress_graduate.html
@@ -1,4 +1,4 @@
-<div class="cc-widget cc-degree-progress-card">
+<div data-ng-if="degreeProgress.graduate.showCard" class="cc-widget cc-degree-progress-card">
   <div class="cc-widget-title">
     <h2>Degree Progress</h2>
   </div>


### PR DESCRIPTION
Parent:  https://jira.berkeley.edu/browse/SISRP-25708

If user is an ex-student, we don't know whether they were grad or undergrad.  We only want to show them the card if they were grad.  

To get around this problem, we will only show the card to ex-students IF the API returns data for the card (effectively indicating that the person was a grad student). (https://jira.berkeley.edu/browse/SISRP-31364)