### PR TITLE
SISRP-35050 - CCAdmin logout button does not log you out

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -85,9 +85,13 @@ class SessionsController < ApplicationController
     url = request.protocol + ApplicationController.correct_port(request.host_with_port, request.env['HTTP_REFERER'])
 
     url = "#{Settings.campus_solutions_proxy.logout_url}&redirect_url=#{CGI.escape url}" if Settings.features.cs_logout
+    cas_logout_url = "#{Settings.cas_logout_url}?service=#{CGI.escape url}"
+
+    # CCAdmin uses Delete request route that does not use JS redirect mechanism
+    return redirect_to cas_logout_url if request.delete?
 
     render :json => {
-      :redirectUrl => "#{Settings.cas_logout_url}?service=#{CGI.escape url}"
+      :redirectUrl => cas_logout_url
     }.to_json
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Calcentral::Application.routes.draw do
   get '/auth/cas/callback' => 'sessions#lookup'
   get '/auth/failure' => 'sessions#failure'
   get '/reauth/admin' => 'sessions#reauth_admin', :as => :reauth_admin
+  delete '/logout' => 'sessions#destroy', :as => :logout_ccadmin
   if Settings.developer_auth.enabled
     # the backdoor for http basic auth (bypasses CAS) only on development environments.
     get '/basic_auth_login' => 'sessions#basic_lookup'


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-35050

Adds HTTP Delete route for /logout that does not return redirect URL in JSON response, but instead directly redirects the user to CAS for logout after destroying session. Needed to support the 'Logout' button presented in CCAdmin.