### PR TITLE
SISRP-36868 - Update CampusSolutions::Link to include only proper camelcase key for isCsLink

### DIFF
--- a/app/models/campus_solutions/link.rb
+++ b/app/models/campus_solutions/link.rb
@@ -89,7 +89,6 @@ module CampusSolutions
         link[:title] = link.delete(:hoverOverText) || ''
         if !link[:showNewWindow]
           link[:isCsLink] = true
-          link['IS_CS_LINK'] = true
         end
       end
       link

--- a/public/dummy/json/degree_progress_ugrd.json
+++ b/public/dummy/json/degree_progress_ugrd.json
@@ -40,8 +40,7 @@
         "ucFromText": "CalCentral",
         "name": "Academic Progress Report",
         "title": "View this student's Academic Progress Report",
-        "isCsLink": true,
-        "iSCsLink": true
+        "isCsLink": true
       }
     }
   },

--- a/public/dummy/json/enrollment_instructions.json
+++ b/public/dummy/json/enrollment_instructions.json
@@ -596,7 +596,6 @@
   "hasHolds": false,
   "links": {
     "ucAddClassEnrollment": {
-      "iSCsLink": true,
       "isCsLink": true,
       "name": "Apply to a Class",
       "title": "Complete your class enrollment application.",
@@ -607,7 +606,6 @@
       "urlId": "UC_CX_GT_SSCNTENRL_ADD"
     },
     "ucEditClassEnrollment": {
-      "iSCsLink": true,
       "isCsLink": true,
       "name": "Edit Class Applications",
       "title": "Edit your submited class enrollment application.",
@@ -618,7 +616,6 @@
       "urlId": "UC_CX_GT_SSCNTENRL_UPD"
     },
     "ucViewClassEnrollment": {
-      "iSCsLink": true,
       "isCsLink": true,
       "name": "Submitted Class Applications",
       "title": "View your submitted class enrollment application.",
@@ -629,7 +626,6 @@
       "urlId": "UC_CX_GT_SSCNTENRL_VIEW"
     },
     "requestLateClassChanges": {
-      "iSCsLink": true,
       "isCsLink": true,
       "name": "Petition for Late Change of Class Schedule",
       "title": "Request late add, drop, grading basis, or unit value changes to class schedule",
@@ -640,7 +636,6 @@
       "urlId": "UC_CX_GT_GRADEOPT_ADD"
     },
     "crossCampusEnroll": {
-      "iSCsLink": true,
       "isCsLink": true,
       "name": "UC Online Courses: Cross-Campus Enrollment",
       "title": "UC Online Courses for Cross-Campus Enrollment",

--- a/public/dummy/json/student_resources.json
+++ b/public/dummy/json/student_resources.json
@@ -2,7 +2,6 @@
   "feed": {
     "resources": {
       "emergencyLoanFormAdd": {
-        "iSCsLink": true,
         "isCsLink": true,
         "name": "Apply for an Emergency Loan",
         "title": "Complete this form to apply for an emergency loan.",
@@ -13,7 +12,6 @@
         "urlId": "UC_CX_GT_FAEMRLAON_ADD"
       },
       "emergencyLoanFormView": {
-        "iSCsLink": true,
         "isCsLink": true,
         "name": "Submitted Emergency Loan Forms",
         "title": "View your submitted emergency loan forms.",
@@ -24,7 +22,6 @@
         "urlId": "UC_CX_GT_FAEMRLAON_VIEW"
       },
       "specialEnrollmentPetition": {
-        "iSCsLink": true,
         "isCsLink": true,
         "name": "Special Enrollment Petition",
         "title": "Special Enrollment Petition form",
@@ -35,7 +32,6 @@
         "urlId": "UC_CX_GT_SRSEP_ADD"
       },
       "updatePendingForms": {
-        "iSCsLink": true,
         "isCsLink": true,
         "name": "Update Pending Forms",
         "title": "Modify and update your pending forms",
@@ -46,7 +42,6 @@
         "urlId": "UC_CX_GT_STUDENT_UPDATE"
       },
       "viewSubmittedForms": {
-        "iSCsLink": true,
         "isCsLink": true,
         "name": "View Submitted Forms",
         "title": "View the status of the forms you have submitted.",
@@ -57,7 +52,6 @@
         "urlId": "UC_CX_GT_STUDENT_VIEW"
       },
       "withdrawFromSemesterAdd": {
-        "iSCsLink": true,
         "isCsLink": true,
         "name": "Add a Withdrawal Request",
         "title": "Complete this form to withdraw from UC Berkeley.",
@@ -68,7 +62,6 @@
         "urlId": "UC_CX_SRWITHDRL_ADD"
       },
       "higherDegreesCommitteeForm": {
-        "iSCsLink": true,
         "isCsLink": true,
         "name": "Higher Degree Committees Form",
         "title": "Advance to Candidacy, apply for the qualifying exam, or modify your Committee.",


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-36868

I originally thought that we needed to move from using HashConverter.camelize to [HashConverter.downcase_and_camelize](https://github.com/ets-berkeley-edu/calcentral/blob/eb795453/lib/hash_converter.rb#L15), but it turns out that this isn't a good idea, because the downcase will destroy existing camelcase keys. Both are used where appropriate for now.

We don't use this 'IS_CS_LINK' key, nor does the ccCampusSolutionsLinkDirective recognize :ISCsLink as a key. So this is just a simple maintenance task to remove the unused key.

```
>> hash = {'IS_CS_LINK' => 'test'}
=> {"IS_CS_LINK"=>"test"}
>> HashConverter.downcase_and_camelize(hash)
=> {:isCsLink=>"test"}
>> HashConverter.camelize(hash)
=> {:iSCsLink=>"test"}

>> hash = {:isCsLink => 'test'}
=> {:isCsLink=>"test"}
>> HashConverter.downcase_and_camelize(hash)
=> {:iscslink=>"test"}
```