### PR TITLE
SISRP-34658 - Surfaces member service dates on Student Committees card

### DIFF
--- a/app/models/my_committees/committees_module.rb
+++ b/app/models/my_committees/committees_module.rb
@@ -75,13 +75,11 @@ module MyCommittees::CommitteesModule
     milestone_attempt
   end
 
-  def parse_cs_committee_member (cs_committee_member)
-    {
-      name: "#{cs_committee_member[:memberNameFirst]} #{cs_committee_member[:memberNameLast]}",
-      email: cs_committee_member[:memberEmail],
-      photo: committee_member_photo_url(cs_committee_member),
-      primaryDepartment:  cs_committee_member[:memberDeptDescr]
-    }
+  def format_member_service_dates(committee_member)
+    start_date = to_display committee_member.try(:[], :memberStartDate)
+    end_date = to_display committee_member.try(:[], :memberEndDate)
+    service_range = "#{ start_date } - #{ end_date }" if start_date.present? && end_date.present?
+    service_range
   end
 
   def member_active?(committee_member)
@@ -92,14 +90,6 @@ module MyCommittees::CommitteesModule
       logger.error "Bad Format for committee member end date; uid = #{@uid}"
     end
     active
-  end
-
-  def parse_cs_committee_student (cs_committee)
-    {
-      name: "#{cs_committee[:studentNameFirst]} #{cs_committee[:studentNameLast]}",
-      email: cs_committee[:studentEmail],
-      photo: committee_student_photo_url(cs_committee)
-    }
   end
 
   def committee_member_photo_url (cs_committee_member)
@@ -203,6 +193,14 @@ module MyCommittees::CommitteesModule
     cs_committee.try(:[], :committeeFinishingMilestoneComplete) != 'Y'
   end
 
+  def to_display(date)
+    if date === '2999-01-01'
+      'Present'
+    else
+      format_date date
+    end
+  end
+
   def format_date(unformatted_date)
     formatted_date = ''
     begin
@@ -212,5 +210,4 @@ module MyCommittees::CommitteesModule
     end
     formatted_date
   end
-
 end

--- a/app/models/my_committees/faculty_committees.rb
+++ b/app/models/my_committees/faculty_committees.rb
@@ -17,7 +17,6 @@ module MyCommittees
       }
       feed = CampusSolutions::FacultyCommittees.new(user_id: @uid).get.try(:[], :feed)
       if feed && (cs_committees = feed[:ucSrFacultyCommittee].try(:[], :facultyCommittees))
-        # Service range will be parsed from nested member data with match on emplid
         @emplid = feed[:ucSrFacultyCommittee].try(:[], :emplid)
         result[:facultyCommittees] = parse_cs_faculty_committees(cs_committees , result[:facultyCommittees])
       end
@@ -28,25 +27,21 @@ module MyCommittees
       cs_committees.compact!
       cs_committees.try(:each) do |cs_committee|
         faculty_committee = parse_cs_committee(cs_committee)
-        if cs_committee.present?
-          # Add additional pieces of data specific to faculty committees
-          cs_faculty_committee_svc = parse_cs_faculty_committee_svc(cs_committee)
-          faculty_committee.merge!(
-            student: parse_cs_committee_student(cs_committee),
-            serviceRange: cs_faculty_committee_svc[:serviceRange],
-            csMemberEndDate: cs_faculty_committee_svc[:memberEndDate],
-            csMemberStartDate: cs_faculty_committee_svc[:memberStartDate]
-          )
-          if member_active? faculty_committee
-            committees_result[:active] << faculty_committee
-          else
-            committees_result[:completed] << faculty_committee
-          end
+        merge_faculty_specific_data(cs_committee, faculty_committee)
+        if member_active? faculty_committee
+          committees_result[:active] << faculty_committee
+        else
+          committees_result[:completed] << faculty_committee
         end
       end
       committees_result[:completed] = sort_committees_by_svc(committees_result[:completed])
       committees_result[:active] = sort_committees_by_svc(committees_result[:active])
       committees_result
+    end
+
+    def merge_faculty_specific_data(cs_committee, faculty_committee)
+      faculty_committee.merge! student: parse_cs_committee_student(cs_committee)
+      faculty_committee.merge! parse_cs_faculty_committee_svc(cs_committee)
     end
 
     def parse_cs_milestone_attempts(cs_committee)
@@ -62,6 +57,15 @@ module MyCommittees
       "Exam #{milestone_attempt[:sequenceNumber]}: #{milestone_attempt[:result]} #{milestone_attempt[:date]}"
     end
 
+    def parse_cs_committee_member (cs_committee_member)
+      {
+        name: "#{cs_committee_member[:memberNameFirst]} #{cs_committee_member[:memberNameLast]}",
+        email: cs_committee_member[:memberEmail],
+        photo: committee_member_photo_url(cs_committee_member),
+        primaryDepartment:  cs_committee_member[:memberDeptDescr]
+      }
+    end
+
     def sort_committees_by_svc(cs_committees)
       cs_committees.try(:sort_by) do |committee|
         # set the enddate to 9999-99-99 to allow for sort_by to do string comparison.
