### PR TITLE
SISRP-31687 - Implement dynamic labeling based on chronological logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ git:
 language: ruby
 bundler_args: --without development testext production --deployment --jobs=4 --retry=5
 cache: bundler
+dist: precise
 
 rvm:
   - jruby-1.7.19

--- a/app/controllers/concerns/advising_resources.rb
+++ b/app/controllers/concerns/advising_resources.rb
@@ -53,9 +53,9 @@ module AdvisingResources
     User::Identifiers.lookup_campus_solutions_id user_id unless user_id.blank?
   end
 
-  def self.lookup_student_career(student_empl_id)
-    feed = HubEdos::MyAcademicStatus.new(student_empl_id).get_feed unless student_empl_id.blank?
-    statuses = MyAcademics::AcademicsModule.parse_hub_academic_statuses feed
+  def self.lookup_student_career(user_id)
+    return nil if user_id.blank?
+    statuses = HubEdos::MyAcademicStatus.get_statuses(user_id)
     career = MyAcademics::AcademicsModule.newest_career statuses
     career.try(:[], 'code')
   end

--- a/app/models/campus_solutions/enrollment_term_expiry.rb
+++ b/app/models/campus_solutions/enrollment_term_expiry.rb
@@ -2,6 +2,8 @@ module CampusSolutions
   module EnrollmentTermExpiry
     def self.expire(uid=nil)
       [
+        CampusSolutions::MyEnrollmentTerm,
+        CampusSolutions::MyEnrollmentTerms,
         EdoOracle::UserCourses::All,
         MyAcademics::Merged,
         MyAcademics::ClassEnrollments,

--- a/app/models/campus_solutions/my_enrollment_term.rb
+++ b/app/models/campus_solutions/my_enrollment_term.rb
@@ -1,0 +1,22 @@
+module CampusSolutions
+  class MyEnrollmentTerm < UserSpecificModel
+    include Cache::CachedFeed
+    include Cache::UserCacheExpiry
+    include Cache::RelatedCacheKeyTracker
+
+    def self.get_term(uid, term_id)
+      if response = self.new(uid, {term_id: term_id}).get_feed
+        response.try(:[], :feed).try(:[], :enrollmentTerm)
+      end
+    end
+
+    def get_feed_internal
+      CampusSolutions::EnrollmentTerm.new({user_id: @uid, term_id: @options[:term_id]}).get
+    end
+
+    def instance_key
+      "#{@uid}-#{@options[:term_id]}"
+    end
+
+  end
+end

--- a/app/models/campus_solutions/my_enrollment_terms.rb
+++ b/app/models/campus_solutions/my_enrollment_terms.rb
@@ -1,0 +1,16 @@
+module CampusSolutions
+  class MyEnrollmentTerms < UserSpecificModel
+    include Cache::CachedFeed
+    include Cache::UserCacheExpiry
+
+    def self.get_terms(uid)
+      if response = self.new(uid).get_feed
+        Array.wrap(response.try(:[], :feed).try(:[], :enrollmentTerms)).sort_by { |term| term.try(:[], :termId) }
+      end
+    end
+
+    def get_feed_internal
+      CampusSolutions::EnrollmentTerms.new({user_id: @uid}).get
+    end
+  end
+end

--- a/app/models/my_academics/academics_module.rb
+++ b/app/models/my_academics/academics_module.rb
@@ -39,21 +39,6 @@ module MyAcademics
       }
     end
 
-    def parse_hub_academic_statuses(response)
-      status = response[:feed] && response[:feed]['student'] && response[:feed]['student']['academicStatuses']
-      status if status.present?
-    end
-
-    def parse_hub_careers(statuses)
-      [].tap do |careers|
-        statuses.each do |status|
-          if (career = status['studentCareer'].try(:[], 'academicCareer').try(:[], 'description'))
-            careers << career
-          end
-        end
-      end.uniq.reject { |level| level.to_s.empty? }
-    end
-
     def newest_career(statuses)
       newest_career_status = statuses.try(:sort) do |this_status, that_status|
         this_from_date = this_status['studentCareer'].try(:[], 'fromDate').to_s
@@ -61,6 +46,15 @@ module MyAcademics
         this_from_date <=> that_from_date
       end.try(:last)
       newest_career_status.try(:[], 'studentCareer').try(:[], 'academicCareer')
+    end
+
+    def filter_inactive_status_plans(statuses)
+      statuses.each do |status|
+        status['studentPlans'].select! do |plan|
+          plan.try(:[], 'statusInPlan').try(:[], 'status').try(:[], 'code') == 'AC'
+        end
+      end
+      statuses
     end
 
     def course_info(campus_course)

--- a/app/models/my_academics/class_enrollments.rb
+++ b/app/models/my_academics/class_enrollments.rb
@@ -122,8 +122,7 @@ module MyAcademics
     def get_enrollment_term_instructions
       instructions = {}
       get_active_term_ids.each do |term_id|
