### PR TITLE
SISRP-34542 - Refactors academic roles to handle multiple roles

### DIFF
--- a/app/models/berkeley/academic_roles.rb
+++ b/app/models/berkeley/academic_roles.rb
@@ -4,49 +4,47 @@ module Berkeley
 
     # Role(s) assigned to a user if they are in an academic plan associated with that role.
     ACADEMIC_PLAN_ROLES = [
-      {role_code: 'fpf', match: ['25000FPFU'], types: [:enrollment]},
-      {role_code: 'haasFullTimeMba', match: ['70141MBAG'], types: [:enrollment]},
-      {role_code: 'haasEveningWeekendMba', match: ['701E1MBAG'], types: [:enrollment]},
-      {role_code: 'haasExecMba', match: ['70364MBAG'], types: [:enrollment]},
-      {role_code: 'haasMastersFinEng', match: ['701F1MFEG'], types: []},
-      {role_code: 'haasMbaPublicHealth', match: ['70141BAPHG'], types: []},
-      {role_code: 'haasMbaJurisDoctor', match: ['70141BAJDG'], types: []},
-      {role_code: 'ugrdUrbanStudies', match: ['19912U'], types: []},
+      {role_code: 'fpf', match: ['25000FPFU']},
+      {role_code: 'haasFullTimeMba', match: ['70141MBAG']},
+      {role_code: 'haasEveningWeekendMba', match: ['701E1MBAG']},
+      {role_code: 'haasExecMba', match: ['70364MBAG']},
+      {role_code: 'haasMastersFinEng', match: ['701F1MFEG']},
+      {role_code: 'haasMbaPublicHealth', match: ['70141BAPHG']},
+      {role_code: 'haasMbaJurisDoctor', match: ['70141BAJDG']},
+      {role_code: 'ugrdUrbanStudies', match: ['19912U']},
       {
         role_code: 'summerVisitor',
         match: %w(99000U 99000INTU 99000G 99000INTG 99V03U 99V04U 99V05U 99V09U 99V03G 99V05G 99V06G 99V07G 99V08G 99V10G 99V06U 99V07U 99V08U 99V10U 99V02G 99V04G 99V09G),
-        types: [:enrollment]
       },
       {
         role_code: 'courseworkOnly',
         match: %w(00014CWOG 00051CWOG 00059CWOG 00063CWOG 00072CWOG 00086CWOG 00090CWOG 00096CWOG 00101CWOG 00126CWOG 00139CWOG 00168CWOG 00174CWOG 00192CWOG 00213CWOG 00239CWOG 00246CWOG 00270CWOG 002A4CWOG 002A5CWOG 002A6CWOG 002C3CWOG 002C7CWOG 002D0CWOG 002E3CWOG 00345CWOG 00360CWOG 00366CWOG 00368CWOG 00387CWOG 00396CWOG 00408CWOG 00424CWOG 00425CWOG 00428CWOG 00429CWOG 00430CWOG 00469CWOG 00470CWOG 00479CWOG 00482CWOG 00498CWOG 00510CWOG 00531CWOG 00540CWOG 00553CWOG 00570CWOG 00579CWOG 00591CWOG 00592CWOG 00594CWOG 00621CWOG 00651CWOG 00666CWOG 00699CWOG 00780CWOG 00807CWOG 00812CWOG 00838CWOG 00843CWOG 00848CWOG 00849CWOG 00867CWOG 00877CWOG 00882CWOG 00891CWOG 00974CWOG 00975CWOG 009B2CWOG 04034CWOG 04189CWOG 042C5CWOG 04380CWOG 04680CWOG 04683CWOG 04798CWOG 10153CWOG 10294CWOG 16201CWOG 16275CWOG 16288CWOG 16290CWOG 16292CWOG 16295CWOG 16298CWOG 162C8CWOG 16328CWOG 16334CWOG 19084CWOG 19165CWOG 19222CWOG 19489CWOG 194A9CWOG 19920CWOG 30FPFU 70141CWOG 71483CWOG 79249CWOG 79892CWOG 81776CWOG 82790CWOG 86864CWOG 91612CWOG 91613C89G 91935CWOG 96132CWOG 96354CWOG 96357CWOG 96789CWOG),
-        types: [:enrollment]
       },
     ]
 
     # Role(s) assigned to a user if they are in a program associated with that role.
     ACADEMIC_PROGRAM_ROLES = [
-      {role_code: 'lettersAndScience', match: ['UCLS'], types: []}
+      {role_code: 'lettersAndScience', match: ['UCLS']}
     ]
 
     # Role(s) assigned to a user if they are in a career associated with that role.
     ACADEMIC_CAREER_ROLES = [
-      {role_code: 'ugrd', match: ['UGRD'], types: []},
-      {role_code: 'grad', match: ['GRAD'], types: [:enrollment]},
-      {role_code: 'law', match: ['LAW'], types: [:enrollment]},
-      {role_code: 'concurrent', match: ['UCBX'], types: [:enrollment]}
+      {role_code: 'ugrd', match: ['UGRD']},
+      {role_code: 'grad', match: ['GRAD']},
+      {role_code: 'law', match: ['LAW']},
+      {role_code: 'concurrent', match: ['UCBX']}
     ]
 
-    def get_academic_plan_role_code(plan_code, type = nil)
-      get_role_code(ACADEMIC_PLAN_ROLES, plan_code, type)
+    def get_academic_plan_role_code(plan_code)
+      get_role_code(ACADEMIC_PLAN_ROLES, plan_code)
     end
 
