### PR TITLE
SISRP-32575 - Calentral FA Cards do not show for new Transfer students if enrolled in Summer w/non-degree plan

### DIFF
--- a/src/assets/templates/finaid.html
+++ b/src/assets/templates/finaid.html
@@ -9,7 +9,7 @@
       </h1>
     </div>
     <div class="medium-6 large-4 columns">
-      <div data-ng-include="'widgets/finaid_summary.html'"></div>
+      <div data-ng-include="'widgets/finaid_summary.html'" data-ng-if="!academicStatus.roles.summerVisitor"></div>
       <div data-ng-include="'widgets/finaid_communications.html'"></div>
       <div data-ng-include="'widgets/finaid_profile.html'"></div>
     </div>


### PR DESCRIPTION
Reverts ets-berkeley-edu/calcentral#6868

This work is being deferred to `2018-01-28 Major` release.