### PR TITLE
SISRP-36097 - Removes milestone attempts and status from Student Committees card

### DIFF
--- a/app/models/my_committees/faculty_committees.rb
+++ b/app/models/my_committees/faculty_committees.rb
@@ -40,8 +40,54 @@ module MyCommittees
     end
 
     def merge_faculty_specific_data(cs_committee, faculty_committee)
+      faculty_committee.merge! milestoneAttempts: parse_cs_qualifying_exam_attempts(cs_committee)
       faculty_committee.merge! student: parse_cs_committee_student(cs_committee)
       faculty_committee.merge! parse_cs_faculty_committee_svc(cs_committee)
+    end
+
+    def set_committee_status(cs_committee, committee)
+      if qualifying_exam?(cs_committee)
+        committee[:statusIcon] = determine_qualifying_exam_status_icon(committee)
+        committee[:statusMessage] = determine_qualifying_exam_status_message(cs_committee)
+      elsif !is_active?(cs_committee) && cs_committee[:studentFilingDate]
+        committee[:statusIcon] = STATUS_ICON_SUCCESS
+        committee[:statusMessage] = "Filing Date: #{format_date(cs_committee[:studentFilingDate])}"
+      elsif (advanced_date = determine_advanced_date(cs_committee))
+        committee[:statusMessage] = "Advanced: #{format_date(advanced_date)}"
+      end
+    end
+
+    def determine_qualifying_exam_status_icon(committee)
+      latest_attempt = committee.try(:[], :milestoneAttempts).try(:first)
+      return '' unless latest_attempt
+      if latest_attempt.try(:[], :result) == Berkeley::GraduateMilestones::QE_RESULTS_STATUS_PASSED
+        STATUS_ICON_SUCCESS
+      elsif latest_attempt.try(:[], :sequenceNumber) === 1
+        STATUS_ICON_WARN
+      else
+        STATUS_ICON_FAIL
+      end
+    end
+
+    def determine_advanced_date(cs_committee)
+      if (advanced_date = cs_committee[:studentAdvancedDate]).blank?
+        advanced_date = latest_milestone_attempt(cs_committee).try(:[], :attemptDate)
+      end
+      advanced_date
+    end
+
+    def latest_milestone_attempt(cs_committee)
+      cs_committee.try(:[], :studentApprovalMilestoneAttempts).try(:sort_by!) do |attempt|
+        attempt.try(:[], :attemptNbr)
+      end.try(:last)
+    end
+
+    def parse_cs_qualifying_exam_attempts(cs_committee)
+      qualifying_exam_attempts = []
+      if qualifying_exam?(cs_committee)
+        qualifying_exam_attempts = parse_cs_milestone_attempts(cs_committee)
+      end
+      qualifying_exam_attempts
     end
 
     def parse_cs_milestone_attempts(cs_committee)
@@ -51,6 +97,16 @@ module MyCommittees
       attempts.try(:sort_by) do |attempt|
         attempt[:sequenceNumber]
       end.try(:reverse)
+    end
+
+    def parse_cs_milestone_attempt(cs_milestone_attempt)
+      milestone_attempt = {
+        sequenceNumber: cs_milestone_attempt[:attemptNbr].to_i,
+        date: format_date(cs_milestone_attempt[:attemptDate]),
+        result: Berkeley::GraduateMilestones.get_status(cs_milestone_attempt[:attemptStatus], Berkeley::GraduateMilestones::QE_RESULTS_MILESTONE)
+      }
+      milestone_attempt[:display] = format_milestone_attempt(milestone_attempt)
+      milestone_attempt
     end
 
     def format_milestone_attempt(milestone_attempt)

--- a/app/models/my_committees/student_committees.rb
+++ b/app/models/my_committees/student_committees.rb
@@ -35,26 +35,10 @@ module MyCommittees
       committee
     end
 
-    def parse_cs_milestone_attempts(cs_committee)
-      attempts = cs_committee[:studentApprovalMilestoneAttempts].try(:map) do |attempt|
-        parse_cs_milestone_attempt(attempt)
+    def set_committee_status(cs_committee, committee)
+      if qualifying_exam?(cs_committee)
+        committee[:statusMessage] = determine_qualifying_exam_status_message(cs_committee)
       end
