### PR TITLE
SISRP-31889 - Grading: Prod: Spring Final Grades Not Appearing for Students in CalCentral (SNow 445421)

### DIFF
--- a/src/assets/templates/academics_semesters.html
+++ b/src/assets/templates/academics_semesters.html
@@ -31,7 +31,7 @@
             </tr>
           </thead>
           <tbody data-ng-if="!semester.summaryFromTranscript" data-ng-repeat="class in semester.classes">
-              <tr data-ng-repeat-start="section in class.sections" data-ng-if="section.is_primary_section && !section.waitlisted">
+              <tr data-ng-repeat-start="section in class.sections" data-ng-if="section.is_primary_section && !section.waitlisted && !class.transcript">
                 <td>
                   <span data-ng-if="class.multiplePrimaries && section.url && !isAdvisingStudentLookup">
                     <a data-ng-href="{{section.url}}">
@@ -81,6 +81,13 @@
                     </tr>
                   </table>
                 </td>
+              </tr>
+              <tr data-ng-if="class.transcript" data-ng-repeat="transcript in class.transcript">
+                <td data-ng-if="class.url && !isAdvisingStudentLookup"><a data-ng-href="{{class.url}}" data-ng-bind="class.course_code"></a>
+                <td data-ng-if="!class.url || isAdvisingStudentLookup" data-ng-bind="class.course_code"></td>
+                <td data-ng-bind="class.title"></td>
+                <td data-ng-bind="transcript.units | number:1" class="cc-table-center"></td>
+                <td data-ng-if="api.user.profile.canViewGrades" data-ng-bind="transcript.grade" class="cc-table-center"></td>
               </tr>
           </tbody>
           <tbody data-ng-if="semester.summaryFromTranscript" data-ng-repeat="class in semester.classes">

--- a/src/assets/templates/widgets/academic_plan.html
+++ b/src/assets/templates/widgets/academic_plan.html
@@ -112,7 +112,6 @@
                         </table>
                       </td>
                     </tr>
-                    </tr>
                   </tbody>
                 </table>
                 <table data-ng-if="!semester.summaryFromTranscript">
@@ -124,7 +123,7 @@
                     </tr>
                   </thead>
                   <tbody data-ng-repeat="class in semester.enrolledClasses">
-                    <tr data-ng-repeat-start="section in class.sections" data-ng-if="section.is_primary_section && !section.waitlisted">
+                    <tr data-ng-repeat-start="section in class.sections" data-ng-if="section.is_primary_section && !section.waitlisted && !class.transcript">
                       <td>
                         <span data-ng-bind="class.course_code"></span>
                         <span data-ng-if="class.multiplePrimaries && section.section_label" data-ng-bind="section.section_label"></span>
@@ -152,6 +151,14 @@
                           </tr>
                         </table>
                       </td>
+                    </tr>
+                    <tr data-ng-if="class.transcript" data-ng-repeat="transcript in class.transcript">
+                      <td>
+                        <span data-ng-bind="class.course_code"></span>
+                        <span data-ng-if="class.session_code" data-ng-bind-template="(Session {{class.session_code}})"></span>
+                      </td>
+                      <td data-ng-bind="transcript.units | number:1"></td>
+                      <td data-ng-bind="transcript.grade" data-ng-if="api.user.profile.canViewGrades"></td>
                     </tr>
                   </tbody>
                 </table>

--- a/src/assets/templates/widgets/academic_summary/academic_summary_semesters.html
+++ b/src/assets/templates/widgets/academic_summary/academic_summary_semesters.html
@@ -14,11 +14,11 @@
           <th width="20%">Class</th>
           <th width="50%">Title</th>
           <th class="cc-table-right cc-academic-summary-table-units" width="15%">Units</th>
-          <th width="15%"><span data-ng-if="semester.summaryFromTranscript">Grade</span></th>
+          <th width="15%">Grade</th>
         </tr>
       </thead>
       <tbody data-ng-if="!semester.summaryFromTranscript" data-ng-repeat="class in semester.classes">
-        <tr data-ng-repeat="section in class.sections" data-ng-if="section.is_primary_section && !section.waitlisted">
+        <tr data-ng-repeat="section in class.sections" data-ng-if="section.is_primary_section && !section.waitlisted && !class.transcript">
           <td>
             <span data-ng-if="class.multiplePrimaries && section.url">
               <a data-ng-href="{{section.url}}">
@@ -46,6 +46,14 @@
           </td>
           <td data-ng-bind="class.title"></td>
           <td class="cc-text-right cc-academic-summary-table-units" data-ng-bind="section.units | number:1"></td>
+          <td>&mdash;</td>
+        </tr>
+        <tr data-ng-if="class.transcript" data-ng-repeat="transcript in class.transcript">
+          <td data-ng-if="class.url"><a data-ng-href="{{class.url}}" data-ng-bind="class.course_code"></a>
+          <td data-ng-if="!class.url" data-ng-bind="class.course_code"></td>
+          <td data-ng-bind="class.title"></td>
+          <td class="cc-text-right cc-academic-summary-table-units" data-ng-bind="transcript.units | number:1"></td>
+          <td data-ng-if="api.user.profile.canViewGrades" data-ng-bind="transcript.grade"></td>
         </tr>
       </tbody>
       <tbody data-ng-if="semester.summaryFromTranscript" data-ng-repeat="class in semester.classes">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-31889

* I want to reiterate as said in the ticket, that this is just a bandage fix so that students can see their grades in the current term.
* [SISRP-32020](https://jira.berkeley.edu/browse/SISRP-32020) will be the larger work of reassessing how `semesters.rb` parses data, and making related changes to the front-end templates.
* QA PR to come since this will be part of Tuesday's Emergency Release.