### PR TITLE
SISRP-35805 - P/NP Bug Fix - Calculate P/NP Total Correctly

### DIFF
--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -450,5 +450,20 @@ module EdoOracle
       SQL
     end
 
+    def self.get_pnp_unit_count (student_id)
+      result = safe_query <<-SQL
+        SELECT STUDENT_ID,
+               PNP_TOT_UNITS_TAKEN as pnp_taken,
+               PNP_TOT_UNITS_PASSED as pnp_passed
+        FROM (
+          SELECT *
+          FROM SISEDO.STUCAR_TERMV00_VW
+          WHERE STUDENT_ID = #{student_id}
+          ORDER BY term_id DESC)
+        WHERE rownum = 1
+      SQL
+      result.first
+    end
+
   end
 end

--- a/app/models/my_academics/gpa_units.rb
+++ b/app/models/my_academics/gpa_units.rb
@@ -2,6 +2,7 @@ module MyAcademics
   class GpaUnits
     include AcademicsModule
     include ClassLogger
+    include User::Identifiers
 
     def merge(data)
       gpa = hub_gpa_units
@@ -9,39 +10,41 @@ module MyAcademics
     end
 
     def hub_gpa_units
-      response = HubEdos::MyAcademicStatus.new(@uid).get_feed
+      hub_response = HubEdos::MyAcademicStatus.new(@uid).get_feed
+      # P/NP units from the Hub are calculated differently than desired, so we grab them from an EDODB view instead
+      # EDODB P/NP units take into account repeat courses, making them more accurate than the values obtained from the Hub
+      edo_response = EdoOracle::Queries.get_pnp_unit_count(get_campus_solutions_id)
       result = {}
-      unit_total = 0
-      unit_sum = 0
-      #copy needed feilds from response obj
-      result[:errored] = response[:errored]
+      #copy needed fields from response obj
+      result[:errored] = hub_response[:errored]
       # TODO: Consult with SR concerning GPA displayed when multiple academic careers present
-      if (status = HubEdos::MyAcademicStatus.parse_academic_statuses(response).try(:first))
+      if (hub_status = HubEdos::MyAcademicStatus.parse_academic_statuses(hub_response).try(:first))
         # GPA is passed as a string to force a decimal point for whole values.
-        result[:cumulativeGpa] = (cumulativeGpa = parse_hub_cumulative_gpa status) && cumulativeGpa.to_s
-        if (totalUnits = parse_hub_total_units status) && totalUnits.present?
+        result[:cumulativeGpa] = (cumulativeGpa = parse_hub_cumulative_gpa hub_status) && cumulativeGpa.to_s
+        if (totalUnits = parse_hub_total_units hub_status) && totalUnits.present?
           result = result.merge(totalUnits)
-          unit_total = result[:totalUnits]
-          unit_sum += (result[:transferUnitsAccepted] + result[:testingUnits])
         end
-        if (totalUnitsForGpa = parse_hub_total_units_for_gpa status) && totalUnitsForGpa.present?
+        if (totalUnitsForGpa = parse_hub_total_units_for_gpa hub_status) && totalUnitsForGpa.present?
           result = result.merge(totalUnitsForGpa)
-          unit_sum += result[:totalUnitsForGpa]
-        end
-        if (totalUnitsTakenNotForGpa = parse_hub_total_units_taken_not_for_gpa status) && totalUnitsTakenNotForGpa.present?
-          result[:totalUnitsTakenNotForGpa] = totalUnitsTakenNotForGpa
-        end
-        if (totalUnitsPassedNotForGpa = parse_hub_total_units_passed_not_for_gpa status) && totalUnitsPassedNotForGpa.present?
-          result[:totalUnitsPassedNotForGpa] = totalUnitsPassedNotForGpa
-          unit_sum += result[:totalUnitsPassedNotForGpa]
-        end
-        if (unit_total != unit_sum)
-          logger.warn("Hub unit conflict for UID #{@uid}: Total units (#{unit_total}) does not match summed units (#{unit_sum}).")
         end
       else
-        result[:empty] = true
+        result[:hub_empty] = true
+      end
+      if (edo_response)
+        if (totalUnitsTakenNotForGpa = parse_edo_total_units_taken_not_for_gpa edo_response) && totalUnitsTakenNotForGpa.present?
+          result[:totalUnitsTakenNotForGpa] = totalUnitsTakenNotForGpa
+        end
+        if (totalUnitsPassedNotForGpa = parse_edo_total_units_passed_not_for_gpa edo_response) && totalUnitsPassedNotForGpa.present?
+          result[:totalUnitsPassedNotForGpa] = totalUnitsPassedNotForGpa
+        end
+      else
+        result[:edo_empty] = true
       end
       result
+    end
+
+    def get_campus_solutions_id
+      lookup_campus_solutions_id
     end
 
     def parse_hub_cumulative_gpa(status)
@@ -68,15 +71,15 @@ module MyAcademics
       end
     end
 
-    def parse_hub_total_units_taken_not_for_gpa(status)
-      if (units = status['cumulativeUnits']) && (total_units = units.find { |u| u['type'] && u['type']['code'] == 'Not For GPA'})
-        total_units['unitsTaken'].to_f
+    def parse_edo_total_units_taken_not_for_gpa(edo_response)
+      if (units = edo_response["pnp_taken"])
+        units.to_f
       end
     end
 
-    def parse_hub_total_units_passed_not_for_gpa(status)
-      if (units = status['cumulativeUnits']) && (total_units = units.find { |u| u['type'] && u['type']['code'] == 'Not For GPA'})
-        total_units['unitsPassed'].to_f
+    def parse_edo_total_units_passed_not_for_gpa(edo_response)
+      if (units = edo_response["pnp_passed"])
+        units.to_f
       end
     end
 

--- a/spec/models/my_academics/gpa_units_spec.rb
+++ b/spec/models/my_academics/gpa_units_spec.rb
@@ -45,7 +45,7 @@ describe 'MyAcademics::GpaUnits' do
     context 'empty status feed' do
       before { status_proxy.set_response(status: 200, body: '{}') }
       it 'reports empty' do
-        expect(feed[:gpaUnits][:empty]).to eq true
+        expect(feed[:gpaUnits][:hub_empty]).to eq true
       end
     end
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-35805

* Obtains cumulative P/NP units from EDODB, which holds values that take into account repeat classes, which are more accurate than the values from the Hub (which are not technically wrong).
* Had to get rid of a "total unit" sanity check for this, because the cumulative units will no longer align with the EDODB units.  According to Design team, this is an expected non-issue.