### PR TITLE
SISRP-31645 - Displaying same Class Information page for students enrolled in courses with section scheduled in multiple sessions

### DIFF
--- a/app/models/edo_oracle/user_courses/base.rb
+++ b/app/models/edo_oracle/user_courses/base.rb
@@ -127,13 +127,15 @@ module EdoOracle
         dept_name, dept_code, catalog_id = parse_course_code row
         slug = [dept_name, catalog_id].map { |str| normalize_to_slug str }.join '-'
         term_code = Berkeley::TermCodes.edo_id_to_code row['term_id']
+        session_code = Berkeley::TermCodes::SUMMER_SESSIONS[row['session_id']]
+        course_id =  session_code.present? ? "#{slug}-#{term_code}-#{session_code}" : "#{slug}-#{term_code}"
         {
           catid: catalog_id,
           course_catalog: catalog_id,
           course_code: "#{dept_name} #{catalog_id}",
           dept: dept_name,
           dept_code: dept_code,
-          id: "#{slug}-#{term_code}",
+          id: course_id,
           slug: slug
         }
       end

--- a/app/models/my_academics/academics_module.rb
+++ b/app/models/my_academics/academics_module.rb
@@ -10,7 +10,7 @@ module MyAcademics
     # This URL is internally routed by JavaScript code rather than Rails.
     def class_to_url(campus_course)
       teaching_str = (campus_course[:role] == 'Instructor') ? 'teaching-' : ''
-      "/academics/#{teaching_str}semester/#{Berkeley::TermCodes.to_slug(campus_course[:term_yr], campus_course[:term_cd])}/class/#{campus_course[:slug]}"
+      "/academics/#{teaching_str}semester/#{Berkeley::TermCodes.to_slug(campus_course[:term_yr], campus_course[:term_cd])}/class/#{campus_course[:id]}"
     end
 
     def semester_info(term_key)

--- a/spec/models/my_academics/teaching_spec.rb
+++ b/spec/models/my_academics/teaching_spec.rb
@@ -32,14 +32,14 @@ describe MyAcademics::Teaching do
         course_id: 'biology-1a-2013-D',
         dept: 'BIOLOGY'
       })
-      expect(bio1a[:url]).to eq '/academics/teaching-semester/fall-2013/class/biology-1a'
+      expect(bio1a[:url]).to eq '/academics/teaching-semester/fall-2013/class/biology-1a-2013-D'
     end
     it 'should properly translate sample COG SCI course' do
       cogsci = teaching[0][:classes].find {|course| course[:listings].find {|listing| listing[:course_code] == 'COG SCI C147'}}
       expect(cogsci).not_to be_empty
       expect(cogsci).to include({
         title: 'Language Disorders',
-        url: '/academics/teaching-semester/fall-2013/class/cog_sci-c147'
+        url: '/academics/teaching-semester/fall-2013/class/cog_sci-c147-2013-D'
       })
       expect(cogsci[:listings].map {|listing| listing[:dept]}).to include 'COG SCI'
     end

--- a/spec/models/my_activities/webcasts_spec.rb
+++ b/spec/models/my_activities/webcasts_spec.rb
@@ -64,6 +64,7 @@ describe MyActivities::Webcasts do
           term_cd: 'B',
           course_code: 'PB HLTH 142',
           slug: 'pb_hlth-142',
+          id: 'pb_hlth-142',
           name: 'Intro to Probability and Statistics',
           sections: sections
         }

--- a/src/assets/javascripts/angular/configuration/routeConfiguration.js
+++ b/src/assets/javascripts/angular/configuration/routeConfiguration.js
@@ -35,12 +35,12 @@ angular.module('calcentral.config').config(function($routeProvider, calcentralCo
       controller: 'AcademicsController',
       pageName: 'My Academics'
     }).
-    when('/academics/semester/:semesterSlug/class/:classSlug', {
+    when('/academics/semester/:semesterSlug/class/:classId', {
       templateUrl: 'academics_classinfo.html',
       controller: 'AcademicsController',
       pageName: 'My Academics'
     }).
-    when('/academics/semester/:semesterSlug/class/:classSlug/:sectionSlug', {
+    when('/academics/semester/:semesterSlug/class/:classId/:sectionSlug', {
       templateUrl: 'academics_classinfo.html',
       controller: 'AcademicsController',
       pageName: 'My Academics'
@@ -50,12 +50,12 @@ angular.module('calcentral.config').config(function($routeProvider, calcentralCo
       controller: 'AcademicsController',
       pageName: 'My Academics'
     }).
-    when('/academics/teaching-semester/:teachingSemesterSlug/class/:classSlug', {
+    when('/academics/teaching-semester/:teachingSemesterSlug/class/:classId', {
       templateUrl: 'academics_classinfo.html',
       controller: 'AcademicsController',
       pageName: 'My Academics'
     }).
-    when('/academics/teaching-semester/:teachingSemesterSlug/class/:classSlug/:category', {
+    when('/academics/teaching-semester/:teachingSemesterSlug/class/:classId/:category', {
       templateUrl: 'academics_classinfo.html',
       controller: 'AcademicsController',
       pageName: 'My Academics'

--- a/src/assets/javascripts/angular/controllers/pages/academicsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicsController.js
@@ -117,7 +117,7 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
     updatePrevNextSemester([data.semesters, data.teachingSemesters], selectedSemester);
 
     $scope.selectedSemester = selectedSemester;
-    if (selectedStudentSemester && !$routeParams.classSlug) {
+    if (selectedStudentSemester && !$routeParams.classId) {
       $scope.selectedCourses = selectedStudentSemester.classes;
       if (!isOnlyInstructor) {
         $scope.allCourses = academicsService.getAllClasses(data.semesters);
@@ -131,7 +131,7 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
     setGradingFlags(selectedTeachingSemester);
 
     // Get selected course from URL params and extract data from selected semester schedule
-    if ($routeParams.classSlug) {
+    if ($routeParams.classId) {
       $scope.isInstructorOrGsi = isOnlyInstructor;
       var classSemester = selectedStudentSemester;
       if (isOnlyInstructor) {
@@ -139,7 +139,7 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
       }
       for (var i = 0; i < classSemester.classes.length; i++) {
         var course = classSemester.classes[i];
-        if (course.slug === $routeParams.classSlug) {
+        if (course.course_id === $routeParams.classId) {
           if ($routeParams.sectionSlug) {
             $scope.selectedSection = academicsService.filterBySectionSlug(course, $routeParams.sectionSlug);
           }


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-31645

* this fix mostly impacts courses with multiple sessions during summer terms
* added session code to course_id is academics feed if available.
* semesters card links now keyed off of course_id and not couse_slug