### PR TITLE
SISRP-37573 - New Admit UX Dev: New Admit Resources card

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,6 +49,11 @@ class ApplicationController < ActionController::Base
     reauthenticate(redirect_path: '/') if session_state_requires_reauthentication?
   end
 
+  def require_applicant_role
+    is_applicant = HubEdos::UserAttributes.new(user_id: current_user.user_id).has_role?(:applicant)
+    render json: { error: 'User must be an applicant to view New Admit data.' }, status: 200 unless is_applicant
+  end
+
   # Only a small subset of student API feeds are available to a delegate, and so
   # these methods filter controller endpoints by default.
   def allow_if_delegate_view_as?

--- a/app/controllers/new_admit_resources_controller.rb
+++ b/app/controllers/new_admit_resources_controller.rb
@@ -1,0 +1,8 @@
+class NewAdmitResourcesController < ApplicationController
+  before_filter :api_authenticate, :require_applicant_role
+
+  def get_feed
+    render json: CampusSolutions::NewAdmitResources.from_session(session).get_feed
+  end
+
+end

--- a/app/controllers/sir_statuses_controller.rb
+++ b/app/controllers/sir_statuses_controller.rb
@@ -5,9 +5,4 @@ class SirStatusesController < ApplicationController
     render json: CampusSolutions::Sir::SirStatuses.from_session(session).get_feed
   end
 
-  def require_applicant_role
-    is_applicant = HubEdos::UserAttributes.new(user_id: current_user.user_id).has_role?(:applicant)
-    render json: { error: 'User must be an applicant to view New Admit data.' }, status: 200 unless is_applicant
-  end
-
 end

--- a/app/models/campus_solutions/new_admit_resources.rb
+++ b/app/models/campus_solutions/new_admit_resources.rb
@@ -23,6 +23,7 @@ module CampusSolutions
         withdrawAfterMatric: 'UC_CX_SRWITHDRL_ADD'
       },
       firstYearPathways: {
+        pathwaysInfo: 'UC_ADMT_FYPATH',
         selectionForm: 'UC_ADMT_FYP_SELECT',
         pathwaysFinAid: 'UC_ADMT_FYPATH_FA_SPG'
       },
@@ -70,6 +71,7 @@ module CampusSolutions
           url: '/finances',
           linkDescription: 'View your estimated cost of attendance and financial aid awards.',
           showNewWindow: false,
+          name: 'Your Financial Aid & Scholarships Awards',
           title: 'Your Financial Aid & Scholarships Awards'
           }
         })
@@ -92,6 +94,7 @@ module CampusSolutions
           url: '/finances',
           linkDescription: pathways_links.try(:[], :pathwaysFinAid).try(:[], :linkDescription),
           showNewWindow: false,
+          name: pathways_links.try(:[], :pathwaysFinAid).try(:[], :name),
           title: pathways_links.try(:[], :pathwaysFinAid).try(:[], :title)
         }
         pathways_links[:pathwaysFinAid] = non_spring_pathways_fin_aid

