### PR TITLE
CLC-6754 Canvas dropped sis_login_id from its Account Admins API

### DIFF
--- a/app/models/canvas/admins.rb
+++ b/app/models/canvas/admins.rb
@@ -24,7 +24,7 @@ module Canvas
 
     def admin_user?(uid, options = {})
       admins = admins_list options
-      admins[:body].present? && admins[:body].index {|acct| acct['user']['sis_login_id'] == uid.to_s}.present?
+      admins[:body].present? && admins[:body].index {|acct| acct['user']['login_id'] == uid.to_s}.present?
     end
 
     def admins_list(options)

--- a/fixtures/json/canvas_admins_90242_page_1.json
+++ b/fixtures/json/canvas_admins_90242_page_1.json
@@ -8,7 +8,6 @@
       "sortable_name": "Hays, Jon",
       "short_name": "Jon Hays",
       "sis_user_id": "323487",
-      "sis_login_id": "323487",
       "login_id": "323487"
     }
   },
@@ -21,7 +20,6 @@
       "sortable_name": "Adams, Sage",
       "short_name": "Sage Adams",
       "sis_user_id": "972716",
-      "sis_login_id": "972716",
       "login_id": "972716"
     }
   }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6754

The undocumented change is currently on bCourses-Beta. Next production release is scheduled for 28 October 2017.