### PR TITLE
SISRP-32561 - Investigate 'GCMT' CS IDs in Prod Error Logs

### DIFF
--- a/app/controllers/my_committees_controller.rb
+++ b/app/controllers/my_committees_controller.rb
@@ -19,9 +19,9 @@ class MyCommitteesController < ApplicationController
   end
 
   def member_photo
-    member_id = Integer(params['member_id'], 10)
+    member_id = Integer(params['member_id'], 10) if params['member_id']
     my_committees = MyCommittees::Merged.from_session(session)
-    if  my_committees.get_feed_as_json.include? "member/#{member_id}"
+    if  member_id && (my_committees.get_feed_as_json.include? "member/#{member_id}")
       member_photo = my_committees.photo_data_or_file(member_id)
       serve_photo(member_photo)
     else

--- a/app/models/my_committees/committees_module.rb
+++ b/app/models/my_committees/committees_module.rb
@@ -95,6 +95,7 @@ module MyCommittees::CommitteesModule
 
   def committee_member_photo_url (cs_committee_member)
     empl_id = cs_committee_member[:memberEmplid]
+    return nil if is_non_berkeley_committee_member? empl_id
     user_id = CalnetCrosswalk::ByCsId.new(user_id: empl_id).lookup_ldap_uid
     "/api/my/committees/photo/member/#{user_id}"
   end
@@ -183,6 +184,10 @@ module MyCommittees::CommitteesModule
       else
         :additionalReps
     end
+  end
+
+  def is_non_berkeley_committee_member?(empl_id)
+    empl_id.to_s.include? 'GCMT'
   end
 
   def is_active?(cs_committee)


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-32561

* Cuts down on # of erroneous calls by not making API calls to `MyCommitteesController#member_photo` or `CalnetCrosswalk::ByCsId` if the EMPL ID given by CS starts with `GCMT`, which is a sign that the committee member is not Berkeley faculty.

Would appreciate it if @lyttam can take a look at this one, along w/ any other reviewers.