@@ -72,28 +76,23 @@ module MyCommittees
       end.try(:reverse)
     end
 
-    def parse_cs_faculty_committee_svc(cs_committee)
-      current_user_member = cs_committee[:committeeMembers].try(:find) do |mem|
-        mem[:memberEmplid].present? &&  mem[:memberEmplid] == @emplid
-      end
-      committee_service_range_result = {}
-      if current_user_member
-        start_date = current_user_member.try(:[], :memberStartDate)
-        end_date = current_user_member.try(:[], :memberEndDate)
-
-        committee_service_range_result[:serviceRange] = "#{ to_display(start_date) } - #{ to_display(end_date) }"
-        committee_service_range_result[:memberEndDate] = end_date
-        committee_service_range_result[:memberStartDate] = start_date
-      end
-      committee_service_range_result
+    def parse_cs_committee_student (cs_committee)
+      {
+        name: "#{cs_committee[:studentNameFirst]} #{cs_committee[:studentNameLast]}",
+        email: cs_committee[:studentEmail],
+        photo: committee_student_photo_url(cs_committee)
+      }
     end
 
-    def to_display(date)
-      if date === '2999-01-01'
-        'Present'
-      else
-        format_date date
+    def parse_cs_faculty_committee_svc(cs_committee)
+      current_user_member = cs_committee.try(:[], :committeeMembers).try(:find) do |member|
+        member.try(:[], :memberEmplid) == @emplid
       end
+      {
+        serviceRange: format_member_service_dates(current_user_member),
+        csMemberEndDate: current_user_member.try(:[], :memberEndDate),
+        csMemberStartDate: current_user_member.try(:[], :memberStartDate)
+      }
     end
   end
 end

--- a/app/models/my_committees/student_committees.rb
+++ b/app/models/my_committees/student_committees.rb
@@ -58,6 +58,16 @@ module MyCommittees
       milestone_attempt[:sequenceNumber] === 1 && milestone_attempt[:result] == Berkeley::GraduateMilestones::QE_RESULTS_STATUS_PASSED
     end
 
+    def parse_cs_committee_member (cs_committee_member)
+      {
+        name: "#{cs_committee_member[:memberNameFirst]} #{cs_committee_member[:memberNameLast]}",
+        email: cs_committee_member[:memberEmail],
+        photo: committee_member_photo_url(cs_committee_member),
+        primaryDepartment:  cs_committee_member[:memberDeptDescr],
+        serviceRange: format_member_service_dates(cs_committee_member)
+      }
+    end
+
     def remove_inactive_members(cs_committee)
       cs_committee[:committeeMembers].try(:reject!) do |member|
         inactive?(member)

--- a/spec/models/my_committees/committees_module_spec.rb
+++ b/spec/models/my_committees/committees_module_spec.rb
@@ -82,6 +82,50 @@ describe MyCommittees::CommitteesModule do
     end
   end
 
+  describe '#format_member_service_dates' do
+    subject { described_class.format_member_service_dates(committee_member) }
+
+    context 'when committee member is nil' do
+      let(:committee_member) { nil }
+      it 'returns nil' do
+        expect(subject).to be nil
+      end
+    end
+    context 'when committee member service start and end dates are missing' do
+      let(:committee_member) do
+        {
+          memberEndDate: nil,
+          memberStartDate: nil
+        }
+      end
+      it 'returns nil' do
+        expect(subject).to be nil
+      end
+    end
+    context 'when one of the committee member service dates is missing' do
+      let(:committee_member) do
+        {
+          memberEndDate: '2016-01-01',
+          memberStartDate: nil
+        }
+      end
+      it 'returns nil' do
+        expect(subject).to be nil
+      end
+    end
+    context 'when committee member service start and end dates are populated' do
+      let(:committee_member) do
+        {
+          memberEndDate: '2016-01-01',
+          memberStartDate: '2015-01-01'
+        }
+      end
+      it 'returns a formatted date range' do
+        expect(subject).to eq 'Jan 01, 2015 - Jan 01, 2016'
+      end
+    end
+  end
+
   describe '#member_active?' do
     subject { described_class.member_active?(committee_member) }
 
@@ -139,6 +183,29 @@ describe MyCommittees::CommitteesModule do
       end
       it 'returns true' do
         expect(subject).to be true
+      end
+    end
+
+    describe '#to_display' do
+      subject { described_class.to_display(date) }
+
+      context 'when date is missing' do
+        let(:date) { nil }
+        it 'returns empty string' do
+          expect(subject).to eq ''
+        end
+      end
+      context 'when date is the special Campus Solutions representation of a null date' do
+        let(:date) { '2999-01-01' }
+        it 'returns Present' do
+          expect(subject).to eq 'Present'
+        end
+      end
+      context 'when date is a valid date' do
+        let(:date) { '2998-12-31' }
+        it 'returns a formatted date' do
+          expect(subject).to eq 'Dec 31, 2998'
+        end
       end
     end
   end

