### PR TITLE
SISRP-31579 - updates Proposed Exam Date logic on Degree Progress

### DIFF
--- a/app/models/berkeley/graduate_milestones.rb
+++ b/app/models/berkeley/graduate_milestones.rb
@@ -1,11 +1,12 @@
 module Berkeley
   class GraduateMilestones
 
-    QE_STATUS_CODE_PASSED = 'P'
+    STATUS_CODE_COMPLETE = 'Y'
+    QE_RESULTS_STATUS_CODE_PASSED = 'P'
 
-    QE_STATUS_FAILED = 'Failed'
-    QE_STATUS_PARTIALLY_FAILED = 'Partially Failed'
-    QE_STATUS_PASSED = 'Passed'
+    QE_RESULTS_STATUS_FAILED = 'Failed'
+    QE_RESULTS_STATUS_PARTIALLY_FAILED = 'Partially Failed'
+    QE_RESULTS_STATUS_PASSED = 'Passed'
     STATUS_INCOMPLETE = 'Not Satisfied'
 
     QE_APPROVAL_MILESTONE = 'AAGQEAPRV'
@@ -75,22 +76,22 @@ module Berkeley
     def self.qualifying_exam_approval_statuses
       @qualifying_exam_approval_statuses ||= {
         'N' => STATUS_INCOMPLETE,
-        'Y' => 'Approved'
+        STATUS_CODE_COMPLETE => 'Approved'
       }
     end
 
     def self.qualifying_exam_results_statuses
       @qualifying_exam_results_statuses ||= {
-        'F' => QE_STATUS_FAILED,
-        'PF' => QE_STATUS_PARTIALLY_FAILED,
-        QE_STATUS_CODE_PASSED => QE_STATUS_PASSED
+        'F' => QE_RESULTS_STATUS_FAILED,
+        'PF' => QE_RESULTS_STATUS_PARTIALLY_FAILED,
+        QE_RESULTS_STATUS_CODE_PASSED => QE_RESULTS_STATUS_PASSED
       }
     end
 
     def self.statuses
       @statuses ||= {
         'N' => STATUS_INCOMPLETE,
-        'Y' => 'Completed'
+        STATUS_CODE_COMPLETE => 'Completed'
       }
     end
 

--- a/app/models/degree_progress/milestones_module.rb
+++ b/app/models/degree_progress/milestones_module.rb
@@ -87,7 +87,7 @@ module DegreeProgress
     end
 
     def format_milestone_attempt(milestone_attempt)
-      if milestone_attempt[:result] == Berkeley::GraduateMilestones::QE_STATUS_PASSED
+      if milestone_attempt[:result] == Berkeley::GraduateMilestones::QE_RESULTS_STATUS_PASSED
         "#{milestone_attempt[:result]} #{milestone_attempt[:date]}"
       else
         "Exam #{milestone_attempt[:sequenceNumber]}: #{milestone_attempt[:result]} #{milestone_attempt[:date]}"
@@ -104,12 +104,12 @@ module DegreeProgress
       qualifying_exam_approval_milestone = requirements.select do |requirement|
         requirement.try(:[], :code) === Berkeley::GraduateMilestones::QE_APPROVAL_MILESTONE
       end.first
-      if qualifying_exam_approval_milestone
+      if qualifying_exam_approval_milestone.try(:[], :statusCode) === Berkeley::GraduateMilestones::STATUS_CODE_COMPLETE
         qualifying_exam_results_milestone = requirements.select do |requirement|
           requirement.try(:[], :code) === Berkeley::GraduateMilestones::QE_RESULTS_MILESTONE
         end.first
-        exam_passed = qualifying_exam_results_milestone.try(:[], :statusCode) === Berkeley::GraduateMilestones::QE_STATUS_CODE_PASSED
-        qualifying_exam_approval_milestone[:proposedExamDate] = qualifying_exam_approval_milestone.try(:[], :dateAnticipated) unless exam_passed
+        exam_attempted = qualifying_exam_results_milestone.try(:[], :attempts).present?
+        qualifying_exam_approval_milestone[:proposedExamDate] = qualifying_exam_approval_milestone.try(:[], :dateAnticipated) unless exam_attempted
       end
     end
   end

--- a/app/models/my_committees/committees_module.rb
+++ b/app/models/my_committees/committees_module.rb
@@ -118,7 +118,7 @@ module MyCommittees::CommitteesModule
   def determine_qualifying_exam_status_icon(committee)
     latest_attempt = committee.try(:[], :milestoneAttempts).try(:first)
     return '' unless latest_attempt
-    if latest_attempt.try(:[], :result) == Berkeley::GraduateMilestones::QE_STATUS_PASSED
+    if latest_attempt.try(:[], :result) == Berkeley::GraduateMilestones::QE_RESULTS_STATUS_PASSED
       STATUS_ICON_SUCCESS
     elsif latest_attempt.try(:[], :sequenceNumber) === 1
       STATUS_ICON_WARN

