### PR TITLE
SISRP-32470 - Returns empty response when no Grad Div milestones to show

### DIFF
--- a/app/models/degree_progress/milestones_module.rb
+++ b/app/models/degree_progress/milestones_module.rb
@@ -17,10 +17,8 @@ module DegreeProgress
           if should_exclude progress
             next
           end
-
-          result.push(progress).last.tap do |prog|
-            prog[:requirements] = normalize(prog.fetch(:requirements))
-          end
+          progress[:requirements] = normalize(progress.fetch(:requirements))
+          result.push(progress) unless progress[:requirements].blank?
         end
       end
       result


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-32470

User can have Degree Progress data without having any valid milestones - in this case, we want to show the "no data" message.

QA PR to follow.