### PR TITLE
SISRP-31609 - Faculty cannot view and communicate via email with visiting summer students - Enrollment page

### DIFF
--- a/app/models/rosters/common.rb
+++ b/app/models/rosters/common.rb
@@ -87,6 +87,7 @@ module Rosters
               .select { |e| [nil, '', 'AC'].include? e['statusinplan_status_code'] }
               .collect { |e| e['major'] }.uniq
             if (enrollment_row = section_enrollments_by_uid[attrs[:ldap_uid]].first)
+              attrs[:email] = enrollment_row['email_address'] if attrs[:email].blank?
               attrs[:student_id] = enrollment_row['student_id']
               attrs[:terms_in_attendance] = terms_in_attendance_code(enrollment_row['academic_career'], enrollment_row['terms_in_attendance_group'])
               attrs[:enroll_status] = enrollment_row['enroll_status']

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -477,6 +477,7 @@ features:
   advising_academic_planner: false
   advising_student_success: false
   allow_legacy_fallback: true
+  allow_alt_email_addr_for_enrollments: true
   authentication_validator: false
   background_jobs_check: true
   cal1card: false


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-31609

* joined the enrollments get_roster EDODB query to PERSON_EMAILV00_VW
* updated enrollment/roster email with EDODB email if email obtained from CALDAP was blank
* added feature flag allow_alt_email_addr_for_enrollments to mitigate any performance issues during ER 