--- a/app/models/my_committees/student_committees.rb
+++ b/app/models/my_committees/student_committees.rb
@@ -56,7 +56,7 @@ module MyCommittees
     end
 
     def first_attempt_exam_passed?(milestone_attempt)
-      milestone_attempt[:sequenceNumber] === 1 && milestone_attempt[:result] == Berkeley::GraduateMilestones::QE_STATUS_PASSED
+      milestone_attempt[:sequenceNumber] === 1 && milestone_attempt[:result] == Berkeley::GraduateMilestones::QE_RESULTS_STATUS_PASSED
     end
 
     def remove_inactive_members(cs_committee)

--- a/fixtures/xml/campus_solutions/degree_progress_graduate.xml
+++ b/fixtures/xml/campus_solutions/degree_progress_graduate.xml
@@ -140,5 +140,26 @@
         </REQUIREMENT>
       </REQUIREMENTS>
     </PROGRESS>
+    <PROGRESS>
+      <CAREER>GRAD</CAREER>
+      <ACAD_PLAN>Physics PhD</ACAD_PLAN>
+      <ACAD_PROG_CODE>GACAD</ACAD_PROG_CODE>
+      <ACAD_PROG>Graduate Academic Programs</ACAD_PROG>
+      <REQUIREMENTS type="array">
+        <REQUIREMENT>
+          <NAME>Approval for Qualifying Exam</NAME>
+          <DATE_COMPLETED>2017-02-14</DATE_COMPLETED>
+          <DATE_ANTICIPATED>2017-02-14</DATE_ANTICIPATED>
+          <STATUS>Y</STATUS>
+          <CODE>AAGQEAPRV</CODE>
+        </REQUIREMENT>
+        <REQUIREMENT>
+          <NAME>Qualifying Exam Results</NAME>
+          <DATE_ANTICIPATED></DATE_ANTICIPATED>
+          <CODE>AAGQERESLT</CODE>
+          <ATTEMPTS type="array" />
+        </REQUIREMENT>
+      </REQUIREMENTS>
+    </PROGRESS>
   </PROGRESSES>
 </UC_AA_PROGRESS>

--- a/spec/support/degree_progress_shared_examples.rb
+++ b/spec/support/degree_progress_shared_examples.rb
@@ -10,7 +10,7 @@ shared_examples 'a proxy that returns graduate milestone data' do
   end
 
   it 'filters out any LAW career programs that are not LACAD' do
-    expect(subject[:feed][:degreeProgress].length).to eql(4)
+    expect(subject[:feed][:degreeProgress].length).to eql(5)
   end
 
   it 'filters out requirements that we don\'t want to display' do
@@ -64,23 +64,23 @@ shared_examples 'a proxy that returns graduate milestone data' do
   end
 
   context 'when the QE Results milestone is not satisfied' do
-    it 'includes the proposed exam date on the QE Approval milestone' do
-      qualifying_exam_approval_milestone = subject[:feed][:degreeProgress][3][:requirements][0]
-      expect(qualifying_exam_approval_milestone[:proposedExamDate]).to eq 'Dec 21, 2016'
+    context 'when the exam hasn\'t been attempted' do
+      it 'includes the proposed exam date on the QE Approval milestone' do
+        qualifying_exam_approval_milestone = subject[:feed][:degreeProgress][4][:requirements][0]
+        expect(qualifying_exam_approval_milestone[:proposedExamDate]).to eq 'Feb 14, 2017'
+      end
+    end
+    context 'when the exam has been attempted' do
+      it 'does not include the proposed exam date on the QE Approval milestone' do
+        qualifying_exam_approval_milestone = subject[:feed][:degreeProgress][3][:requirements][0]
+        expect(qualifying_exam_approval_milestone[:proposedExamDate]).to be nil
+      end
     end
     it 'does not include the proposed exam date on other milestones' do
       other_milestone = subject[:feed][:degreeProgress][0][:requirements][0]
       expect(other_milestone[:proposedExamDate]).not_to be
     end
   end
-
-  context 'when the QE Results milestone is complete' do
-    it 'does not include the proposed exam date on the QE Approval milestone' do
-      qualifying_exam_approval_milestone = subject[:feed][:degreeProgress][2][:requirements][0]
-      expect(qualifying_exam_approval_milestone[:proposedExamDate]).not_to be
-    end
-  end
-
 end
 
 shared_examples 'a proxy that returns undergraduate milestone data' do


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-31579

Degree Progress for graduate students:
We only want to show the proposed exam date between the time when the student is approved to take the qualifying exam and when they first attempt the exam.