### PR TITLE
Revert "SISRP-32253 Remove obsolete scripts"

### DIFF
--- a/script/build-torquebox.sh
+++ b/script/build-torquebox.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Script to build and migrate a new version of a shared deployment of CalCentral.
+# This is meant for running on Bamboo.
+
+cd $( dirname "${BASH_SOURCE[0]}" )/..
+
+LOG=`date +"log/start-stop_%Y-%m-%d.log"`
+LOGIT="tee -a $LOG"
+
+# Enable rvm and use the correct Ruby version and gem set.
+[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"
+source .rvmrc
+
+export RAILS_ENV=${RAILS_ENV:-production}
+export LOGGER_STDOUT=only
+# Temporary workaround for a JRuby 1.7.4 + Java 1.7 + JIT/invokedynamic bug : CLC-2732
+export JRUBY_OPTS="-Xcompile.invokedynamic=false -Xcext.enabled=true -J-Xmx900m -J-Djruby.compile.mode=OFF"
+# export JRUBY_OPTS="-Xcext.enabled=true -J-Xmx900m"
+
+echo | $LOGIT
+echo "------------------------------------------" | $LOGIT
+echo "`date`: Updating and rebuilding CalCentral..." | $LOGIT
+
+# Load all dependencies.
+echo "`date`: bundle install..." | $LOGIT
+bundle install --deployment --local || { echo "ERROR: bundle install failed" ; exit 1 ; }
+
+# Rebuild static assets (HTML, JS, etc.) after update.
+echo "`date`: Rebuilding static assets..." | $LOGIT
+bundle exec rake assets:precompile || { echo "ERROR: asset compilation failed" ; exit 1 ; }
+bundle exec rake fix_assets || { echo "ERROR: asset fix failed" ; exit 1 ; }
+
+# Stamp version number
+git log --pretty=format:'%H' -n 1 > versions/git.txt || { echo "ERROR: git log command failed" ; exit 1 ; }
+
+# copy Oracle jar into ./lib
+echo "`date`: Getting external driver files..." | $LOGIT
+./script/install-jars.rb 2>&1 | $LOGIT
+
+# build the knob
+echo "`date`: Building calcentral.knob..." | $LOGIT
+bundle exec rake torquebox:archive NAME=calcentral || { echo "ERROR: torquebox archive failed" ; exit 1 ; }

--- a/script/install-jars.rb
+++ b/script/install-jars.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+# Extremely primitive JRuby dependency handler for JARs we can't redistribute publicly:
+# 1. Check for the JAR libraries we expect to be in place.
+# 2. If they're not installed yet, try to download from MAVEN_REPO to the JRuby's main "lib" directory.
+# The MAVEN_REPO environment variable must point to a private repository.
+# This confluence page has docs on keeping MAVEN_REPO updated: https://confluence.media.berkeley.edu/confluence/x/jYVcAg
+
+abort "ERROR: No MAVEN_REPO is defined" unless ENV['MAVEN_REPO']
+
+def knows_class?(classname)
+  begin
+    eval("Java::#{classname}.class")
+    true
+  rescue NameError
+    false
+  end
+end
+
+puts "Installing Oracle jar from #{ENV['MAVEN_REPO']}"
+puts "  to #{ENV['MY_RUBY_HOME']}/lib"
+`wget "#{ENV['MAVEN_REPO']}/com/oracle/ojdbc6/11.2.0.3/ojdbc6-11.2.0.3.jar" -P "#{ENV['MY_RUBY_HOME']}/lib"`
+puts "Copying Oracle jar into ./lib"
+`cp -f "#{ENV['MY_RUBY_HOME']}/lib/ojdbc6-11.2.0.3.jar" "#{File.expand_path(File.dirname(__FILE__))}/../lib/"`


### PR DESCRIPTION
Reverts ets-berkeley-edu/calcentral#6579

The Bamboo build is failing due to a missing `build-torquebox.sh` script, which we've narrowed down to this PR.  @raydavis, let's chat this out when you get back to the office.