### PR TITLE
CLC-6707 Set home page of new sites to our preferred default

### DIFF
--- a/app/models/canvas/course_settings.rb
+++ b/app/models/canvas/course_settings.rb
@@ -1,5 +1,8 @@
 module Canvas
   class CourseSettings < Proxy
+    include ClassLogger
+
+    DEFAULT_HOME_PAGE = 'feed'
 
     def initialize(options = {})
       super(options)
@@ -21,6 +24,25 @@ module Canvas
           'grading_standard_id' => grading_scheme_id
         }
       }
+    end
+
+    # WARNING: This is currently undocumented. Described at "https://community.canvaslms.com/thread/11645".
+    def set_default_view(default_view)
+      wrapped_put request_path, {
+        'course' => {
+          'default_view' => default_view
+        }
+      }
+    end
+
+    # If necessary, reset a site to use ETS's preferred default landing page.
+    def fix_default_view(course_properties)
+      if course_properties['default_view'] != DEFAULT_HOME_PAGE
+        logger.info "Will change default view for site ID #{@course_id} from '#{course_properties['default_view']}' to '#{DEFAULT_HOME_PAGE}'"
+        results = set_default_view DEFAULT_HOME_PAGE
+        logger.error "Could not change default view for site ID #{@course_id}" if results[:statusCode] != 200
+        results
+      end
     end
 
     private

--- a/app/models/canvas_lti/project_provision.rb
+++ b/app/models/canvas_lti/project_provision.rb
@@ -23,10 +23,12 @@ module CanvasLti
       worker = Canvas::Course.new(user_id: @uid)
       response = worker.create(project_account_id, project_name, project_name, term_id, unique_sis_project_id)
       if (course_details = response[:body])
+        site_id = course_details['id']
+        Canvas::CourseSettings.new(course_id: site_id).fix_default_view course_details
         enrollment = CanvasLti::CourseAddUser.new(user_id: @uid, canvas_course_id: course_details['id']).add_user_to_course(@uid, 'Owner')
         {
-          projectSiteId: course_details['id'],
-          projectSiteUrl: "#{Settings.canvas_proxy.url_root}/courses/#{course_details['id']}",
+          projectSiteId: site_id,
+          projectSiteUrl: "#{Settings.canvas_proxy.url_root}/courses/#{site_id}",
           enrollment_id: enrollment['id']
         }
       else

--- a/spec/models/canvas/course_settings_spec.rb
+++ b/spec/models/canvas/course_settings_spec.rb
@@ -81,4 +81,32 @@ describe Canvas::CourseSettings do
     end
   end
 
+  describe '#fix_default_view' do
+    let(:default_home_page) { 'modules' }
+    let(:preferred_home_page) { 'feed' }
+    let(:original_course_properties) do
+      {
+        'id'=>canvas_course_id,
+        'default_view'=> default_home_page,
+        'workflow_state'=>'unpublished'
+      }
+    end
+    let(:change_request) do
+      stub_request(:put, /.*\/courses\/#{canvas_course_id}/)
+        .with(body: "#{URI.encode_www_form_component('course[default_view]')}=#{preferred_home_page}")
+        .to_return(status: 200, body: {id: canvas_course_id, default_view: preferred_home_page}.to_json)
+    end
+    it 'sets the site home page to Activity Stream if needed' do
+      subject.fix_default_view original_course_properties
+      expect(change_request).to have_been_requested
+    end
+    context 'when the site home page is initialized in our preferred way' do
+      let(:default_home_page) { preferred_home_page }
+      it 'leaves well enough alone' do
+        subject.fix_default_view original_course_properties
+        expect(change_request).not_to have_been_requested
+      end
+    end
+  end
+
 end

--- a/spec/models/canvas_lti/project_provision_spec.rb
+++ b/spec/models/canvas_lti/project_provision_spec.rb
@@ -44,6 +44,7 @@ describe CanvasLti::ProjectProvision do
         'name'=> project_name,
         'course_code'=> project_name,
         'sis_course_id'=>"PROJ:#{unique_sis_project_id}",
+        'default_view'=> 'modules',
         'workflow_state'=>'unpublished'
       }
     end
@@ -68,6 +69,7 @@ describe CanvasLti::ProjectProvision do
       allow(subject).to receive(:unique_sis_project_id).and_return(unique_sis_project_id)
       allow_any_instance_of(Canvas::Course).to receive(:create).and_return(success_response)
       allow_any_instance_of(CanvasLti::CourseAddUser).to receive(:add_user_to_course).and_return(add_user_to_course_response)
+      allow_any_instance_of(Canvas::CourseSettings).to receive(:fix_default_view).with(new_course)
     end
 
     it 'raises exception if error encountered with API request' do
@@ -87,5 +89,12 @@ describe CanvasLti::ProjectProvision do
       result = subject.create_project(project_name)
       expect(result[:enrollment_id]).to eq 20959
     end
+
+    it 'resets the site home page if needed' do
+      expect_any_instance_of(Canvas::CourseSettings).to receive(:fix_default_view).with(new_course)
+      result = subject.create_project(project_name)
+      expect(result[:projectSiteId]).to eq 23
+    end
+
   end
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6707

Aimed at a Junction-only emergency release to be deployed before July 15, when Instructure's change takes effect.