### PR TITLE
SISRP-27378 - moves url param replacement outside of cached model

### DIFF
--- a/app/controllers/campus_solutions/link_controller.rb
+++ b/app/controllers/campus_solutions/link_controller.rb
@@ -1,8 +1,9 @@
 module CampusSolutions
   class LinkController < CampusSolutionsController
+    include LinkFetcher
 
     def get
-      render json: CampusSolutions::Link.new.get_url(params['urlId'], params['placeholders'])
+      render json: link_feed(params['urlId'], params['placeholders'])
     end
 
   end

--- a/lib/link_fetcher.rb
+++ b/lib/link_fetcher.rb
@@ -3,10 +3,27 @@ module LinkFetcher
   include ClassLogger
 
   def fetch_link(link_key, placeholders = {})
-    if (link_feed = CampusSolutions::Link.new.get_url link_key, placeholders)
-      link = link_feed.try(:fetch, :link)
+    link_feed(link_key, placeholders).try(:fetch, :link)
+  end
+
+  def link_feed(link_key, placeholders = {})
+    link_feed = CampusSolutions::Link.new.get_url link_key
+    if (link = link_feed.try(:fetch, :link))
+      replace_url_params(link_key, link, placeholders)
+      link_feed[:link] = link
+    else
+      logger.debug "Could not parse CS link response for id #{link_key}, params: #{placeholders}"
     end
-    logger.debug "Could not parse CS link response for id #{link_key}, params: #{placeholders}" unless link
-    link
+    link_feed
+  end
+
+  def replace_url_params(link_key, link, placeholders)
+    placeholders.try(:each) do |k, v|
+      if v.nil?
+        logger.debug "Could not set url parameter #{k} on link id #{link_key}"
+      else
+        link[:url] = link[:url].gsub("{#{k}}", v)
+      end
+    end
   end
 end

--- a/spec/lib/link_fetcher_spec.rb
+++ b/spec/lib/link_fetcher_spec.rb
@@ -4,71 +4,76 @@ describe LinkFetcher do
     extend LinkFetcher
   end
 
-  describe '#fetch_link' do
-    before do
-      allow(proxy_class).to receive(:new).and_return mock_proxy
-      allow(TestLinkFetcher).to receive(:logger).and_return ClassLogger::LogWrapper.new('TestLinkFetcher')
-    end
-    let(:url) { 'fake url' }
-    let(:proxy_class) { CampusSolutions::Link }
-    let(:mock_proxy) { proxy_class.new(fake: true) }
+  before do
+    allow(proxy_class).to receive(:new).and_return mock_proxy
+    allow(mock_proxy).to receive(:get_url).and_return(proxy_response)
+    allow(TestLinkFetcher).to receive(:logger).and_return ClassLogger::LogWrapper.new('TestLinkFetcher')
+  end
+  let(:proxy_response) do
+    {
+      link: {
+        url: url
+      }
+    }
+  end
+  let(:url) { 'fake url foo={foo}' }
+  let(:placeholders) { {foo: 'bar'} }
+  let(:proxy_class) { CampusSolutions::Link }
+  let(:mock_proxy) { proxy_class.new(fake: true) }
 
-    context 'when proxy returns malformed response' do
-      before do
-        allow(mock_proxy).to receive(:get_url).and_return('bad response')
-      end
-      subject do
-        TestLinkFetcher.fetch_link(link_key, placeholders)
-      end
+  shared_examples 'a model that fetches a link' do
+    it 'calls proxy with appropriate arguments and returns url' do
+      expect(mock_proxy).to receive(:get_url).with(link_key)
+      expect(output).to eq url
+    end
+  end
+  shared_examples 'an obedient link fetcher' do
+    context 'when proxy returns malformed proxy_response' do
       let(:link_key) { 123 }
-      let(:placeholders) { {foo: 'bar'} }
-
-      it 'calls the proxy with appropriate arguments and logs an error' do
-        expect(mock_proxy).to receive(:get_url).with(link_key, placeholders)
+      let(:proxy_response) { 'bad response' }
+      it 'calls proxy with appropriate arguments and logs an error' do
+        expect(mock_proxy).to receive(:get_url).with(link_key)
         expect(Rails.logger).to receive(:send).with(:debug, "[TestLinkFetcher] Could not parse CS link response for id #{link_key}, params: {:foo=>\"bar\"}")
-        expect(subject).to eq nil
+        expect(subject).to eq bad_output
       end
     end
-
     context 'when proxy returns expected response' do
-      before do
-        allow(mock_proxy).to receive(:get_url).and_return({link: url})
-      end
-
       context 'when parameters are not provided' do
-        subject do
-          TestLinkFetcher.fetch_link(link_key)
-        end
-
+        let(:placeholders) { nil }
         context 'when key is blank' do
           let(:link_key) { nil }