-        term_details = CampusSolutions::EnrollmentTerm.new(user_id: @uid, term_id: term_id).get
-        instructions[term_id] = term_details.try(:[], :feed).try(:[], :enrollmentTerm)
+        instructions[term_id] = CampusSolutions::MyEnrollmentTerm.get_term(@uid, term_id)
         instructions[term_id][:concurrentApplyDeadline] = get_concurrent_apply_deadline(term_id)
         instructions[term_id][:termIsSummer] = Berkeley::TermCodes.edo_id_is_summer?(term_id)
       end
@@ -155,8 +154,7 @@ module MyAcademics
 
     def get_active_career_terms
       get_career_terms = Proc.new do
-        terms = CampusSolutions::EnrollmentTerms.new({user_id: @uid}).get
-        terms = Array.wrap(terms.try(:[], :feed).try(:[], :enrollmentTerms)).sort_by { |term| term.try(:[], :termId) }
+        terms = CampusSolutions::MyEnrollmentTerms.get_terms(@uid)
         terms.collect do |term|
           term[:termName] = Berkeley::TermCodes.normalized_english(term[:termDescr])
           term[:termIsSummer] = Berkeley::TermCodes.edo_id_is_summer?(term[:termId])

--- a/app/models/my_academics/filtered_for_advisor.rb
+++ b/app/models/my_academics/filtered_for_advisor.rb
@@ -14,7 +14,8 @@ module MyAcademics
         TransferCredit,
         Exams,
         AcademicPlan,
-        AdvisorLinks
+        AdvisorLinks,
+        Graduation
       ]
     end
 

--- a/app/models/my_academics/gpa_units.rb
+++ b/app/models/my_academics/gpa_units.rb
@@ -16,7 +16,7 @@ module MyAcademics
       #copy needed feilds from response obj
       result[:errored] = response[:errored]
       # TODO: Consult with SR concerning GPA displayed when multiple academic careers present
-      if (status = parse_hub_academic_statuses(response).try :first)
+      if (status = HubEdos::MyAcademicStatus.parse_academic_statuses(response).try(:first))
         # GPA is passed as a string to force a decimal point for whole values.
         result[:cumulativeGpa] = (cumulativeGpa = parse_hub_cumulative_gpa status) && cumulativeGpa.to_s
         if (totalUnits = parse_hub_total_units status) && totalUnits.present?

--- a/app/models/my_academics/graduation.rb
+++ b/app/models/my_academics/graduation.rb
@@ -1,0 +1,78 @@
+module MyAcademics
+  class Graduation < UserSpecificModel
+    require 'set'
+    include Cache::CachedFeed
+    include Cache::UserCacheExpiry
+    include AcademicsModule
+
+    def merge(data)
+      data[:graduation] = get_feed
+      data
+    end
+
+    def get_feed_internal
+      return {} unless HubEdos::UserAttributes.new(user_id: @uid).has_role?(:student)
+      exp_grad_term = last_expected_graduation_term
+      terms_with_appts = active_terms_with_enrollment_appointments
+      HashConverter.camelize({
+        lastExpectedGraduationTerm: exp_grad_term,
+        activeTermsWithEnrollmentAppointments: terms_with_appts,
+        isNotGraduateOrLawStudent: isNotGraduateOrLawStudent,
+        appointmentsInGraduatingTerm: appointmentsInGraduatingTerm(exp_grad_term, terms_with_appts),
+      })
+    end
+
+    def last_expected_graduation_term
+      expected_graduation_term = { code: nil, name: nil }
+      if (statuses = HubEdos::MyAcademicStatus.get_statuses(@uid))
+        filtered_statuses = filter_inactive_status_plans(statuses)
+        filtered_statuses.each do |status|
+          Array.wrap(status.try(:[], 'studentPlans')).each do |plan|
+            current_expected_graduation_term = get_expected_graduation_term(plan)
+
+            # Catch Last Expected Graduation Date
+            if (expected_graduation_term.try(:[], :code).to_i < current_expected_graduation_term.try(:[], :code).to_i)
+              expected_graduation_term = current_expected_graduation_term
+            end
+          end
+        end
+      end
+      expected_graduation_term
+    end
+
+    def active_terms_with_enrollment_appointments
+      if terms = CampusSolutions::MyEnrollmentTerms.get_terms(@uid)
+        term_ids = terms.collect {|t| t.try(:[], :termId) }.compact
+        term_ids.select do |term_id|
+          term_details = CampusSolutions::MyEnrollmentTerm.get_term(@uid, term_id)
+          term_details[:enrollmentPeriod].any?
+        end
+      end
+    end
+
+    def get_expected_graduation_term(plan)
+      if expected_graduation_term = plan.try(:[], 'expectedGraduationTerm')
+        term_id = expected_graduation_term.try(:[], 'id')
+        term_name = expected_graduation_term.try(:[], 'name')
+        {
+          code: term_id,
+          name: Berkeley::TermCodes.normalized_english(term_name)
+        }
+      end
+    end
+
+    def isNotGraduateOrLawStudent
+      if (careers = HubEdos::MyAcademicStatus.get_careers(@uid))
+        codes = careers.map { |c| c.try(:[], 'code') }
+        intersection = codes.to_set.intersection(Set['GRAD', 'LAW'])
+        return intersection.length == 0
+      end
+      false
+    end
+
+    def appointmentsInGraduatingTerm(last_expected_graduation_term, terms_with_appointments)
+      term_code = last_expected_graduation_term.try(:[], :code)
+      terms_with_appointments.include?(term_code)
+    end
+  end
+end

