### PR TITLE
SISRP-34223 - For Grad/LAW student not enrollment then CNP message should be Red Colored Text 'Not Enrolled in Classes'

### DIFF
--- a/app/models/my_registrations/registrations_module.rb
+++ b/app/models/my_registrations/registrations_module.rb
@@ -90,7 +90,7 @@ module MyRegistrations
           end
         end
       else
-        summary = 'Not Enrolled in Classes'
+        summary = 'Not Enrolled'
       end
       summary
     end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-34223

* Luckily, there was an existing bug that made this implementation very easy to do!