### PR TITLE
SISRP-34657 - Marks faculty committee as active based on service date

### DIFF
--- a/app/models/my_committees/committees_module.rb
+++ b/app/models/my_committees/committees_module.rb
@@ -1,5 +1,6 @@
 module MyCommittees::CommitteesModule
   extend self
+  include ClassLogger
 
   COMMITTEE_TYPES = {
     QE: {
@@ -81,6 +82,16 @@ module MyCommittees::CommitteesModule
       photo: committee_member_photo_url(cs_committee_member),
       primaryDepartment:  cs_committee_member[:memberDeptDescr]
     }
+  end
+
+  def member_active?(committee_member)
+    active = false
+    begin
+      active = Time.zone.parse(committee_member[:csMemberEndDate].to_s).to_datetime.try(:future?)
+    rescue
+      logger.error "Bad Format for committee member end date; uid = #{@uid}"
+    end
+    active
   end
 
   def parse_cs_committee_student (cs_committee)

--- a/app/models/my_committees/faculty_committees.rb
+++ b/app/models/my_committees/faculty_committees.rb
@@ -37,7 +37,7 @@ module MyCommittees
             csMemberEndDate: cs_faculty_committee_svc[:memberEndDate],
             csMemberStartDate: cs_faculty_committee_svc[:memberStartDate]
           )
-          if is_active? cs_committee
+          if member_active? faculty_committee
             committees_result[:active] << faculty_committee
           else
             committees_result[:completed] << faculty_committee

--- a/spec/models/my_committees/committees_module_spec.rb
+++ b/spec/models/my_committees/committees_module_spec.rb
@@ -81,4 +81,65 @@ describe MyCommittees::CommitteesModule do
       end
     end
   end
+
+  describe '#member_active?' do
+    subject { described_class.member_active?(committee_member) }
+
+    context 'when committee member is nil' do
+      let(:committee_member) { nil }
+      it 'returns false' do
+        expect(subject).to be false
+      end
+    end
+    context 'when committee member service end date is missing' do
+      let(:committee_member) do
+        {
+          csMemberEndDate: nil,
+        }
+      end
+      it 'returns false' do
+        expect(subject).to be false
+      end
+    end
+    context 'when committee member service end date is malformed' do
+      let(:committee_member) do
+        {
+          csMemberEndDate: 'Present',
+        }
+      end
+      it 'returns false' do
+        expect(subject).to be false
+      end
+    end
+    context 'when committee member service end date is in the past' do
+      let(:committee_member) do
+        {
+          csMemberEndDate: '2009-01-01',
+        }
+      end
+      it 'returns false' do
+        expect(subject).to be false
+      end
+    end
+    context 'when committee member service end date is today' do
+      let(:committee_member) do
+        {
+          csMemberEndDate: DateTime.now.strftime('%F'),
+        }
+      end
+      it 'returns false' do
+        expect(subject).to be false
+      end
+    end
+    context 'when committee member service end date is in the future' do
+      let(:committee_member) do
+        {
+          csMemberEndDate: '2999-01-01',
+        }
+      end
+      it 'returns true' do
+        expect(subject).to be true
+      end
+    end
+  end
 end

--- a/spec/models/my_committees/faculty_committees_spec.rb
+++ b/spec/models/my_committees/faculty_committees_spec.rb
@@ -14,35 +14,35 @@ describe MyCommittees::FacultyCommittees do
         double(lookup_campus_solutions_id: user_cs_id))
     end
 
-    it 'sorts active and inactive committees into separate lists' do
-      expect(feed[:facultyCommittees][:active].count).to eq 2
-      expect(feed[:facultyCommittees][:completed].count).to eq 3
+    it 'categorizes committees as active or inactive based on faculty member\'s service end date' do
+      expect(feed[:facultyCommittees][:active].count).to eq 1
+      expect(feed[:facultyCommittees][:completed].count).to eq 4
     end
 
     it 'sorts the committees by the current user\'s membership end date and start date, most recent first' do
       activeCommittees = feed[:facultyCommittees][:active]
       completedCommittees = feed[:facultyCommittees][:completed]
 
-      expect(activeCommittees[0][:csMemberStartDate]).to be nil
-      expect(activeCommittees[0][:csMemberEndDate]).to be nil
-      expect(activeCommittees[1][:csMemberStartDate]).to eq '2014-08-31'
-      expect(activeCommittees[1][:csMemberEndDate]).to eq '2015-01-01'
+      expect(activeCommittees[0][:csMemberStartDate]).to eq '2016-08-31'
+      expect(activeCommittees[0][:csMemberEndDate]).to eq '2999-01-01'
 
-      expect(completedCommittees[0][:csMemberStartDate]).to eq '2016-08-31'
-      expect(completedCommittees[0][:csMemberEndDate]).to eq '2999-01-01'
+      expect(completedCommittees[0][:csMemberStartDate]).to be nil
+      expect(completedCommittees[0][:csMemberEndDate]).to be nil
       expect(completedCommittees[1][:csMemberStartDate]).to eq '2016-08-30'
       expect(completedCommittees[1][:csMemberEndDate]).to eq '2017-08-30'
       expect(completedCommittees[2][:csMemberStartDate]).to eq '2015-08-31'
       expect(completedCommittees[2][:csMemberEndDate]).to eq '2016-01-01'
+      expect(completedCommittees[3][:csMemberStartDate]).to eq '2014-08-31'
+      expect(completedCommittees[3][:csMemberEndDate]).to eq '2015-01-01'
     end
 
     it 'correctly parses a committee with no members' do
-      committee = feed[:facultyCommittees][:active][0]
+      committee = feed[:facultyCommittees][:completed][0]
       expect(committee[:serviceRange]).to be nil
     end
 
     it 'correctly parses a Dissertation committee' do
-      committee = feed[:facultyCommittees][:completed][0]
+      committee = feed[:facultyCommittees][:active][0]
       expect(committee[:committeeType]).to eq 'Dissertation Committee'
       expect(committee[:program]).to eq 'Education PhD'
       expect(committee[:statusMessage]).to eq 'Advanced: Oct 06, 2017'
@@ -61,7 +61,7 @@ describe MyCommittees::FacultyCommittees do
     end
 
     it 'correctly parses a Qualifying Exam committee with exam not passed' do
-      committee = feed[:facultyCommittees][:active][0]
+      committee = feed[:facultyCommittees][:completed][0]
       expect(committee[:committeeType]).to eq 'Qualifying Exam Committee'
       expect(committee[:program]).to eq 'Underwater Basket Weaving PhD'
       expect(committee[:statusMessage]).to eq nil
@@ -109,7 +109,7 @@ describe MyCommittees::FacultyCommittees do
     end
 
     context 'when student has not yet attempted the Qualifying Exam milestone' do
-      let(:qe_committee_with_proposed_exam) { feed[:facultyCommittees][:active][1] }
+      let(:qe_committee_with_proposed_exam) { feed[:facultyCommittees][:completed][3] }
 
       it 'has an empty attempts list' do
         expect(qe_committee_with_proposed_exam[:milestoneAttempts]).to eq []
@@ -127,7 +127,7 @@ describe MyCommittees::FacultyCommittees do
     end
 
     it 'replaces bogus dates with text' do
-      committee = feed[:facultyCommittees][:completed][0]
+      committee = feed[:facultyCommittees][:active][0]
       expect(committee[:serviceRange]).to eq 'Aug 31, 2016 - Present'
     end
   end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-34657

Previously, a committee was presented to faculty as 'Completed' if the student had finished the necessary milestones.  With this change we will instead show a faculty committee as 'Completed' if the faculty member's service on the committee has ended.  