### PR TITLE
SISRP-31911 - Refactors Link API calls into a mixin

### DIFF
--- a/app/models/advising/my_advising.rb
+++ b/app/models/advising/my_advising.rb
@@ -6,6 +6,7 @@ module Advising
     include Cache::JsonifiedFeed
     include Cache::UserCacheExpiry
     include DatedFeed
+    include LinkFetcher
 
     RELATIONSHIP_ORDER = [
       'GSAO', # Graduate Student Affairs Offcr
@@ -95,12 +96,6 @@ module Advising
       else
         yield response[:feed]
       end
-    end
-
-    def fetch_link(link_key, placeholders = {})
-      link = CampusSolutions::Link.new.get_url(link_key, placeholders).try(:[], :link)
-      logger.debug "Could not retrieve CS link #{link_key} for MyAdvising feed, uid = #{@uid}" unless link
-      link
     end
 
     def transform_date(item, key)

--- a/app/models/campus_solutions/advising_resources.rb
+++ b/app/models/campus_solutions/advising_resources.rb
@@ -3,6 +3,7 @@ module CampusSolutions
 
     include CampusSolutionsIdRequired
     include Cache::RelatedCacheKeyTracker
+    include LinkFetcher
 
     def initialize(options = {})
       @student = {
@@ -92,10 +93,6 @@ module CampusSolutions
         links: links,
         cs_links: cs_links
       }
-    end
-
-    def fetch_link(link_key, placeholders = {})
-      CampusSolutions::Link.new.get_url(link_key, placeholders).try(:[], :link)
     end
 
     def instance_key

--- a/app/models/campus_solutions/student_resources.rb
+++ b/app/models/campus_solutions/student_resources.rb
@@ -2,6 +2,7 @@ module CampusSolutions
   class StudentResources < Proxy
 
     include CampusSolutionsIdRequired
+    include LinkFetcher
 
     def initialize(options = {})
       super options
@@ -45,10 +46,5 @@ module CampusSolutions
     def xml_filename
       'file_is_not_used_in_test.xml'
     end
-
-    def fetch_link(link_key, placeholders = {})
-      CampusSolutions::Link.new.get_url(link_key, placeholders).try(:[], :link)
-    end
-
   end
 end

--- a/app/models/degree_progress/my_graduate_milestones.rb
+++ b/app/models/degree_progress/my_graduate_milestones.rb
@@ -6,6 +6,7 @@ module DegreeProgress
     include Cache::JsonifiedFeed
     include Cache::UserCacheExpiry
     include MilestonesModule
+    include LinkFetcher
 
     LINKS_CONFIG = [
       { feed_key: :apply_for_advancement_to_candidacy, cs_link_key: 'UC_CX_GT_GRAD_ADVC' },
@@ -31,14 +32,6 @@ module DegreeProgress
         links[setting[:feed_key]] = link unless link.blank?
       end
       links
-    end
-
-    def fetch_link(link_key)
-      if (link_feed = CampusSolutions::Link.new.get_url link_key)
-        link = link_feed.try(:[], :link)
-      end
-      logger.error "Could not retrieve CS link #{link_key} for #{self.class.name} feed, uid = #{@uid}" unless link
-      link
     end
 
     private

--- a/app/models/degree_progress/undergrad_requirements.rb
+++ b/app/models/degree_progress/undergrad_requirements.rb
@@ -6,6 +6,7 @@ module DegreeProgress
     include Cache::JsonifiedFeed
     include Cache::UserCacheExpiry
     include RequirementsModule
+    include LinkFetcher
 
     def get_feed_internal
       return {} unless is_feature_enabled?
@@ -37,14 +38,6 @@ module DegreeProgress
         links[setting[:feed_key]] = link unless link.blank?
       end
       links
-    end
-
-    def fetch_link(link_key, placeholders = {})
-      if (link_feed = CampusSolutions::Link.new.get_url(link_key, placeholders))
-        link = link_feed.try(:[], :link)
-      end
-      logger.error "Could not retrieve CS link #{link_key} for #{self.class.name} feed, uid = #{@uid}" unless link
-      link
     end
 
     def is_feature_enabled?

--- a/app/models/my_academics/academics_module.rb
+++ b/app/models/my_academics/academics_module.rb
@@ -224,12 +224,6 @@ module MyAcademics
       end
     end
 
-    def fetch_link(link_key, placeholders = {})
-      link = CampusSolutions::Link.new.get_url(link_key, placeholders).try(:[], :link)
-      logger.debug "Could not retrieve CS link #{link_key} for Class #{self.class.name} feed, uid = #{@uid}" unless link
-      link
-    end
-
     def get_campus_solutions_id(uid)
       CalnetCrosswalk::ByUid.new(user_id: uid).lookup_campus_solutions_id
     end

--- a/app/models/my_academics/advisor_links.rb
+++ b/app/models/my_academics/advisor_links.rb
@@ -2,6 +2,7 @@ module MyAcademics
   class AdvisorLinks
     include AcademicsModule
     include ClassLogger
+    include LinkFetcher
 
     def merge(data)
       data[:advisorLinks] = links

--- a/app/models/my_academics/class_enrollments.rb
+++ b/app/models/my_academics/class_enrollments.rb
@@ -4,6 +4,7 @@ module MyAcademics
     include Cache::CachedFeed
     include Cache::UserCacheExpiry
     include CampusSolutions::EnrollmentCardFeatureFlagged
+    include LinkFetcher
 
     def get_feed_internal
       return {} unless is_feature_enabled && user_is_student?
@@ -174,7 +175,7 @@ module MyAcademics
       ]
 
       campus_solutions_link_settings.each do |setting|
-        link = AcademicsModule::fetch_link(setting[:cs_link_key], setting[:cs_link_params])
+        link = fetch_link(setting[:cs_link_key], setting[:cs_link_params])
         cs_links[setting[:feed_key]] = link unless link.blank?
       end
 

--- a/app/models/my_academics/grading.rb
+++ b/app/models/my_academics/grading.rb
@@ -1,6 +1,8 @@
 module MyAcademics
   class Grading < UserSpecificModel
 
+    include LinkFetcher
+
     def merge(data)
       teaching_semesters = data[:teachingSemesters]
       if teaching_semesters
@@ -169,7 +171,7 @@ module MyAcademics
 
     def get_grading_link(ccn, term_code, is_law, cs_grading_status)
       return nil unless ccn && term_code
-      grading_link = AcademicsModule::fetch_link('UC_CX_SSS_GRADE_ROSTER', { STRM: term_code, CLASS_NBR: ccn, INSTITUTION: 'UCB01' })
+      grading_link = fetch_link('UC_CX_SSS_GRADE_ROSTER', { STRM: term_code, CLASS_NBR: ccn, INSTITUTION: 'UCB01' })
       return grading_link if cs_grading_status[:finalStatus] != :noCsData
       if !is_law && cs_grading_status.key?(:midpointStatus)
         return grading_link if cs_grading_status[:midpointStatus] != :noCsData

--- a/app/models/my_academics/student_links.rb
+++ b/app/models/my_academics/student_links.rb
@@ -2,6 +2,7 @@ module MyAcademics
   class StudentLinks
     include AcademicsModule
     include ClassLogger
+    include LinkFetcher
 
     def merge(data)
       data[:studentLinks] = links

--- a/app/models/my_committees/committees_module.rb
+++ b/app/models/my_committees/committees_module.rb
@@ -1,6 +1,8 @@
 module MyCommittees::CommitteesModule
   extend self
 
+  include LinkFetcher
+
   COMMITTEE_TYPES = {
     QE: {
       code: 'QE',
@@ -195,12 +197,6 @@ module MyCommittees::CommitteesModule
       logger.error "Bad Format For Committees Date for Class #{self.class.name} feed, uid = #{@uid}"
     end
     formatted_date
-  end
-
-  def fetch_link(link_key, placeholders = {})
-    link = CampusSolutions::Link.new.get_url(link_key, placeholders).try(:[], :link)
-    logger.debug "Could not retrieve CS link #{link_key} for Class #{self.class.name} feed, uid = #{@uid}" unless link
-    link
   end
 
 end

--- a/lib/link_fetcher.rb
+++ b/lib/link_fetcher.rb
@@ -1,0 +1,11 @@
+module LinkFetcher
+  include ClassLogger
+
+  def fetch_link(link_key, placeholders = {})
+    if (link_feed = CampusSolutions::Link.new.get_url link_key, placeholders)
+      link = link_feed.try(:fetch, :link)
+    end
+    logger.debug "Could not parse CS link response for id #{link_key}, uid = #{@uid}" unless link
+    link
+  end
+end

--- a/spec/lib/link_fetcher_spec.rb
+++ b/spec/lib/link_fetcher_spec.rb
@@ -1,0 +1,71 @@
+describe LinkFetcher do
+
+  describe '#fetch_link' do
+    before do
+      allow(proxy_class).to receive(:new).and_return mock_proxy
+      link_fetcher.extend(LinkFetcher)
+      allow(link_fetcher).to receive(:logger).and_return ClassLogger::LogWrapper.new('Object')
+    end
+    let(:link_fetcher) { Object.new }
+    let(:url) { 'fake url' }
+    let(:proxy_class) { CampusSolutions::Link }
+    let(:mock_proxy) { proxy_class.new(fake: true) }
+
+    context 'when proxy returns malformed response' do
+      before do
+        allow(mock_proxy).to receive(:get_url).and_return('bad response')
+      end
+      subject do
+        link_fetcher.fetch_link(link_key)
+      end
+      let(:link_key) { nil }
+
+      it 'calls the proxy with appropriate arguments and logs an error' do
+        expect(mock_proxy).to receive(:get_url).with(nil, {})
+        expect(Rails.logger).to receive(:send).with(:debug, /\[Object\] Could not parse CS link response for id/)
+        expect(subject).to eq nil
+      end
+    end
+
+    context 'when proxy returns expected response' do
+      before do
+        allow(mock_proxy).to receive(:get_url).and_return({link: url})
+      end
+
+      context 'when parameters are not provided' do
+        subject do
+          link_fetcher.fetch_link(link_key)
+        end
+
+        context 'when key is blank' do
+          let(:link_key) { nil }
+
+          it 'calls the proxy with appropriate arguments and returns url' do
+            expect(mock_proxy).to receive(:get_url).with(nil, {})
+            expect(subject).to eq url
+          end
+        end
+        context 'when key is present'
+        let(:link_key) { 'gimme a link' }
+
+        it 'calls the proxy with appropriate arguments and returns url' do
+          expect(mock_proxy).to receive(:get_url).with('gimme a link', {})
+          expect(subject).to eq url
+        end
+      end
+
+      context 'when parameters are provided' do
+        subject do
+          link_fetcher.fetch_link(link_key, placeholders)
+        end
+        let(:link_key) { nil }
+        let(:placeholders) { 'some params' }
+
+        it 'calls the proxy with appropriate arguments and returns url' do
+          expect(mock_proxy).to receive(:get_url).with(nil, 'some params')
+          expect(subject).to eq url
+        end
+      end
+    end
+  end
+end

--- a/spec/models/my_academics/grading_spec.rb
+++ b/spec/models/my_academics/grading_spec.rb
@@ -161,7 +161,11 @@ describe MyAcademics::Grading do
   context 'when mapping CC grading status to grading link' do
     let(:fake_grading_url) { 'http://fake.grading.com' }
     before do
-      allow(MyAcademics::AcademicsModule).to receive(:fetch_link).and_return(fake_grading_url)
+      link_proxy_class = CampusSolutions::Link
+      link_fake_proxy = link_proxy_class.new(fake: true)
+      allow(link_proxy_class).to receive(:new).and_return link_fake_proxy
+      allow(link_fake_proxy).to receive(:get_url).and_return({link: fake_grading_url})
+
       allow(subject).to receive(:get_grading_period_status).and_return(:gradingPeriodNotSet)
     end
 
@@ -196,7 +200,12 @@ describe MyAcademics::Grading do
       allow(Settings.terms).to receive(:legacy_cutoff).and_return 'summer-2014'
       allow(Settings.features).to receive(:hub_term_api).and_return true
       allow(CampusSolutions::Grading).to receive(:new).and_return(grading_proxy)
-      allow(MyAcademics::AcademicsModule).to receive(:fetch_link).and_return(fake_grading_url)
+
+      link_proxy_class = CampusSolutions::Link
+      link_fake_proxy = link_proxy_class.new(fake: true)
+      allow(link_proxy_class).to receive(:new).and_return link_fake_proxy
+      allow(link_fake_proxy).to receive(:get_url).and_return({link: fake_grading_url})
+
       allow(subject).to receive(:get_grading_period_status).and_return(:gradingPeriodNotSet)
     end
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-31911

Original goal was just to change the log level to DEBUG on a couple proxies that were treating missing links as ERRORs, but it felt right to take a step further to promote DRYness.  

Going forward:  for any proxies needing to call the Link API, simply include `LinkFetcher`. 