### PR TITLE
SISRP-32341 - Add logging of UID obtained from SAML response

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,9 @@ class SessionsController < ApplicationController
 
   def lookup
     auth = request.env['omniauth.auth']
+    logger.info "Omniauth auth hash from SAML = #{auth.inspect}"
     auth_uid = auth['uid']
+    logger.info "UID obtained from Omniauth auth hash = #{auth_uid}"
 
     # Save crosswalk some work by caching critical IDs if they were asserted to us via SAML.
     if auth.respond_to?(:extra)


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-32341

Adds a bit of logging so we can validate a proper UID from SAML, whoever we are authenticating with.