### PR TITLE
NOJIRA Fix Capistrano deploy script

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -18,23 +18,22 @@ namespace :calcentral_dev do
   desc "Update and restart the calcentral_dev machine"
   task :update, :roles => :calcentral_dev_host do
     # Take everything offline first.
-    script_folder = project_root + ("/script")
-    run "cd #{script_folder}; ./init.d/calcentral stop"
+    run "cd #{project_root}; ./script/init.d/calcentral stop"
     servers = find_servers_for_task(current_task)
 
     transaction do
       servers.each_with_index do |server, index|
         # update source
-        run "cd #{script_folder}; ./update-build.sh", :hosts => server
+        run "cd #{project_root}; ./script/update-build.sh", :hosts => server
 
         # Run db migrate on the first app server ONLY
         if index == 0
           logger.debug "---- Server: #{server.host} running migrate in transaction on offline app servers"
-          run "cd #{script_folder}; ./migrate.sh", :hosts => server
+          run "cd #{project_root}; ./script/migrate.sh", :hosts => server
         end
 
         # start it up
-        run "cd #{script_folder}; ./init.d/calcentral start", :hosts => server
+        run "cd #{project_root}; ./script/init.d/calcentral start", :hosts => server
 
         if index < (servers.length - 1)
           # Allow time for Torquebox to quiesce before adding a node to the cluster. This appears to


### PR DESCRIPTION
The shell scripts assume they will be started from the top "calcentral" directory & should write output to the "./log/" directory.
Capistrano instead started them from "calcentral/scripts", leading to errors for all logging.
This is an old bug but the Bamboo agent is the only one who would have seen it in action.