### PR TITLE
SISRP-31823 - UX: Academic Summary - Non-Adjusted and Transfer Credit Total Switched

### DIFF
--- a/src/assets/templates/widgets/academic_summary/academic_summary_transfer_credit.html
+++ b/src/assets/templates/widgets/academic_summary/academic_summary_transfer_credit.html
@@ -27,12 +27,13 @@
             <td class="cc-text-center" data-ng-if="showPointsColumn && credit.ucbGradePoints" data-ng-bind="credit.ucbGradePoints | number:3"></td>
             <td class="cc-text-center" data-ng-if="showPointsColumn && !credit.ucbGradePoints">&mdash;</td>
           </tr>
+          <!-- TODO: Fix course unit counts in SISRP-34230 after API fix in SISRP-34229 -->
           <tr>
-            <td class="cc-text-right" colspan="2">Total Course Units: <strong data-ng-bind="transferCredit.ucTransferCrseSch.unitsTotal | number:3"></strong></td>
+            <td class="cc-text-right" colspan="2">Total Course Units: <strong data-ng-bind="transferCredit.ucTransferCrseSch.unitsNonAdjusted | number:3"></strong></td>
             <td></td>
           </tr>
           <tr>
-            <td class="cc-text-right" colspan="2" data-ng-if="transferCredit.ucTransferCrseSch.unitsNonAdjusted" data-ng-bind-template="Non-Adjusted Course Units: {{transferCredit.ucTransferCrseSch.unitsNonAdjusted | number:3}}"></td>
+            <td class="cc-text-right" colspan="2" data-ng-if="transferCredit.ucTransferCrseSch.unitsTotal" data-ng-bind-template="Non-Adjusted Course Units: {{transferCredit.ucTransferCrseSch.unitsTotal | number:3}}"></td>
             <td></td>
           </tr>
         </tbody>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-31823

The API that this template depends on is reflecting the wrong values for two nodes. The values should be swapped in the API, but we do not have time for that in GL 9.2

After this update the Academic Summary card will reflect the correct values. The [Transfer Credit card template](https://github.com/ets-berkeley-edu/calcentral/blob/e2ca0a6a/src/assets/templates/widgets/transfer_credit.html#L27,L28) already reflects this swap. 

It is noted in [SISRP-34230](https://jira.berkeley.edu/browse/SISRP-34230) that both of these templates should be updated once the API is fixed to reflect the proper values in the right nodes in [SISRP-34229](https://jira.berkeley.edu/browse/SISRP-34229).