--- a/app/models/my_academics/merged.rb
+++ b/app/models/my_academics/merged.rb
@@ -21,6 +21,7 @@ module MyAcademics
         CanvasSites,
         FacultyDelegate,
         Grading,
+        Graduation,
         StudentLinks
       ]
     end

--- a/app/models/student_success/term_gpa.rb
+++ b/app/models/student_success/term_gpa.rb
@@ -35,13 +35,8 @@ module StudentSuccess
     end
 
     def get_active_careers
-      if (statuses = parse_hub_academic_statuses academic_status)
-        parse_hub_careers statuses
-      end
-    end
-
-    def academic_status
-      @academic_status ||= HubEdos::MyAcademicStatus.new(@student_uid_param).get_feed
+      careers = HubEdos::MyAcademicStatus.get_careers(@student_uid_param)
+      careers.collect {|c| c.try(:[], 'description') }.uniq
     end
 
     def current_term

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -247,9 +247,6 @@ cache:
 
     Advising::MyAdvising: <%= 2.hours %>
 
-    MyAcademics::CollegeAndLevel: NEXT_08_00
-    MyAcademics::GpaUnits: NEXT_08_00
-
     Berkeley::Terms: NEXT_08_00
     Berkeley::LegacyTerms: <%= 29.days %>
     Finaid::TimeRange: <%= 4.hours %>

--- a/public/dummy/json/academics.json
+++ b/public/dummy/json/academics.json
@@ -80,6 +80,19 @@
     "totalUnitsTakenNotForGpa": 3,
     "totalUnitsPassedNotForGpa": 0
   },
