### PR TITLE
SISRP-38047 - Prevents user from updating any name other than the preferred name

### DIFF
--- a/app/models/campus_solutions/person_name.rb
+++ b/app/models/campus_solutions/person_name.rb
@@ -12,7 +12,6 @@ module CampusSolutions
     def self.field_mappings
       @field_mappings ||= FieldMapping.to_hash(
         [
-          FieldMapping.required(:type, :NAME_TYPE),
           FieldMapping.required(:firstName, :FIRST_NAME),
           FieldMapping.required(:lastName, :LAST_NAME),
           FieldMapping.required(:initials, :NAME_INITIALS),
@@ -43,7 +42,8 @@ module CampusSolutions
     def default_post_params
       super.merge(
         {
-          COUNTRY_NM_FORMAT: '001'
+          COUNTRY_NM_FORMAT: '001',
+          NAME_TYPE: 'PRF'
         })
     end
 

--- a/spec/models/campus_solutions/person_name_spec.rb
+++ b/spec/models/campus_solutions/person_name_spec.rb
@@ -10,13 +10,15 @@ describe CampusSolutions::PersonName do
       let(:params) { {
         bogus: 1,
         invalid: 2,
+        type: 'LEG',
         firstName: 'Joe'
       } }
       subject { proxy.filter_updateable_params(params) }
-      it 'should strip out invalid fields' do
-        expect(subject.keys.length).to eq 16
+      it 'should strip out invalid and non-permitted fields' do
+        expect(subject.keys.length).to eq 15
         expect(subject[:bogus]).to be_nil
         expect(subject[:invalid]).to be_nil
+        expect(subject[:nameType]).to be_nil
         expect(subject[:firstName]).to eq 'Joe'
       end
     end
@@ -31,8 +33,10 @@ describe CampusSolutions::PersonName do
         MultiXml.parse(result)['NAMES']
       }
       it 'should convert the CalCentral params to Campus Solutions params without exploding on bogus fields' do
-        expect(subject['NAME_TYPE']).to eq 'LEG'
         expect(subject['FIRST_NAME']).to eq 'Joe'
+      end
+      it 'should force the type to be PRF (preferred)' do
+        expect(subject['NAME_TYPE']).to eq 'PRF'
       end
     end
 

--- a/src/assets/javascripts/angular/controllers/widgets/profile/basicPreferredNameController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/profile/basicPreferredNameController.js
@@ -59,7 +59,6 @@ angular.module('calcentral.controllers').controller('BasicPreferredNameControlle
 
   $scope.save = function(item) {
     apiService.profile.save($scope, profileFactory.postName, {
-      type: 'PRF',
       firstName: item.givenName,
       middleName: item.middleName,
       lastName: item.familyName,


### PR DESCRIPTION
master PR for #6937 

The change will be included in a 1/21 emergency release.  This PR will port the change over to master so it doesn't get overwritten by the 1/28 release.