### PR TITLE
SISRP-31635 - adds 'grad' to enrollment roles

### DIFF
--- a/app/models/berkeley/academic_roles.rb
+++ b/app/models/berkeley/academic_roles.rb
@@ -27,7 +27,7 @@ module Berkeley
     # Role(s) assigned to a user if they are in a career associated with that role.
     ACADEMIC_CAREER_ROLES = [
       {role_code: 'ugrd', match: ['UGRD'], types: []},
-      {role_code: 'grad', match: ['GRAD'], types: []},
+      {role_code: 'grad', match: ['GRAD'], types: [:enrollment]},
       {role_code: 'law', match: ['LAW'], types: [:enrollment]},
       {role_code: 'concurrent', match: ['UCBX'], types: [:enrollment]}
     ]


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-31635

Students with the 'grad' role see the default version of the Enrollment card... but we still need to flag their enrollment as 'grad' so that we can show the Late Add/Drop link on the card (only shows for grad, summerVisitor, and courseworkOnly roles).