### PR TITLE
SISRP-38220 - Pay Deposit button stays even after a deposit is paid and it takes few minute to show confirmation message to student

### DIFF
--- a/app/models/notifications/sis_expiry_processor.rb
+++ b/app/models/notifications/sis_expiry_processor.rb
@@ -39,7 +39,7 @@ module Notifications
       'sis:student:affiliation' => CampusSolutions::UserApiExpiry,
       'sis:student:checklist' => CampusSolutions::ChecklistDataExpiry,
       'sis:student:delegate' => CampusSolutions::DelegateStudentsExpiry,
-      'sis:student:deposit' => CampusSolutions::Sir::MyDeposit,
+      'sis:student:deposit' => CampusSolutions::Sir::SirStatuses,
       'sis:student:enrollment' => CampusSolutions::EnrollmentTermExpiry,
       'sis:student:eft' => Eft::MyEftEnrollment,
       'sis:student:ferpa' => nil,


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-38220

I folded `CampusSolutions::Sir::MyDeposit` into `CampusSolutions::Sir::SirStatuses`, so I removed caching on `MyDeposit` since we're already caching it in `SirStatuses`.  This led to a breakage in functionality, since CalCentral was not updating correctly after payment was made to HigherOne (which triggers the ENF).  This should fix it.