### PR TITLE
SISRP-32544 - Delegate UX: remove page links, bConnected icons, profile menu item

### DIFF
--- a/app/controllers/my_badges_controller.rb
+++ b/app/controllers/my_badges_controller.rb
@@ -1,5 +1,4 @@
 class MyBadgesController < ApplicationController
-  include AllowDelegateViewAs
 
   before_filter :api_authenticate
 

--- a/app/models/user/api.rb
+++ b/app/models/user/api.rb
@@ -106,6 +106,10 @@ module User
       authentication_state.authenticated_as_delegate?
     end
 
+    def has_campus_role?
+      @user_attributes[:roles].values.any?
+    end
+
     def super_user?
       authentication_state.policy.can_administrate? && !is_delegate_user_emulating_student?
     end
@@ -127,7 +131,7 @@ module User
 
     def has_dashboard_tab?
       return false if is_delegate_user_emulating_student?
-      @user_attributes[:roles].values.any? || super_user?
+      has_campus_role? || super_user?
     end
 
     def has_academics_tab?(has_instructor_history, has_student_history)
@@ -140,7 +144,7 @@ module User
 
     def has_badges?
       return false if is_delegate_user_emulating_student? || is_advisor_user_emulating_student?
-      @user_attributes[:roles].values.any? || super_user?
+      has_campus_role? || super_user?
     end
 
     def has_financials_tab?(has_student_history)
@@ -152,7 +156,7 @@ module User
     end
 
     def has_campus_tab?
-      @user_attributes[:roles].values.any? || super_user?
+      has_campus_role? || super_user?
     end
 
     def has_toolbox_tab?(policy)
@@ -162,7 +166,7 @@ module User
 
     def show_sis_profile_ui?
       return false if is_delegate_user_emulating_student?
-      return @user_attributes[:sisProfileVisible] if @user_attributes[:roles].values.any? || super_user?
+      return @user_attributes[:sisProfileVisible] if has_campus_role? || super_user?
       false
     end
 

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -91,7 +91,7 @@ describe User::Api do
     let(:feed) { User::Api.new(uid).get_feed }
     include_context 'has no delegate students'
 
-    it 'should return a user data structure' do
+    it 'should return a user data structure with default values' do
       expect(feed[:preferredName]).to eq ''
       expect(feed[:isLegacyStudent]).to be false
       expect(feed[:isDelegateUser]).to be false
@@ -99,6 +99,7 @@ describe User::Api do
       expect(feed[:hasAcademicsTab]).to be false
       expect(feed[:canViewGrades]).to be false
       expect(feed[:hasToolboxTab]).to be false
+      expect(feed[:hasBadges]).to be false
       expect(feed[:officialBmailAddress]).to eq nil
       expect(feed[:campusSolutionsID]).to eq '1234567890'
       expect(feed[:sid]).to eq nil
@@ -116,6 +117,9 @@ describe User::Api do
       it 'shows My Academics tab' do
         expect(feed[:hasAcademicsTab]).to be true
       end
+      it 'shows bConnected badges' do
+        expect(feed[:hasBadges]).to be true
+      end
       it 'shows profile' do
         expect(feed[:showSisProfileUI]).to be true
       end
@@ -128,6 +132,9 @@ describe User::Api do
       let(:has_advisor_role) { true }
       it 'hides My Academics tab' do
         expect(feed[:hasAcademicsTab]).to be false
+      end
+      it 'shows bConnected badges' do
+        expect(feed[:hasBadges]).to be true
       end
       it 'shows profile' do
         expect(feed[:showSisProfileUI]).to be true
@@ -173,6 +180,9 @@ describe User::Api do
         it 'hides My Toolbox tab' do
           expect(feed[:hasToolboxTab]).to be false
         end
+        it 'hides bConnected badges' do
+          expect(feed[:hasBadges]).to be false
+        end
         it 'hides profile' do
           expect(feed[:showSisProfileUI]).to be false
         end
@@ -195,6 +205,9 @@ describe User::Api do
         end
         it 'hides profile' do
           expect(feed[:showSisProfileUI]).to be false
+        end
+        it 'hides bConnected badges' do
+          expect(feed[:hasBadges]).to be false
         end
         it 'withholds delegate role' do
           expect(feed[:isDelegateUser]).to be false
@@ -221,6 +234,9 @@ describe User::Api do
           it 'hides profile' do
             expect(feed[:showSisProfileUI]).to be false
           end
+          it 'hides bConnected badges' do
+            expect(feed[:hasBadges]).to be false
+          end
           it 'assigns delegate role' do
             expect(feed[:isDelegateUser]).to be true
           end
@@ -240,6 +256,9 @@ describe User::Api do
             end
             it 'shows profile' do
               expect(feed[:showSisProfileUI]).to be true
+            end
+            it 'shows bConnected badges' do
+              expect(feed[:hasBadges]).to be true
             end
             it 'assigns privileges relevant to both delegates and advisors' do
               expect(feed[:canViewGrades]).to be true
@@ -263,6 +282,9 @@ describe User::Api do
             it 'hides profile' do
               expect(feed[:showSisProfileUI]).to be false
             end
+            it 'hides bConnected badges' do
+              expect(feed[:hasBadges]).to be false
+            end
             it 'withholds delegate role' do
               expect(feed[:isDelegateUser]).to be false
             end
@@ -281,6 +303,9 @@ describe User::Api do
             end
             it 'hides profile' do
               expect(feed[:showSisProfileUI]).to be false
+            end
+            it 'hides bConnected badges' do
+              expect(feed[:hasBadges]).to be false
             end
             it 'assigns privileges relevant to the student' do
               expect(feed[:canViewGrades]).to be false

