### PR TITLE
SISRP-30166 - Hides popover alert icon when zero alerts

### DIFF
--- a/src/assets/javascripts/angular/controllers/widgets/statusController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/statusController.js
@@ -150,6 +150,7 @@ angular.module('calcentral.controllers').controller('StatusController', function
     }
     return academicStatusFactory.getHolds().then(
       function(parsedHolds) {
+        var holdsCount;
         if (parsedHolds.isError) {
           $scope.holds = {
             errored: true
@@ -158,8 +159,9 @@ angular.module('calcentral.controllers').controller('StatusController', function
           $scope.hasWarnings = true;
         } else {
           $scope.holds = _.get(parsedHolds, 'holds');
-          $scope.count += _.get(parsedHolds, 'holds.length');
-          $scope.hasAlerts = true;
+          holdsCount = _.get(parsedHolds, 'holds.length');
+          $scope.count += holdsCount;
+          $scope.hasAlerts = (holdsCount > 0);
         }
       }
     );


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-30166

We were setting `hasAlerts` to true even when the number of holds was zero.