-    def get_academic_program_role_code(program_code, type = nil)
-      get_role_code(ACADEMIC_PROGRAM_ROLES, program_code, type)
+    def get_academic_program_role_code(program_code)
+      get_role_code(ACADEMIC_PROGRAM_ROLES, program_code)
     end
 
-    def get_academic_career_role_code(career_code, type = nil)
-      get_role_code(ACADEMIC_CAREER_ROLES, career_code, type)
+    def get_academic_career_role_code(career_code)
+      get_role_code(ACADEMIC_CAREER_ROLES, career_code)
     end
 
     def role_defaults
@@ -55,13 +53,11 @@ module Berkeley
 
     private
 
-    def get_role_code(roles, academic_code, type = nil)
-      role_codes = roles.select do |matcher|
-        is_match = matcher[:match].include?(academic_code)
-        is_type = type.blank? || matcher[:types].include?(type.to_sym)
-        is_match && is_type
+    def get_role_code(roles, academic_code)
+      matched_role_codes = roles.select do |matcher|
+        matcher[:match].include?(academic_code)
       end
-      role_codes.empty? ? nil : role_codes.first[:role_code]
+      matched_role_codes.empty? ? nil : matched_role_codes.first[:role_code]
     end
 
     def role_codes

--- a/app/models/my_academics/academics_module.rb
+++ b/app/models/my_academics/academics_module.rb
@@ -48,13 +48,12 @@ module MyAcademics
       newest_career_status.try(:[], 'studentCareer').try(:[], 'academicCareer')
     end
 
-    def filter_inactive_status_plans(statuses)
-      statuses.each do |status|
-        status['studentPlans'].select! do |plan|
-          plan.try(:[], 'statusInPlan').try(:[], 'status').try(:[], 'code') == 'AC'
-        end
-      end
-      statuses
+    def active?(plan)
+      plan.try(:[], 'statusInPlan').try(:[], 'status').try(:[], 'code') == 'AC'
+    end
+
+    def has_holds?(holds)
+      holds.to_a.length > 0
     end
 
     def course_info(campus_course)

--- a/app/models/my_academics/college_and_level.rb
+++ b/app/models/my_academics/college_and_level.rb
@@ -53,7 +53,7 @@ module MyAcademics
       holds = {hasHolds: false}
       holds_feed = response[:feed] && response[:feed]['student'] && response[:feed]['student']['holds']
       if holds_feed.present?
-        holds[:hasHolds] = true if holds_feed.to_a.length > 0
+        holds[:hasHolds] = has_holds?(holds_feed)
       end
       holds
     end
@@ -152,6 +152,15 @@ module MyAcademics
       end
     end
 
+    def filter_inactive_status_plans(statuses)
+      statuses.each do |status|
+        status['studentPlans'].select! do |plan|
+          active? plan
+        end
+      end
+      statuses
+    end
+
     def parse_hub_term_name(term)
       if term
         term['name'] = Berkeley::TermCodes.normalized_english term.try(:[], 'name')
@@ -207,7 +216,6 @@ module MyAcademics
           }
         end
         flat_plan[:role] = hub_plan[:role]
-        flat_plan[:enrollmentRole] = hub_plan[:enrollmentRole]
         flat_plan[:primary] = !!hub_plan['primary']
         flat_plan[:type] = categorize_plan_type(academic_plan['type'])
 

--- a/app/models/my_academics/graduation.rb
+++ b/app/models/my_academics/graduation.rb
@@ -25,10 +25,9 @@ module MyAcademics
     def last_expected_graduation_term
       expected_graduation_term = { code: nil, name: nil }
       if (statuses = HubEdos::MyAcademicStatus.get_statuses(@uid))
-        filtered_statuses = filter_inactive_status_plans(statuses)
-        filtered_statuses.each do |status|
+        statuses.each do |status|
           Array.wrap(status.try(:[], 'studentPlans')).each do |plan|
-            current_expected_graduation_term = get_expected_graduation_term(plan)
+            current_expected_graduation_term = get_expected_graduation_term(plan) if MyAcademics::AcademicsModule.active? plan
 
             # Catch Last Expected Graduation Date
             if (expected_graduation_term.try(:[], :code).to_i < current_expected_graduation_term.try(:[], :code).to_i)

--- a/public/dummy/json/academics.json
+++ b/public/dummy/json/academics.json
@@ -53,7 +53,6 @@
         },
         "subPlan": {},
         "role": "ugrdUrbanStudies",
-        "enrollmentRole": "default",
         "primary": true,
         "type": {
           "code": "MAJ",

--- a/public/dummy/json/enrollment_instructions.json
+++ b/public/dummy/json/enrollment_instructions.json
@@ -54,7 +54,6 @@
                 "description": "Undergraduate"
               },
               "college": "Undergrad Natural Resources",
-              "enrollmentRole": "default",
               "expectedGraduationTerm": {
                 "code": "2192",
                 "name": "Spring 2019"
@@ -94,7 +93,6 @@
                 "description": "Undergraduate"
               },
               "college": "Undergrad Natural Resources",
-              "enrollmentRole": "default",
               "expectedGraduationTerm": {
                 "code": "2192",
                 "name": "Spring 2019"
@@ -134,7 +132,6 @@
                 "description": "Undergraduate"
               },
               "college": "Undergrad Natural Resources",