--- a/src/assets/javascripts/angular/controllers/widgets/statusController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/statusController.js
@@ -206,7 +206,7 @@ angular.module('calcentral.controllers').controller('StatusController', function
       var statusGets = [loadHolds(), getRegistrations, getStudentAttributes];
 
       // Only fetch financial data for delegates who have been given explicit permssion.
-      var includeFinancial = (!apiService.user.profile.delegateActingAsUid || apiService.user.profile.delegateViewAsPrivileges.financial);
+      var includeFinancial = (!apiService.user.profile.delegateActingAsUid || apiService.user.profile.canActOnFinances);
       if (includeFinancial) {
         var getCarsFinances = financesFactory.getFinances().then(loadCarsFinances);
         var getCsFinances = financesFactory.getCsFinances().then(loadCsFinances);

--- a/src/assets/javascripts/angular/services/userService.js
+++ b/src/assets/javascripts/angular/services/userService.js
@@ -29,8 +29,10 @@ angular.module('calcentral.services').service('userService', function($http, $lo
           utilService.redirect('academics');
         } else if (profile.hasFinancialsTab) {
           utilService.redirect('finances');
-        } else {
+        } else if (profile.hasCampusTab) {
           utilService.redirect('campus');
+        } else {
+          utilService.redirect('toolbox');
         }
       } else {
         utilService.redirect('toolbox');

--- a/src/assets/stylesheets/_toolbox.scss
+++ b/src/assets/stylesheets/_toolbox.scss
@@ -52,11 +52,5 @@
         width: 72px;
       }
     }
-    .cc-toolbox-widget-academic-calendar-item {
-      padding: 5px 0;
-      &:first-of-type {
-        padding-top: 20px;
-      }
-    }
   }
 }

--- a/src/assets/templates/launcher.html
+++ b/src/assets/templates/launcher.html
@@ -9,7 +9,7 @@
     </a>
   </div>
   <nav class="cc-header-icons" data-ng-cloak data-ng-show="api.user.events.isAuthenticated">
-    <div class="cc-left" data-ng-include="'widgets/badges_popover.html'" data-ng-if="!api.user.profile.delegateActingAsUid && !api.user.profile.advisorActingAsUid"></div>
+    <div class="cc-left" data-ng-include="'widgets/badges_popover.html'" data-ng-if="api.user.profile.hasBadges"></div>
     <div class="cc-left" data-ng-include="'widgets/gear_popover.html'"></div>
   </nav>
 </header>

--- a/src/assets/templates/navigation.html
+++ b/src/assets/templates/navigation.html
@@ -10,7 +10,7 @@
     <li data-ng-class="{true:'active'}[controllerName=='MyFinancesController']" data-ng-if="api.user.profile.hasFinancialsTab">
       <a href="/finances" data-ng-click="offCanvasMenu.show=false"><i class="fa fa-usd"></i>My Finances</a>
     </li>
-    <li data-ng-class="{true:'active'}[controllerName=='CampusController']">
+    <li data-ng-class="{true:'active'}[controllerName=='CampusController']" data-ng-if="api.user.profile.hasCampusTab">
       <a href="/campus" data-ng-click="offCanvasMenu.show=false"><i class="fa fa-th-large"></i>My Campus</a>
     </li>
     <li data-ng-class="{true:'active'}[controllerName=='MyToolboxController']" data-ng-if="api.user.profile.hasToolboxTab">

--- a/src/assets/templates/widgets/profile_popover.html
+++ b/src/assets/templates/widgets/profile_popover.html
@@ -1,5 +1,5 @@
 <ul class="cc-popover-items cc-profile-popover-links">
-  <li class="cc-popover-item" data-ng-if="api.user.profile.showSisProfileUI && !api.user.profile.delegateActingAsUid">
+  <li class="cc-popover-item" data-ng-if="api.user.profile.showSisProfileUI">
     <button class="cc-button-link cc-popover-link"
       data-ng-click="api.popover.clickThrough('Gear - Profile');api.util.redirect('profile')">Profile
     </button>

--- a/src/assets/templates/widgets/toolbox/academic_dates.html
+++ b/src/assets/templates/widgets/toolbox/academic_dates.html
@@ -2,27 +2,15 @@
   <div class="cc-widget-title">
     <h2>Academic Dates &amp; Deadlines</h2>
   </div>
-  <div class="cc-widget-list">
-    <ul class="cc-toolbox-widget-academic-calendar">
-      <li class="cc-toolbox-widget-academic-calendar-item" data-ng-repeat="item in academicDates.items">
-        <strong class="cc-nowrap">
-          <span data-ng-bind="item.date | dateInYearFilter:'Mmm dd'"></span>:
-        </strong>
-        <span data-ng-bind="item.title" data-ng-if="!item.isList"></span>
-        <ul class="cc-list-bullets" data-ng-if="item.isList">
-          <li data-ng-repeat="title in item.title">
-            <span data-ng-bind="title"></span>
-          </li>
-        </ul>
-      </li>
-    </ul>
-  </div>
-  <hr>
   <div class="cc-list-link-container">
-    <h3>Links</h3>
     <ul class="cc-list-links">
       <li>
-        <a href="http://registrar.berkeley.edu/CalendarDisp.aspx">
+        <a href="http://registrar.berkeley.edu/calendar">
+          View the Academic Calendar
+        </a>
+      </li>
+      <li>
+        <a href="http://registrar.berkeley.edu/add-academic-calendar-bcal">
           Subscribe to the Academic Calendar
         </a>
       </li>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-32544

Only users who are delegates and nothing else should have the special delegate experience.  If they are a delegate and also an advisor, for example, they still need to see stuff that is relevant to advisors.

Also did some refactoring of api/my/status feed.  