### PR TITLE
SISRP-34493 - Change  Logic in Status and Holds Controller (+userOverview)

### DIFF
--- a/src/assets/javascripts/angular/controllers/pages/academicsController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicsController.js
@@ -217,7 +217,7 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
                                  ($scope.numberOfHolds));
     $scope.showAdvising = !$scope.filteredForDelegate && apiService.user.profile.features.advising && apiService.user.profile.roles.student && isMbaJdOrNotLaw();
     $scope.showProfileMessage = (!$scope.isAcademicInfoAvailable || !$scope.collegeAndLevel || _.isEmpty($scope.collegeAndLevel.careers));
-    $scope.showResidency = apiService.user.profile.roles.student && !$scope.academicStatus.roles.summerVisitor && hasResidency();
+    $scope.showResidency = apiService.user.profile.roles.student && academicsService.showResidency($scope.academicStatus.roles);
   };
 
   /**
@@ -229,10 +229,6 @@ angular.module('calcentral.controllers').controller('AcademicsController', funct
       return true;
     }
     return false;
-  };
-
-  var hasResidency = function() {
-    return (!$scope.academicStatus.roles.haasMastersFinEng && !$scope.academicStatus.roles.haasExecMba && !$scope.academicStatus.roles.haasEveningWeekendMba);
   };
 
   var loadAcademicRoles = function() {

--- a/src/assets/javascripts/angular/controllers/widgets/academicsStatusHoldsBlocksController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/academicsStatusHoldsBlocksController.js
@@ -9,28 +9,13 @@ var _ = require('lodash');
 angular.module('calcentral.controllers').controller('AcademicsStatusHoldsBlocksController', function(apiService, academicsFactory, linkService, slrDeeplinkFactory, registrationsFactory, statusHoldsService, $scope) {
   linkService.addCurrentRouteSettings($scope);
 
-  // Data for csHolds is pulled by the AcademicsController that
-  // governs the academics template. The statusHoldsBlocks segment watches those
-  // for changes in order to display the corresponding UI elements.
-  $scope.statusHoldsBlocks = {};
-  $scope.regStatus = {
-    registrations: [],
+  $scope.statusHolds = {
     isLoading: true
   };
-
-  $scope.$watchGroup(['regStatus.registrations', 'residency.official.description', 'api.user.profile.features.csHolds'], function(newValues) {
-    var enabledSections = [];
-
-    if (newValues[0] || newValues[1]) {
-      enabledSections.push('Status');
-    }
-
-    if (newValues[2]) {
-      enabledSections.push('Holds');
-    }
-
-    $scope.statusHoldsBlocks.enabledSections = enabledSections;
-  });
+  $scope.regStatus = {
+    registrations: [],
+    show: false
+  };
 
   // Request-and-parse sequence for the Statement of Legal Residency deeplink
   var fetchSlrDeeplink = slrDeeplinkFactory.getUrl;
@@ -52,6 +37,9 @@ angular.module('calcentral.controllers').controller('AcademicsStatusHoldsBlocksC
         $scope.regStatus.registrations.push(registration);
       }
     });
+    if ($scope.regStatus.registrations.length) {
+      $scope.regStatus.show = true;
+    }
   };
 
   var getSlrDeeplink = function() {
@@ -92,8 +80,7 @@ angular.module('calcentral.controllers').controller('AcademicsStatusHoldsBlocksC
     .then(getSlrDeeplink)
     .then(getRegistrations)
     .finally(function() {
-      $scope.residency.isLoading = false;
-      $scope.regStatus.isLoading = false;
+      $scope.statusHolds.isLoading = false;
     });
   };
 

--- a/src/assets/javascripts/angular/services/academicsService.js
+++ b/src/assets/javascripts/angular/services/academicsService.js
@@ -316,6 +316,19 @@ angular.module('calcentral.services').service('academicsService', function() {
     return numericTransferUnits + numericTestUnits;
   };
 
+  var showResidency = function(academicRoles) {
+    var show = true;
+    var blacklistedRoles = ['summerVisitor', 'haasMastersFinEng', 'haasExecMba', 'haasEveningWeekendMba'];
+    _.forEach(blacklistedRoles, function(role) {
+      if (_.get(academicRoles, role)) {
+        show = false;
+        // Break the loop if we get a hit on a blacklisted role
+        return false;
+      }
+    });
+    return show;
+  };
+
   // Expose methods
   return {
     chooseDefaultSemester: chooseDefaultSemester,
@@ -333,6 +346,7 @@ angular.module('calcentral.services').service('academicsService', function() {
     isLSStudent: isLSStudent,
     isSummerSemester: isSummerSemester,
     normalizeGradingData: normalizeGradingData,
+    showResidency: showResidency,
     textbookRequestInfo: textbookRequestInfo,
     totalTransferUnits: totalTransferUnits
   };

--- a/src/assets/templates/widgets/status_and_holds.html
+++ b/src/assets/templates/widgets/status_and_holds.html
@@ -1,67 +1,65 @@
 <div class="cc-widget cc-status-holds">
   <div class="cc-widget-title">
-    <h2 data-ng-bind="statusHoldsBlocks.enabledSections | andFilter"></h2>
+    <h2>Status and Holds</h2>
   </div>
 
-  <div class="cc-widget-padding">
+  <div class="cc-widget-padding" data-cc-spinner-directive="statusHolds.isLoading">
+    <h3 class="cc-status-holds-status-header" data-ng-if="regStatus.show || showResidency">Status</h3>
     <div data-ng-if="api.user.profile.features.regstatus">
-      <div data-cc-spinner-directive="regStatus.isLoading">
-        <div data-ng-if="(statusHoldsBlocks.enabledSections.indexOf('Status') !== -1)">
-          <h3 class="cc-status-holds-status-header">Status</h3>
-          <div class="cc-status-holds-section" data-ng-repeat="registration in regStatus.registrations | orderBy:'-id'">
-            <h4 data-ng-bind="registration.term.name"></h4>
-            <ul class="cc-widget-list cc-status-holds-list">
-              <li class="cc-widget-list-hover"
-                  data-ng-if="registration.regStatus.explanation"
-                  data-ng-class="{'cc-widget-list-hover-opened':(registration.regStatus.show)}"
-                  data-cc-accessible-focus-directive
-                  data-ng-click="api.widget.toggleShow($event, null, registration.regStatus, 'My Academics - Status and Holds')">
-                <div class="cc-status-holds-list-section">
-                  <div class="cc-status-holds-list-item">
-                    <span>
-                      <i class="cc-icon fa" data-ng-class="regStatusIcon(registration.regStatus.summary)"></i>
-                    </span>
-                    <span data-ng-bind="registration.regStatus.summary"></span>
-                  </div>
-                  <div class="cc-status-holds-expanded-text" data-ng-show="registration.regStatus.show">
-                    <span data-ng-bind-html="registration.regStatus.explanation"></span>
-                  </div>
+      <div data-ng-if="regStatus.show">
+        <div class="cc-status-holds-section" data-ng-repeat="registration in regStatus.registrations | orderBy:'-id'">
+          <h4 data-ng-bind="registration.term.name"></h4>
+          <ul class="cc-widget-list cc-status-holds-list">
+            <li class="cc-widget-list-hover"
+                data-ng-if="registration.regStatus.explanation"
+                data-ng-class="{'cc-widget-list-hover-opened':(registration.regStatus.show)}"
+                data-cc-accessible-focus-directive
+                data-ng-click="api.widget.toggleShow($event, null, registration.regStatus, 'My Academics - Status and Holds')">
+              <div class="cc-status-holds-list-section">
+                <div class="cc-status-holds-list-item">
+                  <span>
+                    <i class="cc-icon fa" data-ng-class="regStatusIcon(registration.regStatus.summary)"></i>
+                  </span>
+                  <span data-ng-bind="registration.regStatus.summary"></span>
                 </div>
-              </li>
-              <li data-ng-if="!registration.regStatus.explanation">
-                <div class="cc-status-holds-list-section">
-                  <div class="cc-status-holds-list-item">
-                    <span>
-                      <i class="cc-icon fa" data-ng-class="regStatusIcon(registration.regStatus.summary)"></i>
-                    </span>
-                    <span data-ng-bind="registration.regStatus.summary"></span>
-                  </div>
+                <div class="cc-status-holds-expanded-text" data-ng-show="registration.regStatus.show">
+                  <span data-ng-bind-html="registration.regStatus.explanation"></span>
                 </div>
-              </li>
-              <li class="cc-widget-list-hover"
-                  data-ng-if="registration.showCnp"
-                  data-ng-class="{'cc-widget-list-hover-opened':(registration.cnpStatus.show)}"
-                  data-cc-accessible-focus-directive
-                  data-ng-click="api.widget.toggleShow($event, null, registration.cnpStatus, 'My Academics - Status and Holds')">
-                <div class="cc-status-holds-list-section">
-                  <div class="cc-status-holds-list-item">
-                    <span>
-                      <i class="cc-icon fa" data-ng-class="cnpStatusIcon(registration)"></i>
-                    </span>
-                    <span data-ng-bind="registration.cnpStatus.summary"></span>
-                  </div>
-                  <div class="cc-status-holds-expanded-text" data-ng-show="registration.cnpStatus.show">
-                    <span data-ng-bind-html="registration.cnpStatus.explanation"></span>
-                  </div>
+              </div>
+            </li>
+            <li data-ng-if="!registration.regStatus.explanation">
+              <div class="cc-status-holds-list-section">
+                <div class="cc-status-holds-list-item">
+                  <span>
+                    <i class="cc-icon fa" data-ng-class="regStatusIcon(registration.regStatus.summary)"></i>
+                  </span>
+                  <span data-ng-bind="registration.regStatus.summary"></span>
                 </div>
-              </li>
-            </ul>
-          </div>
+              </div>
+            </li>
+            <li class="cc-widget-list-hover"
+                data-ng-if="registration.showCnp"
+                data-ng-class="{'cc-widget-list-hover-opened':(registration.cnpStatus.show)}"
+                data-cc-accessible-focus-directive
+                data-ng-click="api.widget.toggleShow($event, null, registration.cnpStatus, 'My Academics - Status and Holds')">
+              <div class="cc-status-holds-list-section">
+                <div class="cc-status-holds-list-item">
+                  <span>
+                    <i class="cc-icon fa" data-ng-class="cnpStatusIcon(registration)"></i>
+                  </span>
+                  <span data-ng-bind="registration.cnpStatus.summary"></span>
+                </div>
+                <div class="cc-status-holds-expanded-text" data-ng-show="registration.cnpStatus.show">
+                  <span data-ng-bind-html="registration.cnpStatus.explanation"></span>
+                </div>
+              </div>
+            </li>
+          </ul>
         </div>
       </div>
     </div>
 
-    <div data-cc-spinner-directive="residency.isLoading" data-ng-if="showResidency">
+    <div data-ng-if="showResidency">
       <div class="cc-status-holds-section">
         <div data-ng-if="residency.official.description">
           <h4>California Residency</h4>
@@ -85,7 +83,7 @@
       </div>
     </div>
 
-    <div data-ng-if="statusHoldsBlocks.enabledSections.indexOf('Holds') !== -1">
+    <div data-ng-if="api.user.profile.features.csHolds">
       <h3>Active Holds</h3>
       <div data-ng-include="'widgets/holds.html'"></div>
     </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-34493

* Finally makes `My Academics` + `User Overview` follow the same logic on whether or not we show Residency information.
* Removes crazy spinner behavior, and unifies all proxy calls within the `Status and Holds` card to one spinner.
* Most importantly, removes unnecessary `$watch` usage.  [Here](https://www.airpair.com/angularjs/posts/angularjs-performance-large-applications) are some thoughts on why `$watch` should be avoided:
> scope.$watch() has now been discussed on several occasions. In general, scope.$watch is indicative of bad architecture. There are very few cases when some combination of services and reference bindings can not achieve the same results with lower overhead.