-
-          it 'calls the proxy with appropriate arguments and returns url' do
-            expect(mock_proxy).to receive(:get_url).with(nil, {})
-            expect(subject).to eq url
-          end
+          it_behaves_like 'a model that fetches a link'
         end
-        context 'when key is present'
-        let(:link_key) { 'gimme a link' }
-
-        it 'calls the proxy with appropriate arguments and returns url' do
-          expect(mock_proxy).to receive(:get_url).with('gimme a link', {})
-          expect(subject).to eq url
+        context 'when key is present' do
+          let(:link_key) { 'gimme a link' }
+          it_behaves_like 'a model that fetches a link'
         end
       end
-
       context 'when parameters are provided' do
-        subject do
-          TestLinkFetcher.fetch_link(link_key, placeholders)
+        let(:link_key) { 'gimme a link' }
+        it 'calls proxy with appropriate arguments and replaces placeholders with parameters' do
+          expect(mock_proxy).to receive(:get_url).with(link_key)
+          expect(output).to eq 'fake url foo=bar'
         end
-        let(:link_key) { nil }
-        let(:placeholders) { 'some params' }
-
-        it 'calls the proxy with appropriate arguments and returns url' do
-          expect(mock_proxy).to receive(:get_url).with(nil, 'some params')
-          expect(subject).to eq url
+        context 'when invalid parameters are provided they are ignored' do
+          let(:placeholders) { {foo: nil} }
+          it_behaves_like 'a model that fetches a link'
         end
       end
     end
+  end
+
+  describe '#fetch_link' do
+    subject { TestLinkFetcher.fetch_link(link_key, placeholders) }
+    let(:bad_output) { nil }
+    let(:output) { subject[:url] }
+    it_behaves_like 'an obedient link fetcher'
+  end
+
+  describe '#link_feed' do
+    subject { TestLinkFetcher.link_feed(link_key, placeholders) }
+    let(:bad_output) { proxy_response }
+    let(:output) { subject[:link][:url] }
+    it_behaves_like 'an obedient link fetcher'
   end
 end

--- a/spec/models/campus_solutions/link_spec.rb
+++ b/spec/models/campus_solutions/link_spec.rb
@@ -1,5 +1,4 @@
 describe CampusSolutions::Link do
-  let(:placeholder_empl_id) { "1234567" }
   let(:proxy) { CampusSolutions::Link.new(fake: fake_proxy) }
   let(:url_id) { "UC_CX_APPOINTMENT_ADV_SETUP" }
 
@@ -12,13 +11,10 @@ describe CampusSolutions::Link do
 
   context 'mock proxy' do
     let(:fake_proxy) { true }
-    let(:placeholders) { {:EMPLID => placeholder_empl_id, :IGNORED_PLACEHOLDER => "not used"} }
 
     let(:link_set_response) { proxy.get }
     let(:link_get_url_response) { proxy.get_url(url_id) }
-    let(:link_get_url_with_bad_placeholder_response) { proxy.get_url(url_id, {:BAD_PLACEHOLDER => nil}) }
-    let(:link_get_url_with_bad_url_id_response) { proxy.get_url('BAD_URL_ID', {:BAD_PLACEHOLDER => nil}) }
-    let(:link_get_url_and_replace_placeholders_response) { proxy.get_url(url_id, placeholders) }
+    let(:link_get_url_with_bad_url_id_response) { proxy.get_url('BAD_URL_ID') }
     let(:link_get_url_for_properties_response) { proxy.get_url(url_id) }
 
     before do
@@ -53,7 +49,7 @@ describe CampusSolutions::Link do
       end
     end
 
-    context 'returns links as an array' do
+    context 'when returning links as an array' do
       context 'with multiple links' do
         let(:filename) { 'link_api_multiple.xml' }
 
@@ -73,56 +69,30 @@ describe CampusSolutions::Link do
       end
     end
 
-    context 'returns a single link by its urlId' do
+    context 'when returning a single link by its urlId' do
       let(:filename) { 'link_api_multiple.xml' }
 
       it_should_behave_like 'a proxy that gets data'
       it 'returns data with the expected structure' do
         expect(link_get_url_response[:link][:urlId]).to eq url_id
-        # Verify that {placeholder} text is present
-        expect(link_get_url_response[:link][:url]).to include("EMPLID={EMPLID}")
       end
-    end
 
