### PR TITLE
SISRP-33211 - Removes check for column values

### DIFF
--- a/app/models/edo_oracle/view_checker.rb
+++ b/app/models/edo_oracle/view_checker.rb
@@ -2,15 +2,6 @@ class EdoOracle::ViewChecker
 
   VIEW_DEPENDENCIES = [
     {
-      :id => 'SISEDO.TERM_TBL_VW',
-      :columns => [
-        'STRM',
-        'DESCR',
-        'TERM_BEGIN_DT',
-        'TERM_END_DT',
-      ]
-    },
-    {
       :id => 'SISEDO.API_COURSEV00_MVW',
       :columns => [
         'catalogNumber-formatted',
@@ -164,22 +155,9 @@ class EdoOracle::ViewChecker
 
   def check_view(view)
     results = EdoOracle::Queries.query "SELECT #{to_query_columns(view[:columns])} FROM #{view[:id]} WHERE rownum=1"
-    check_results(view[:columns], view[:id], results)
+    log_result(:successes, "#{view[:id]} has no issues") if results
   rescue => e
     log_result(:errors, "Failure to query #{view[:id]} - #{e.to_s}")
-  end
-
-  def check_results(column_array, view_name, results)
-    errors = 0
-    column_array.each do |column|
-      if results[0][column.downcase].blank?
-        errors += 1
-        log_result(:errors, "#{column} column value blank in #{view_name} results")
-      end
-    end
-    if errors == 0
-      log_result(:successes, "#{view_name} has no issues")
-    end
   end
 
   def log_result(type, message)


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-33211

I realized that blank values doesn't necessarily mean that the data is invalid. For instance, not every course has a catalog number prefix or suffix.

```
- catalogNumber-prefix column value blank in SISEDO.API_COURSEV00_MVW results
- catalogNumber-suffix column value blank in SISEDO.API_COURSEV00_MVW results
- finalExam column value blank in SISEDO.CLASSSECTIONALLV00_MVW results
- WAITLISTPOSITION column value blank in SISEDO.ENROLLMENTV00_VW results
- WAITLISTPOSITION column value blank in SISEDO.CC_ENROLLMENTV00_VW results
```

The script now only checks if the query that includes the dependent columns succeeds or fails.
```
--- SISEDO Checkup ----------

Successes:
- SISEDO.API_COURSEV00_MVW has no issues
- SISEDO.CLASSSECTIONALLV00_MVW has no issues
- SISEDO.DISPLAYNAMEXLAT_MVW has no issues
- SISEDO.ENROLLMENTV00_VW has no issues
- SISEDO.CC_ENROLLMENTV00_VW has no issues
- SISEDO.ASSIGNEDINSTRUCTORV00_VW has no issues
- SISEDO.EXAMV00_VW has no issues
- SISEDO.MEETINGV00_VW has no issues
- SISEDO.PERSON_EMAILV00_VW has no issues
- SISEDO.API_COURSEIDENTIFIERSV00_VW has no issues

Errors:
- Failure to query SISEDO.TERM_TBL_VW - ActiveRecord::JDBCError: java.sql.SQLSyntaxErrorException: ORA-01031: insufficient privileges
: SELECT "STRM","DESCR","TERM_BEGIN_DT","TERM_END_DT" FROM SISEDO.TERM_TBL_VW WHERE rownum=1

-----------------------------
```