### PR TITLE
SISRP-26133 - Fixes rspec-rails dependency issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,7 +121,7 @@ group :development, :test , :testext do
   gem 'rspec-core', '~> 3.1.7'
   gem 'rspec-rails', '~> 3.1.0'
   gem 'rspec-mocks', '~> 3.1.3'
-  gem 'rspec-support', '~> 3.1.2'
+  gem 'rspec-support', '~> 3.1.0'
   gem 'rspec-its', '~> 1.1.0'
   gem 'rspec-collection_matchers', '~> 1.1.2'
   gem 'minitest-reporters', '~> 1.0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,6 +350,7 @@ GEM
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
       rspec-mocks (~> 3.1.0)
+      rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
     ruby-debug (0.10.5.rc9)
       columnize (>= 0.1)
@@ -509,7 +510,7 @@ DEPENDENCIES
   rspec-its (~> 1.1.0)
   rspec-mocks (~> 3.1.3)
   rspec-rails (~> 3.1.0)
-  rspec-support (~> 3.1.2)
+  rspec-support (~> 3.1.0)
   rspec_junit_formatter!
   ruby-debug (>= 0.10.5.rc9)
   ruby-debug-ide (~> 0.6.0)


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26133

When running `bundle install` after the jruby upgrade, we were seeing this message:

```
Downloading rspec-rails-3.1.0 revealed dependencies not in the API or the
lockfile (rspec-support (~> 3.1.0)).
Either installing with `--full-index` or running `bundle update rspec-rails`
should fix the problem.
```

The "problem" was that our Gemfile and Gemfile.lock were both specifying rspec-support ~> 3.1.2 (which allows anything 3.1.2 and above, short of 3.2).

I changed it to allow rspec-support-3.1.0 and above, short of 3.2 (see https://rubygems.org/gems/rspec-rails/versions/3.1.0).  This should allow us to run a clean `bundle install` without doing any extra steps.