-              "enrollmentRole": "default",
               "expectedGraduationTerm": {
                 "code": "2192",
                 "name": "Spring 2019"

--- a/spec/models/berkeley/academic_roles_spec.rb
+++ b/spec/models/berkeley/academic_roles_spec.rb
@@ -1,25 +1,14 @@
 describe Berkeley::AcademicRoles do
-  let(:type) { nil }
 
   shared_examples 'a map of academic status codes to roles' do
     it 'includes plans and career matchers' do
       expect(subject.count).to_not eq 0
     end
 
-    it 'defines type code and match string for each matcher' do
+    it 'defines role code and match string for each matcher' do
       subject.each do |matcher|
         expect(matcher).to have_key(:role_code)
         expect(matcher).to have_key(:match)
-      end
-    end
-
-    it 'includes types array' do
-      subject.each do |matcher|
-        expect(matcher).to have_key(:types)
-        expect(matcher[:types]).to be_an Array
-        matcher[:types].each do |type|
-          expect(type).to be_a Symbol
-        end
       end
     end
   end
@@ -29,7 +18,6 @@ describe Berkeley::AcademicRoles do
       let(:code) { nil }
       it { should be nil }
     end
-
     context 'when code is not mapped' do
       let(:code) { 'BUNK' }
       it { should be nil }
@@ -38,7 +26,6 @@ describe Berkeley::AcademicRoles do
 
   context 'when defining plan roles' do
     subject { described_class::ACADEMIC_PLAN_ROLES }
-
     it_behaves_like 'a map of academic status codes to roles'
   end
 
@@ -50,43 +37,21 @@ describe Berkeley::AcademicRoles do
 
   context 'when defining career roles' do
     subject { described_class::ACADEMIC_CAREER_ROLES }
-
     it_behaves_like 'a map of academic status codes to roles'
   end
 
   describe '#get_academic_plan_role_code' do
-    subject { described_class.get_academic_plan_role_code(code, type) }
-
+    subject { described_class.get_academic_plan_role_code code }
     it_behaves_like 'a translator that returns the role corresponding to an academic status'
 
     context 'when a match is found' do
       let(:code) { '99V06G' }
       it { should eq 'summerVisitor' }
     end
-
-    context 'when looking for a type-specific role' do
-      let(:type) { :enrollment }
-
-      context 'when no type match is found for this code' do
-        let(:code) { '701F1MFEG' }
-        it { should be nil }
-      end
-
-      context 'when a match is found' do
-        let(:code) { '25000FPFU' }
-        it { should eq 'fpf' }
-      end
-
-      context 'when type is not mapped' do
-        let(:type) { :garbage }
-        let(:code) { '25000FPFU' }
-        it { should be nil }
-      end
-    end
   end
 
   describe '#get_academic_program_role_code' do
-    subject { described_class.get_academic_program_role_code(code, type) }
+    subject { described_class.get_academic_program_role_code(code) }
 
     it_behaves_like 'a translator that returns the role corresponding to an academic status'
 
@@ -97,34 +62,17 @@ describe Berkeley::AcademicRoles do
   end
 
   describe '#get_academic_career_role_code' do
-    subject { described_class.get_academic_career_role_code(code, type) }
-
+    subject { described_class.get_academic_career_role_code(code) }
     it_behaves_like 'a translator that returns the role corresponding to an academic status'
 
     context 'when a match is found' do
       let(:code) { 'LAW' }
       it { should eq 'law' }
     end
-
-    context 'when looking for a type-specific role' do
-      let(:type) { :enrollment }
-
-      context 'when a match is found' do
-        let(:code) { 'UCBX' }
-        it { should eq 'concurrent' }
-      end
-
-      context 'when type is not mapped' do
-        let(:type) { :garbage }
-        let(:code) { 'UCBX' }
-        it { should be nil }
-      end
-    end
   end
 
   describe '#role_defaults' do
     subject { described_class.role_defaults }
-
     it 'returns all possible roles set to false' do
       expect(subject.keys.count).to eq (15)
       expect(subject['ugrd']).to eq false
@@ -144,4 +92,4 @@ describe Berkeley::AcademicRoles do
       expect(subject['courseworkOnly']).to eq false
     end
   end
-  end
+end

--- a/spec/models/my_academics/class_enrollments_spec.rb
+++ b/spec/models/my_academics/class_enrollments_spec.rb
@@ -20,101 +20,118 @@ describe MyAcademics::ClassEnrollments do
       waitlistedClassesTotalUnits: 2.0,
     }
   end