-      return [] unless attempts
-      attempts.try(:sort_by) do |attempt|
-        attempt[:sequenceNumber]
-      end.last(1)
-    end
-
-    def format_milestone_attempt(milestone_attempt)
-      if first_attempt_exam_passed?(milestone_attempt)
-        "#{milestone_attempt[:result]} #{milestone_attempt[:date]}"
-      else
-        "Exam #{milestone_attempt[:sequenceNumber]}: #{milestone_attempt[:result]} #{milestone_attempt[:date]}"
-      end
-    end
-
-    def first_attempt_exam_passed?(milestone_attempt)
-      milestone_attempt[:sequenceNumber] === 1 && milestone_attempt[:result] == Berkeley::GraduateMilestones::QE_RESULTS_STATUS_PASSED
     end
 
     def parse_cs_committee_member (cs_committee_member)

--- a/spec/models/my_committees/faculty_committees_spec.rb
+++ b/spec/models/my_committees/faculty_committees_spec.rb
@@ -38,7 +38,7 @@ describe MyCommittees::FacultyCommittees do
 
     it 'correctly parses a committee with no members' do
       committee = feed[:facultyCommittees][:completed][0]
-      expect(committee[:serviceRange]).to be nil
+      expect(committee[:serviceRange]).not_to be
     end
 
     it 'correctly parses a Dissertation committee' do
@@ -46,7 +46,7 @@ describe MyCommittees::FacultyCommittees do
       expect(committee[:committeeType]).to eq 'Dissertation Committee'
       expect(committee[:program]).to eq 'Education PhD'
       expect(committee[:statusMessage]).to eq 'Advanced: Oct 06, 2017'
-      expect(committee[:statusIcon]).to eq nil
+      expect(committee[:statusIcon]).not_to be
       expect(committee[:serviceRange]).to eq 'Aug 31, 2016 - Present'
       expect(committee[:milestoneAttempts]).to eq []
     end
@@ -55,8 +55,8 @@ describe MyCommittees::FacultyCommittees do
       committee = feed[:facultyCommittees][:completed][1]
       expect(committee[:committeeType]).to eq 'Qualifying Exam Committee'
       expect(committee[:program]).to eq 'Civil Environmental Eng MS'
-      expect(committee[:statusMessage]).to eq nil
-      expect(committee[:statusIcon]).to eq 'check'
+      expect(committee[:statusMessage]).not_to be
+      expect(committee[:statusIcon]).to eq ''
       expect(committee[:serviceRange]).to eq 'Aug 30, 2016 - Aug 30, 2017'
     end
 
@@ -64,9 +64,9 @@ describe MyCommittees::FacultyCommittees do
       committee = feed[:facultyCommittees][:completed][0]
       expect(committee[:committeeType]).to eq 'Qualifying Exam Committee'
       expect(committee[:program]).to eq 'Underwater Basket Weaving PhD'
-      expect(committee[:statusMessage]).to eq nil
-      expect(committee[:statusIcon]).to eq 'exclamation-circle'
-      expect(committee[:serviceRange]).to eq nil
+      expect(committee[:statusMessage]).not_to be
+      expect(committee[:statusIcon]).to eq ''
+      expect(committee[:serviceRange]).not_to be
     end
 
     it 'correctly parses a Masters Thesis committee' do

--- a/spec/models/my_committees/student_committees_spec.rb
+++ b/spec/models/my_committees/student_committees_spec.rb
@@ -41,70 +41,40 @@ describe MyCommittees::StudentCommittees do
       committee = feed[:studentCommittees][0]
       expect(committee[:committeeType]).to eq 'Qualifying Exam Committee'
       expect(committee[:program]).to eq 'STUDENTACADPLAN1'
-      expect(committee[:statusIcon]).to eq 'check'
-      expect(committee[:statusMessage]).to eq nil
+      expect(committee[:statusIcon]).not_to be
+      expect(committee[:statusMessage]).not_to be
+      expect(committee[:milestoneAttempts]).not_to be
     end
 
     it 'correctly parses a qualifying exam committee when student has failed the exam' do
       committee = feed[:studentCommittees][2]
       expect(committee[:committeeType]).to eq 'Qualifying Exam Committee'
       expect(committee[:program]).to eq 'STUDENTACADPLAN3'
-      expect(committee[:statusIcon]).to eq 'exclamation-triangle'
-      expect(committee[:statusMessage]).to be nil
+      expect(committee[:statusIcon]).not_to be
+      expect(committee[:statusMessage]).not_to be
+      expect(committee[:milestoneAttempts]).not_to be
     end
 
     it 'contains the expected student data for a dissertation committee' do
       committee = feed[:studentCommittees][3]
       expect(committee[:committeeType]).to eq 'Dissertation Committee'
       expect(committee[:program]).to eq 'STUDENTACADPLAN4'
