### PR TITLE
SISRP-35815 - GSI's not able to view waitlist details in Cal Central 

### DIFF
--- a/src/assets/javascripts/angular/services/rosterService.js
+++ b/src/assets/javascripts/angular/services/rosterService.js
@@ -90,10 +90,10 @@ angular.module('calcentral.services').factory('rosterService', function($filter)
   var doesStudentMatchEnrollStatus = function(student, enrollStatus) {
     switch (enrollStatus) {
       case 'enrolled': {
-        return (!_.get(student, 'waitlist_position'));
+        return (_.get(student, 'enroll_status') === 'E');
       }
       case 'waitlisted': {
-        return (_.get(student, 'waitlist_position'));
+        return (_.get(student, 'enroll_status') === 'W');
       }
       default: {
         return true;


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-35815

* Updates logic to rely on 'enroll_status' code, rather than the 'waitlist_position' value, as it appears that the waitlist position is not always present for waitlisted rosters
* Also includes update to docs to specify specific Bundler version when setting up workstation