-    context 'no matching url_id' do
-      let(:filename) { 'link_api.xml' }
-
-      it_should_behave_like 'a proxy that gets data'
-      it 'returns data with the expected structure' do
-        expect(link_get_url_with_bad_url_id_response[:link]).not_to be
-      end
-    end
-
-    context 'returns empty link when a placeholder value is blank' do
-      let(:filename) { 'link_api.xml' }
-
-      it_should_behave_like 'a proxy that gets data'
-      it 'returns data with the expected structure' do
-        expect(link_get_url_with_bad_placeholder_response[:link]).not_to be
-      end
-    end
-
-    context 'replaces matching placeholders' do
-      let(:filename) { 'link_api_multiple.xml' }
-
-      it_should_behave_like 'a proxy that gets data'
-      it 'returns data with the expected structure' do
-        # Verify that {placeholder} text is replaced
-        expect(link_get_url_and_replace_placeholders_response[:link][:url]).to include("EMPLID=#{placeholder_empl_id}")
-      end
-    end
-
-    context 'replaces the properties hash with only certain properties' do
-      let(:filename) { 'link_api_multiple.xml' }
-
-      it_should_behave_like 'a proxy that gets data'
-      it 'returns data with the expected structure' do
+      it 'replaces the properties hash with only certain properties' do
         expect(link_get_url_response[:link][:properties]).not_to be
         expect(link_get_url_for_properties_response[:link][:ucFrom]).to eq 'CalCentral'
         expect(link_get_url_for_properties_response[:link][:ucFromLink]).to eq 'https://calcentral-sis-dev-01.ist.berkeley.edu/'
         expect(link_get_url_for_properties_response[:link][:ucFromText]).to eq 'CalCentral'
         expect(link_get_url_for_properties_response[:link][:linkDescription]).to eq 'May your hats fly as high as your dreams'
         expect(link_get_url_for_properties_response[:link][:linkDescriptionDisplay]).to eq true
+      end
+    end
+
+    context 'when no matching url_id' do
+      let(:filename) { 'link_api.xml' }
+
+      it_should_behave_like 'a proxy that gets data'
+      it 'returns data with the expected structure' do
+        expect(link_get_url_with_bad_url_id_response[:link]).not_to be
       end
     end
   end

--- a/spec/models/my_academics/advisor_links_spec.rb
+++ b/spec/models/my_academics/advisor_links_spec.rb
@@ -24,8 +24,8 @@ describe MyAcademics::AdvisorLinks do
 
     # stub CS Link proxy responses
     fake_cs_link_proxy = double
-    allow(fake_cs_link_proxy).to receive(:get_url).with('UC_CX_XFER_CREDIT_REPORT_ADVSR', {:EMPLID => user_cs_id}).and_return(tcReportLink)
-    allow(fake_cs_link_proxy).to receive(:get_url).with('UC_CX_PLANNER_ADV_STDNT', {:EMPLID => user_cs_id}).and_return(updatePlanUrl)
+    allow(fake_cs_link_proxy).to receive(:get_url).with('UC_CX_XFER_CREDIT_REPORT_ADVSR').and_return(tcReportLink)
+    allow(fake_cs_link_proxy).to receive(:get_url).with('UC_CX_PLANNER_ADV_STDNT').and_return(updatePlanUrl)
     allow(CampusSolutions::Link).to receive(:new).and_return(fake_cs_link_proxy)
   end
 

--- a/spec/models/my_academics/enrollment_verification_spec.rb
+++ b/spec/models/my_academics/enrollment_verification_spec.rb
@@ -35,7 +35,6 @@ describe MyAcademics::EnrollmentVerification do
     end
 
     it 'provides academic roles' do
-      puts "feed: #{feed.inspect}"
       expect(feed[:academicRoles]).to be
       expect(feed[:academicRoles]['ugrd']).to eq true
       expect(feed[:academicRoles]['law']).to eq false

--- a/spec/models/my_academics/grading_spec.rb
+++ b/spec/models/my_academics/grading_spec.rb
@@ -2,7 +2,11 @@ describe MyAcademics::Grading do
 
   let(:uid) { '123456' }
   let(:fake) { true }
-  let(:fake_grading_url) { 'http://fake.grading.com' }
+  let(:fake_grading_url) do
+    {
+      url: 'http://fake.grading.com'
+    }
+  end
   let(:link_proxy_class) { CampusSolutions::Link }
   let(:link_fake_proxy) { link_proxy_class.new(fake: true) }
   let(:fake_spring_term) { double(is_summer: false, :year => 2015, :code => 'B') }

--- a/spec/models/my_academics/student_links_spec.rb
+++ b/spec/models/my_academics/student_links_spec.rb
@@ -13,7 +13,7 @@ describe MyAcademics::StudentLinks do
   before do
     # stub CS Link proxy responses
     fake_cs_link_proxy = double
-    allow(fake_cs_link_proxy).to receive(:get_url).with('UC_CX_XFER_CREDIT_REPORT_STDNT', {}).and_return(tcReportLink)
+    allow(fake_cs_link_proxy).to receive(:get_url).with('UC_CX_XFER_CREDIT_REPORT_STDNT').and_return(tcReportLink)
     allow(CampusSolutions::Link).to receive(:new).and_return(fake_cs_link_proxy)
   end
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-27378

This moves the URL parameter replacement up one layer from the caching, so that only the generic form of each link will be cached (and not the form that has particular URL params).

The way it was working before, a link with EMPLID param would be cached with "EMPLID=12345", and when that link was requested again for a new EMPLID, the item in the cache would be replaced by the new one.