--- a/app/models/campus_solutions/new_admit_resources.rb
+++ b/app/models/campus_solutions/new_admit_resources.rb
@@ -1,0 +1,150 @@
+module CampusSolutions
+  class NewAdmitResources < UserSpecificModel
+
+    include Cache::CachedFeed
+    include Cache::UserCacheExpiry
+    include Cache::RelatedCacheKeyTracker
+    include LinkFetcher
+    include User::Identifiers
+
+    SECTION_LINK_IDS = {
+      map: {
+        status: 'UC_ADMT_MAP_STATUS',
+      },
+      finAid: {
+        fasoFaq: 'UC_ADMT_FA_FAQ',
+        summerFinAid: 'UC_ADMT_SUM_FINAID'
+      },
+      admissions: {
+        admissionsConditionsFreshman: 'UC_ADMT_COND_FRESH',
+        admissionsConditionsTransfer: 'UC_ADMT_COND_TRANS',
+        deferral: 'UC_ADMT_DEFER',
+        withdrawBeforeMatric: 'UC_ADMT_WITHDR',
+        withdrawAfterMatric: 'UC_CX_SRWITHDRL_ADD'
+      },
+      firstYearPathways: {
+        selectionForm: 'UC_ADMT_FYP_SELECT',
+        pathwaysFinAid: 'UC_ADMT_FYPATH_FA_SPG'
+      },
+      general: {
+        admissionsFaq: 'UC_ADMT_ADMSSNS_FAQ',
+        calStudentCentral: 'UC_ADMT_CAL_STDNT_CNTRL',
+        contactUgrdAdmissions: 'UC_ADMT_CNTCT_UGRD_ADMSSNS'
+      }
+    }
+
+    def get_feed_internal
+      return { visible: false } unless attributes.try(:[], :visible)
+      {
+        visible: attributes.try(:[], :visible),
+        links: get_links,
+        admissionsEvaluator: get_admissions_evaluator
+      }
+    end
+
+    def get_admissions_evaluator
+      evaluator = { name: nil, email: nil }
+      cs_id = lookup_campus_solutions_id
+      application_number = attributes.try(:[], :applicationNbr)
+      if cs_id && application_number
+        evaluator_data = EdoOracle::Queries.get_new_admit_evaluator(cs_id, application_number)
+        evaluator[:name] = evaluator_data.try(:[], 'evaluator_name')
+        evaluator[:email] = evaluator_data.try(:[], 'evaluator_email')
+      end
+      evaluator
+    end
+
+    def get_links
+      {
+        map: links[:map],
+        finAid: parse_fin_aid_links(links[:finAid]),
+        admissions: parse_admissions_links(links[:admissions]),
+        firstYearPathways: parse_first_year_pathways_links(links[:firstYearPathways]),
+        general: links[:general]
+      }
+    end
+
+    def parse_fin_aid_links(fin_aid_links)
+      fin_aid_links.merge!({
+        finAidAwards: {
+          url: '/finances',
+          linkDescription: 'View your estimated cost of attendance and financial aid awards.',
+          showNewWindow: false,
+          title: 'Your Financial Aid & Scholarships Awards'
+          }
+        })
+    end
+
+    def parse_admissions_links(admissions_links)
+      roles = attributes.try(:[], :roles)
+      admissions_links.try(:delete_if) do |link_key, link_value|
+        (link_key == :admissionsConditionsFreshman && is_transfer_or_athlete(roles)) ||
+        (link_key == :admissionsConditionsTransfer && is_freshman_non_athlete(roles)) ||
+        (link_key == :withdrawAfterMatric && roles.try(:[], :preMatriculated)) ||
+        (link_key == :withdrawBeforeMatric && !roles.try(:[], :preMatriculated))
+      end
+    end
+
+    def parse_first_year_pathways_links(pathways_links)
+      return {} unless attributes.try(:[], :roles).try(:[], :firstYearPathway)
+      if non_spring_admit(attributes.try(:[], :admitTerm))
+        non_spring_pathways_fin_aid = {
+          url: '/finances',
+          linkDescription: pathways_links.try(:[], :pathwaysFinAid).try(:[], :linkDescription),
+          showNewWindow: false,
+          title: pathways_links.try(:[], :pathwaysFinAid).try(:[], :title)
+        }
+        pathways_links[:pathwaysFinAid] = non_spring_pathways_fin_aid
+      end
+      pathways_links
+    end
+
+    def links
+      @link_config ||= {}.tap do |link_config|
+        SECTION_LINK_IDS.each do |section, link_collection|
+          link_config[section] = get_section_links link_collection
+        end
+      end
+    end
+
+    def get_section_links(link_collection)
+      {}.tap do |section_links|
+        link_collection.each do |link_descr, link_id|
+          section_links[link_descr] = fetch_link(link_id)
+        end
+      end
+    end
+
+    def attributes
+      @new_admit_attributes ||= {}.tap do |new_admit_attributes|
+        new_admit_statuses = CampusSolutions::Sir::SirStatuses.new(@uid).get_feed
+        undergraduate_status = new_admit_statuses.try(:[], :sirStatuses).try(:find) do |status|
+          status.try(:[], :isUndergraduate)
+        end
+        new_admit_attributes.merge!({
+          admitTerm: undergraduate_status.try(:[], :newAdmitAttributes).try(:[], :admitTerm),
+          applicationNbr: undergraduate_status.try(:[], :checkListMgmtAdmp).try(:[], :admApplNbr).try(:to_s),
+          roles: undergraduate_status.try(:[], :newAdmitAttributes).try(:[], :roles),
+          visible: is_visible?(undergraduate_status)
+        })
+      end
+    end
+
+    def is_visible?(undergraduate_status)
+      ['I', 'R'].include?(undergraduate_status.try(:[], :itemStatusCode)) || undergraduate_status.try(:[], :newAdmitAttributes).try(:[], :visible)
+    end
+
+    def is_freshman_non_athlete(roles)
+      roles.try(:[], :firstYearFreshman) && !roles.try(:[], :athlete)
+    end
+
+    def is_transfer_or_athlete(roles)
+      roles.try(:[], :transfer) || roles.try(:[], :athlete)
+    end
+
+    def non_spring_admit(admit_term)
+      admit_term.try(:[], :type) != 'Spring'
+    end
+
+  end
+end

