### PR TITLE
SISRP-33580 - Fixes bug in delegate-filtered semesters feed

### DIFF
--- a/app/models/my_academics/semesters.rb
+++ b/app/models/my_academics/semesters.rb
@@ -33,7 +33,7 @@ module MyAcademics
       withdrawal_terms = withdrawal_data.map {|row| Berkeley::TermCodes.edo_id_to_code(row['term_id'])}
       (enrollment_terms.keys | transcript_terms.keys | withdrawal_terms).sort.reverse.map do |term_key|
         semester = semester_info term_key
-        semester.delete :slug if @filtered
+        semester[:filteredForDelegate] = !!@filtered
         if enrollment_terms[term_key]
           semester[:hasEnrollmentData] = true
           semester[:summaryFromTranscript] = (semester[:timeBucket] == 'past')

--- a/spec/models/my_academics/semesters_spec.rb
+++ b/spec/models/my_academics/semesters_spec.rb
@@ -162,6 +162,12 @@ describe MyAcademics::Semesters do
         end
       end
     end
+
+    it 'should not flag it as filtered for delegate' do
+      feed[:semesters].each do |s|
+        expect(s[:filteredForDelegate]).to eq false
+      end
+    end
   end
 
   shared_examples 'a legacy semester with additional credits' do
@@ -527,6 +533,7 @@ describe MyAcademics::Semesters do
       feed[:semesters].each do |s|
         expect(s[:hasEnrollmentData]).to eq true
         expect(s[:summaryFromTranscript]).to eq (s[:timeBucket] == 'past')
+        expect(s).to include :slug
         enrollment_semester = enrollment_summary_data["#{s[:termYear]}-#{s[:termCode]}"]
         expect(s[:classes].length).to eq enrollment_semester.length
         s[:classes].each do |course|
@@ -549,9 +556,9 @@ describe MyAcademics::Semesters do
       end
     end
 
-    it 'should filter out semester slugs' do
+    it 'should flag it as filtered for delegate' do
       feed[:semesters].each do |s|
-        expect(s).not_to include :slug
+        expect(s[:filteredForDelegate]).to eq true
       end
     end
 

--- a/src/assets/templates/academics_semesters.html
+++ b/src/assets/templates/academics_semesters.html
@@ -11,12 +11,12 @@
   <div class="cc-widget-padding cc-flex-space-between-vertical-15">
     <div class="cc-table cc-academics-semester cc-academics-semester-{{semester.timeBucket}}" data-ng-repeat="semester in semesters | limitTo:pastSemestersLimit">
       <div>
-        <h3 data-ng-if="!semester.hasWithdrawalData && semester.hasEnrollmentData && semester.slug && !isAdvisingStudentLookup"><a class="cc-left" data-ng-href="/academics/semester/{{semester.slug}}" data-ng-bind="semester.name"></a></h3>
-        <h3 class="cc-left" data-ng-if="semester.hasWithdrawalData || !semester.hasEnrollmentData || !semester.slug || isAdvisingStudentLookup" data-ng-bind="semester.name"></h3>
+        <h3 data-ng-if="!semester.hasWithdrawalData && semester.hasEnrollmentData && !semester.filteredForDelegate && !isAdvisingStudentLookup"><a class="cc-left" data-ng-href="/academics/semester/{{semester.slug}}" data-ng-bind="semester.name"></a></h3>
+        <h3 class="cc-left" data-ng-if="semester.hasWithdrawalData || !semester.hasEnrollmentData || semester.filteredForDelegate || isAdvisingStudentLookup" data-ng-bind="semester.name"></h3>
         <h4 class="cc-left" data-ng-if="semester.hasWithdrawalData" data-ng-bind="semester.withdrawalStatus.withcnclTypeDescr"></h4>
         <h4 class="cc-left" data-ng-if="semester.hasWithdrawalData" data-ng-bind="semester.withdrawalStatus.withcnclFromDate"></h4>
         <h4 class="cc-left" data-ng-if="semester.notation" data-ng-bind="semester.notation"></h4>
-        <a class="cc-right cc-academics-semester-title-link" data-ng-href="/academics/booklist/{{semester.slug}}" data-ng-if="semester.hasEnrollmentData && semester.slug && semester.timeBucket !== 'past' && !isAdvisingStudentLookup">Book List</a>
+        <a class="cc-right cc-academics-semester-title-link" data-ng-href="/academics/booklist/{{semester.slug}}" data-ng-if="semester.hasEnrollmentData && !semester.filteredForDelegate && semester.timeBucket !== 'past' && !isAdvisingStudentLookup">Book List</a>
         <br>
         <div class="cc-widget-text" data-ng-if="!semester.hasEnrolledClasses && !semester.summaryFromTranscript && !semester.hasWithdrawalData">
           You are currently not enrolled in any classes for


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-33580

For each semester in the feed, if the feed was being filtered for a delegate user then we were removing the semester `slug`.  We would then rely on the existence or non-existence of that key in the UI to determine whether to suppress information that a delegate shouldn't see.

Unfortunately this caused `merge_withdrawals` to blow up because it relies on the slug being present.  This fix sets a `filteredForDelegate` flag instead of removing the `slug`.