### PR TITLE
SISRP-29407 - Handles empty ERRMSGTXT response

### DIFF
--- a/app/models/campus_solutions/proxy.rb
+++ b/app/models/campus_solutions/proxy.rb
@@ -93,7 +93,7 @@ module CampusSolutions
 
     def is_errored?(feed)
       error_key = error_response_root_xml_node.intern
-      !feed.is_a?(Hash) || feed[:errmsgtext].present? || feed[error_key].present?
+      !feed.is_a?(Hash) || feed.key?(:errmsgtext) || feed[error_key].present?
     end
 
     def request_options

--- a/spec/models/campus_solutions/proxy_spec.rb
+++ b/spec/models/campus_solutions/proxy_spec.rb
@@ -17,8 +17,13 @@ describe CampusSolutions::Proxy do
       end
     end
 
-    context 'errmsgtext in response' do
+    context 'populated errmsgtext node in response' do
       let(:feed) { { 'ERRMSGTEXT' => 'Wicked problems' } }
+      it_behaves_like 'a proxy that handles errors'
+    end
+
+    context 'empty errmsgtext node in response' do
+      let(:feed) { { 'ERRMSGTEXT' => nil } }
       it_behaves_like 'a proxy that handles errors'
     end
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-29407

CS proxies will now return a 400 error response if the `<ERRMSGTEXT/>` node exists but is empty.