### PR TITLE
widgetService: Fix nodeName check in `toggleShow`

### DIFF
--- a/src/assets/javascripts/angular/services/widgetService.js
+++ b/src/assets/javascripts/angular/services/widgetService.js
@@ -7,9 +7,9 @@ angular.module('calcentral.services').service('widgetService', function(analytic
    * Toggle whether an item for a widget should be shown or not
    */
   var toggleShow = function(event, items, item, widget) {
-    var tagName = (event && event.toElement && event.toElement.tagName);
-    // Ignore toggling on Anchor events
-    if (['A', 'INPUT', 'TEXTAREA'].indexOf(tagName) !== -1) {
+    var ignoreTogglingTags = ['A', 'INPUT', 'TEXTAREA'];
+    var nodeName = (event && event.target && event.target.nodeName);
+    if (nodeName && ignoreTogglingTags.indexOf(nodeName) !== -1) {
       return;
     }
     // Toggle the current item


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-36753

This prevents the corresponding "Class Enrollment" section from collapsing when a link inside a section is clicked.