--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -513,5 +513,19 @@ module EdoOracle
       result.first
     end
 
+    def self.get_new_admit_evaluator (student_id, application_nbr)
+      result = safe_query <<-SQL
+        SELECT
+          EVALUATOR_NAME as evaluator_name,
+          EVALUATOR_EMAIL as evaluator_email
+        FROM
+          SISEDO.APPLICANT_ADMIT_DATA_UGV00_VW
+        WHERE
+          STUDENT_ID = '#{student_id}' AND
+          APPLICATION_NBR = '#{application_nbr}'
+      SQL
+      result.first
+    end
+
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,7 @@ Calcentral::Application.routes.draw do
     get '/api/my/campuslinks/refresh' => 'my_campus_links#refresh', :defaults => { :format => 'json' }
     get '/api/my/registrations' => 'my_registrations#get_feed', :defaults => { :format => 'json' }
     get '/api/my/sir_statuses' => 'sir_statuses#get_feed', :defaults => { :format => 'json' }
+    get '/api/my/new_admit_resources' =>'new_admit_resources#get_feed', :defaults => { :format => 'json' }
     get '/api/academics/enrollment_verification' => 'enrollment_verification#get_feed', :defaults => { :format => 'json' }
     get '/api/academics/degree_progress/ugrd' => 'my_degree_progress#get_undergraduate_requirements', :defaults => { :format => 'json' }
     get '/api/academics/degree_progress/grad' => 'my_degree_progress#get_graduate_milestones', :defaults => { :format => 'json' }