-  let(:college_and_level_feed) do
+  let(:academic_status_feed) do
     {
-      collegeAndLevel: {
-        statusCode: 200,
-        studentNotFound: nil,
-        holds: college_and_level_holds,
-        careers: ["Undergraduate"],
-        level: "Senior",
-        termName: "Fall 2016",
-        termsInAttendance: "3",
-        majors: college_and_level_majors,
-        minors: college_and_level_minors,
-        plans: college_and_level_plans,
-        lastExpectedGraduationTerm: college_and_level_last_expected_grad_term,
-        isCurrent: true
+      feed: {
+        'student'=> {
+          'holds'=> holds,
+          'academicStatuses'=> academic_statuses
+        }
       }
     }
   end
-  let(:college_and_level_holds) { { hasHolds: false } }
-  let(:college_and_level_majors) { [undergrad_nutritional_science_major] }
-  let(:college_and_level_minors) { [] }
-  let(:college_and_level_last_expected_grad_term) { { code: nil, description: nil, name: nil} }
-  let(:college_and_level_plans) { [undergrad_nutritional_science_plan] }
-  let(:undergrad_nutritional_science_major) do
-    {:college=>"Undergrad Natural Resources", :major=>"Nutritional Science BS"}
+  let(:holds) { [] }
+  let(:academic_statuses) { [] }
+  let(:student_plans) { [undergrad_nutritional_science_plan] }
+  let(:undergrad_career) do
+    {
+      'academicCareer' => { 'code' => 'UGRD', 'description' => 'Undergraduate' },
+      :role => 'ugrd'
+    }
+  end
+  let(:grad_career) do
+    {
+      'academicCareer' => { 'code' => 'GRAD', 'description' => 'Graduate' },
+      :role => 'grad'
+    }
+  end
+  let(:law_career) do
+    {
+      'academicCareer' => { 'code' => 'LAW', 'description' => 'Law' },
+      :role => 'law'
+    }
   end
   let(:undergrad_nutritional_science_plan) do
     {
-      career: { code: "UGRD", description: "Undergraduate" },
-      program: { code: "UCNR", description: "Undergrad Natural Resources" },
-      plan: { code: "04606U", description: "Nutritional Science BS" },
-      type: { code: "MAJ", description: "Major - Regular Acad/Prfnl", category: "Major" },
-      college: "Undergrad Natural Resources",
-      role: "default",
-      enrollmentRole: "default",
+      career: undergrad_career,
+      program: { code: 'UCNR', description: 'Undergrad Natural Resources' },
+      plan: { code: '04606U', description: 'Nutritional Science BS' },
+      type: { code: 'MAJ', description: 'Major - Regular Acad/Prfnl', category: 'Major' },
+      college: 'Undergrad Natural Resources',
+      role: nil,
+      statusInPlan: {
+        status: { code: 'AC' }
+      },
       primary: true,
     }
   end
   let(:undergrad_computer_science_plan) do
     {
-      career: { code: "UGRD", description: "Undergraduate" },
-      program: { code: "UCLS", description: "Undergrad Letters & Science" },
-      plan: { code: "25201U", description: "Computer Science BA" },
-      type: { code: "MAJ", description: "Major - Regular Acad/Prfnl", category: "Major" },
-      college: "Undergrad Letters & Science",
-      role: "default",
-      enrollmentRole: "default",
+      career: undergrad_career,
+      program: { code: 'UCLS', description: 'Undergrad Letters & Science' },
+      plan: { code: '25201U', description: 'Computer Science BA' },
+      type: { code: 'MAJ', description: 'Major - Regular Acad/Prfnl', category: 'Major' },
+      college: 'Undergrad Letters & Science',
+      role: nil,
+      statusInPlan: {
+        status: { code: 'AC' }
+      },
       primary: true,
     }
   end
   let(:undergrad_cognitive_science_plan) do
     {
-      career: { code: "UGRD", description: "Undergraduate" },
-      program: { code: "UCLS", description: "Undergrad Letters & Science" },
-      plan: { code: "25179U", description: "Cognitive Science BA" },
-      type: { code: "MAJ", description: "Major - Regular Acad/Prfnl", category: "Major"},
-      college: "Undergrad Letters & Science",
-      role: "default",
-      enrollmentRole: "default",
+      career: undergrad_career,
+      program: { code: 'UCLS', description: 'Undergrad Letters & Science' },
+      plan: { code: '25179U', description: 'Cognitive Science BA' },
+      type: { code: 'MAJ', description: 'Major - Regular Acad/Prfnl', category: 'Major'},
+      college: 'Undergrad Letters & Science',
+      role: nil,
+      statusInPlan: {
+        status: { code: 'AC' }
+      },
       primary: true,
     }
   end
   let(:undergrad_fall_program_for_freshmen_plan) do
     {
-      career: { code: "UGRD", description: "Undergraduate" },
-      program: { code: "UCLS", description: "Undergrad Letters & Science" },
-      plan: { code: "25000FPFU", description: "L&S Undcl Fall Pgm Freshmen UG" },
-      type: { code: "MAJ", description: "Major - Regular Acad/Prfnl", category: "Major"},
-      college: "Undergrad Letters & Science",
-      role: "fpf",
-      enrollmentRole: "fpf",
+      career: undergrad_career,
+      program: { code: 'UCLS', description: 'Undergrad Letters & Science' },
+      plan: { code: '25000FPFU', description: 'L&S Undcl Fall Pgm Freshmen UG' },
+      type: { code: 'MAJ', description: 'Major - Regular Acad/Prfnl', category: 'Major'},
+      college: 'Undergrad Letters & Science',
+      role: 'fpf',
+      statusInPlan: {
+        status: { code: 'AC' }
+      },
       primary: true,
     }
   end
   let(:graduate_electrical_engineering_plan) do
     {
-      career: { code: "GRAD", description: "Graduate" },
-      program: { code: "GACAD", description: "Graduate Academic Programs" },
-      plan: { code: "16290PHDG", description: "Electrical Eng & Comp Sci PhD" },
-      type: { code: "MAJ", description: "Major - Regular Acad/Prfnl", category: "Major" },
-      college: "Graduate Academic Programs",
-      role: "default",
-      enrollmentRole: "default",
+      career: grad_career,
+      program: { code: 'GACAD', description: 'Graduate Academic Programs' },
+      plan: { code: '16290PHDG', description: 'Electrical Eng & Comp Sci PhD' },
+      type: { code: 'MAJ', description: 'Major - Regular Acad/Prfnl', category: 'Major' },
+      college: 'Graduate Academic Programs',
+      role: nil,
+      statusInPlan: {
+        status: { code: 'AC' }
+      },
       primary: true,
     }
   end
   let(:law_jsp_plan) do
     {
-      career: { code: "LAW", description: "Law" },
-      program: { code: "LACAD", description: "Law Academic Programs" },
-      plan: { code: "84485PHDG", description: "JSP PhD" },
-      type: { code: "MAJ", description: "Major - Regular Acad/Prfnl", category: "Major" },
-      college: "Law Academic Programs",
-      role: "law",
-      enrollmentRole: "law",
+      career: law_career,
+      program: { code: 'LACAD', description: 'Law Academic Programs' },
+      plan: { code: '84485PHDG', description: 'JSP PhD' },
+      type: { code: 'MAJ', description: 'Major - Regular Acad/Prfnl', category: 'Major' },
+      college: 'Law Academic Programs',
+      role: nil,
+      statusInPlan: {
+        status: { code: 'AC' }
+      },
       primary: true,
     }
   end
@@ -135,9 +152,7 @@ describe MyAcademics::ClassEnrollments do
   before do
     allow(subject).to receive(:is_feature_enabled).and_return(is_feature_enabled_flag)
     allow(subject).to receive(:user_is_student?).and_return(user_is_student)
-    allow_any_instance_of(MyAcademics::CollegeAndLevel).to receive(:merge) do |feed_hash|
-      feed_hash.merge!(college_and_level_feed)
-    end
+    allow_any_instance_of(HubEdos::MyAcademicStatus).to receive(:get_feed).and_return(academic_status_feed)
     allow(CampusSolutions::MyEnrollmentTerms).to receive(:get_terms).and_return(cs_enrollment_career_terms)
     allow(CampusSolutions::MyEnrollmentTerm).to receive(:get_term) do |uid, term_id|
       cs_enrollment_term_detail.merge({:term => term_id})
@@ -159,7 +174,11 @@ describe MyAcademics::ClassEnrollments do
     end
 
     context 'when the user is a student' do
-      let(:college_and_level_plans) { [undergrad_computer_science_plan] }
+      let(:academic_statuses) do
+        [
+          { 'studentCareer'=> undergrad_career, 'studentPlans'=> [undergrad_computer_science_plan] }
+        ]
+      end
       let(:cs_enrollment_career_terms) { [{ termId: '2168', termDescr: '2016 Fall', acadCareer: 'UGRD' }] }
       let(:user_is_student) { true }
       let(:feed) { subject.get_feed }
@@ -202,13 +221,12 @@ describe MyAcademics::ClassEnrollments do
   context 'when determining the users hold status' do
     let(:user_holds_status) { subject.user_has_holds? }
     context 'when no holds present' do
-      let(:college_and_level_holds) { { hasHolds: false } }
       it 'should return false' do
         expect(user_holds_status).to eq false
       end
     end
     context 'when holds are present' do
-      let(:college_and_level_holds) { { hasHolds: true } }
+      let(:holds) { ['a hold'] }
       it 'should return true' do
         expect(user_holds_status).to eq true
       end
@@ -217,7 +235,13 @@ describe MyAcademics::ClassEnrollments do
 
   context 'when grouping student plans by role' do
     let(:student_plan_roles) { subject.grouped_student_plan_roles }
-    let(:college_and_level_plans) { [undergrad_computer_science_plan, graduate_electrical_engineering_plan, law_jsp_plan] }
+    let(:academic_statuses) do
+      [
+        { 'studentCareer'=> undergrad_career, 'studentPlans'=> [undergrad_computer_science_plan] },
+        { 'studentCareer'=> grad_career, 'studentPlans'=> [graduate_electrical_engineering_plan] },
+        { 'studentCareer'=> law_career, 'studentPlans'=> [law_jsp_plan] }
+      ]
+    end
     it 'groups plans by role and career code' do
       expect(student_plan_roles[:data]).to have_keys([ ['default','UGRD'], ['default','GRAD'], ['law','LAW'] ])
     end
@@ -245,7 +269,13 @@ describe MyAcademics::ClassEnrollments do
   end
 
   context 'when providing career term role decks' do
-    let(:college_and_level_plans) { [undergrad_computer_science_plan, law_jsp_plan, graduate_electrical_engineering_plan] }
+    let(:academic_statuses) do
+      [
+        { 'studentCareer'=> undergrad_career, 'studentPlans'=> [undergrad_computer_science_plan] },
+        { 'studentCareer'=> grad_career, 'studentPlans'=> [graduate_electrical_engineering_plan] },
+        { 'studentCareer'=> law_career, 'studentPlans'=> [law_jsp_plan] }
+      ]
+    end
     let(:decks) { subject.get_career_term_role_decks }
     context 'when more than one role in any term' do
       let(:cs_enrollment_career_terms) do
@@ -272,8 +302,8 @@ describe MyAcademics::ClassEnrollments do
       let(:cs_enrollment_career_terms) do
         [
           { termId: '2168', termDescr: '2016 Fall', acadCareer: 'UGRD' },
-          { termId: '2172', termDescr: '2017 Spring', acadCareer: 'GRAD' },
-          { termId: '2175', termDescr: '2017 Summer', acadCareer: 'GRAD' },
+          { termId: '2172', termDescr: '2017 Spring', acadCareer: 'UGRD' },
+          { termId: '2175', termDescr: '2017 Summer', acadCareer: 'UGRD' },
         ]
       end
       it 'groups roles into single deck' do
@@ -289,7 +319,11 @@ describe MyAcademics::ClassEnrollments do
       end
     end
     context 'when no plans present for student' do
-      let(:college_and_level_plans) { [] }
+      let(:academic_statuses) do
+        [
+          { 'studentCareer'=> undergrad_career, 'studentPlans'=> [] }
+        ]
+      end
       it 'returns empty array' do
         expect(decks).to be_an_instance_of Array
         expect(decks.length).to eq 0
@@ -355,7 +389,12 @@ describe MyAcademics::ClassEnrollments do
       ]
     end
     context 'when multiple student plan roles match a career code for an active career-term' do
