### PR TITLE
SISRP-32149 - Remove logic that hides certain features from summer visitors

### DIFF
--- a/src/assets/javascripts/angular/controllers/widgets/financesLinksController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/financesLinksController.js
@@ -116,8 +116,7 @@ angular.module('calcentral.controllers').controller('FinancesLinksController', f
   var loadAcademicStatus = function(roles) {
     if (!_.isEmpty(roles)) {
       $scope.canViewEftLink = $scope.api.user.profile.roles.student &&
-        ($scope.api.user.profile.roles.undergrad || $scope.api.user.profile.roles.graduate || $scope.api.user.profile.roles.law) &&
-        !roles.summerVisitor;
+        ($scope.api.user.profile.roles.undergrad || $scope.api.user.profile.roles.graduate || $scope.api.user.profile.roles.law);
       $scope.canViewEmergencyLoanLink = !roles.summerVisitor;
     }
   };

--- a/src/assets/templates/academics.html
+++ b/src/assets/templates/academics.html
@@ -41,7 +41,7 @@
 
       <div data-ng-include="'widgets/final_exam_schedule.html'" data-ng-if="canViewFinalExamSchedule && api.user.profile.features.finalExamSchedule"></div>
 
-      <div data-ng-include="'widgets/my_advising.html'" data-ng-if="showAdvising && !collegeAndLevel.roles.summerVisitor"></div>
+      <div data-ng-include="'widgets/my_advising.html'" data-ng-if="showAdvising"></div>
 
       <div data-ng-include="'widgets/transfer_credit.html'" data-ng-if="!collegeAndLevel.roles.summerVisitor"></div>
     </div>

--- a/src/assets/templates/academics_student_profile.html
+++ b/src/assets/templates/academics_student_profile.html
@@ -71,7 +71,7 @@
 
       <div data-ng-include="'widgets/academics/college_and_level.html'"></div>
 
-      <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="!collegeAndLevel.roles.summerVisitor && gpaUnits.totalUnits > 0">
+      <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="gpaUnits.totalUnits > 0">
         <table>
           <tbody>
             <tr>
@@ -82,7 +82,7 @@
         </table>
       </div>
 
-      <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="!collegeAndLevel.roles.summerVisitor && gpaUnits.cumulativeGpa > 0 && !api.user.profile.roles.law">
+      <div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="gpaUnits.cumulativeGpa > 0 && !api.user.profile.roles.law">
         <table>
           <tbody>
             <tr>

--- a/src/assets/templates/myfinances.html
+++ b/src/assets/templates/myfinances.html
@@ -11,7 +11,7 @@
     </div>
 
     <div class="medium-6 large-4 cc-column-2 columns">
-      <div data-ng-include="'widgets/finaid_summary.html'" data-ng-if="api.user.profile.features.csFinAid && !academicStatus.roles.summerVisitor"></div>
+      <div data-ng-include="'widgets/finaid_summary.html'" data-ng-if="api.user.profile.features.csFinAid"></div>
     </div>
 
     <div class="medium-6 large-4 cc-column-3 columns" data-ng-class="{'medium-pull-4':(api.user.profile.isApplicantOnly), 'cc-column-3':(!api.user.profile.isApplicantOnly)}">

--- a/src/assets/templates/widgets/academics/college_and_level.html
+++ b/src/assets/templates/widgets/academics/college_and_level.html
@@ -1,8 +1,9 @@
 <div data-cc-academic-plans-directive data-plans="collegeAndLevel.majors" data-options="{labels: {'1': 'Major', 'other': 'Majors'}}" data-type="major"> </div>
+<div data-cc-academic-plans-directive data-plans="collegeAndLevel.majors" data-options="{labels: {'1': 'Major', 'other': 'Majors'}}" data-type="major"> </div>
 <div data-cc-academic-plans-directive data-plans="collegeAndLevel.minors" data-options="{labels: {'1': 'Minor', 'other': 'Minors'}}" data-type="minor"> </div>
 <div data-cc-academic-plans-directive data-plans="collegeAndLevel.designatedEmphases" data-options="{labels: {'1': 'Designated Emphasis', 'other': 'Designated Emphases'}}" data-type="designatedEmphasis"> </div>
 
-<div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="!collegeAndLevel.roles.summerVisitor && collegeAndLevel.careers.length">
+<div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="collegeAndLevel.careers.length">
   <table class="cc-widget-profile-table">
     <tbody>
     <tr>
@@ -15,7 +16,7 @@
   </table>
 </div>
 
-<div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="!collegeAndLevel.roles.summerVisitor && collegeAndLevel.level">
+<div class="cc-table cc-table-top-border cc-clearfix" data-ng-if="collegeAndLevel.level">
   <table class="cc-widget-profile-table">
     <tbody>
       <tr>
@@ -40,7 +41,7 @@
 </div>
 
 <div class="cc-table cc-table-top-border cc-clearfix"
-  data-ng-if="!collegeAndLevel.roles.summerVisitor && (collegeAndLevel.termsInAttendance || expectedGradTerm(collegeAndLevel))">
+  data-ng-if="collegeAndLevel.termsInAttendance || expectedGradTerm(collegeAndLevel)">
   <table class="cc-widget-profile-table">
     <tbody>
       <tr>


### PR DESCRIPTION
"Summer visitors" are students with one of a dozen or more particular academic plans.  In a prior release we created a filtered experience since they don't need full access to CC.

This became a problem for students that have a regular academic plan besides their summer visitor plan.  As a short term solution, we're reversing some of the filtering so those students can see necessary information.

https://jira.berkeley.edu/browse/SISRP-32149

Design:  https://jira.berkeley.edu/browse/SISRP-32933