--- a/public/dummy/json/new_admit_resources.json
+++ b/public/dummy/json/new_admit_resources.json
@@ -1,0 +1,132 @@
+{
+   "visible":true,
+   "links":{
+      "map":{
+         "status":{
+            "url":"https://apply.berkeley.edu/status",
+            "urlId":"UC_ADMT_MAP_STATUS",
+            "linkDescription":"Important admissions documents and forms are available in MAP@berkeley.edu.",
+            "linkDescriptionDisplay":true,
+            "showNewWindow":true,
+            "name":"MAP@berkeley.edu",
+            "title":"MAP@berkeley.edu"
+         }
+      },
+      "finAid":{
+         "fasoFaq":{
+            "url":"https://http://financialaid.berkeley.edu/newly-admitted-student-faq",
+            "urlId":"UC_ADMT_FA_FAQ",
+            "linkDescription":"Information about common financial aid topics.",
+            "linkDescriptionDisplay":true,
+            "showNewWindow":true,
+            "name":"Financial Aid & Scholarships FAQ",
+            "title":"Financial Aid & Scholarships FAQ"
+         },
+         "summerFinAid":{
+            "url":"https://financialaid.berkeley.edu/summer-aid",
+            "urlId":"UC_ADMT_SUM_FINAID",
+            "linkDescription":"Aid and scholarships information related to starting in the summer term.",
+            "linkDescriptionDisplay":true,
+            "showNewWindow":true,
+            "name":"Summer Financial Aid & Scholarships",
+            "title":"Summer Financial Aid & Scholarships"
+         },
+         "finAidAwards":{
+            "url":"/finances",
+            "linkDescription":"View your estimated cost of attendance and financial aid awards.",
+            "showNewWindow":false,
+            "name":"Your Financial Aid & Scholarships Awards",
+            "title":"Your Financial Aid & Scholarships Awards"
+         }
+      },
+      "admissions":{
+         "admissionsConditionsFreshman":{
+            "url":"https://apply.berkeley.edu/apply/form?id=d4bba55a-ce4f-4c5e-8c70-af5c814da58b",
+            "urlId":"UC_ADMT_COND_FRESH",
+            "linkDescription":"Meet these conditions to secure your admission.",
+            "linkDescriptionDisplay":true,
+            "showNewWindow":true,
+            "name":"Conditions of Admission",
+            "title":"Conditions of Admission"
+         },
+         "deferral":{
+            "url":"https://apply.berkeley.edu/apply/form?id=9c1a9370-c2a4-4022-8d25-b0aecb850d38",
+            "urlId":"UC_ADMT_DEFER",
+            "linkDescription":"Request a deferral of your enrollment.",
+            "linkDescriptionDisplay":true,
+            "showNewWindow":true,
+            "name":"Deferral Form",
+            "title":"Deferral Form"
+         },
+         "withdrawBeforeMatric":{
+            "url":"https://apply.berkeley.edu/apply/form?id=8af84e30-3cd9-4914-8840-226cc045d8e7",
+            "urlId":"UC_ADMT_WITHDR",
+            "linkDescription":"Cancel your admission.",
+            "linkDescriptionDisplay":true,
+            "showNewWindow":true,
+            "name":"Withdraw Form",
+            "title":"Withdraw Form"
+         }
+      },
+      "firstYearPathways":{
+         "pathwaysInfo":{
+            "url":"https://admissions.berkeley.edu/firstyearpathways",
+            "urlId":"UC_ADMT_FYPATH",
+            "linkDescription":"Learn about First-Year Pathways.",
+            "linkDescriptionDisplay":true,
+            "showNewWindow":true,
+            "name":"First-Year Pathways",
+            "title":"First-Year Pathways Learn More"
+         },
+         "selectionForm":{
+            "url":"https://apply.berkeley.edu/apply/form?id=ba3db23c-fd08-4e73-922e-374d6a4691e9",
+            "urlId":"UC_ADMT_FYP_SELECT",
+            "linkDescription":"Sign up for a pathway while space is available. Learn about First-Year Pathways.",
+            "linkDescriptionDisplay":true,
+            "showNewWindow":true,
+            "name":"First-Year Pathways Selection Form",
+            "title":"First-Year Pathways Selection Form"
+         },
+         "pathwaysFinAid":{
+            "url":"/finances",
+            "linkDescription":"Estimating your financial aid and scholarships based on your pathway choice.",
+            "showNewWindow":false,
+            "name":"First-Year Pathways Financial Aid",
+            "title":"First-Year Pathways Financial Aid"
+         }
+      },
+      "general":{
+         "admissionsFaq":{
+            "url":"https://apply.berkeley.edu/apply/form?id=fd3dad1e-6ba6-44bf-a9fd-8fc1152d0e2e",
+            "urlId":"UC_ADMT_ADMSSNS_FAQ",
+            "linkDescription":"Answers to common admissions questions.",
+            "linkDescriptionDisplay":true,
+            "showNewWindow":true,
+            "name":"Admissions FAQ",
+            "title":"Admissions FAQ"
+         },
+         "calStudentCentral":{
+            "url":"https://studentcentral.berkeley.edu/newlyadmitted",
+            "urlId":"UC_ADMT_CAL_STDNT_CNTRL",
+            "linkDescription":"Contact for questions about billing, financial aid, etc.",
+            "linkDescriptionDisplay":true,
+            "showNewWindow":true,
+            "name":"Cal Student Central",
+            "title":"Cal Student Central"
+         },
+         "contactUgrdAdmissions":{
+            "url":"https://admissions.berkeley.edu/contactus",
+            "urlId":"UC_ADMT_CNTCT_UGRD_ADMSSNS",
+            "linkDescription":"For specific questions about changing majors, deferment, withdrawal, transcripts, exams, etc.",
+            "linkDescriptionDisplay":true,
+            "showNewWindow":true,
+            "name":"Contact Office of Undergraduate Admissions",
+            "title":"Contact Office of Undergraduate Admissions"
+         }
+      }
+   },
+   "admissionsEvaluator":{
+      "name":"Scott Summers",
+      "email":"cyclops@xmen.edu"
+   }
+}

--- a/spec/models/campus_solutions/new_admit_resources_spec.rb
+++ b/spec/models/campus_solutions/new_admit_resources_spec.rb
@@ -210,7 +210,6 @@ describe CampusSolutions::NewAdmitResources do
         end
         subject { proxy.new(uid).get_feed }
         it 'returns a simple response indicating expiration of the card' do
-          pp subject
           expect(subject[:visible]).to eq false
         end
       end

