### PR TITLE
SISRP-32562 - CalnetCrosswalk::ByCsId being called with a UID, returning Error

### DIFF
--- a/app/models/calnet_crosswalk/proxy.rb
+++ b/app/models/calnet_crosswalk/proxy.rb
@@ -62,7 +62,7 @@ module CalnetCrosswalk
         statusCode: response.code,
         feed: response.parsed_response
       }
-      if response.code == 404 && response.parsed_response.nil?
+      if response.code == 404 && response.parsed_response['status'] == 404
         logger.info "Requested #{self.class.id_type} #{@uid} not found in Crosswalk"
         internal_response[:notFound] = true
       end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-32562

* Lots of stuff in the JIRA, but basically CalNet changed their 404 response body and we started logging errors because of it.
* This conforms to the new 404 response body.