-      let(:college_and_level_plans) { [undergrad_computer_science_plan, undergrad_cognitive_science_plan, law_jsp_plan] }
+      let(:academic_statuses) do
+        [
+          { 'studentCareer'=> undergrad_career, 'studentPlans'=> [undergrad_computer_science_plan, undergrad_cognitive_science_plan] },
+          { 'studentCareer'=> law_career, 'studentPlans'=> [law_jsp_plan] }
+        ]
+      end
       let(:cs_enrollment_career_terms) { [{ termId: '2168', termDescr: '2016 Fall', acadCareer: 'UGRD' }] }
       it 'excludes student plan roles with non-matching career code' do
         expect(career_term_roles.count).to eq 1
@@ -373,7 +412,11 @@ describe MyAcademics::ClassEnrollments do
     end
 
     context 'when a student plan role matches a career code for multiple active career-terms' do
-      let(:college_and_level_plans) { [law_jsp_plan] }
+      let(:academic_statuses) do
+        [
+          { 'studentCareer'=> law_career, 'studentPlans'=> [law_jsp_plan] }
+        ]
+      end
       let(:cs_enrollment_career_terms) {
         [
           { termId: '2168', termDescr: '2016 Fall', acadCareer: 'LAW' },
@@ -394,7 +437,11 @@ describe MyAcademics::ClassEnrollments do
     end
 
     context 'when a student plan role does not match the career code for any active career-term' do
-      let(:college_and_level_plans) { [law_jsp_plan] }
+      let(:academic_statuses) do
+        [
+          { 'studentCareer'=> law_career, 'studentPlans'=> [law_jsp_plan] }
+        ]
+      end
       let(:cs_enrollment_career_terms) { [{ termId: '2168', termDescr: '2016 Fall', acadCareer: 'UGRD' }] }
       it 'does not include an career term role object for the student plan role' do
         expect(career_term_roles.count).to eq 0
@@ -402,7 +449,11 @@ describe MyAcademics::ClassEnrollments do
     end
 
     context 'when a student plan role is fpf and matches multiple career-terms' do
-      let(:college_and_level_plans) { [undergrad_fall_program_for_freshmen_plan] }
+      let(:academic_statuses) do
+        [
+          { 'studentCareer'=> undergrad_career, 'studentPlans'=> [undergrad_fall_program_for_freshmen_plan] }
+        ]
+      end
       let(:cs_enrollment_career_terms) { [
         { termId: '2168', termDescr: '2016 Fall', acadCareer: 'UGRD' },
         { termId: '2172', termDescr: '2017 Spring', acadCareer: 'UGRD' },
@@ -431,7 +482,11 @@ describe MyAcademics::ClassEnrollments do
     end
 
     context 'when a student plan roles are fpf and default and both match multiple career-terms' do
-      let(:college_and_level_plans) { [undergrad_fall_program_for_freshmen_plan, undergrad_nutritional_science_plan] }
+      let(:academic_statuses) do
+        [
+          { 'studentCareer'=> undergrad_career, 'studentPlans'=> [undergrad_fall_program_for_freshmen_plan, undergrad_nutritional_science_plan] }
+        ]
+      end
       let(:cs_enrollment_career_terms) { [
         { termId: '2168', termDescr: '2016 Fall', acadCareer: 'UGRD' },
         { termId: '2172', termDescr: '2017 Spring', acadCareer: 'UGRD' }

--- a/spec/models/my_academics/college_and_level_spec.rb
+++ b/spec/models/my_academics/college_and_level_spec.rb
@@ -229,7 +229,6 @@ describe MyAcademics::CollegeAndLevel do
       plan_code: '25345U',
       plan_description: 'English BA',
       role: 'default',
-      enrollmentRole: 'default',
       admin_owners: [{org_code: 'ENGLISH', org_description: 'English', percentage: 100}],
       expected_grad_term_id: '2202',
       expected_grad_term_name: '2020 Spring'
@@ -244,7 +243,6 @@ describe MyAcademics::CollegeAndLevel do
       plan_code: '25971U',
       plan_description: 'MCB-Cell & Dev Biology BA',
       role: 'default',
-      enrollmentRole: 'default',
       type_code: 'SP',
       type_description: 'Major - UG Specialization',
       sub_plan_code: '25966SA02U',
@@ -262,7 +260,6 @@ describe MyAcademics::CollegeAndLevel do
       plan_code: '25090U',
       plan_description: 'Art BA',
       role: 'default',
-      enrollmentRole: 'default',
       type_code: 'MIN',
       type_description: 'Major - UG Specialization',
       admin_owners: [{org_code: 'MCELLBI', org_description: 'Molecular & Cell Biology', percentage: 100}],
@@ -279,7 +276,6 @@ describe MyAcademics::CollegeAndLevel do
       plan_code: '00E017G',
       plan_description: 'Women, Gender and Sexuality DE',
       role: 'default',
-      enrollmentRole: 'default',
       type_code: 'DE',
       type_description: 'Designated Emphasis',
       admin_owners: [{org_code: 'MCELLBI', org_description: 'Molecular & Cell Biology', percentage: 100}],
@@ -295,7 +291,6 @@ describe MyAcademics::CollegeAndLevel do
       plan_code: '82790PPJDG',
       plan_description: 'Public Policy MPP-JD CDP',
       role: 'default',
-      enrollmentRole: 'default',
       admin_owners: [
         {org_code: 'LAW', org_description: 'School of Law', percentage: 50},
         {org_code: 'PUBPOL', org_description: 'Goldman School Public Policy', percentage: 50},
@@ -311,7 +306,6 @@ describe MyAcademics::CollegeAndLevel do
       plan_code: '84501JDPPG',
       plan_description: 'Law JD-MPP CDP',
       role: 'law',
-      enrollmentRole: 'law',
       admin_owners: [
         {org_code: 'LAW', org_description: 'School of Law', percentage: 50},
         {org_code: 'PUBPOL', org_description: 'Goldman School Public Policy', percentage: 50},
@@ -341,7 +335,6 @@ describe MyAcademics::CollegeAndLevel do
       plan_code: '70141BAPHG',
       plan_description: 'Business Admin MBA-MPH CDP',
       role: 'haasMbaPublicHealth',
-      enrollmentRole: 'default',
       admin_owners: [
         {org_code: 'BUS', org_description: 'Haas School of Business', percentage: 50},
         {org_code: 'PUBHEALTH', org_description: 'School of Public Health', percentage: 50},
@@ -460,7 +453,6 @@ describe MyAcademics::CollegeAndLevel do
         expect(feed[:collegeAndLevel][:plans][0][:expectedGraduationTerm][:code]).to eq '2202'
         expect(feed[:collegeAndLevel][:plans][0][:expectedGraduationTerm][:name]).to eq 'Spring 2020'
         expect(feed[:collegeAndLevel][:plans][0][:role]).to eq 'default'
-        expect(feed[:collegeAndLevel][:plans][0][:enrollmentRole]).to eq 'default'
         expect(feed[:collegeAndLevel][:plans][0][:primary]).to eq true
         expect(feed[:collegeAndLevel][:plans][0][:type][:code]).to eq 'MAJ'
         expect(feed[:collegeAndLevel][:plans][0][:type][:category]).to eq 'Major'
@@ -471,7 +463,6 @@ describe MyAcademics::CollegeAndLevel do
         expect(feed[:collegeAndLevel][:plans][1][:plan][:code]).to eq '25971U'
         expect(feed[:collegeAndLevel][:plans][1][:expectedGraduationTerm]).to eq nil
         expect(feed[:collegeAndLevel][:plans][1][:role]).to eq 'default'
-        expect(feed[:collegeAndLevel][:plans][1][:enrollmentRole]).to eq 'default'
         expect(feed[:collegeAndLevel][:plans][1][:primary]).to eq false
         expect(feed[:collegeAndLevel][:plans][1][:type][:code]).to eq 'SP'
         expect(feed[:collegeAndLevel][:plans][1][:type][:category]).to eq 'Major'
@@ -482,7 +473,6 @@ describe MyAcademics::CollegeAndLevel do
         expect(feed[:collegeAndLevel][:plans][2][:plan][:code]).to eq '25090U'
         expect(feed[:collegeAndLevel][:plans][2][:expectedGraduationTerm]).to eq nil
         expect(feed[:collegeAndLevel][:plans][2][:role]).to eq 'default'
-        expect(feed[:collegeAndLevel][:plans][2][:enrollmentRole]).to eq 'default'
         expect(feed[:collegeAndLevel][:plans][2][:primary]).to eq false
         expect(feed[:collegeAndLevel][:plans][2][:type][:code]).to eq 'MIN'
         expect(feed[:collegeAndLevel][:plans][2][:type][:category]).to eq 'Minor'
@@ -493,7 +483,6 @@ describe MyAcademics::CollegeAndLevel do
         expect(feed[:collegeAndLevel][:plans][3][:plan][:code]).to eq '00E017G'
         expect(feed[:collegeAndLevel][:plans][3][:expectedGraduationTerm]).to eq nil
         expect(feed[:collegeAndLevel][:plans][3][:role]).to eq 'default'
-        expect(feed[:collegeAndLevel][:plans][3][:enrollmentRole]).to eq 'default'
         expect(feed[:collegeAndLevel][:plans][3][:primary]).to eq false
         expect(feed[:collegeAndLevel][:plans][3][:type][:code]).to eq 'DE'
         expect(feed[:collegeAndLevel][:plans][3][:type][:category]).to eq 'Designated Emphasis'
@@ -632,7 +621,6 @@ describe MyAcademics::CollegeAndLevel do
         expect(feed[:collegeAndLevel][:plans][0][:plan][:code]).to eq '84501JDPPG'
         expect(feed[:collegeAndLevel][:plans][0][:expectedGraduationTerm]).to eq nil
         expect(feed[:collegeAndLevel][:plans][0][:role]).to eq 'law'
-        expect(feed[:collegeAndLevel][:plans][0][:enrollmentRole]).to eq 'law'
         expect(feed[:collegeAndLevel][:plans][0][:primary]).to eq true
         expect(feed[:collegeAndLevel][:plans][0][:type][:code]).to eq 'MAJ'
         expect(feed[:collegeAndLevel][:plans][0][:type][:category]).to eq 'Major'
@@ -643,7 +631,6 @@ describe MyAcademics::CollegeAndLevel do
         expect(feed[:collegeAndLevel][:plans][1][:plan][:code]).to eq '82790PPJDG'
         expect(feed[:collegeAndLevel][:plans][1][:expectedGraduationTerm]).to eq nil
         expect(feed[:collegeAndLevel][:plans][1][:role]).to eq 'default'
-        expect(feed[:collegeAndLevel][:plans][1][:enrollmentRole]).to eq 'default'
         expect(feed[:collegeAndLevel][:plans][1][:primary]).to eq true
         expect(feed[:collegeAndLevel][:plans][1][:type][:code]).to eq 'MAJ'
         expect(feed[:collegeAndLevel][:plans][1][:type][:category]).to eq 'Major'
@@ -755,10 +742,6 @@ describe MyAcademics::CollegeAndLevel do
       expect(flattened_status[:role]).to eq 'default'
     end
 
-    it 'includes the students plan enrollment role' do
-      expect(flattened_status[:enrollmentRole]).to eq 'default'
-    end
-
     it 'includes the primary plan boolean' do
       expect(flattened_status[:primary]).to eq true
     end
@@ -784,7 +767,6 @@ describe MyAcademics::CollegeAndLevel do
         plan_code: '25971U',
         plan_description: 'MCB-Cell & Dev Biology BA',
         role: 'default',
-        enrollmentRole: 'default',
         is_primary: false,
         status_in_plan_status_code: 'X',
         status_in_plan_status_description: 'Invalid Status'

--- a/spec/models/my_academics/graduation_spec.rb
+++ b/spec/models/my_academics/graduation_spec.rb
@@ -1,5 +1,5 @@
 describe MyAcademics::Graduation do
-  def student_plan(grad_term_id, grad_term_name)
+  def student_plan(grad_term_id, grad_term_name, is_active = true)
     {
       'expectedGraduationTerm' => {
         'id' => grad_term_id,
@@ -7,7 +7,7 @@ describe MyAcademics::Graduation do
       },
       'statusInPlan' => {
         'status' => {
-          'code' => 'AC'
+          'code' => is_active ? 'AC' : nil
         }
       }
     }
@@ -111,6 +111,20 @@ describe MyAcademics::Graduation do
         result = subject.get_feed
         expect(result[:lastExpectedGraduationTerm][:code]).to eq '2207'
         expect(result[:lastExpectedGraduationTerm][:name]).to eq 'Fall 2020'
+      end
+    end
+    context 'when student has an inactive plan' do
+      let(:second_career_academic_status) do
+        {
+          "studentPlans" => [
+            student_plan('2207', '2020 Fall', false)
+          ]
+        }
+      end
+      it 'does not include the inactive plan in determining latest expected graduation term' do
+        result = subject.get_feed
+        expect(result[:lastExpectedGraduationTerm][:code]).to eq '2205'
+        expect(result[:lastExpectedGraduationTerm][:name]).to eq 'Summer 2020'
       end
     end
   end

--- a/spec/support/spec_helper_module.rb
+++ b/spec/support/spec_helper_module.rb
@@ -85,7 +85,6 @@ module SpecHelperModule
         }
       },
       :role => cpp_hash[:role],
-      :enrollmentRole => cpp_hash[:enrollmentRole]
     }
     if (cpp_hash[:expected_grad_term_id] && cpp_hash[:expected_grad_term_name])
       plan.merge!({

--- a/src/assets/javascripts/angular/controllers/widgets/enrollment/enrollmentCardController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/enrollment/enrollmentCardController.js
@@ -7,7 +7,7 @@ var _ = require('lodash');
  * Enrollment Card Controller
  * Main controller for the enrollment card on the My Academics and Student Overview pages
  */
-angular.module('calcentral.controllers').controller('EnrollmentCardController', function(apiService, enrollmentFactory, linkService, $route, $scope) {
+angular.module('calcentral.controllers').controller('EnrollmentCardController', function(apiService, academicStatusFactory, enrollmentFactory, linkService, $route, $scope) {
   $scope.accessibilityAnnounce = apiService.util.accessibilityAnnounce;
   linkService.addCurrentRouteSettings($scope);
 
@@ -225,11 +225,24 @@ angular.module('calcentral.controllers').controller('EnrollmentCardController', 
     $scope.enrollmentInstructionDecks = enrollmentInstructionDecks;
   };
 
+  var loadEnrollmentInstructionDecks = function() {
+    return enrollmentFactory.getEnrollmentInstructionDecks();
+  };
+
+  var loadAcademicRoles = function() {
+    return academicStatusFactory.getAcademicRoles().then(
+      function(parsedAcademicRoles) {
+        $scope.isGrad = _.get(parsedAcademicRoles, 'roles.grad');
+      }
+    );
+  };
+
   /**
    * Load the enrollment data and fire off subsequent events
    */
   var loadEnrollmentData = function() {
-    enrollmentFactory.getEnrollmentInstructionDecks()
+    loadAcademicRoles()
+      .then(loadEnrollmentInstructionDecks)
       .then(parseEnrollmentInstructionDecks)
       .then(stopMainSpinner);
   };

--- a/src/assets/templates/widgets/enrollment/adjust.html
+++ b/src/assets/templates/widgets/enrollment/adjust.html
@@ -24,7 +24,7 @@
   </div>
 </div>
 
-<div class="cc-enrollment-card-section-content" data-ng-if="enrollmentInstruction.termIsSummer && isInstructionType(enrollmentInstruction, ['summerVisitor', 'courseworkOnly', 'grad', 'haasFullTimeMba', 'haasEveningWeekendMba', 'haasExecMba', 'haasMastersFinEng', 'haasMbaPublicHealth', 'haasMbaJurisDoctor'])">
+<div class="cc-enrollment-card-section-content" data-ng-if="enrollmentInstruction.termIsSummer && (isGrad || isInstructionType(enrollmentInstruction, ['summerVisitor', 'courseworkOnly']))">
   <a data-cc-campus-solutions-link-directive="enrollmentInstruction.csLinks.requestLateClassChanges"
     data-cc-campus-solutions-link-directive-cc-page-name="currentPage.name"
     data-cc-campus-solutions-link-directive-cc-page-url="currentPage.url"


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-34542

This is a big refactor of academic roles, and how they are used by the enrollment card to determine which version of the card to display.  It will enable more flexibility in how these roles are assigned, so that we can assign multiple roles to a single student based on their career, program, plan, or any other CPP stack data.