+  "graduation": {
+    "activeTermsWithEnrollmentAppointments": [
+      "2178",
+      "2182",
+      "2185"
+    ],
+    "lastExpectedGraduationTerm": {
+      "code": "2188",
+      "name": "Fall 2018"
+    },
+    "isNotGraduateOrLawStudent": true,
+    "appointmentsInGraduatingTerm": false
+  },
   "semesters": [
     {
       "name": "Fall 2017",

--- a/public/dummy/json/advising_student_academics.json
+++ b/public/dummy/json/advising_student_academics.json
@@ -35,6 +35,19 @@
     "totalUnits":114.3,
     "totalUnitsAttempted":38
   },
+  "graduation": {
+    "activeTermsWithEnrollmentAppointments": [
+      "2178",
+      "2182",
+      "2185"
+    ],
+    "lastExpectedGraduationTerm": {
+      "code": "2188",
+      "name": "Fall 2018"
+    },
+    "isNotGraduateOrLawStudent": true,
+    "appointmentsInGraduatingTerm": false
+  },
   "requirements":[
     {
       "name":"UC Entry Level Writing",

--- a/spec/controllers/concerns/advising_resources_spec.rb
+++ b/spec/controllers/concerns/advising_resources_spec.rb
@@ -1,18 +1,32 @@
 describe AdvisingResources do
-
   let(:empl_id) { 123 }
-  let(:student_career_code) { 'LAW' }
-  let(:student_career) do
-    {
-      'code' => student_career_code,
-      'description' => 'Law'
-    }
-  end
   let(:mock_link) { 'here is your link' }
+  let(:academic_statuses) do
+    [
+      {
+        'studentCareer' => {
+          'academicCareer' => {'code' => 'LAW', 'description' => 'Law'},
+          'fromDate' => '2017-08-09'
+        }
+      },
+      {
+        'studentCareer' => {
+          'academicCareer' => {'code' => 'UGRD', 'description' => 'Undergraduate'},
+          'fromDate' => '2011-01-12'
+        }
+      },
+      {
+        'studentCareer' => {
+          'academicCareer' => {'code' => 'GRAD', 'description' => 'Graduate'},
+          'fromDate' => '2015-02-24'
+        }
+      },
+    ]
+  end
+
   before do
     allow(User::Identifiers).to receive(:lookup_campus_solutions_id).and_return empl_id
-    # allow(MyAcademics::AcademicsModule).to receive(:parse_hub_academic_statuses).and_return {}
-    allow(MyAcademics::AcademicsModule).to receive(:newest_career).and_return student_career
+    allow(HubEdos::MyAcademicStatus).to receive(:get_statuses).and_return(academic_statuses)
     allow(LinkFetcher).to receive(:fetch_link).and_return mock_link
   end
 
@@ -26,7 +40,7 @@ describe AdvisingResources do
   describe '#lookup_student_career' do
     subject { described_class.lookup_student_career random_id }
     it 'returns the career code' do
-      expect(subject).to eq student_career_code
+      expect(subject).to eq 'LAW'
     end
   end
 

--- a/spec/models/campus_solutions/my_enrollment_term_spec.rb
+++ b/spec/models/campus_solutions/my_enrollment_term_spec.rb
@@ -1,0 +1,32 @@
+describe CampusSolutions::MyEnrollmentTerm do
+  let(:user_id) { random_id }
+  let(:term_id) { random_id }
+  let(:api_response) do
+    {
+      feed: {
+        enrollmentTerm: {
+          studentId: "1234567",
+          term: "2178"
+        }
+      }
+    }
+  end
+  describe '.get_term' do
+    context 'when feed is empty' do
+      before { allow_any_instance_of(described_class).to receive(:get_feed).and_return(nil) }
+      it 'returns nil' do
+        result = described_class.get_term(user_id, term_id)
+        expect(result).to eq nil
+      end
+    end
+    context 'when feed is populated' do
+      before { allow_any_instance_of(described_class).to receive(:get_feed).and_return(api_response) }
+      it 'returns enrollment term object' do
+        result = described_class.get_term(user_id, term_id)
+        puts "result: #{result.inspect}"
+        expect(result[:studentId]).to eq "1234567"
+        expect(result[:term]).to eq "2178"
+      end
+    end
+  end
+end

--- a/spec/models/campus_solutions/my_enrollment_terms_spec.rb
+++ b/spec/models/campus_solutions/my_enrollment_terms_spec.rb
@@ -1,0 +1,32 @@
+describe CampusSolutions::MyEnrollmentTerms do
+  let(:user_id) { random_id }
+  let(:api_response) do
+    {
+      feed: {
+        enrollmentTerms: [
+          { termId: '2178' },
+          { termId: '2168' },
+          { termId: '2172' },
+        ]
+      }
+    }
+  end
+  describe '.get_terms' do
+    context 'when feed is empty' do
+      before { allow_any_instance_of(described_class).to receive(:get_feed).and_return(nil) }
+      it 'returns nil' do
+        result = described_class.get_terms(user_id)
+        expect(result).to eq nil
+      end
+    end
+    context 'when feed is populated' do
+      before { allow_any_instance_of(described_class).to receive(:get_feed).and_return(api_response) }
+      it 'returns sorts list of term objects' do
+        result = described_class.get_terms(user_id)
+        expect(result[0][:termId]).to eq '2168'
+        expect(result[1][:termId]).to eq '2172'
+        expect(result[2][:termId]).to eq '2178'
+      end
+    end
+  end
+end

--- a/spec/models/hub_edos/my_academic_status_spec.rb
+++ b/spec/models/hub_edos/my_academic_status_spec.rb
@@ -39,50 +39,58 @@ describe HubEdos::MyAcademicStatus do
     let(:academic_status_response) do
       {
         'statusCode' => 200,
-        :feed => {
-          'student' => {
-            'academicStatuses' => [
-              {
-                'studentCareer' => {
-                  'academicCareer' => academic_career,
-                  'fromDate' => '2011-05-23'
-                },
-                'studentPlans' => academic_plans,
-                'currentRegistration' => {
-                  'term' => {
-                    'id' => '2115',
-                    'name' => '2011 Summer'
-                  },
-                  'academicCareer' => {
-                    'code' => 'UGRD',
-                    'description' => 'Undergraduate'
-                  },
-                  'eligibleToRegister' => false,
-                  'registered' => false,
-                  'disabled' => false,
-                  'athlete' => false,
-                  'intendsToGraduate' => false,
-                  'academicLevel' => {
-                    'type' => {
-                      'code' => 'Self Reported'
-                    },
-                    'level' => {
-                      'code' => '',
-                      'description' => ''
-                    }
-                  },
-                  'termUnits' => [],
-                  'termGPA' => {},
-                  'new' => true
-                }
-              }
-            ],
-            'holds' => [],
-            'awardHonors' => [],
-            'degrees' => []
-          }
-        },
+        :feed => feed,
         'studentNotFound' => nil
+      }
+    end
+    let(:roles) do
+      {
+        'fpf' => false,
+        'ugrd' => true
+      }
+    end
+    let(:feed) { {'student' => student} }
+    let(:student) do
+      {
+        'academicStatuses' => [
+          {
+            'studentCareer' => {
+              'academicCareer' => academic_career,
+              'fromDate' => '2011-05-23'
+            },
+            'studentPlans' => academic_plans,
+            'currentRegistration' => {
+              'term' => {
+                'id' => '2115',
+                'name' => '2011 Summer'
+              },
+              'academicCareer' => {
+                'code' => 'UGRD',
+                'description' => 'Undergraduate'
+              },
+              'eligibleToRegister' => false,
+              'registered' => false,
+              'disabled' => false,
+              'athlete' => false,
+              'intendsToGraduate' => false,
+              'academicLevel' => {
+                'type' => {
+                  'code' => 'Self Reported'
+                },
+                'level' => {
+                  'code' => '',
+                  'description' => ''
+                }
+              },
+              'termUnits' => [],
+              'termGPA' => {},
+              'new' => true
+            }
+          }
+        ],
+        'holds' => [],
+        'awardHonors' => [],
+        'degrees' => []
       }
     end
     let(:academic_plans) {
@@ -288,40 +296,73 @@ describe HubEdos::MyAcademicStatus do
     end
 
     context 'get roles' do
-      let(:feed) do
-        {
-          feed: {
-            'student' => student
-          }
-        }
-      end
       subject { described_class.get_roles(random_id) }
-      before { allow_any_instance_of(described_class).to receive(:get_feed_internal).and_return(feed) }
+      before { allow_any_instance_of(described_class).to receive(:get_feed_internal).and_return(response_with_merged_student_roles) }
+      let(:response_with_merged_student_roles) do
+        academic_status_response[:feed]['student']['roles'] = roles
+        academic_status_response
+      end
       context 'no feed' do
-        let(:feed) { nil }
+        let(:response_with_merged_student_roles) { nil }
         it 'returns nil' do
           expect(subject).to be_nil
         end
       end
       context 'no student present' do
-        let(:student) { nil }
+        let(:response_with_merged_student_roles) { {feed: {}} }
         it 'returns nil' do
           expect(subject).to be_nil
         end
       end
       context 'student with roles present' do
-        let(:student) do
-          {
-            'roles' => {
-              'fpf' => false
-            }
-          }
-        end
         it 'returns roles' do
           expect(subject['fpf']).to eq false
+          expect(subject['ugrd']).to eq true
         end
       end
     end
 
+    context 'get statuses' do
+      before { allow_any_instance_of(described_class).to receive(:get_feed_internal).and_return(academic_status_response) }
+      subject { described_class.get_statuses(random_id) }
+      context 'no feed' do
+        let(:academic_status_response) { nil }
+        it 'returns nil' do
+          expect(subject).to be_nil
+        end
+      end
+      context 'academic statuses present in feed' do
+        it 'returns academic statuses' do
+          expect(subject.count).to eq 1
+          expect(subject[0]['studentCareer']).to be
+          expect(subject[0]['studentPlans']).to be
+          expect(subject[0]['currentRegistration']).to be
+        end
+      end
+    end
+
+    context 'get careers' do
+      before { allow_any_instance_of(described_class).to receive(:get_feed_internal).and_return(academic_status_response) }
+      subject { described_class.get_careers(random_id) }
+      context 'no feed' do
+        let(:academic_status_response) { nil }
+        it 'returns nil' do
+          expect(subject).to be_nil
+        end
+      end
+      context 'careers present in academic statuses' do
+        let(:academic_career) {
+          {
+            'code' => 'LAW',
+            'description' => 'Bob Loblaw\'s Law Blog'
+          }
+        }
+        it 'returns careers' do
+          expect(subject.count).to eq 1
+          expect(subject[0]['code']).to eq 'LAW'
+          expect(subject[0]['description']).to eq 'Bob Loblaw\'s Law Blog'
+        end
+      end
+    end
   end
 end

--- a/spec/models/my_academics/college_and_level_spec.rb
+++ b/spec/models/my_academics/college_and_level_spec.rb
@@ -422,13 +422,6 @@ describe MyAcademics::CollegeAndLevel do
         expect(feed[:collegeAndLevel][:termsInAttendance]).to eq '2'
       end
 
-      it 'includes the farthest graduation term available from all plans' do
-        expect(feed[:collegeAndLevel][:lastExpectedGraduationTerm]).to eq({
-          code: "2202",
-          name: 'Spring 2020'
-        })
-      end
-
       it 'specifies term name' do
         expect(feed[:collegeAndLevel][:termName]).to eq 'Fall 2016'
       end

--- a/spec/models/my_academics/graduation_spec.rb
+++ b/spec/models/my_academics/graduation_spec.rb
@@ -1,0 +1,194 @@
+describe MyAcademics::Graduation do
+  def student_plan(grad_term_id, grad_term_name)
+    {
+      'expectedGraduationTerm' => {
+        'id' => grad_term_id,
+        'name' => grad_term_name
+      },
+      'statusInPlan' => {
+        'status' => {
+          'code' => 'AC'
+        }
+      }
+    }
+  end
+
+  let(:uid) { random_id }
+  let(:student_id) { random_id }
+  let(:academic_statuses) do
+    [
+      {
+        "studentPlans" => [
+          student_plan('2202', '2020 Spring'),
+          student_plan('2205', '2020 Summer'),
+        ]
+      },
+      second_career_academic_status
+    ].compact
+  end
+  let(:second_career_academic_status) do
+    {
+      "studentPlans" => [
+        student_plan('2207', '2020 Fall')
+      ]
+    }
+  end
+  let(:enrollment_terms) do
+    [
+      {:termId=>"2168", :termDescr=>"2016 Fall", :acadCareer=>"UGRD"},
+      {:termId=>"2172", :termDescr=>"2017 Spring", :acadCareer=>"UGRD"},
+      {:termId=>"2175", :termDescr=>"2017 Summer", :acadCareer=>"UGRD"}
+    ]
+  end
+  let(:enrollment_terms_to_term_map) do
+    {
+      '2168' => {
+        studentId: student_id,
+        enrollmentPeriod: fall_2016_enrollment_periods
+      },
+      '2172' => {
+        studentId: student_id,
+        enrollmentPeriod: spring_2017_enrollment_periods
+      },
+      '2175' => {
+        studentId: student_id,
+        enrollmentPeriod: summer_2017_enrollment_periods
+      },
+    }
+  end
+  let(:fall_2016_enrollment_periods) do
+    [{:id=>"phase1"}, {:id=>"phase2"}, {:id=>"adjust"}]
+  end
+  let(:spring_2017_enrollment_periods) do
+    [{:id=>"phase1"}, {:id=>"phase2"}, {:id=>"adjust"}]
+  end
+  let(:summer_2017_enrollment_periods) do
+    [{:id=>"phase1"}, {:id=>"phase2"}, {:id=>"adjust"}]
+  end
+  let(:careers) do
+    [
+      {"code"=>"UGRD", "description"=>"Undergraduate"},
+      {"code"=>"GRAD", "description"=>"Graduate"},
+      {"code"=>"LAW", "description"=>"Law"},
+    ]
+  end
+
+  subject { MyAcademics::Graduation.new(uid) }
+
+  before do
+    allow_any_instance_of(HubEdos::UserAttributes).to receive(:has_role?).and_return(true)
+    allow(HubEdos::MyAcademicStatus).to receive(:get_statuses).and_return(academic_statuses)
+    allow(CampusSolutions::MyEnrollmentTerms).to receive(:get_terms).and_return(enrollment_terms)
+    allow(CampusSolutions::MyEnrollmentTerm).to receive(:get_term) do |uid, term_id|
+      enrollment_terms_to_term_map[term_id]
+    end
+    allow(HubEdos::MyAcademicStatus).to receive(:get_careers).and_return(careers)
+  end
+
+  context 'merge' do
+    it 'adds feed data to hash' do
+      my_academics_feed = {}
+      result = subject.merge(my_academics_feed)
+      expect(result[:graduation][:lastExpectedGraduationTerm][:code]).to eq '2207'
+      expect(result[:graduation][:lastExpectedGraduationTerm][:name]).to eq 'Fall 2020'
+      expect(result[:graduation][:activeTermsWithEnrollmentAppointments]).to eq ["2168", "2172", "2175"]
+      expect(result[:graduation][:isNotGraduateOrLawStudent]).to eq false
+      expect(result[:graduation][:appointmentsInGraduatingTerm]).to eq false
+    end
+  end
+
+  context 'last expected graduation term' do
+    context 'when only single academic career status' do
+      let(:second_career_academic_status) { nil }
+      it 'returns latest expected graduation term' do
+        result = subject.get_feed
+        expect(result[:lastExpectedGraduationTerm][:code]).to eq '2205'
+        expect(result[:lastExpectedGraduationTerm][:name]).to eq 'Summer 2020'
+      end
+    end
+    context 'when multiple acdemic career statuses' do
+      it 'returns latest expected graduation term' do
+        result = subject.get_feed
+        expect(result[:lastExpectedGraduationTerm][:code]).to eq '2207'
+        expect(result[:lastExpectedGraduationTerm][:name]).to eq 'Fall 2020'
+      end
+    end
+  end
+
+  context 'active terms with enrollment appointments' do
+    context 'when no active enrollment terms' do
+      let(:enrollment_terms) { [] }
+      it 'returns no term codes' do
+        result = subject.get_feed
+        expect(result[:activeTermsWithEnrollmentAppointments].count).to eq 0
+      end
+    end
+    context 'when all enrollment terms have appointments' do
+      it 'returns all term codes' do
+        result = subject.get_feed
+        expect(result[:activeTermsWithEnrollmentAppointments]).to eq ["2168", "2172", "2175"]
+      end
+    end
+    context 'when some enrollment terms have appointments' do
+      let(:summer_2017_enrollment_periods) { [] }
+      it 'returns some term codes' do
+        result = subject.get_feed
+        expect(result[:activeTermsWithEnrollmentAppointments]).to eq ["2168", "2172"]
+      end
+    end
+  end
+
+  context 'is not graduate or law career student' do
+    subject { MyAcademics::Graduation.new(uid).get_feed.try(:[], :isNotGraduateOrLawStudent) }
+    context 'when no careers present' do
+      let(:careers) { [] }
+    end
+    context 'when graduate career present' do
+      let(:careers) do
+        [
+          {"code"=>"UGRD", "description"=>"Undergraduate"},
+          {"code"=>"GRAD", "description"=>"Graduate"},
+        ]
+      end
+      it 'returns false' do
+        expect(subject).to eq false
+      end
+    end
+    context 'when law career present' do
+      let(:careers) do
+        [
+          {"code"=>"UGRD", "description"=>"Undergraduate"},
+          {"code"=>"LAW", "description"=>"Law"},
+        ]
+      end
+      it 'returns false' do
+        expect(subject).to eq false
+      end
+    end
+    context 'when no law or graduate career present' do
+      let(:careers) { [{"code"=>"UGRD", "description"=>"Undergraduate"}] }
+      it 'returns true' do
+        expect(subject).to eq true
+      end
+    end
+  end
+
+  context 'indicating if student has enrollment appointments in their expected graduation term' do
+    subject { MyAcademics::Graduation.new(uid).appointmentsInGraduatingTerm(last_expected_graduation_term, terms_with_appointments) }
+    context 'when no enrollment appointments in expected graduation term' do
+      let(:last_expected_graduation_term) { {:code=>"2178", :name=>"Fall 2017"} }
+      let(:terms_with_appointments) { ['2172', '2175'] }
+      it 'returns false' do
+        expect(subject).to eq false
+      end
+    end
+    context 'when enrollment appointments in expected graduation term are present' do
+      let(:last_expected_graduation_term) { {:code=>"2178", :name=>"Fall 2017"} }
+      let(:terms_with_appointments) { ['2175', '2178'] }
+      it 'returns true' do
+        expect(subject).to eq true
+      end
+    end
+  end
+
+end

--- a/spec/models/my_academics/merged_spec.rb
+++ b/spec/models/my_academics/merged_spec.rb
@@ -7,7 +7,11 @@ describe MyAcademics::Merged do
       MyAcademics::Teaching,
       MyAcademics::TransferCredit,
       MyAcademics::Exams,
-      MyAcademics::CanvasSites
+      MyAcademics::CanvasSites,
+      MyAcademics::FacultyDelegate,
+      MyAcademics::Grading,
+      MyAcademics::Graduation,
+      MyAcademics::StudentLinks
     ]
   end
 

--- a/spec/models/student_success/term_gpa_spec.rb
+++ b/spec/models/student_success/term_gpa_spec.rb
@@ -1,5 +1,5 @@
 describe StudentSuccess::TermGpa do
-
+  let(:user_id) { '61889' }
   context 'a mock proxy' do
     before do
       allow(Settings.campus_solutions_proxy).to receive(:fake).and_return true
@@ -7,7 +7,7 @@ describe StudentSuccess::TermGpa do
       allow(Berkeley::Terms.fetch).to receive(:current).and_return 2142
     end
     context 'correctly parses the feed' do
-      let(:subject) { StudentSuccess::TermGpa.new(user_id: 61889).merge }
+      let(:subject) { StudentSuccess::TermGpa.new(user_id: user_id).merge }
       it 'returns data in an array' do
         expect(subject).to be_an Array
       end
@@ -18,6 +18,23 @@ describe StudentSuccess::TermGpa do
           expect(term[:termGpaUnits]).not_to equal (0)
         end
       end
+    end
+  end
+
+  context 'get_active_careers' do
+    let(:subject) { StudentSuccess::TermGpa.new(user_id: user_id) }
+    let(:careers) do
+      [
+        {"code"=>"GRAD", "description"=>"Graduate"},
+        {"code"=>"LAW", "description"=>"Law"},
+        {"code"=>"GRAD", "description"=>"Graduate"},
+      ]
+    end
+    before do
+      allow(HubEdos::MyAcademicStatus).to receive(:get_careers).and_return careers
+    end
+    it 'return unique career descriptions' do
+      expect(subject.get_active_careers).to eq ['Graduate', 'Law']
     end
   end
 

--- a/src/assets/javascripts/angular/controllers/pages/academicSummaryController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicSummaryController.js
@@ -9,7 +9,7 @@ angular.module('calcentral.controllers').controller('AcademicSummaryController',
   $scope.academicSummary = {
     isLoading: true
   };
-  $scope.expectedGradTerm = academicsService.expectedGradTerm;
+  $scope.expectedGradTermName = academicsService.expectedGradTermName;
   $scope.printPage = function() {
     apiService.util.printPage();
   };

--- a/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
+++ b/src/assets/javascripts/angular/controllers/pages/userOverviewController.js
@@ -9,7 +9,7 @@ var _ = require('lodash');
 angular.module('calcentral.controllers').controller('UserOverviewController', function(academicsService, adminService, advisingFactory, apiService, enrollmentVerificationFactory, linkService, statusHoldsService, $route, $routeParams, $scope) {
   linkService.addCurrentRouteSettings($scope);
 
-  $scope.expectedGradTerm = academicsService.expectedGradTerm;
+  $scope.expectedGradTermName = academicsService.expectedGradTermName;
   $scope.academics = {
     isLoading: true,
     excludeLinksToRegistrar: true

--- a/src/assets/javascripts/angular/controllers/widgets/academicProfileController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/academicProfileController.js
@@ -7,5 +7,5 @@ var angular = require('angular');
  */
 angular.module('calcentral.controllers').controller('AcademicProfileController', function(academicsService, $scope) {
   $scope.profilePicture = {};
-  $scope.expectedGradTerm = academicsService.expectedGradTerm;
+  $scope.expectedGradTermName = academicsService.expectedGradTermName;
 });

--- a/src/assets/javascripts/angular/services/academicsService.js
+++ b/src/assets/javascripts/angular/services/academicsService.js
@@ -45,19 +45,6 @@ angular.module('calcentral.services').service('academicsService', function() {
     return count;
   };
 
-  /**
-   * Returns last expected graduation term name when student is not an undergrad
-   * @param  {Object} collegeAndLevel College And Level node of My Academics feed
-   * @return {String}                 Name for graduation term
-   */
-  var expectedGradTerm = function(collegeAndLevel) {
-    var careers = _.get(collegeAndLevel, 'careers');
-    if (isNotGradOrLawStudent(careers) && collegeAndLevel.lastExpectedGraduationTerm) {
-      return collegeAndLevel.lastExpectedGraduationTerm.name;
-    }
-    return '';
-  };
-
   var filterBySectionSlug = function(course, sectionSlug) {
     if (!course.multiplePrimaries) {
       return null;
@@ -197,14 +184,18 @@ angular.module('calcentral.services').service('academicsService', function() {
   };
 
   /**
-   * Returns true if student is not a Graduate or Law student
+   * Returns expected graduation term name if student is not a graduate or law student
+   * @param  {Object} graduation      Graduation node of My Academics feed
+   * @return {String}                 expected graduation term name string
    */
-  var isNotGradOrLawStudent = function(careers) {
-    if (_.get(careers, 'length')) {
-      var matches = _.intersection(careers, ['Graduate', 'Law']);
-      return matches.length === 0;
+  var expectedGradTermName = function(graduation) {
+    var lastExpectedGraduationTermName = _.get(graduation, 'lastExpectedGraduationTerm.name');
+    var isNotGraduateOrLawStudent = _.get(graduation, 'isNotGraduateOrLawStudent');
+    if (isNotGraduateOrLawStudent && lastExpectedGraduationTermName) {
+      return lastExpectedGraduationTermName;
+    } else {
+      return '';
     }
-    return false;
   };
 
   var normalizeGradingData = function(course) {
@@ -331,7 +322,7 @@ angular.module('calcentral.services').service('academicsService', function() {
     containsLawClass: containsLawClass,
     containsMidpointClass: containsMidpointClass,
     countSectionItem: countSectionItem,
-    expectedGradTerm: expectedGradTerm,
+    expectedGradTermName: expectedGradTermName,
     filterBySectionSlug: filterBySectionSlug,
     findSemester: findSemester,
     getAllClasses: getAllClasses,

--- a/src/assets/templates/widgets/academic_summary/academic_summary_student_profile.html
+++ b/src/assets/templates/widgets/academic_summary/academic_summary_student_profile.html
@@ -93,12 +93,16 @@
       <tr>
         <th class="cc-academic-summary-row-title"><h4>Terms</h4></th>
         <th class="cc-academic-summary-row-header" data-ng-if="collegeAndLevel.termsInAttendance">Terms in Attendance</th>
-        <th class="cc-academic-summary-row-header" data-ng-if="expectedGradTerm(collegeAndLevel)">Expected Graduation</th>
+        <th class="cc-academic-summary-row-header" data-ng-if="expectedGradTermName(graduation)">Expected Graduation</th>
       </tr>
       <tr>
         <td></td>
-        <td data-ng-if="collegeAndLevel.termsInAttendance"><span data-ng-bind="collegeAndLevel.termsInAttendance"></span></td>
-        <td data-ng-if="expectedGradTerm(collegeAndLevel)"><span data-ng-bind="expectedGradTerm(collegeAndLevel)"></span></td>
+        <td data-ng-if="collegeAndLevel.termsInAttendance">
+          <span data-ng-bind="collegeAndLevel.termsInAttendance"></span>
+        </td>
+        <td data-ng-if="expectedGradTermName(graduation)">
+          <span data-ng-bind="expectedGradTermName(graduation)"></span>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/src/assets/templates/widgets/academics/college_and_level.html
+++ b/src/assets/templates/widgets/academics/college_and_level.html
@@ -52,13 +52,21 @@
               <strong data-ng-bind="collegeAndLevel.termsInAttendance"></strong>
             </div>
           </div>
-          <div class="cc-widget-profile-section-block" data-ng-if="expectedGradTerm(collegeAndLevel)">
+          <div class="cc-widget-profile-section-block" data-ng-if="expectedGradTermName(graduation)">
             <div class="cc-text-light">Expected Graduation</div>
             <div>
-              <strong data-ng-bind="expectedGradTerm(collegeAndLevel)"></strong>
+              <i class="fa fa-clock-o cc-icon-grey" data-ng-if="graduation.appointmentsInGraduatingTerm"></i>
+              <strong data-ng-bind="graduation.lastExpectedGraduationTerm.name"></strong>
             </div>
             <div class="cc-widget-profile-footnote">
-              Consult your college advisor with questions or concerns.
+              <span data-ng-if="graduation.appointmentsInGraduatingTerm">
+                <span data-ng-bind="graduation.lastExpectedGraduationTerm.name"></span>
+                will be your final term to complete all degree requirements.
+                If you have questions, please contact your College Advisor.
+              </span>
+              <span data-ng-if="!graduation.appointmentsInGraduatingTerm">
+                Consult your college advisor with questions or concerns.
+              </span>
             </div>
           </div>
         </td>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-31687

* Migrates parsing logic to class methods in HubEdos::MyAcademicStatus
* Implements cacheing wrapper models for CampusSolutions::EnrollmentTerms (CampusSolutions::MyEnrollmentTerms) and CampusSolutions::EnrollmentTerm (CampusSolutions::MyEnrollmentTerm), extended by some logic for shared parsing
* Migrates academic status parsing from MyAcademics::AcademicsModule to HubEdos::MyAcademicStatus for shared use
* Updates career parsing to include career objects, for better matching on career codes (rather than names which are subject to change)
* Adds MyAcademics::Graduation model with support for merging into MyAcademics::Merged and related feeds (MyAcademics::FilteredForAdvisor), as well as serving cached data objects directly (for future use by My Dashboard - Graduation card)
** Moves front-end career logic (show Expected Graduation Date only to non-Grad and non-Law) to back-end with tests in new Graduation model
* Front-end updates as per Profile card design
