### PR TITLE
SISRP-33192 - Adds graceful handling of empty Link API responses

### DIFF
--- a/app/models/campus_solutions/link.rb
+++ b/app/models/campus_solutions/link.rb
@@ -33,65 +33,76 @@ module CampusSolutions
     def get_url(url_id, placeholders = {})
       # get cached response
       link_resources = get
+      status = link_resources[:status]
 
       if url_id
         # Need this due to side-effect of the lift process in normalize_response.
         link_id = url_id.downcase.camelize(:lower).to_sym
-        entry = link_resources[:feed][:ucLinkResources][:links][link_id]
-
-        if entry.nil?
-          logger.debug "Could not retrieve CS link by id #{url_id}, with parameters #{placeholders}"
+        links = link_resources.try(:[], :feed).try(:[], :ucLinkResources)
+        if links.blank?
+          logger.error "Empty response from CS Link API for link id #{url_id}, with parameters #{placeholders}"
+          status = 500
         else
-          link = entry.slice(:url, :urlId, :description, :hoverOverText)
+          entry = links.try(:[], :links).try(:[], link_id)
+          link = parse_link(url_id, entry, placeholders)
+        end
+      end
+      {
+        status: status,
+        link: link
+      }
+    end
 
-          placeholders.try(:each) do |k, v|
-            if v.nil?
-              logger.debug "Could not set placeholder for #{k} on link id #{url_id}"
-              link = nil
-              break
-            else
-              link[:url] = link[:url].gsub("{#{k}}", v)
-            end
-          end
+    def parse_link(url_id, entry, placeholders)
+      if entry.nil?
+        logger.debug "Could not retrieve CS link by id #{url_id}, with parameters #{placeholders}"
+        return nil
+      end
 
-          if !link.nil?
-            # promote properties we're interested in
-            entry[:properties].each do |property|
-              if property[:name] == 'NEW_WINDOW' && property[:value] == 'Y'
-                link[:showNewWindow] = true
-              end
-              if property[:name] == 'UCFROM'
-                link[:ucFrom] = property[:value]
-              end
-              if property[:name] == 'UCFROMLINK'
-                link[:ucFromLink] = property[:value]
-              end
-              if property[:name] == 'UCFROMTEXT'
-                link[:ucFromText] = property[:value]
-              end
-              if property[:name] == 'LINK_DESCRIPTION'
-                link[:linkDescription] = property[:value]
-              end
-              if property[:name] == 'LINK_DESCRIPTION_DISPLAY'
-                link[:linkDescriptionDisplay] = property[:value] == 'Y'
-              end
-            end
+      link = entry.slice(:url, :urlId, :description, :hoverOverText)
 
-            # convert campus solutions property names to calcentral
-            link[:name] = link.delete(:description)
-            link[:title] = link.delete(:hoverOverText) || ''
-            if !link[:showNewWindow]
-              link[:isCsLink] = true
-              link['IS_CS_LINK'] = true
-            end
-          end
+      placeholders.try(:each) do |k, v|
+        if v.nil?
+          logger.debug "Could not set placeholder for #{k} on link id #{url_id}"
+          link = nil
+          break
+        else
+          link[:url] = link[:url].gsub("{#{k}}", v)
         end
       end
 
-      {
-        status: link_resources[:status],
-        link: link
-      }
+      if !link.nil?
+        # promote properties we're interested in
+        entry[:properties].each do |property|
+          if property[:name] == 'NEW_WINDOW' && property[:value] == 'Y'
+            link[:showNewWindow] = true
+          end
+          if property[:name] == 'UCFROM'
+            link[:ucFrom] = property[:value]
+          end
+          if property[:name] == 'UCFROMLINK'
+            link[:ucFromLink] = property[:value]
+          end
+          if property[:name] == 'UCFROMTEXT'
+            link[:ucFromText] = property[:value]
+          end
+          if property[:name] == 'LINK_DESCRIPTION'
+            link[:linkDescription] = property[:value]
+          end
+          if property[:name] == 'LINK_DESCRIPTION_DISPLAY'
+            link[:linkDescriptionDisplay] = property[:value] == 'Y'
+          end
+        end
+
+        # convert campus solutions property names to calcentral
+        link[:name] = link.delete(:description)
+        link[:title] = link.delete(:hoverOverText) || ''
+        if !link[:showNewWindow]
+          link[:isCsLink] = true
+          link['IS_CS_LINK'] = true
+        end
+      end
+      link
     end
 
     def url

--- a/fixtures/xml/campus_solutions/link_api_empty.xml
+++ b/fixtures/xml/campus_solutions/link_api_empty.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<UC_LINK_RESOURCES />

--- a/spec/models/campus_solutions/link_spec.rb
+++ b/spec/models/campus_solutions/link_spec.rb
@@ -34,6 +34,23 @@ describe CampusSolutions::Link do
         expect(link_set_response[:feed][:ucLinkResources][:links]).not_to be
         expect(link_set_response[:feed][:ucLinkResources][:status][:details][:msgs][:msg][:messageSeverity]).to eq "E"
       end
+      it 'returns a parsed response with the expected structure' do
+        expect(link_get_url_response[:link]).not_to be
+        expect(link_get_url_response[:status]).not_to be
+      end
+    end
+
+    context 'returns an empty response' do
+      let(:filename) { 'link_api_empty.xml' }
+
+      it_should_behave_like 'a proxy that gets data'
+      it 'returns data with the expected structure' do
+        expect(link_set_response[:feed][:ucLinkResources]).not_to be
+      end
+      it 'returns a parsed response with the expected structure' do
+        expect(link_get_url_response[:link]).not_to be
+        expect(link_get_url_response[:status]).to eq 500
+      end
     end
 
     context 'returns links as an array' do


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-33187

This will prevent our proxies that fetch links from blowing up when the link API response is empty or otherwise bad.