### PR TITLE
SISRP-28717 - 8.1: Update SOR to CS for CalCentral

### DIFF
--- a/app/models/my_academics/academics_module.rb
+++ b/app/models/my_academics/academics_module.rb
@@ -22,6 +22,10 @@ module MyAcademics
         termCode: term_cd,
         termYear: term_yr,
         timeBucket: time_bucket(term_yr, term_cd),
+        # TODO: With Settings.features.allow_legacy_fallback == false for GL8.1, this is no longer accurate, and should be removed.
+        # We will be pulling from EDODB for all terms including legacy terms, so every term will be a CampusSolutionsTerm.
+        # But until we decide to remove the flag, we should leave this, in case we need to fallback onto CampusOracle again.  In that case,
+        # a lot of the logic dependent on this flag will still be valid.
         campusSolutionsTerm: !Berkeley::Terms.legacy?(term_yr, term_cd),
         gradingInProgress: (terms.grading_in_progress && (slug == terms.grading_in_progress.slug)),
         classes: []

--- a/spec/models/my_academics/semesters_spec.rb
+++ b/spec/models/my_academics/semesters_spec.rb
@@ -162,6 +162,9 @@ describe MyAcademics::Semesters do
         end
       end
     end
+  end
+
+  shared_examples 'a legacy semester with additional credits' do
     it 'should include additional credits' do
       expect(feed[:additionalCredits]).to eq transcript_data[:additional_credits]
       expect(feed[:pastSemestersLimit]).to eq (feed[:pastSemestersCount] + 2)
@@ -172,11 +175,13 @@ describe MyAcademics::Semesters do
     before do
       allow(Settings.terms).to receive(:fake_now).and_return '2016-04-01'
       allow(Settings.terms).to receive(:legacy_cutoff).and_return 'spring-2017'
+      allow(Settings.features).to receive(:allow_legacy_fallback).and_return true
       allow_any_instance_of(CampusOracle::UserCourses::All).to receive(:get_all_campus_courses).and_return enrollment_data
       expect(EdoOracle::Queries).not_to receive :get_enrolled_sections
     end
     let(:enrollment_data) { generate_enrollment_data(edo_source: false)  }
     it_should_behave_like 'a good and proper munge'
+    it_should_behave_like 'a legacy semester with additional credits'
     it 'advertises legacy source' do
       expect(feed[:semesters]).to all include({campusSolutionsTerm: false})
     end
@@ -186,6 +191,7 @@ describe MyAcademics::Semesters do
     before do
       allow(Settings.terms).to receive(:fake_now).and_return '2016-04-01'
       allow(Settings.terms).to receive(:legacy_cutoff).and_return 'fall-2009'
+      allow(Settings.features).to receive(:allow_legacy_fallback).and_return false
       expect(CampusOracle::Queries).not_to receive :get_enrolled_sections
       allow_any_instance_of(EdoOracle::UserCourses::All).to receive(:get_all_campus_courses).and_return enrollment_data
     end
@@ -246,6 +252,7 @@ describe MyAcademics::Semesters do
       allow_any_instance_of(EdoOracle::UserCourses::All).to receive(:get_all_campus_courses).and_return edo_enrollment_data
     end
     it_should_behave_like 'a good and proper munge'
+    it_should_behave_like 'a legacy semester with additional credits'
     it 'advertises mixed source' do
       expect(feed[:semesters][0..1]).to all include({campusSolutionsTerm: true})
       expect(feed[:semesters][2..3]).to all include({campusSolutionsTerm: false})


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-28717

* Cleans up some minor bugs when switching the `allow_legacy_fallback` flag to `false`.
* Updates the Rspec tests to not expect a `semesters[:additionalCredits]` node when only pulling from CS.
* Double-checked with Student Records regarding the `semesters[:additionalCredits]` node - we are pulling EAP/AP/UC EXT data from there according to #3483 - all of which are covered by other avenues in CalCentral (can expand more on this if needed)
* Would like @nkutub to give this a review before merging
* Once this is merged, we'll be able to flip the switch in all clusters to only pull from EDODB.
* QA PR to come