### PR TITLE
[QA] SISRP-30580 - Fixes testext test failures

### DIFF
--- a/spec/models/degree_progress/my_undergrad_requirements_spec.rb
+++ b/spec/models/degree_progress/my_undergrad_requirements_spec.rb
@@ -7,6 +7,7 @@ describe DegreeProgress::MyUndergradRequirements do
     proxy_class = CampusSolutions::DegreeProgress::UndergradRequirements
     fake_proxy = proxy_class.new(user_id: user_id, fake: true)
     allow(proxy_class).to receive(:new).and_return fake_proxy
+    allow(Settings.features).to receive(flag).and_return(true)
   end
 
   describe '#get_feed_internal' do
@@ -17,7 +18,6 @@ describe DegreeProgress::MyUndergradRequirements do
     it_behaves_like 'a proxy that returns undergraduate milestone data'
 
     it 'does not include the Academic Progress Report link in the response' do
-      allow(Settings.features).to receive(flag).and_return(true)
       expect(subject[:feed][:links]).not_to be
     end
   end

--- a/spec/models/degree_progress/undergrad_requirements_spec.rb
+++ b/spec/models/degree_progress/undergrad_requirements_spec.rb
@@ -2,6 +2,13 @@ describe DegreeProgress::UndergradRequirements do
 
   let(:model) { described_class.new(user_id) }
   let(:user_id) { '12345' }
+  let(:emplid) { '12345678' }
+  before do
+    proxy_class = CampusSolutions::DegreeProgress::UndergradRequirements
+    fake_proxy = proxy_class.new(user_id: user_id, fake: true)
+    allow(proxy_class).to receive(:new).and_return fake_proxy
+    allow(Settings.features).to receive(flag).and_return(true)
+  end
 
   describe '#get_feed_internal' do
     let(:flag) { :cs_degree_progress_ugrd_advising }


### PR DESCRIPTION
QA PR for #6520

-----

https://jira.berkeley.edu/browse/SISRP-30580

Unit tests for student-facing undergrad Degree Progress were still failing on bamboo, despite using fake data. Fixed them by stubbing the feature flag to be true.

Also stubbed the advisor-facing feed to return fake data, although these tests were not failing (yet).