### PR TITLE
SISRP-31399 - Delegates Seeing Duplicate Classes in Semesters

### DIFF
--- a/app/models/edo_oracle/user_courses/all.rb
+++ b/app/models/edo_oracle/user_courses/all.rb
@@ -29,7 +29,9 @@ module EdoOracle
           campus_classes = {}
           merge_enrollments campus_classes
           sort_courses campus_classes
-          Hash[campus_classes.sort.reverse]
+          campus_classes = Hash[campus_classes.sort.reverse]
+          remove_duplicate_sections(campus_classes)
+          campus_classes
         end
       end
 

--- a/app/models/edo_oracle/user_courses/base.rb
+++ b/app/models/edo_oracle/user_courses/base.rb
@@ -190,6 +190,14 @@ module EdoOracle
         section_data
       end
 
+      def remove_duplicate_sections(campus_classes)
+        campus_classes.each_value do |semester|
+          semester.each do |course|
+            course[:sections].uniq!
+          end
+        end
+      end
+
       def merge_cross_listed_titles(course)
         if (course[:catid].start_with? 'C') && !course[:name]
           title_results = self.class.fetch_from_cache "cross_listed_title-#{course[:course_code]}" do


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-31399

* If you're not a delegate, your `semesters` feed will be based off of `EdoOracle::UserCourses::All#get_all_campus_courses`, which includes `EdoOracle::UserCourses::Base#merge_detailed_section_data`.  This function uses `#uniq!` to get rid of duplicate section data. 
* If you are a delegate, your `semesters` feed will be based off of `EdoOracle::UserCourses::All#get_enrollments_summary`, which does not have the `#uniq!` function called.
* This PR adds the call to `#uniq!` to `#get_enrollments_summary`.  

* Why did we only start seeing this bug now?  Either we missed it in multiple QA attempts on the delegate experience, or, more likely, the EDODB query started returning duplicate sections for each class.  Maybe this has something to do with the refactoring/optimization going on?  We might have to expect to see some weirdness for a little bit while we iron out details for the query optimizations.  cc @nkutub @lyttam @redconfetti 

* QA PR to come.