### PR TITLE
SISRP-36573 - Fixes issue with missing font-awesome assets

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -459,12 +459,6 @@
       .pipe(RevAll.manifestFile())
       .pipe(gulp.dest('public/')
     );
-
-    // Keep the following lines for debugging purposes
-    // This puts out a manifest file with the links to all the resources
-    // e.g. "fonts/FontAwesome.otf": "/fonts/FontAwesome.4f97a8a6.otf",
-    // .pipe(revall.manifest())
-    // .pipe(gulp.dest('public/assets/'));
   });
 
   /**

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "gulp-angular-templatecache": "~2.0.0",
     "gulp-autoprefixer": "~3.1.1",
     "gulp-base64": "~0.1.3",
-    "gulp-clean-css": "~3.9.0",
+    "gulp-clean-css": "3.4.0",
     "gulp-concat": "~2.6.0",
     "gulp-header": "1.8.9",
     "gulp-htmlmin": "~3.0.0",


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-36573

"Fixes" by forcing our builds to use gulp-clean-css@3.4.0.  It's not clear to me what the breaking change to the underlying clean-css library was, but this seems like an acceptable workaround.