### PR TITLE
CLC-6739 OEC should include explicitly selected non-participating departments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
 env:
   - JRUBY_OPTS="--dev -J-Xmx900m" DISPLAY=:99.0 LOGGER_LEVEL=WARN TRAVIS_NODE_VERSION="4"
 
+before_install:
+  - gem update --system 2.4.5
+
 before_script:
   - ./script/front-end-build.sh
 

--- a/app/models/oec/api_task_wrapper.rb
+++ b/app/models/oec/api_task_wrapper.rb
@@ -101,8 +101,7 @@ module Oec
       }
       if params['departmentCode'].present?
         translated_params.merge!({
-          dept_codes: Array.wrap(params['departmentCode']).join(' '),
-          import_all: true
+          dept_codes: Array.wrap(params['departmentCode']).join(' ')
         })
       end
       translated_params

--- a/app/models/oec/department_mappings.rb
+++ b/app/models/oec/department_mappings.rb
@@ -35,9 +35,12 @@ module Oec
       end
     end
 
+    # This means "excluded so far as the specified dept_name is concerned." The mapping row
+    # which defines the dept_name itself will not be excluded, even if (in a wider context)
+    # it is not participating in OEC.
     def excluded_courses(dept_name, home_dept_code)
       catalog_id_specific_mappings.select do |m|
-        (m.dept_name == dept_name) && (m.dept_code != home_dept_code || !m.include_in_oec)
+        (m.dept_name == dept_name) && (m.dept_code != home_dept_code || (m.catalog_id.present? && !m.include_in_oec))
       end
     end
 

--- a/app/models/oec/queries.rb
+++ b/app/models/oec/queries.rb
@@ -3,8 +3,8 @@ module Oec
     extend self
 
     # Only used in SisImportTask.import_courses
-    def courses_for_codes(term_code, course_codes, import_all = false)
-      return [] unless (filter = EdoOracle::Oec.depts_clause(term_code, course_codes, import_all))
+    def courses_for_codes(term_code, course_codes)
+      return [] unless (filter = EdoOracle::Oec.depts_clause(term_code, course_codes))
       get_courses(term_code, filter)
     end
 

--- a/app/models/oec/sis_import_task.rb
+++ b/app/models/oec/sis_import_task.rb
@@ -19,7 +19,7 @@ module Oec
       course_codes_by_ccn = {}
       cross_listed_ccns = Set.new
 
-      home_dept_rows = Oec::Queries.courses_for_codes(@term_code, course_codes, @opts[:import_all])
+      home_dept_rows = Oec::Queries.courses_for_codes(@term_code, course_codes)
       home_dept_rows_imported = 0
       log :info, "SIS data returned #{home_dept_rows.count} course-instructor pairings under home department"
       home_dept_rows.each do |course_row|

--- a/app/models/oec/task.rb
+++ b/app/models/oec/task.rb
@@ -29,7 +29,6 @@ module Oec
         term_code: term_code,
         allow_past_term: ENV['allow_past_term'].present?,
         local_write: ENV['local_write'].present?,
-        import_all: ENV['import_all'].present?,
         dept_codes: ENV['dept_codes']
       }
     end

--- a/spec/models/oec/api_task_wrapper_spec.rb
+++ b/spec/models/oec/api_task_wrapper_spec.rb
@@ -11,7 +11,6 @@ describe Oec::ApiTaskWrapper do
     end
     it 'should not populate department options' do
       expect(translated_params[:dept_codes]).to be_nil
-      expect(translated_params[:import_all]).to be_nil
     end
   end
 
@@ -20,7 +19,6 @@ describe Oec::ApiTaskWrapper do
     let(:params) { {'term' => 'Summer 2014', 'departmentCode' => 'SYPSY'} }
     it 'should translate params to task options' do
       expect(translated_params[:dept_codes]).to eq 'SYPSY'
-      expect(translated_params[:import_all]).to eq true
       expect(translated_params[:validate_without_export]).to be_nil
     end
   end

--- a/spec/models/oec/sis_import_task_spec.rb
+++ b/spec/models/oec/sis_import_task_spec.rb
@@ -84,7 +84,7 @@ describe Oec::SisImportTask do
     before(:each) do
       load_fixture_courses
       expect(Oec::Queries).to receive(:courses_for_codes)
-        .with(term_code, fake_code_mapping, nil).exactly(1).times
+        .with(term_code, fake_code_mapping).exactly(1).times
         .and_return courses_for_dept
       expect(Oec::Queries).to receive(:courses_for_cntl_nums)
         .with(term_code, additional_cross_listings.to_a).exactly(1).times


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6739

These changes all affect the include-only-these-explicit-departments code path in the OEC UX.

The include-all-participating-departments logic remains buried in `Oec::Tasks initialize`:
```
      @departments_filter = if opts[:dept_codes]
                             {dept_code: opts[:dept_codes].split}
                           else
                             {include_in_oec: true}
                           end
```

and `Oec::SisImportTask run_internal`:
```
      Oec::DepartmentMappings.new(term_code: @term_code).by_dept_code(@departments_filter).each do |dept_code, course_codes|
```

where the `course_codes` values eventually make their way to `EdoOracle::Oec.depts_clause` calls.