### PR TITLE
SISRP-33544 - Url encode ampersands used in query string of CS Links

### DIFF
--- a/src/assets/javascripts/angular/directives/campusSolutionsLinkDirective.js
+++ b/src/assets/javascripts/angular/directives/campusSolutionsLinkDirective.js
@@ -157,19 +157,22 @@ angular.module('calcentral.directives').directive('ccCampusSolutionsLinkDirectiv
       linkUrl = linkService.fixLastQuestionMark(linkUrl);
 
       if (includeUcFrom) {
-        linkUrl = linkService.addQueryStringParameterEncodedAmpersand(linkUrl, 'ucFrom', 'CalCentral');
+        linkUrl = linkService.updateQueryStringParameter(linkUrl, 'ucFrom', 'CalCentral');
       }
       if (includeUcFromText) {
-        linkUrl = linkService.addQueryStringParameterEncodedAmpersand(linkUrl, 'ucFromText', ccPageName);
+        var urlEncodedCcPageText = encodeURIComponent(ccPageName);
+        linkUrl = linkService.updateQueryStringParameter(linkUrl, 'ucFromText', urlEncodedCcPageText);
       }
       if (includeUcFromLink) {
         if (ccCacheString) {
-          ccPageUrl = linkService.addQueryStringParameterEncodedAmpersand(ccPageUrl, 'ucUpdateCache', ccCacheString);
+          ccPageUrl = linkService.updateQueryStringParameter(ccPageUrl, 'ucUpdateCache', ccCacheString);
         }
         var urlEncodedCcPageUrl = encodeURIComponent(ccPageUrl);
-        linkUrl = linkService.addQueryStringParameterEncodedAmpersand(linkUrl, 'ucFromLink', urlEncodedCcPageUrl);
+        linkUrl = linkService.updateQueryStringParameter(linkUrl, 'ucFromLink', urlEncodedCcPageUrl);
       }
     }
+    /* Temporary hack to make GL 9.2 CS links work - See SISRP-33544 */
+    linkUrl = linkService.encodeQueryStringAmpersands(linkUrl);
     return linkUrl;
   };
 

--- a/src/assets/javascripts/angular/services/linkService.js
+++ b/src/assets/javascripts/angular/services/linkService.js
@@ -82,17 +82,26 @@ angular.module('calcentral.services').factory('linkService', function($location,
     }
   };
 
-  /* Temporary hack to get CalCentral through testing of 9.2 - See SISRP-33544 */
-  var addQueryStringParameterEncodedAmpersand = function(uri, key, value) {
-    var separator = uri.indexOf('?') !== -1 ? '%26' : '?';
-    return uri + separator + key + '=' + value;
+  /* Temporary hack to make GL 9.2 CS links work - See SISRP-33544 */
+  var encodeQueryStringAmpersands = function(url) {
+    if (url.indexOf('?')) {
+      var parser = document.createElement('a');
+      parser.href = url;
+      var queryString = parser.search;
+      queryString = queryString.replace(/&/g, '%26');
+      parser.search = queryString;
+      url = parser.href;
+      return url;
+    } else {
+      return url;
+    }
   };
 
   return {
     addCurrentPagePropertiesToLink: addCurrentPagePropertiesToLink,
     addCurrentPagePropertiesToResources: addCurrentPagePropertiesToResources,
     addCurrentRouteSettings: addCurrentRouteSettings,
-    addQueryStringParameterEncodedAmpersand: addQueryStringParameterEncodedAmpersand,
+    encodeQueryStringAmpersands: encodeQueryStringAmpersands,
     fixLastQuestionMark: fixLastQuestionMark,
     makeOutboundlink: makeOutboundlink,
     updateQueryStringParameter: updateQueryStringParameter


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-33544

This is an amendment to #6677