### PR TITLE
SISRP-26133 - Downgrades jruby and jruby-openssl

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -12,4 +12,4 @@
 # The variable PROJECT_JRUBY_OPTS requires the following to be run in shell:
 #    chmod +x ${rvm_path}/hooks/after_use_jruby_opts
 
-rvm --create use jruby-9.1.5.0@calcentral
+rvm --create use jruby-9.0.1.0@calcentral

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ bundler_args: --without development testext production --deployment --jobs=4 --r
 cache: bundler
 
 rvm:
-  - jruby-9.1.5.0
+  - jruby-9.0.1.0
 
 matrix:
   include:
-    - { rvm: jruby-9.1.5.0 }
+    - { rvm: jruby-9.0.1.0 }
 
 env:
   - JRUBY_OPTS="--dev -J-Xmx900m" DISPLAY=:99.0 LOGGER_LEVEL=WARN TRAVIS_NODE_VERSION="4"

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN git clone https://github.com/sstephenson/ruby-build.git /tmp/ruby-build && \
 RUN ruby-build --definitions
 
 # Install ruby
-RUN ruby-build -v jruby-9.1.5.0 /usr/local
+RUN ruby-build -v jruby-9.0.1.0 /usr/local
 
 # Install base gems
 RUN gem install bundler rubygems-bundler --no-rdoc --no-ri

--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'jruby-activemq', '~> 5.13.0', git: 'https://github.com/ets-berkeley-edu/jru
 # To support SSL TLSv1.2.
 # jruby-openssl versions 0.9.8 through 0.9.16 trigger runaway memory consumption in CalCentral.
 # Track progress at https://github.com/jruby/jruby-openssl/issues/86 and SISRP-18781.
-gem 'jruby-openssl', '0.9.19'
+gem 'jruby-openssl', '0.9.7'
 
 # Addressable is a replacement for the URI implementation that is part of Ruby's standard library.
 # https://github.com/sporkmonger/addressable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.0)
       railties (>= 3.2.16)
-    jruby-openssl (0.9.19-java)
+    jruby-openssl (0.9.7-java)
     json (1.8.3-java)
     jwt (1.5.4)
     kaminari (0.16.1)
@@ -488,7 +488,7 @@ DEPENDENCIES
   ims-lti!
   jmx (~> 1.0)
   jruby-activemq (~> 5.13.0)!
-  jruby-openssl (= 0.9.19)
+  jruby-openssl (= 0.9.7)
   json (~> 1.8.0)
   link_header (~> 0.0.7)
   log4r (~> 1.1)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 * [Git](https://help.github.com/articles/set-up-git)
 * [JDBC Oracle driver](http://www.oracle.com/technetwork/database/enterprise-edition/jdbc-112010-090769.html)
 * [Java 7 SDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
-* [JRuby 9.1.5.0](http://jruby.org/)
+* [JRuby 9.0.1.0](http://jruby.org/)
 * [Node.js >=0.10.30](http://nodejs.org/)
 * [PostgreSQL](http://www.postgresql.org/)
 * [Rails 3.2.x](http://rubyonrails.org/download)
@@ -94,7 +94,7 @@ http://www.oracle.com/technetwork/java/javase/downloads/index.html
 
     ```bash
     rvm get head
-    rvm install jruby-9.1.5.0
+    rvm install jruby-9.0.1.0
     cd ..
     cd calcentral
     # Answer "yes" again if it asks you to trust a new .rvmrc file.

--- a/app/models/my_academics/college_and_level.rb
+++ b/app/models/my_academics/college_and_level.rb
@@ -58,15 +58,15 @@ module MyAcademics
     end
 
     def parse_hub_award_honors(response)
-      honors = sort_award_honors response.dig(:feed, 'student', 'awardHonors')
+      honors = sort_award_honors response.try(:[], :feed).try(:[], 'student').try(:[], 'awardHonors')
       honors_by_term = {}
-      honors&.each do |honor|
-        term_id = honor.dig('term', 'id')
+      honors.try(:each) do |honor|
+        term_id = honor.try(:[], 'term').try(:[], 'id')
         honors_by_term[term_id] ||= []
         honors_by_term[term_id] << {
-          awardDate: parse_date(honor.dig('awardDate')),
-          code: honor.dig('type', 'code'),
-          description: honor.dig('type', 'description')
+          awardDate: parse_date(honor.try(:[], 'awardDate')),
+          code: honor.try(:[], 'type').try(:[], 'code'),
+          description: honor.try(:[], 'type').try(:[], 'description')
         }
       end
       honors_by_term
@@ -74,7 +74,7 @@ module MyAcademics
 
     def sort_award_honors(honors)
       honors.try(:sort_by) do |honor|
-        honor.dig('term', 'id')
+        honor.try(:[], 'term').try(:[], 'id')
       end.try(:reverse)
     end
 

--- a/script/update-build.sh
+++ b/script/update-build.sh
@@ -57,7 +57,7 @@ cat versions/git.txt | ${LOGIT}
 
 # Fix permissions on files that need to be executable
 chmod u+x ./script/*
-chmod u+x ./vendor/bundle/jruby/2.3.0/bin/*
+chmod u+x ./vendor/bundle/jruby/2.2.0/bin/*
 find ./vendor/bundle -name standalone.sh | xargs chmod u+x
 
 echo | ${LOGIT}


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-26133

jruby-openssl-0.9.19 seemed to cause performance issues - so we are switching back to the last-used version, 0.9.7.  This requires a downgrade of jruby to 9.0.* (going with 9.0.1.0 in this case).