### PR TITLE
SISRP-31635 - allows grad students who have a plan-based role to see Late Add/Drop link

### DIFF
--- a/src/assets/templates/widgets/enrollment/adjust.html
+++ b/src/assets/templates/widgets/enrollment/adjust.html
@@ -24,7 +24,7 @@
   </div>
 </div>
 
-<div class="cc-enrollment-card-section-content" data-ng-if="enrollmentInstruction.termIsSummer && isInstructionType(enrollmentInstruction, ['summerVisitor', 'courseworkOnly', 'grad'])">
+<div class="cc-enrollment-card-section-content" data-ng-if="enrollmentInstruction.termIsSummer && isInstructionType(enrollmentInstruction, ['summerVisitor', 'courseworkOnly', 'grad', 'haasFullTimeMba', 'haasEveningWeekendMba', 'haasExecMba', 'haasMastersFinEng', 'haasMbaPublicHealth', 'haasMbaJurisDoctor'])">
   <a data-cc-campus-solutions-link-directive="enrollmentInstruction.csLinks.requestLateClassChanges"
     data-cc-campus-solutions-link-directive-cc-page-name="currentPage.name"
     data-cc-campus-solutions-link-directive-cc-page-url="currentPage.url"


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-31635

Academic roles are currently designed to be exclusive - for example, if someone has a Haas plan and a GRAD career, we assign only one role and plan takes precedence over the career.  In that instance, the enrollment card won't know that the person is a grad student because the Haas plan role prevented the GRAD career role from getting assigned.

This fix is a temporary workaround to enable Haas/GRAD students to see the Late Add/Drop link (which should show for ALL grad students).  In the future, we can rework the design of the academic roles to avoid this problem.