### PR TITLE
CLC-6666 Fix OEC cross-listings bug caught by testext

### DIFF
--- a/app/models/oec/department_mappings.rb
+++ b/app/models/oec/department_mappings.rb
@@ -57,7 +57,7 @@ module Oec
     end
 
     # Only used for cross-listings sort.
-    def self.participating_dept_names
+    def participating_dept_names
       all_mappings.map {|c| c[:dept_name] if c[:include_in_oec]}.uniq.compact
     end
 

--- a/spec/models/oec/department_mappings_spec.rb
+++ b/spec/models/oec/department_mappings_spec.rb
@@ -139,4 +139,29 @@ describe Oec::DepartmentMappings, if: in_memory_database? do
     end
   end
 
+  describe '#participating_dept_names' do
+    it 'does not contain excluded departments' do
+      expect(subject.participating_dept_names).to include(
+        'A,RESEC',
+        'BIOLOGY',
+        'CATALAN',
+        'CHEM',
+        'INTEGBI'
+      )
+      expect(subject.participating_dept_names).not_to include(
+        'CLASSIC',
+        'FSSEM'
+      )
+    end
+    context 'with FSSEM' do
+      let(:include_fssem) {true}
+      it 'contains all included departments, even if only catalog-ID-specific and not in local DB' do
+        expect(subject.participating_dept_names).to include(
+          'CLASSIC',
+          'FSSEM'
+        )
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
I missed this boneheaded refactoring error because my higher-level tests all stubbed the broken method. Thanks for the catch, Bamboo!