### PR TITLE
Display assigned advisor program in parentheses only if truthy

### DIFF
--- a/src/assets/templates/widgets/my_advising.html
+++ b/src/assets/templates/widgets/my_advising.html
@@ -78,7 +78,9 @@
             data-ng-repeat="advisor in myAdvising.advisors"
             data-ng-if="myAdvising.advisors.length > 0">
             <div>
-              <strong data-ng-bind="advisor.assignedAdvisorType"></strong> (<span data-ng-bind="advisor.assignedAdvisorProgram"></span>)
+              <strong data-ng-bind="advisor.assignedAdvisorType"></strong>
+              <span data-ng-if="advisor.assignedAdvisorProgram"
+                data-ng-bind=" '(' + advisor.assignedAdvisorProgram + ')'"></span>
             </div>
             <div>
               <span data-ng-bind="advisor.assignedAdvisorName"></span>


### PR DESCRIPTION
So that it will not show an empty pair of parentheses at cases