### PR TITLE
SISRP-29026 - Downgrades jruby-openssl to lowest version compatible with jruby-9.1.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'jruby-activemq', '~> 5.13.0', git: 'https://github.com/ets-berkeley-edu/jru
 # To support SSL TLSv1.2.
 # jruby-openssl versions 0.9.8 through 0.9.16 trigger runaway memory consumption in CalCentral.
 # Track progress at https://github.com/jruby/jruby-openssl/issues/86 and SISRP-18781.
-gem 'jruby-openssl', '0.9.19'
+gem 'jruby-openssl', '0.9.14'
 
 # Addressable is a replacement for the URI implementation that is part of Ruby's standard library.
 # https://github.com/sporkmonger/addressable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.0)
       railties (>= 3.2.16)
-    jruby-openssl (0.9.19-java)
+    jruby-openssl (0.9.14-java)
     json (1.8.3-java)
     jwt (1.5.4)
     kaminari (0.16.1)
@@ -488,7 +488,7 @@ DEPENDENCIES
   ims-lti!
   jmx (~> 1.0)
   jruby-activemq (~> 5.13.0)!
-  jruby-openssl (= 0.9.19)
+  jruby-openssl (= 0.9.14)
   json (~> 1.8.0)
   link_header (~> 0.0.7)
   log4r (~> 1.1)


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-29026