### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README-VAGRANT.md
+++ b/README-VAGRANT.md
@@ -1,6 +1,6 @@
-#CalCentral with Vagrant
+# CalCentral with Vagrant
 
-##Overview
+## Overview
 
 Our Vagrant environment has 2 layers. First, Vagrant automates the startup & shutdown of a virtual machine that
 runs Linux. Inside this virtual machine, Docker is used to automate the startup of "containers" that run the
@@ -9,7 +9,7 @@ was used as the core of our Vagrant/Docker setup, and has a lot of helpful backg
 and Docker work. You should also read and understand the [Docker user guide](https://docs.docker.com/userguide/) as the
 Docker container way of doing things can often be counterintuitive.
 
-##New developer setup
+## New developer setup
 1. Install Vagrant https://www.vagrantup.com/downloads.html
 1. Install VirtualBox  https://www.virtualbox.org/wiki/Downloads
 1. Install vagrant-vbguest (to keep guest additions up to date):

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#CalCentral
+# CalCentral
 
 [![Dependency Status](https://img.shields.io/gemnasium/ets-berkeley-edu/calcentral.svg)](https://gemnasium.com/ets-berkeley-edu/calcentral) [![devDependency Status](https://david-dm.org/ets-berkeley-edu/calcentral/dev-status.svg)](https://david-dm.org/ets-berkeley-edu/calcentral#info=devDependencies) [![Code Climate](https://img.shields.io/codeclimate/github/ets-berkeley-edu/calcentral.svg)](https://codeclimate.com/github/ets-berkeley-edu/calcentral)
 * Master Build: [![Build Status](https://api.travis-ci.org/ets-berkeley-edu/calcentral.svg?branch=master)](https://travis-ci.org/ets-berkeley-edu/calcentral)

--- a/docs/Canvas-README.md
+++ b/docs/Canvas-README.md
@@ -1,4 +1,4 @@
-#Canvas support
+# Canvas support
 
 ## Canvas maintenance Rake tasks
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
