### PR TITLE
CLC-6625 OEC: tighten course code mappings

### DIFF
--- a/app/models/oec/course_code.rb
+++ b/app/models/oec/course_code.rb
@@ -9,9 +9,13 @@ module Oec
     end
 
     def self.catalog_id_specific_mapping(dept_name, catalog_id)
+      self.catalog_id_specific_mappings(dept_name).find { |m| m.catalog_id == catalog_id }
+    end
+
+    def self.catalog_id_specific_mappings(dept_name)
       # Cached retrieval for the small number of mappings, such as BIOLOGY 1A/1B, that depend on specific catalog IDs.
       @catalog_id_specific_mappings ||= Oec::CourseCode.where.not(catalog_id: '').to_a
-      @catalog_id_specific_mappings.find { |m| m.dept_name == dept_name && m.catalog_id == catalog_id }
+      @catalog_id_specific_mappings.select { |m| m.dept_name == dept_name }
     end
 
     def self.dept_names_for_code(dept_code)

--- a/spec/models/edo_oracle/oec_spec.rb
+++ b/spec/models/edo_oracle/oec_spec.rb
@@ -11,10 +11,10 @@ describe EdoOracle::Oec do
     context 'limiting query by department code' do
       let(:course_codes) do
         [
-          Oec::CourseCode.new(dept_name: 'CATALAN', catalog_id: nil, dept_code: 'LPSPP', include_in_oec: true),
-          Oec::CourseCode.new(dept_name: 'PORTUG', catalog_id: nil, dept_code: 'LPSPP', include_in_oec: true),
-          Oec::CourseCode.new(dept_name: 'SPANISH', catalog_id: nil, dept_code: 'LPSPP', include_in_oec: true),
-          Oec::CourseCode.new(dept_name: 'ILA', catalog_id: nil, dept_code: 'LPSPP', include_in_oec: false)
+          Oec::CourseCode.new(dept_name: 'CATALAN', catalog_id: '', dept_code: 'LPSPP', include_in_oec: true),
+          Oec::CourseCode.new(dept_name: 'PORTUG', catalog_id: '', dept_code: 'LPSPP', include_in_oec: true),
+          Oec::CourseCode.new(dept_name: 'SPANISH', catalog_id: '', dept_code: 'LPSPP', include_in_oec: true),
+          Oec::CourseCode.new(dept_name: 'ILA', catalog_id: '', dept_code: 'LPSPP', include_in_oec: false)
         ]
       end
       it { should include(
@@ -34,14 +34,14 @@ describe EdoOracle::Oec do
     context 'limiting query by course code' do
       let(:course_codes) do
         [
-          Oec::CourseCode.new(dept_name: 'INTEGBI', catalog_id: nil, dept_code: 'IBIBI', include_in_oec: true),
+          Oec::CourseCode.new(dept_name: 'INTEGBI', catalog_id: '', dept_code: 'IBIBI', include_in_oec: true),
           Oec::CourseCode.new(dept_name: 'BIOLOGY', catalog_id: '1B', dept_code: 'IBIBI', include_in_oec: true),
           Oec::CourseCode.new(dept_name: 'BIOLOGY', catalog_id: '1BL', dept_code: 'IBIBI', include_in_oec: true)
         ]
       end
       it { should include(
         "(sec.\"displayName\" LIKE 'INTEGBI %'",
-        "(sec.\"displayName\" LIKE 'BIOLOGY %' and (sec.\"displayName\" LIKE '%1B' or sec.\"displayName\" LIKE '%1BL')"
+        "(sec.\"displayName\" = 'BIOLOGY 1B' or sec.\"displayName\" = 'BIOLOGY 1BL')"
       )}
       it { should_not include 'NOT' }
     end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6625

OEC mappings by specific catalog ID should match on that precise ID rather than using substrings.

Also, specific OEC mappings to a foreign department should be excluded from the home department: that is, if MCELLBI 90A appears under Freshman and Sophomore Seminars, it should not also appear under Molecular and Cell Biology.