### PR TITLE
SISRP-32137 - Number each attempt on the Qualifying Exam milestone

### DIFF
--- a/app/models/degree_progress/milestones_module.rb
+++ b/app/models/degree_progress/milestones_module.rb
@@ -76,22 +76,13 @@ module DegreeProgress
     end
 
     def parse_milestone_attempt(milestone_attempt)
-      milestone_attempt = {
-        sequenceNumber: milestone_attempt[:attemptNbr].to_i,
-        date: parse_date(milestone_attempt[:attemptDate]),
-        result: Berkeley::GraduateMilestones.get_status(milestone_attempt[:attemptStatus], Berkeley::GraduateMilestones::QE_RESULTS_MILESTONE),
-        statusCode: milestone_attempt[:attemptStatus]
+      attempt_result = Berkeley::GraduateMilestones.get_status(milestone_attempt[:attemptStatus], Berkeley::GraduateMilestones::QE_RESULTS_MILESTONE)
+      sequence_number = milestone_attempt[:attemptNbr].to_i
+      {
+        sequenceNumber: sequence_number,
+        statusCode: milestone_attempt[:attemptStatus],
+        display: "Exam #{sequence_number}: #{attempt_result} #{parse_date(milestone_attempt[:attemptDate])}"
       }
-      milestone_attempt[:display] = format_milestone_attempt(milestone_attempt)
-      milestone_attempt
-    end
-
-    def format_milestone_attempt(milestone_attempt)
-      if milestone_attempt[:result] == Berkeley::GraduateMilestones::QE_RESULTS_STATUS_PASSED
-        "#{milestone_attempt[:result]} #{milestone_attempt[:date]}"
-      else
-        "Exam #{milestone_attempt[:sequenceNumber]}: #{milestone_attempt[:result]} #{milestone_attempt[:date]}"
-      end
     end
 
     def determine_status_code(status_code, milestone_attempts)

--- a/spec/support/degree_progress_shared_examples.rb
+++ b/spec/support/degree_progress_shared_examples.rb
@@ -50,16 +50,14 @@ shared_examples 'a proxy that returns graduate milestone data' do
     qualifying_exam_attempts = subject[:feed][:degreeProgress][2][:requirements][1][:attempts]
     expect(qualifying_exam_attempts.count).to eq 2
     expect(qualifying_exam_attempts[0][:sequenceNumber]).to eq 2
-    expect(qualifying_exam_attempts[0][:date]).to eq 'Dec 22, 2016'
-    expect(qualifying_exam_attempts[0][:result]).to eq 'Passed'
+    expect(qualifying_exam_attempts[0][:statusCode]).to eq 'P'
     expect(qualifying_exam_attempts[1][:sequenceNumber]).to eq 1
-    expect(qualifying_exam_attempts[1][:date]).to eq 'Oct 01, 2016'
-    expect(qualifying_exam_attempts[1][:result]).to eq 'Failed'
+    expect(qualifying_exam_attempts[1][:statusCode]).to eq 'F'
   end
 
   it 'builds a string to represent the milestone attempt' do
     qualifying_exam_attempts = subject[:feed][:degreeProgress][2][:requirements][1][:attempts]
-    expect(qualifying_exam_attempts[0][:display]).to eq 'Passed Dec 22, 2016'
+    expect(qualifying_exam_attempts[0][:display]).to eq 'Exam 2: Passed Dec 22, 2016'
     expect(qualifying_exam_attempts[1][:display]).to eq 'Exam 1: Failed Oct 01, 2016'
   end
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-32137

This brings the Degree Progress card more in line with the Committees card.  We weren't bothering to show "Exam n:" on the second or third exam attempt as long as they passed it on that attempt.  Now we will show the exam number on every attempt.