### PR TITLE
[QA] SISRP-31367 - Defaults milestone status to 'Not Satisfied'

### DIFF
--- a/app/models/berkeley/graduate_milestones.rb
+++ b/app/models/berkeley/graduate_milestones.rb
@@ -6,6 +6,7 @@ module Berkeley
     QE_STATUS_FAILED = 'Failed'
     QE_STATUS_PARTIALLY_FAILED = 'Partially Failed'
     QE_STATUS_PASSED = 'Passed'
+    STATUS_INCOMPLETE = 'Not Satisfied'
 
     QE_APPROVAL_MILESTONE = 'AAGQEAPRV'
     QE_RESULTS_MILESTONE = 'AAGQERESLT'
@@ -68,7 +69,7 @@ module Berkeley
         'F' => QE_STATUS_FAILED,
         'PF' => QE_STATUS_PARTIALLY_FAILED,
         QE_STATUS_CODE_PASSED => QE_STATUS_PASSED,
-        'N' => 'Not Satisfied',
+        'N' => STATUS_INCOMPLETE,
         'Y' => 'Completed'
       }
     end

--- a/app/models/degree_progress/milestones_module.rb
+++ b/app/models/degree_progress/milestones_module.rb
@@ -37,7 +37,7 @@ module DegreeProgress
           normalized = {
             name: name,
             code: requirement[:code],
-            status:  Berkeley::GraduateMilestones.get_status(requirement[:status]),
+            status:  parse_status(requirement),
             orderNumber: Berkeley::GraduateMilestones.get_order_number(requirement[:code]),
             dateCompleted: parse_date(requirement[:dateCompleted]),
             dateAnticipated: parse_date(requirement[:dateAnticipated]),
@@ -50,6 +50,10 @@ module DegreeProgress
       end.compact
       set_proposed_exam_date(normalized_requirements)
       normalized_requirements
+    end
+
+    def parse_status(requirement)
+      Berkeley::GraduateMilestones.get_status(requirement[:status]) || Berkeley::GraduateMilestones::STATUS_INCOMPLETE
     end
 
     def parse_date(date)
@@ -93,7 +97,7 @@ module DegreeProgress
     def determine_status_code(status_code, milestone_attempts)
       return status_code unless status_code.blank?
       latest_attempt = milestone_attempts.first unless milestone_attempts.blank?
-      return latest_attempt.try(:[], :statusCode)
+      latest_attempt.try(:[], :statusCode)
     end
 
     def set_proposed_exam_date(requirements)

--- a/fixtures/xml/campus_solutions/degree_progress_graduate.xml
+++ b/fixtures/xml/campus_solutions/degree_progress_graduate.xml
@@ -19,7 +19,7 @@
           <NAME>Capstone</NAME>
           <DATE_COMPLETED></DATE_COMPLETED>
           <DATE_ANTICIPATED></DATE_ANTICIPATED>
-          <STATUS>N</STATUS>
+          <STATUS>I</STATUS>
           <CODE>AAGACADP2</CODE>
         </REQUIREMENT>
         <REQUIREMENT>

--- a/spec/support/degree_progress_shared_examples.rb
+++ b/spec/support/degree_progress_shared_examples.rb
@@ -14,7 +14,6 @@ shared_examples 'a proxy that returns graduate milestone data' do
   end
 
   it 'filters out requirements that we don\'t want to display' do
-    puts subject[:feed][:degreeProgress][0].pretty_inspect
     expect(subject[:feed][:degreeProgress][0][:requirements].length).to eql(2)
     expect(subject[:feed][:degreeProgress][1][:requirements].length).to eql(2)
   end
@@ -22,12 +21,14 @@ shared_examples 'a proxy that returns graduate milestone data' do
   it 'replaces codes with descriptive names' do
     expect(subject[:feed][:degreeProgress][0][:requirements][0][:name]).to eql('Advancement to Candidacy (Thesis Plan)')
     expect(subject[:feed][:degreeProgress][0][:requirements][0][:status]).to eql('Not Satisfied')
-    expect(subject[:feed][:degreeProgress][1][:requirements][0][:name]).to eql('Advancement to Candidacy (Thesis Plan)')
-    expect(subject[:feed][:degreeProgress][1][:requirements][0][:status]).to be nil
     expect(subject[:feed][:degreeProgress][1][:requirements][1][:name]).to eql('Advancement to Candidacy (Capstone Plan)')
-    expect(subject[:feed][:degreeProgress][1][:requirements][0][:status]).to be nil
+    expect(subject[:feed][:degreeProgress][1][:requirements][1][:status]).to eql('Not Satisfied')
     expect(subject[:feed][:degreeProgress][2][:requirements][0][:name]).to eql('Approval for Qualifying Exam')
     expect(subject[:feed][:degreeProgress][2][:requirements][0][:status]).to eql('Completed')
+  end
+
+  it 'marks a milestone \'Not Satisfied\' if it has an unexpected status code' do
+    expect(subject[:feed][:degreeProgress][0][:requirements][1][:status]).to eql('Not Satisfied')
   end
 
   it 'formats dates' do


### PR DESCRIPTION
QA PR for #6512

-----

Parent: https://jira.berkeley.edu/browse/SISRP-25708

UAT found some milestones with unexpected status codes. We'll show these as 'Not Satisfied'. If status code is missing, also show 'Not Satisfied'. (https://jira.berkeley.edu/browse/SISRP-31367)