### PR TITLE
Revert "SISRP-31200 - Revision asset files in development build mode"

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -374,11 +374,15 @@
    * Add hashes to the files and update the includes (production)
    */
   gulp.task('revall', function() {
+    if (!isProduction) {
+      return;
+    }
+
     var path = require('path');
     var RevAll = require('gulp-rev-all');
     var revAllAssets = new RevAll({
-      // Add some extra logging in production mode
-      debug: isProduction,
+      // Since we only run this in production mode, add some extra logging
+      debug: true,
       dontGlobal: [
         /favicon\.ico/g,
         'manifest.json'


### PR DESCRIPTION
Reverts ets-berkeley-edu/calcentral#6586

Seems like this did mess up browser-sync after all.  Reverting for now, more research needed.