### PR TITLE
NOJIRA - Fixes intermittently failing unit test

### DIFF
--- a/spec/models/my_committees/committees_module_spec.rb
+++ b/spec/models/my_committees/committees_module_spec.rb
@@ -168,7 +168,7 @@ describe MyCommittees::CommitteesModule do
     context 'when committee member service end date is today' do
       let(:committee_member) do
         {
-          csMemberEndDate: DateTime.now.strftime('%F'),
+          csMemberEndDate: DateTime.now.to_date.strftime('%F'),
         }
       end
 


### PR DESCRIPTION
Committees test fails occasionally due to a timing issue with date comparisons. Hoping to fix it by setting the time attributes to zero (making the mock data into a date rather than a timestamp).