--- a/spec/models/campus_solutions/new_admit_resources_spec.rb
+++ b/spec/models/campus_solutions/new_admit_resources_spec.rb
@@ -1,0 +1,237 @@
+describe CampusSolutions::NewAdmitResources do
+
+  let(:uid) { 61889 }
+  let(:proxy) { CampusSolutions::NewAdmitResources }
+  let(:link_api_response) { {url: true} }
+  before(:each) do
+    allow_any_instance_of(LinkFetcher).to receive(:fetch_link).and_return link_api_response
+  end
+
+  let(:sir_statuses_incomplete_base_response) {
+    {
+      sirStatuses: [
+        {
+          checkListMgmtAdmp: {
+            acadCareer: 'UGRD',
+            admApplNbr: '00111591'
+          },
+          isUndergraduate: true,
+          itemStatusCode: 'I'
+        }
+      ]
+    }
+  }
+
+  let(:sir_statuses_complete_base_response) {
+    {
+      sirStatuses: [
+        {
+          checkListMgmtAdmp: {
+            acadCareer: 'UGRD',
+            admApplNbr: '00111591'
+          },
+          isUndergraduate: true,
+          itemStatusCode: 'C'
+        }
+      ]
+    }
+  }
+
+  let(:new_admit_attributes_freshman) {
+    {
+      newAdmitAttributes: {
+        roles: {
+          athlete: false,
+          firstYearFreshman: true,
+          firstYearPathway: false,
+          preMatriculated: true,
+          transfer: false
+        },
+        admitTerm: {
+          term: 2165,
+          type: 'Fall'
+        },
+        visible: true
+      }
+    }
+  }
+
+  let(:new_admit_attributes_transfer) {
+    {
+      newAdmitAttributes: {
+        roles: {
+          athlete: false,
+          firstYearFreshman: false,
+          firstYearPathway: false,
+          preMatriculated: true,
+          transfer: true
+        },
+        admitTerm: {
+          term: 2178,
+          type: 'Spring'
+        },
+        visible: true
+      }
+    }
+  }
+
+  let(:new_admit_attributes_first_year_pathway) {
+    {
+      newAdmitAttributes: {
+        roles: {
+          athlete: false,
+          firstYearFreshman: true,
+          firstYearPathway: true,
+          preMatriculated: false,
+          transfer: false
+        },
+        admitTerm: {
+          term: 2165,
+          type: 'Fall'
+        },
+        visible: true
+      }
+    }
+  }
+
+  let(:new_admit_attributes_expired) {
+    {
+      newAdmitAttributes: {
+        roles: {
+          athlete: false,
+          firstYearFreshman: true,
+          firstYearPathway: true,
+          preMatriculated: true,
+          transfer: false
+        },
+        admitTerm: {
+          term: 2178,
+          type: 'Spring'
+        },
+        visible: false
+      }
+    }
+  }
+
+  let(:evaluator_response) {
+    {
+      'evaluator_name' => 'James P. Sullivan',
+      'evaluator_email' => 'sully@monsters.inc'
+    }
+  }
+
+  let(:evaluator_response_empty) {
+    {
+      'evaluator_name' => nil,
+      'evaluator_email' => nil
+    }
+  }
+
+  shared_examples 'a general response' do
+    it 'has all link sections attached' do
+      expect(subject[:links][:map]).to be
+      expect(subject[:links][:finAid]).to be
+      expect(subject[:links][:admissions]).to be
+      expect(subject[:links][:firstYearPathways]).to be
+      expect(subject[:links][:general]).to be
+    end
+
+    it 'has all non-dependent links attached' do
+      expect(subject[:links][:map][:status][:url]).to be_truthy
+      expect(subject[:links][:finAid][:finAidAwards][:url]).to be_truthy
+      expect(subject[:links][:finAid][:fasoFaq][:url]).to be_truthy
+      expect(subject[:links][:finAid][:summerFinAid][:url]).to be_truthy
+      expect(subject[:links][:admissions][:deferral][:url]).to be_truthy
+      expect(subject[:links][:general][:admissionsFaq][:url]).to be_truthy
+      expect(subject[:links][:general][:calStudentCentral][:url]).to be_truthy
+      expect(subject[:links][:general][:contactUgrdAdmissions][:url]).to be_truthy
+    end
+  end
+
+  describe 'attempting to view new admit resources' do
+
+    context 'as an incomplete new admit' do
+      context 'as a pre-matriculated non-first-year pathway freshman with an admissions evaluator' do
+        before do
+          sir_statuses_incomplete_base_response[:sirStatuses][0].merge!(new_admit_attributes_freshman)
+          CampusSolutions::Sir::SirStatuses.stub_chain(:new, :get_feed).and_return sir_statuses_incomplete_base_response
+          EdoOracle::Queries.stub(:get_new_admit_evaluator) { evaluator_response }
+        end
+        subject { proxy.new(uid).get_feed }
+        it_behaves_like 'a general response'
+        it 'removes all irrelevant links' do
+          expect(subject[:links][:admissions][:admissionsConditionsTransfer]).to be_falsey
+          expect(subject[:links][:admissions][:withdrawAfterMatric]).to be_falsey
+          expect(subject[:links][:firstYearPathways]).to be_empty
+        end
+        it 'adds all relevant links' do
+          expect(subject[:links][:admissions][:admissionsConditionsFreshman]).to be_truthy
+        end
+        it 'contains admissions evaluator information' do
+          expect(subject[:admissionsEvaluator][:name]).to eq 'James P. Sullivan'
+          expect(subject[:admissionsEvaluator][:email]).to eq 'sully@monsters.inc'
+        end
+      end
+
+      context 'as a matriculated first-year pathway freshman without an admissions evaluator admitted in Fall' do
+        before do
+          sir_statuses_incomplete_base_response[:sirStatuses][0].merge!(new_admit_attributes_first_year_pathway)
+          CampusSolutions::Sir::SirStatuses.stub_chain(:new, :get_feed).and_return sir_statuses_incomplete_base_response
+          EdoOracle::Queries.stub(:get_new_admit_evaluator) { evaluator_response_empty }
+        end
+        subject { proxy.new(uid).get_feed }
+        it_behaves_like 'a general response'
+        it 'removes all irrelevant links' do
+          expect(subject[:links][:admissions][:admissionsConditionsTransfer]).to be_falsey
+          expect(subject[:links][:admissions][:withdrawBeforeMatric]).to be_falsey
+        end
+        it 'adds all relevant links' do
+          expect(subject[:links][:admissions][:admissionsConditionsFreshman]).to be_truthy
+          expect(subject[:links][:admissions][:withdrawAfterMatric]).to be_truthy
+          expect(subject[:links][:firstYearPathways][:selectionForm][:url]).to be_truthy
+          expect(subject[:links][:firstYearPathways][:pathwaysFinAid][:url]).to be_truthy
+        end
+        it 'shows the fall-admit first-year-pathway financial aid link' do
+          expect(subject[:links][:firstYearPathways][:pathwaysFinAid][:url]).to eq '/finances'
+        end
+        it 'does not contain admissions evaluator information' do
+          expect(subject[:admissionsEvaluator][:name]).to be_nil
+          expect(subject[:admissionsEvaluator][:email]).to be_nil
+        end
+      end
+    end
+
+    context 'as a completed new admit' do
+      context 'as a student whose SIR card has expired' do
+        before do
+          sir_statuses_complete_base_response[:sirStatuses][0].merge!(new_admit_attributes_expired)
+          CampusSolutions::Sir::SirStatuses.stub_chain(:new, :get_feed).and_return sir_statuses_complete_base_response
+          EdoOracle::Queries.stub(:get_new_admit_evaluator) { evaluator_response_empty }
+        end
+        subject { proxy.new(uid).get_feed }
+        it 'returns a simple response indicating expiration of the card' do
+          pp subject
+          expect(subject[:visible]).to eq false
+        end
+      end
+
+      context 'as a transfer student whose SIR card has not expired' do
+        before do
+          sir_statuses_complete_base_response[:sirStatuses][0].merge!(new_admit_attributes_transfer)
+          CampusSolutions::Sir::SirStatuses.stub_chain(:new, :get_feed).and_return sir_statuses_complete_base_response
+          EdoOracle::Queries.stub(:get_new_admit_evaluator) { evaluator_response_empty }
+        end
+        subject { proxy.new(uid).get_feed }
+        it_behaves_like 'a general response'
+        it 'removes irrelevant links' do
+          expect(subject[:links][:admissions][:admissionsConditionsFreshman]).to be_falsey
+        end
+        it 'adds relevant links' do
+          expect(subject[:links][:admissions][:admissionsConditionsTransfer]).to be_truthy
+        end
+      end
+
+    end
+  end
+
+end

