### PR TITLE
SISRP-34598 - DIS sort still not working in calcentral rosters

### DIFF
--- a/src/assets/templates/widgets/roster.html
+++ b/src/assets/templates/widgets/roster.html
@@ -169,7 +169,7 @@
           <th data-cc-sortable-column-directive="majors" data-column-heading="Majors" class="show-for-medium-up"></th>
           <th class="show-for-medium-up"
             data-ng-repeat="column in columnHeaders"
-            data-cc-sortable-column-directive="{{column.instruction_format}}"
+            data-cc-sortable-column-directive="columns[{{$index}}].section_number"
             data-column-heading="{{column.instruction_format}}"></th>
           <th data-cc-sortable-column-directive="terms_in_attendance" data-column-heading="Terms" class="show-for-large-up"></th>
           <th data-cc-sortable-column-directive="student_id" data-column-heading="SID" class="show-for-large-up cc-print-hide"></th>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-34598

Fixes sorting issue in Rosters page, List view. Similar to #6697