### PR TITLE
SISRP-29647 Remove obsolete legacy advising (bHive) settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -247,7 +247,6 @@ cache:
     CanvasLti::Egrades: <%= 1.minute %>
     CanvasLti::Lti: <%= 5.minutes %>
 
-    Advising::LegacyMyAdvising: <%= 2.hours %>
     Advising::MyAdvising: <%= 2.hours %>
 
     MyAcademics::CollegeAndLevel: NEXT_08_00
@@ -391,12 +390,6 @@ ui_selenium:
   ets_qa_gmail_username: secret
   ets_qa_gmail_password: secret
   admin_uid: secret
-
-advising_proxy:
-  fake: false
-  base_url: 'https://bhive.berkeley.edu/api'
-  username: secret
-  password: secret
 
 campus_solutions_proxy:
   fake: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -62,9 +62,6 @@ ist_jms:
 hot_plate:
   enabled: false
 
-advising_proxy:
-  fake: true
-
 eft_proxy:
   fake: true
 

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -78,9 +78,6 @@ cache:
     UpNext::MyUpNext: <%= 1.day %>
     User::Api: <%= 1.day %>
 
-advising_proxy:
-  fake: true
-
 grading_period:
   links:
     final: '#'
@@ -122,7 +119,6 @@ features:
   advising: true
   advising_academic_planner: true
   advising_student_success: true
-  bearfacts: true
   cal1card: true
   class_info_enrollment_tab: true
   cs_academic_planner: true

--- a/config/settings/testext.yml
+++ b/config/settings/testext.yml
@@ -76,7 +76,6 @@ features:
   advising: true
   advising_academic_planner: true
   advising_student_success: true
-  bearfacts: true
   cal1card: true
   class_info_enrollment_tab: true
   cs_academic_planner: true

--- a/spec/models/calnet_ldap/user_attributes_spec.rb
+++ b/spec/models/calnet_ldap/user_attributes_spec.rb
@@ -144,12 +144,12 @@ describe CalnetLdap::UserAttributes do
   end
 
   context 'test user from real LDAP connection', testext: true do
-    let(:uid) { '212373' }
+    let(:uid) { '61889' }
     it 'translates attributes' do
-      expect(feed[:ldap_uid]).to eq '212373'
-      expect(feed[:first_name]).to eq 'AFF-GUEST'
-      expect(feed[:last_name]).to eq 'TEST'
-      expect(feed[:person_name]).to eq 'AFF-GUEST TEST'
+      expect(feed[:ldap_uid]).to eq '61889'
+      expect(feed[:first_name]).to be_present
+      expect(feed[:last_name]).to be_present
+      expect(feed[:person_name]).to be_present
       expect(feed[:campus_solutions_id]).to be_present
     end
   end


### PR DESCRIPTION
Two followups from https://github.com/ets-berkeley-edu/calcentral/pull/6571

* [SISRP-29647](https://jira.berkeley.edu/browse/SISRP-29647) - Remove still more obsolete legacy advising (bHive) settings
* [SISRP-31764](https://jira.berkeley.edu/browse/SISRP-31764) - When I added a testext check for CS ID, I neglected to confirm that my chosen UID was actually in CS.