### PR TITLE
SISRP-31756 - Hides Degree Progress link header when no links to show

### DIFF
--- a/src/assets/javascripts/angular/controllers/widgets/academics/graduateDegreeProgressController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/academics/graduateDegreeProgressController.js
@@ -14,8 +14,9 @@ angular.module('calcentral.controllers').controller('GraduateDegreeProgressContr
   var loadGraduateDegreeProgress = function() {
     degreeProgressFactory.getGraduateMilestones().then(
       function(response) {
+        var links = _.get(response, 'data.feed.links');
+        $scope.degreeProgress.graduate.links = _.isEmpty(links) ? undefined : links;
         $scope.degreeProgress.graduate.progresses = _.get(response, 'data.feed.degreeProgress');
-        $scope.degreeProgress.graduate.links = _.get(response, 'data.feed.links');
         $scope.degreeProgress.graduate.errored = _.get(response, 'errored');
       }
     ).finally(


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-31756

The links that show on the student-facing Degree Progress card were disabled, but the header was still showing.