--- a/src/assets/javascripts/angular/controllers/widgets/newAdmitResourcesController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/newAdmitResourcesController.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var angular = require('angular');
+var _ = require('lodash');
+
+angular.module('calcentral.controllers').controller('NewAdmitResourcesController', function($scope, newAdmitResourcesFactory) {
+  $scope.newAdmitResources = {
+    admissionsSection: {},
+    isLoading: true,
+    pathwaysSection: {
+      visible: false
+    }
+  };
+
+  var parseNewAdmitResources = function(response) {
+    var newAdmitResources = _.get(response, 'data');
+    _.merge($scope.newAdmitResources, newAdmitResources);
+    $scope.newAdmitResources.pathwaysSection.visible = !_.isEmpty(_.get(newAdmitResources, 'links.firstYearPathways'));
+    $scope.newAdmitResources.isLoading = false;
+  };
+
+  var getNewAdmitResources = function() {
+    return newAdmitResourcesFactory.getNewAdmitResources().then(parseNewAdmitResources);
+  };
+
+  getNewAdmitResources();
+});

--- a/src/assets/javascripts/angular/directives/expandableLinkListDirective.js
+++ b/src/assets/javascripts/angular/directives/expandableLinkListDirective.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var angular = require('angular');
+
+angular.module('calcentral.directives').directive('ccExpandableLinkListDirective', function(widgetService) {
+  return {
+    restrict: 'E',
+    scope: {
+      links: '=',
+      sectionTitle: '='
+    },
+    templateUrl: 'directives/expandable_link_list.html',
+    link: function(scope) {
+      scope.toggleShow = widgetService.toggleShow;
+      scope.section = {};
+    }
+  };
+});