--- a/spec/models/my_committees/student_committees_spec.rb
+++ b/spec/models/my_committees/student_committees_spec.rb
@@ -115,10 +115,12 @@ describe MyCommittees::StudentCommittees do
       expect(members[:chair][0][:name]).to eq 'MEMBERFIRSTNAME1 MEMBERLASTNAME1'
       expect(members[:chair][0][:email]).to eq 'MEMBER@EMAIL.1'
       expect(members[:chair][0][:primaryDepartment]).to eq 'MEMBERDEPTDESCR1'
+      expect(members[:chair][0][:serviceRange]).to eq 'Jan 01, 2021 - Oct 10, 2100'
 
       expect(members[:chair][1][:name]).to eq 'MEMBERFIRSTNAME2 MEMBERLASTNAME2'
       expect(members[:chair][1][:email]).to eq 'MEMBER@EMAIL.2'
       expect(members[:chair][1][:primaryDepartment]).to eq 'MEMBERDEPTDESCR2'
+      expect(members[:chair][1][:serviceRange]).to eq 'Jan 01, 2022 - Oct 10, 2100'
     end
 
     it 'contains the expected student committee data for co-chairs' do
@@ -126,10 +128,12 @@ describe MyCommittees::StudentCommittees do
       expect(members[:coChair][0][:name]).to eq 'MEMBERFIRSTNAME3 MEMBERLASTNAME3'
       expect(members[:coChair][0][:email]).to eq 'MEMBER@EMAIL.3'
       expect(members[:coChair][0][:primaryDepartment]).to eq 'MEMBERDEPTDESCR3'
+      expect(members[:coChair][0][:serviceRange]).to eq 'Jan 01, 2023 - Oct 10, 2100'
 
       expect(members[:coChair][1][:name]).to eq 'MEMBERFIRSTNAME4 MEMBERLASTNAME4'
       expect(members[:coChair][1][:email]).to eq 'MEMBER@EMAIL.4'
       expect(members[:coChair][1][:primaryDepartment]).to eq 'MEMBERDEPTDESCR4'
+      expect(members[:coChair][1][:serviceRange]).to eq 'Jan 01, 2024 - Oct 10, 2100'
     end
 
     it 'contains the expected student committee data for additional reps' do
@@ -137,10 +141,12 @@ describe MyCommittees::StudentCommittees do
       expect(members[:additionalReps][0][:name]).to eq 'MEMBERFIRSTNAME5 MEMBERLASTNAME5'
       expect(members[:additionalReps][0][:email]).to eq 'MEMBER@EMAIL.5'
       expect(members[:additionalReps][0][:primaryDepartment]).to eq 'MEMBERDEPTDESCR5'
+      expect(members[:additionalReps][0][:serviceRange]).to eq 'Jan 01, 2025 - Oct 10, 2100'
 
       expect(members[:additionalReps][1][:name]).to eq 'MEMBERFIRSTNAME6 MEMBERLASTNAME6'
       expect(members[:additionalReps][1][:email]).to eq 'MEMBER@EMAIL.6'
       expect(members[:additionalReps][1][:primaryDepartment]).to eq 'MEMBERDEPTDESCR6'
+      expect(members[:additionalReps][1][:serviceRange]).to eq 'Jan 01, 2026 - Oct 10, 2999'
     end
 
     it 'contains the expected student committee data for academic senate' do
@@ -148,6 +154,7 @@ describe MyCommittees::StudentCommittees do
       expect(members[:academicSenate][0][:name]).to eq 'MEMBERFIRSTNAME7 MEMBERLASTNAME7'
       expect(members[:academicSenate][0][:email]).to eq 'MEMBER@EMAIL.7'
       expect(members[:academicSenate][0][:primaryDepartment]).to eq 'MEMBERDEPTDESCR7'
+      expect(members[:academicSenate][0][:serviceRange]).to eq 'Jan 01, 2027 - Oct 10, 2999'
     end
   end
 

--- a/src/assets/templates/widgets/academics/higher_degree_committee_member.html
+++ b/src/assets/templates/widgets/academics/higher_degree_committee_member.html
@@ -8,12 +8,13 @@
     </div>
   </div>
   <div class="cc-higher-degree-committees-content">
-    <div class="cc-higher-degree-committees-content-fullname">
+    <div>
       <div><strong><span data-ng-bind="member.name"></span></strong></div>
       <a data-ng-href="mailto:{{instructor.email}}">
         <div><strong class="cc-button-link"><span data-ng-bind="member.email"></span></strong></div>
       </a>
       <div><span data-ng-bind="member.primaryDepartment"></span></div>
+      <div data-ng-if="member.serviceRange" class="cc-text-light">Service:&nbsp;<span data-ng-bind="member.serviceRange"></span></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-34658

Students will now be able to see the start and end date of each faculty member's service on that student's committees.