### PR TITLE
SISRP-31677 - Updates logic to allow link visibility for Advisors viewing as Students

### DIFF
--- a/src/assets/templates/widgets/transfer_credit.html
+++ b/src/assets/templates/widgets/transfer_credit.html
@@ -74,7 +74,7 @@
             </td>
           </tr>
         </tbody>
-        <tbody data-ng-if="studentLinks.tcReportLink.url && !api.user.profile.roles.advisor">
+        <tbody data-ng-if="studentLinks.tcReportLink.url && !advisorLinks.tcReportLink.url">
           <tr><td class="cc-transfer-credit-table-border" colspan="3"></td></tr>
           <tr class="cc-transfer-credit-table-parent-row">
             <td colspan="3">
@@ -86,7 +86,7 @@
             </td>
           </tr>
         </tbody>
-        <tbody data-ng-if="advisorLinks.tcReportLink.url && api.user.profile.roles.advisor">
+        <tbody data-ng-if="advisorLinks.tcReportLink.url">
           <tr><td class="cc-transfer-credit-table-border" colspan="3"></td></tr>
           <tr class="cc-transfer-credit-table-parent-row">
             <td colspan="3">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-31677

The CalCentral back-end already ensures that Students are able to get the data from the My Academics feed, and that Advisors are able to obtain the Advisor Student Academics feed (for Student Overview page).

Because the back-end ensures that the user is gaining access ONLY to the link they should see, this updates the logic to only show the link that is available, with Advisor link presence suppressing the Student link from displaying. This closes the gap of an Advisor viewing-as a student, but not seeing the Advisor link.