### PR TITLE
SISRP-34230 - Revert Non-Adjusted and Total Transfer Credit Unit count after API Swap

### DIFF
--- a/app/models/my_academics/transfer_credit.rb
+++ b/app/models/my_academics/transfer_credit.rb
@@ -11,9 +11,9 @@ module MyAcademics
       response = CampusSolutions::TransferCredit.new(user_id: @uid).get
       response = response.try(:[], :feed).try(:[], :root).try(:[], :ucTransferCredits).try(:[], :transferCredit)
       if (credit = response.try(:[], :ucTransferCrseSch))
-        adjusted_units = credit[:unitsAdjust].to_f
-        nonadjusted_units = credit[:unitsNonAdjusted].to_f
-        response[:ucTransferCrseSch][:unitsTotal] = adjusted_units + nonadjusted_units
+        transfer_credit_adjustment = credit[:tcAdjust].to_f
+        adjusted_units = credit[:unitsAdjusted].to_f
+        response[:ucTransferCrseSch][:unitsTotal] = transfer_credit_adjustment + adjusted_units
       end
       response
     end

--- a/fixtures/xml/campus_solutions/transfer_credit.xml
+++ b/fixtures/xml/campus_solutions/transfer_credit.xml
@@ -5,23 +5,27 @@
         <ITEMS type="array">
           <ITEM>
             <INSTITUTION>LOS ANGELES CITY COLL</INSTITUTION>
-            <UCB_UNITS type="float">27.0</UCB_UNITS>
+            <TRANSFER_UNITS type="float">27.0</TRANSFER_UNITS>
+            <UCB_GRADE_POINTS type="float">.000</UCB_GRADE_POINTS>
           </ITEM>
           <ITEM>
             <INSTITUTION>LOS ANGELES VALLEY COLL</INSTITUTION>
-            <UCB_UNITS type="float">42.0</UCB_UNITS>
+            <TRANSFER_UNITS type="float">42.0</TRANSFER_UNITS>
+            <UCB_GRADE_POINTS type="float">.000</UCB_GRADE_POINTS>
           </ITEM>
           <ITEM>
             <INSTITUTION>MOORPARK COLL</INSTITUTION>
-            <UCB_UNITS type="float">3.0</UCB_UNITS>
+            <TRANSFER_UNITS type="float">3.0</TRANSFER_UNITS>
+            <UCB_GRADE_POINTS type="float">.000</UCB_GRADE_POINTS>
           </ITEM>
           <ITEM>
             <INSTITUTION>PASADENA CITY COLL</INSTITUTION>
-            <UCB_UNITS type="float">27.0</UCB_UNITS>
+            <TRANSFER_UNITS type="float">27.0</TRANSFER_UNITS>
+            <UCB_GRADE_POINTS type="float">.000</UCB_GRADE_POINTS>
           </ITEM>
         </ITEMS>
-        <UNITS_ADJUST type="float">29.0</UNITS_ADJUST>
-        <UNITS_NON_ADJUSTED type="float">70.0</UNITS_NON_ADJUSTED>
+        <TC_ADJUST type="float">29.0</TC_ADJUST>
+        <UNITS_ADJUSTED type="float">70.0</UNITS_ADJUSTED>
       </UC_TRANSFER_CRSE_SCH>
       <UC_TEST_COMPONENT>
         <AP_UNITS type="float">5.2</AP_UNITS>