--- a/src/assets/javascripts/angular/factories/newAdmitResourcesFactory.js
+++ b/src/assets/javascripts/angular/factories/newAdmitResourcesFactory.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var angular = require('angular');
+
+/**
+ * SIR Factory
+ */
+angular.module('calcentral.factories').factory('newAdmitResourcesFactory', function(apiService) {
+  var urlNewAdmitResources = '/api/my/new_admit_resources';
+  // var urlNewAdmitResources = '/dummy/json/new_admit_resources.json';
+
+  var getNewAdmitResources = function(options) {
+    return apiService.http.request(options, urlNewAdmitResources);
+  };
+
+  return {
+    getNewAdmitResources: getNewAdmitResources
+  };
+});

--- a/src/assets/stylesheets/_new_admit_resources.scss
+++ b/src/assets/stylesheets/_new_admit_resources.scss
@@ -1,0 +1,18 @@
+.cc-widget-new-admit-resources {
+  .cc-widget-new-admit-resources-admissions-evaluator {
+    margin-bottom: 20px;
+    p {
+      margin: 0;
+    }
+  }
+  .cc-widget-new-admit-resources-section {
+    border-bottom: 1px solid $cc-color-whisper;
+    h3 {
+      margin: 0;
+    }
+    &:first-child {
+      padding-bottom: 10px;
+      padding-top: 0;
+    }
+  }
+}

--- a/src/assets/stylesheets/calcentral.scss
+++ b/src/assets/stylesheets/calcentral.scss
@@ -80,6 +80,7 @@
 @import "google_reminder";
 @import "user_search";
 @import "advising_resources";
+@import "new_admit_resources";
 
 // Campus
 @import "campus";

--- a/src/assets/templates/dashboard.html
+++ b/src/assets/templates/dashboard.html
@@ -1,6 +1,7 @@
 <div data-ng-if="api.user.profile.hasDashboardTab">
   <div class="medium-5 large-3 columns">
     <div data-ng-include="'widgets/sir/sir.html'" data-ng-if="!api.user.profile.delegateActingAsUid && api.user.profile.roles.applicant"></div>
+    <div data-ng-include="'widgets/new_admit_resources.html'" data-ng-if="!api.user.profile.delegateActingAsUid && api.user.profile.roles.applicant"></div>
     <div data-ng-include="'widgets/up_next.html'" data-ng-if="!api.user.profile.isApplicantOnly"></div>
     <div data-ng-include="'widgets/my_classes.html'" data-ng-if="!api.user.profile.isApplicantOnly"></div>
     <div data-ng-include="'widgets/my_groups.html'" data-ng-if="!api.user.profile.isApplicantOnly"></div>

--- a/src/assets/templates/directives/expandable_link_list.html
+++ b/src/assets/templates/directives/expandable_link_list.html
@@ -1,0 +1,10 @@
+<h3 class="cc-widget-list-hover"
+    data-ng-class="{'cc-widget-list-hover-opened':(section.show)}"
+    data-ng-click="toggleShow($event, null, section, 'Dashboard - New Admit Resources')"
+    data-ng-bind="sectionTitle"></h3>
+<ul data-ng-if="section.show" class="cc-list-bullets">
+  <li data-ng-repeat="(linkName, link) in links">
+    <a data-ng-href="{{link.url}}" data-ng-attr-title="{{link.title}}"><span data-ng-bind="link.name"></span></a>
+    <p data-ng-bind="link.linkDescription"></p>
+  </li>
+</ul>

