### PR TITLE
SISRP-31578 - Replaces QE Approval 'Completed' status label with 'Approved'

### DIFF
--- a/app/models/berkeley/graduate_milestones.rb
+++ b/app/models/berkeley/graduate_milestones.rb
@@ -11,8 +11,16 @@ module Berkeley
     QE_APPROVAL_MILESTONE = 'AAGQEAPRV'
     QE_RESULTS_MILESTONE = 'AAGQERESLT'
 
-    def self.get_status(status_code)
-      statuses.try(:[], status_code.strip.upcase) unless status_code.blank?
+    def self.get_status(status_code, milestone_code = nil)
+      status_code_standardized = status_code.strip.upcase unless status_code.blank?
+
+      if milestone_code === QE_APPROVAL_MILESTONE
+        qualifying_exam_approval_statuses.try(:[], status_code_standardized)
+      elsif milestone_code === QE_RESULTS_MILESTONE
+        qualifying_exam_results_statuses.try(:[], status_code_standardized)
+      else
+        statuses.try(:[], status_code_standardized)
+      end
     end
 
     def self.get_description(milestone_code)
@@ -64,11 +72,23 @@ module Berkeley
       }
     end
 
-    def self.statuses
-      @statuses ||= {
+    def self.qualifying_exam_approval_statuses
+      @qualifying_exam_approval_statuses ||= {
+        'N' => STATUS_INCOMPLETE,
+        'Y' => 'Approved'
+      }
+    end
+
+    def self.qualifying_exam_results_statuses
+      @qualifying_exam_results_statuses ||= {
         'F' => QE_STATUS_FAILED,
         'PF' => QE_STATUS_PARTIALLY_FAILED,
-        QE_STATUS_CODE_PASSED => QE_STATUS_PASSED,
+        QE_STATUS_CODE_PASSED => QE_STATUS_PASSED
+      }
+    end
+
+    def self.statuses
+      @statuses ||= {
         'N' => STATUS_INCOMPLETE,
         'Y' => 'Completed'
       }

--- a/app/models/degree_progress/milestones_module.rb
+++ b/app/models/degree_progress/milestones_module.rb
@@ -53,7 +53,7 @@ module DegreeProgress
     end
 
     def parse_status(requirement)
-      Berkeley::GraduateMilestones.get_status(requirement[:status]) || Berkeley::GraduateMilestones::STATUS_INCOMPLETE
+      Berkeley::GraduateMilestones.get_status(requirement[:status], requirement[:code]) || Berkeley::GraduateMilestones::STATUS_INCOMPLETE
     end
 
     def parse_date(date)
@@ -79,7 +79,7 @@ module DegreeProgress
       milestone_attempt = {
         sequenceNumber: milestone_attempt[:attemptNbr].to_i,
         date: parse_date(milestone_attempt[:attemptDate]),
-        result: Berkeley::GraduateMilestones.get_status(milestone_attempt[:attemptStatus]),
+        result: Berkeley::GraduateMilestones.get_status(milestone_attempt[:attemptStatus], Berkeley::GraduateMilestones::QE_RESULTS_MILESTONE),
         statusCode: milestone_attempt[:attemptStatus]
       }
       milestone_attempt[:display] = format_milestone_attempt(milestone_attempt)

--- a/app/models/my_committees/committees_module.rb
+++ b/app/models/my_committees/committees_module.rb
@@ -46,7 +46,7 @@ module MyCommittees::CommitteesModule
     milestone_attempt = {
       sequenceNumber: cs_milestone_attempt[:attemptNbr].to_i,
       date: format_date(cs_milestone_attempt[:attemptDate]),
-      result: Berkeley::GraduateMilestones.get_status(cs_milestone_attempt[:attemptStatus])
+      result: Berkeley::GraduateMilestones.get_status(cs_milestone_attempt[:attemptStatus], Berkeley::GraduateMilestones::QE_RESULTS_MILESTONE)
     }
     milestone_attempt[:display] = format_milestone_attempt(milestone_attempt)
     milestone_attempt

--- a/spec/models/berkeley/graduate_milestones_spec.rb
+++ b/spec/models/berkeley/graduate_milestones_spec.rb
@@ -1,0 +1,111 @@
+describe Berkeley::GraduateMilestones do
+
+  describe '#get_status' do
+
+    shared_examples 'a translator that gracefully handles invalid values' do
+      context 'when status_code is nil' do
+        let(:status_code) { nil }
+        it 'returns nil' do
+          expect(subject).to eq nil
+        end
+      end
+      context 'when status_code is garbage' do
+        let(:status_code) { 'GOATYOGA' }
+        it 'returns nil' do
+          expect(subject).to eq nil
+        end
+      end
+    end
+
+    shared_examples 'a translator for generic statuses' do
+      context 'when status_code is N' do
+        let(:status_code) { 'N' }
+        it 'returns Not Satisfied' do
+          expect(subject).to eq 'Not Satisfied'
+        end
+      end
+      context 'when status_code is Y' do
+        let(:status_code) { 'Y' }
+        it 'returns Completed' do
+          expect(subject).to eq 'Completed'
+        end
+      end
+    end
+
+    shared_examples 'a translator for statuses specific to Qualifying Approval' do
+      context 'when status_code is N' do
+        let(:status_code) { 'N' }
+        it 'returns Not Satisfied' do
+          expect(subject).to eq 'Not Satisfied'
+        end
+      end
+      context 'when status_code is Y' do
+        let(:status_code) { 'Y' }
+        it 'returns Approved' do
+          expect(subject).to eq 'Approved'
+        end
+      end
+    end
+
+    shared_examples 'a translator for statuses specific to Qualifying Results' do
+      context 'when status_code is P' do
+        let(:status_code) { 'P' }
+        it 'returns Passed' do
+          expect(subject).to eq 'Passed'
+        end
+      end
+      context 'when status_code is F' do
+        let(:status_code) { 'F' }
+        it 'returns Failed' do
+          expect(subject).to eq 'Failed'
+        end
+      end
+      context 'when status_code is PF' do
+        let(:status_code) { 'PF' }
+        it 'returns Partially Failed' do
+          expect(subject).to eq 'Partially Failed'
+        end
+      end
+    end
+
+    context 'when milestone_code is not provided' do
+      subject { described_class.get_status(status_code) }
+
+      it_behaves_like 'a translator that gracefully handles invalid values'
+      it_behaves_like 'a translator for generic statuses'
+    end
+
+    context 'when milestone_code is provided' do
+      subject { described_class.get_status(status_code, milestone_code) }
+
+      context 'when milestone_code is garbage' do
+        let(:milestone_code) { 'CATCAFE'}
+
+        it_behaves_like 'a translator that gracefully handles invalid values'
+        it_behaves_like 'a translator for generic statuses'
+      end
+
+      context 'when milestone_code is valid but not special' do
+        let(:milestone_code) { 'AAGADVMAS1'}
+
+        it_behaves_like 'a translator that gracefully handles invalid values'
+        it_behaves_like 'a translator for generic statuses'
+      end
+
+      context 'when milestone_code is special (Qualifying Approval)' do
+        let(:milestone_code) { 'AAGQEAPRV'}
+
+        it_behaves_like 'a translator that gracefully handles invalid values'
+        it_behaves_like 'a translator for statuses specific to Qualifying Approval'
+      end
+
+      context 'when milestone_code is special (Qualifying Results)' do
+        let(:milestone_code) { 'AAGQERESLT'}
+
+        it_behaves_like 'a translator that gracefully handles invalid values'
+        it_behaves_like 'a translator for statuses specific to Qualifying Results'
+      end
+    end
+
+  end
+end

--- a/spec/support/degree_progress_shared_examples.rb
+++ b/spec/support/degree_progress_shared_examples.rb
@@ -24,7 +24,9 @@ shared_examples 'a proxy that returns graduate milestone data' do
     expect(subject[:feed][:degreeProgress][1][:requirements][1][:name]).to eql('Advancement to Candidacy (Capstone Plan)')
     expect(subject[:feed][:degreeProgress][1][:requirements][1][:status]).to eql('Not Satisfied')
     expect(subject[:feed][:degreeProgress][2][:requirements][0][:name]).to eql('Approval for Qualifying Exam')
-    expect(subject[:feed][:degreeProgress][2][:requirements][0][:status]).to eql('Completed')
+    expect(subject[:feed][:degreeProgress][2][:requirements][0][:status]).to eql('Approved')
+    expect(subject[:feed][:degreeProgress][2][:requirements][2][:name]).to eql('Advancement to Candidacy')
+    expect(subject[:feed][:degreeProgress][2][:requirements][2][:status]).to eql('Completed')
   end
 
   it 'marks a milestone \'Not Satisfied\' if it has an unexpected status code' do


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-31578

This required some refactoring of the status code translation that's used by both Degree Progress and Committees.  Previously, we mapped all the status codes to their labels in a single Hash.  That won't work anymore since we now have a one-to-many relationship between status codes and labels, so I split it into three separate mappings.