### PR TITLE
SISRP-32864 - Surfaces honors for scholarship in a plan

### DIFF
--- a/fixtures/json/hub_academic_status.json
+++ b/fixtures/json/hub_academic_status.json
@@ -281,12 +281,20 @@
                     }
                   }
                 ],
-                "honors": [
-                  {
-                    "code": "C2",
-                    "description": "High Distinction: CNR"
-                  }
-                ],
+                "honors": {
+                  "honors": [
+                    {
+                      "code": "C2",
+                      "description": "High Distinction: CNR",
+                      "formalDescription": "High Distinction: College of Natural Resources"
+                    },
+                    {
+                      "code": "P1",
+                      "description": "Honors in Society and Environment",
+                      "formalDescription": "Honors in Society and Environment"
+                    }
+                  ]
+                },
                 "dateAwarded": "2010-05-14",
                 "status": {
                   "code": "Awarded"

--- a/spec/models/my_academics/college_and_level_spec.rb
+++ b/spec/models/my_academics/college_and_level_spec.rb
@@ -144,7 +144,20 @@ describe MyAcademics::CollegeAndLevel do
           }
         }
       ],
-      'honors' => {},
+      'honors' => {
+        'honors' => [
+        {
+        'code' => 'C2',
+        'description' => 'High Distinction: CNR',
+        'formalDescription' => 'High Distinction: College of Natural Resources'
+      },
+      {
+        'code' => 'P1',
+        'description' => 'Honors in Society and Environment',
+        'formalDescription' => 'Honors in Society and Environment'
+      }
+    ]
+    },
       'dateAwarded' => '2012-12-14',
       'status' => {
         'code' => 'Awarded'
@@ -154,29 +167,29 @@ describe MyAcademics::CollegeAndLevel do
   end
   let(:hub_degree_not_awarded) do
     {
-      :academicDegree => {
-        :type => {
-          :code => 'PD',
-          :description => 'Doctor of Philosophy'
+      'academicDegree' => {
+        'type' => {
+          'code' => 'PD',
+          'description' => 'Doctor of Philosophy'
         }
       },
-      :completionTerm => {
-        :name => '2010 Spring'
+      'completionTerm' => {
+        'name' => '2010 Spring'
       },
-      :academicPlans => [
+      'academicPlans' => [
         {
-          :plan => {
-            :code => '00345PHDG',
-            :description => 'English PhD'
+          'plan' => {
+            'code' => '00345PHDG',
+            'description' => 'English PhD'
           }
         }
       ],
-        :honors => {},
-        :dateAwarded => '2010-05-14',
-        :status => {
-        :code => 'Not Awarded'
+        'honors' => {},
+        'dateAwarded' => '2010-05-14',
+        'status' => {
+        'code' => 'Not Awarded'
       },
-      :statusDate => '2015-12-12'
+      'statusDate' => '2015-12-12'
     }
   end
 
@@ -528,6 +541,13 @@ describe MyAcademics::CollegeAndLevel do
         expect(feed[:collegeAndLevel][:degrees][0]['academicPlans'][0]['plan']['description']).to eq 'Education MA'
 
         expect(feed[:collegeAndLevel][:degrees][0]['honors']).to be
+        expect(feed[:collegeAndLevel][:degrees][0]['honors']['honors']).to be
+        expect(feed[:collegeAndLevel][:degrees][0]['honors']['honors'].count).to eq 2
+        expect(feed[:collegeAndLevel][:degrees][0]['honors']['honors'][0]['code']).to eq 'C2'
+        expect(feed[:collegeAndLevel][:degrees][0]['honors']['honors'][0]['formalDescription']).to eq 'High Distinction: College of Natural Resources'
+        expect(feed[:collegeAndLevel][:degrees][0]['honors']['honors'][1]['code']).to eq 'P1'
+        expect(feed[:collegeAndLevel][:degrees][0]['honors']['honors'][1]['formalDescription']).to eq 'Honors in Society and Environment'
+
         expect(feed[:collegeAndLevel][:degrees][0]['dateAwarded']).to eq '2012-12-14'
         expect(feed[:collegeAndLevel][:degrees][0]['status']).to be
         expect(feed[:collegeAndLevel][:degrees][0]['status']['code']).to eq 'Awarded'

--- a/spec/models/my_committees/committees_module_spec.rb
+++ b/spec/models/my_committees/committees_module_spec.rb
@@ -171,6 +171,7 @@ describe MyCommittees::CommitteesModule do
           csMemberEndDate: DateTime.now.strftime('%F'),
         }
       end
+
       it 'returns false' do
         expect(subject).to be false
       end

--- a/src/assets/templates/widgets/academics/degrees_conferred.html
+++ b/src/assets/templates/widgets/academics/degrees_conferred.html
@@ -10,8 +10,8 @@
           <div data-ng-repeat="academicPlan in degree.academicPlans">
             <strong data-ng-bind="academicPlan.plan.description"></strong>&nbsp;awarded on&nbsp;<strong data-ng-bind="degree.dateAwarded | date:'MMM dd, yyyy'"></strong>
           </div>
-          <div data-ng-repeat="degreeHonor in degree.honors">
-            <span data-ng-bind="degreeHonor.description"></span>
+          <div data-ng-repeat="degreeHonor in degree.honors.honors">
+            <span data-ng-bind="degreeHonor.formalDescription"></span>
           </div>
         </div>
       </td>


### PR DESCRIPTION
Student can have two types of honor attached to their conferred degree - a general scholarship honor and a plan honor (AKA honor for scholarship in a plan).  This update will surface the plan honors, and will also fix the general scholarship honor so that it displays the full name rather than an abbreviated version.

https://jira.berkeley.edu/browse/SISRP-32864
This update also fixes a bug:  https://jira.berkeley.edu/browse/SISRP-35376