--- a/src/assets/templates/widgets/new_admit_resources.html
+++ b/src/assets/templates/widgets/new_admit_resources.html
@@ -1,0 +1,57 @@
+<div class="cc-widget cc-widget-new-admit-resources" data-ng-controller="NewAdmitResourcesController">
+  <div class="cc-widget-title">
+    <h2>New Admit Resources</h2>
+  </div>
+  <div class="cc-widget-text">
+    <div class="cc-widget-new-admit-resources-section">
+      Important admissions documents and forms are available in <a data-ng-href="{{newAdmitResources.links.map.status.url}}">MAP@berkeley.edu.</a>
+    </div>
+    <div class="cc-widget-new-admit-resources-section">
+      <data-cc-expandable-link-list-directive data-links="newAdmitResources.links.finAid" data-section-title="'Financial Aid &amp; Scholarships'"></data-cc-expandable-link-list-directive>
+    </div>
+    <div class="cc-widget-new-admit-resources-section">
+      <h3 class="cc-widget-list-hover"
+          data-ng-class="{'cc-widget-list-hover-opened':(newAdmitResources.admissionsSection.show)}"
+          data-ng-click="api.widget.toggleShow($event, null, newAdmitResources.admissionsSection, 'Dashboard - New Admit Resources')">Admissions Changes</h3>
+      <ul data-ng-if="newAdmitResources.admissionsSection.show" class="cc-list-bullets">
+        <li data-ng-repeat="(linkName, link) in newAdmitResources.links.admissions">
+          <a data-ng-href="{{link.url}}" data-ng-attr-title="{{link.title}}"><span data-ng-bind="link.name"></span></a>
+          <p data-ng-bind="link.linkDescription"></p>
+        </li>
+      </ul>
+      <div data-ng-if="newAdmitResources.admissionsEvaluator.name && newAdmitResources.admissionsEvaluator.email && newAdmitResources.admissionsSection.show" class="cc-widget-new-admit-resources-admissions-evaluator">
+        <h4>Admissions Officer</h4>
+        <p data-ng-bind="newAdmitResources.admissionsEvaluator.name"></p>
+        <a data-ng-href="mailto:{{newAdmitResources.admissionsEvaluator.email}}" data-ng-bind="newAdmitResources.admissionsEvaluator.email"></a>
+        <br/>
+        <br/>
+        <p>Contact if you have questions regarding your conditions of admission.</p>
+      </div>
+    </div>
+    <div data-ng-if="newAdmitResources.pathwaysSection.visible" class="cc-widget-new-admit-resources-section">
+      <h3 class="cc-widget-list-hover"
+          data-ng-class="{'cc-widget-list-hover-opened':(newAdmitResources.pathwaysSection.show)}"
+          data-ng-click="api.widget.toggleShow($event, null, newAdmitResources.pathwaysSection, 'Dashboard - New Admit Resources')">First-Year Pathways</h3>
+      <ul data-ng-if="newAdmitResources.pathwaysSection.show" class="cc-list-bullets">
+        <li data-ng-if="newAdmitResources.links.firstYearPathways.selectionForm.url">
+          <a data-ng-href="{{newAdmitResources.links.firstYearPathways.selectionForm.url}}"
+             data-ng-attr-title="{{newAdmitResources.links.firstYearPathways.selectionForm.title}}"><span data-ng-bind="newAdmitResources.links.firstYearPathways.selectionForm.name"></span>
+           </a>
+          <p>Sign up for a pathway while space is available. Learn about
+             <a data-ng-href="{{newAdmitResources.links.firstYearPathways.pathwaysInfo.url}}" data-ng-attr-title="newAdmitResources.links.firstYearPathways.pathwaysInfo.title">First-Year Pathways.</a>
+          </p>
+        </li>
+        <li data-ng-if="newAdmitResources.links.firstYearPathways.pathwaysFinAid.url">
+          <a data-ng-href="{{newAdmitResources.links.firstYearPathways.pathwaysFinAid.url}}"
+             data-ng-attr-title="{{newAdmitResources.links.firstYearPathways.pathwaysFinAid.title}}">
+             <span data-ng-bind="newAdmitResources.links.firstYearPathways.pathwaysFinAid.name"></span>
+          </a>
+          <p data-ng-bind="newAdmitResources.links.firstYearPathways.pathwaysFinAid.linkDescription"></p>
+        </li>
+      </ul>
+    </div>
+    <div class="cc-widget-new-admit-resources-section">
+      <data-cc-expandable-link-list-directive data-links="newAdmitResources.links.general" data-section-title="'Your Questions Answered Here'"></data-cc-expandable-link-list-directive>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Dev JIRA: https://jira.berkeley.edu/browse/SISRP-37573
Design JIRA: https://jira.berkeley.edu/browse/SISRP-36596

* 2 commits, one for back-end and one for the front-end
* Speaking with the designer, she mentioned that the format of the New Admit Resources card, which is a collection of expandable lists, will most likely be re-used in the future.  This is why I chose to create an angular directive (`cc-expandable-link-list`) for it, even though I'm only using it twice (couldn't use it more because of one-off weirdness, like inline links in the link description)