### PR TITLE
SISRP-33544 - UX Dev: Url encode ampersands used in query string of CS Links

### DIFF
--- a/src/assets/javascripts/angular/directives/campusSolutionsLinkDirective.js
+++ b/src/assets/javascripts/angular/directives/campusSolutionsLinkDirective.js
@@ -157,17 +157,17 @@ angular.module('calcentral.directives').directive('ccCampusSolutionsLinkDirectiv
       linkUrl = linkService.fixLastQuestionMark(linkUrl);
 
       if (includeUcFrom) {
-        linkUrl = linkService.updateQueryStringParameter(linkUrl, 'ucFrom', 'CalCentral');
+        linkUrl = linkService.addQueryStringParameterEncodedAmpersand(linkUrl, 'ucFrom', 'CalCentral');
       }
       if (includeUcFromText) {
-        linkUrl = linkService.updateQueryStringParameter(linkUrl, 'ucFromText', ccPageName);
+        linkUrl = linkService.addQueryStringParameterEncodedAmpersand(linkUrl, 'ucFromText', ccPageName);
       }
       if (includeUcFromLink) {
         if (ccCacheString) {
-          ccPageUrl = linkService.updateQueryStringParameter(ccPageUrl, 'ucUpdateCache', ccCacheString);
+          ccPageUrl = linkService.addQueryStringParameterEncodedAmpersand(ccPageUrl, 'ucUpdateCache', ccCacheString);
         }
         var urlEncodedCcPageUrl = encodeURIComponent(ccPageUrl);
-        linkUrl = linkService.updateQueryStringParameter(linkUrl, 'ucFromLink', urlEncodedCcPageUrl);
+        linkUrl = linkService.addQueryStringParameterEncodedAmpersand(linkUrl, 'ucFromLink', urlEncodedCcPageUrl);
       }
     }
     return linkUrl;

--- a/src/assets/javascripts/angular/services/linkService.js
+++ b/src/assets/javascripts/angular/services/linkService.js
@@ -82,10 +82,17 @@ angular.module('calcentral.services').factory('linkService', function($location,
     }
   };
 
+  /* Temporary hack to get CalCentral through testing of 9.2 - See SISRP-33544 */
+  var addQueryStringParameterEncodedAmpersand = function(uri, key, value) {
+    var separator = uri.indexOf('?') !== -1 ? '%26' : '?';
+    return uri + separator + key + '=' + value;
+  };
+
   return {
     addCurrentPagePropertiesToLink: addCurrentPagePropertiesToLink,
     addCurrentPagePropertiesToResources: addCurrentPagePropertiesToResources,
     addCurrentRouteSettings: addCurrentRouteSettings,
+    addQueryStringParameterEncodedAmpersand: addQueryStringParameterEncodedAmpersand,
     fixLastQuestionMark: fixLastQuestionMark,
     makeOutboundlink: makeOutboundlink,
     updateQueryStringParameter: updateQueryStringParameter


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-33544

This is a temporary fix not intended to actually go into GL 9.0. It's just a workaround to get past an issue with CAS URL encoding so that testing can continue 05/30/17 - 05/31/17