--- a/src/assets/javascripts/angular/controllers/pages/academicSummaryController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicSummaryController.js
@@ -32,9 +32,9 @@ angular.module('calcentral.controllers').controller('AcademicSummaryController',
   var parseGpaUnits = function() {
     // Testing units are lumped in with Transfer Units on the academic summary
     if ($scope.gpaUnits && !$scope.gpaUnits.errored) {
-      var unitsNonAdjusted = _.get($scope, 'transferCredit.ucTransferCrseSch.unitsNonAdjusted');
+      var unitsAdjusted = _.get($scope, 'transferCredit.ucTransferCrseSch.unitsAdjusted');
       var totalTestUnits = _.get($scope, 'transferCredit.ucTestComponent.totalTestUnits');
-      var totalTransferAndTestingUnits = academicsService.totalTransferUnits(unitsNonAdjusted, totalTestUnits);
+      var totalTransferAndTestingUnits = academicsService.totalTransferUnits(unitsAdjusted, totalTestUnits);
       _.set($scope.gpaUnits, 'testingAndTransferUnits', totalTransferAndTestingUnits);
     }
   };

--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -251,9 +251,9 @@ angular.module('calcentral.controllers').controller('UserOverviewController', fu
   };
 
   $scope.totalTransferUnits = function() {
-    var unitsNonAdjusted = _.get($scope, 'transferCredit.ucTransferCrseSch.unitsNonAdjusted');
+    var unitsAdjusted = _.get($scope, 'transferCredit.ucTransferCrseSch.unitsAdjusted');
     var totalTestUnits = _.get($scope, 'transferCredit.ucTestComponent.totalTestUnits');
-    return academicsService.totalTransferUnits(unitsNonAdjusted, totalTestUnits);
+    return academicsService.totalTransferUnits(unitsAdjusted, totalTestUnits);
   };
 
   $scope.expireAcademicsCache = function() {

--- a/src/assets/templates/widgets/academic_summary/academic_summary_transfer_credit.html
+++ b/src/assets/templates/widgets/academic_summary/academic_summary_transfer_credit.html
@@ -23,13 +23,12 @@
         <tbody>
           <tr data-ng-repeat="credit in transferCredit.ucTransferCrseSch.items">
             <td data-ng-bind="credit.institution"></td>
-            <td class="cc-text-right" data-ng-bind="credit.ucbUnits | number:3"></td>
+            <td class="cc-text-right" data-ng-bind="credit.transferUnits | number:3"></td>
             <td class="cc-text-center" data-ng-if="showPointsColumn && credit.ucbGradePoints" data-ng-bind="credit.ucbGradePoints | number:3"></td>
             <td class="cc-text-center" data-ng-if="showPointsColumn && !credit.ucbGradePoints">&mdash;</td>
           </tr>
-          <!-- TODO: Fix course unit counts in SISRP-34230 after API fix in SISRP-34229 -->
           <tr>
-            <td class="cc-text-right" colspan="2">Total Course Units: <strong data-ng-bind="transferCredit.ucTransferCrseSch.unitsNonAdjusted | number:3"></strong></td>
+            <td class="cc-text-right" colspan="2">Total Course Units: <strong data-ng-bind="transferCredit.ucTransferCrseSch.unitsAdjusted | number:3"></strong></td>
             <td></td>
           </tr>
           <tr>

--- a/src/assets/templates/widgets/transfer_credit.html
+++ b/src/assets/templates/widgets/transfer_credit.html
@@ -24,7 +24,7 @@
           <tr class="cc-transfer-credit-table-parent-row">
             <td colspan="1">Transfer Units</td>
             <td class="cc-table-right cc-toggle-triangle cc-transfer-credit-table-right-padding" colspan="2">
-              <span data-ng-bind="transferCredit.ucTransferCrseSch.unitsNonAdjusted | number:3"></span>
+              <span data-ng-bind="transferCredit.ucTransferCrseSch.unitsAdjusted | number:3"></span>
               <span data-ng-if="transferCredit.ucTransferCrseSch.unitsTotal && (transferCredit.ucTransferCrseSch.unitsTotal !== transferCredit.ucTransferCrseSch.unitsNonAdjusted)" data-ng-bind-template="(Non-Adjusted: {{transferCredit.ucTransferCrseSch.unitsTotal | number:3}})"></span>
             </td>
           </tr>
@@ -33,7 +33,7 @@
               <span data-ng-bind="item.institution"></span>
             </td>
             <td class="cc-table-right cc-transfer-credit-table-right-padding" colspan="1">
-              <span data-ng-bind="item.ucbUnits | number:3"></span>
+              <span data-ng-bind="item.transferUnits | number:3"></span>
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-34230

We ended up not reverting the swap, because the swap was actually correct. We instead ensured that the keys used are more correct, specifically the 'unitsNonAdjusted' being renamed as 'unitsAdjusted'... because that's actually what it represents.