-      expect(committee[:statusIcon]).to eq 'check'
-      expect(committee[:statusMessage]).to eq 'Filing Date: Jun 16, 2025'
-      expect(committee[:milestoneAttempts]).to eq []
+      expect(committee[:statusIcon]).not_to be
+      expect(committee[:statusMessage]).not_to be
+      expect(committee[:milestoneAttempts]).not_to be
     end
 
     it 'contains the expected student data for a Masters Thesis committee' do
       committee = feed[:studentCommittees][5]
       expect(committee[:committeeType]).to eq 'Master\'s Thesis Committee'
       expect(committee[:program]).to eq 'STUDENTACADPLAN6'
-      expect(committee[:statusIcon]).to eq nil
-      expect(committee[:statusMessage]).to eq 'Advanced: Jun 16, 2018'
-      expect(committee[:milestoneAttempts]).to eq []
-    end
-
-    context 'when student has attempted the Qualifying Exam milestone' do
-      it 'contains only the most recent attempt' do
-        qualifying_exam_attempts = feed[:studentCommittees][0][:milestoneAttempts]
-        expect(qualifying_exam_attempts.count).to eq 1
-        expect(qualifying_exam_attempts[0][:sequenceNumber]).to eq 2
-        expect(qualifying_exam_attempts[0][:date]).to eq 'Jan 01, 2015'
-        expect(qualifying_exam_attempts[0][:result]).to eq 'Passed'
-      end
-
-      context 'when building a string to represent the attempt' do
-        it 'includes the attempt number if student did not pass the first attempt' do
-          qualifying_exam_attempts = feed[:studentCommittees][2][:milestoneAttempts]
-          expect(qualifying_exam_attempts[0][:display]).to eq 'Exam 1: Failed Jan 01, 2014'
-        end
-        it 'does not include the attempt number if student passed the first attempt' do
-          qualifying_exam_attempts = feed[:studentCommittees][4][:milestoneAttempts]
-          expect(qualifying_exam_attempts[0][:display]).to eq 'Passed Jan 01, 2016'
-        end
-      end
-
-      it 'has a blank status message' do
-        expect(feed[:studentCommittees][0][:statusMessage]).to be nil
-        expect(feed[:studentCommittees][2][:statusMessage]).to be nil
-        expect(feed[:studentCommittees][4][:statusMessage]).to be nil
-      end
+      expect(committee[:statusIcon]).not_to be
+      expect(committee[:statusMessage]).not_to be
+      expect(committee[:milestoneAttempts]).not_to be
     end
 
     context 'when student has not yet attempted the Qualifying Exam milestone' do
       let(:qe_committee_with_proposed_exam) { feed[:studentCommittees][6] }
-
-      it 'has an empty attempts list' do
-        expect(qe_committee_with_proposed_exam[:milestoneAttempts]).to eq []
-      end
-
       it 'populates the status message with the proposed exam date' do
         expect(qe_committee_with_proposed_exam[:statusMessage]).to eq 'Proposed Exam Date: Dec 10, 2020'
       end

--- a/src/assets/templates/widgets/higher_degree_committees.html
+++ b/src/assets/templates/widgets/higher_degree_committees.html
@@ -25,16 +25,7 @@
             <div>
               <h3 data-ng-bind="committee.header.type"></h3>
               <h4 data-ng-bind="committee.header.program"></h4>
-              <div data-ng-if="!committee.milestoneAttempts.length">
-                <i data-ng-class="committee.header.statusIcon"></i>
-                <strong><span data-ng-bind="committee.header.statusMessage"></span></strong>
-              </div>
-              <ul class="cc-milestone-attempts">
-                <li data-ng-repeat="attempt in committee.milestoneAttempts">
-                  <i data-ng-class="committee.header.statusIcon"></i>
-                  <strong><span data-ng-bind="attempt.display"></span></strong>
-                </li>
-              </ul>
+
               <div data-ng-include="'widgets/academics/higher_degree_committee.html'"></div>
             </div>
           </li>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-36097

Removes some data from the student-facing card, but leaves it as-is on the faculty card.  This required some moving around of code, since we want to have `CommitteesModule` contain only functionality that is shared between the faculty and student versions.