### PR TITLE
SISRP-38224 - On New Admit Resource Card > Your Financial Aid & Scholarships Awards - Link under Financial Aid & Scholarships section should take you directly to financial page

### DIFF
--- a/app/models/campus_solutions/new_admit_resources.rb
+++ b/app/models/campus_solutions/new_admit_resources.rb
@@ -69,7 +69,7 @@ module CampusSolutions
 
     def parse_fin_aid_links(fin_aid_links)
       fin_aid_links[:finAidAwards] = {
-         url: '/finances',
+         url: calcentral_financial_aid_link,
          linkDescription: 'View your estimated cost of attendance and financial aid awards.',
          showNewWindow: false,
          name: 'Your Financial Aid & Scholarships Awards',
@@ -92,7 +92,7 @@ module CampusSolutions
       return {} unless attributes.try(:[], :roles).try(:[], :firstYearPathway)
       if non_spring_admit(attributes.try(:[], :admitTerm))
         non_spring_pathways_fin_aid = {
-          url: '/finances',
+          url: calcentral_financial_aid_link,
           linkDescription: pathways_links.try(:[], :pathwaysFinAid).try(:[], :linkDescription),
           showNewWindow: false,
           name: pathways_links.try(:[], :pathwaysFinAid).try(:[], :name),
@@ -101,6 +101,23 @@ module CampusSolutions
         pathways_links[:pathwaysFinAid] = non_spring_pathways_fin_aid
       end
       pathways_links
+    end
+
+    def calcentral_financial_aid_link
+      latest_aid_year.present? ? '/finances/finaid/' + latest_aid_year.to_s : '/finances'
+    end
+
+    def latest_aid_year
+      @aid_year ||= get_latest_aid_year
+    end
+
+    def get_latest_aid_year
+      aid_years = []
+      aid_years_feed = CampusSolutions::MyAidYears.new(@uid).get_feed
+      aid_years_feed.try(:[], :feed).try(:[], :finaidSummary).try(:[], :finaidYears).try(:each) do |aid_year_obj|
+        aid_years.push(aid_year_obj.try(:[], :id).try(:to_i))
+      end
+      aid_years.max
     end
 
     def links

--- a/spec/models/campus_solutions/new_admit_resources_spec.rb
+++ b/spec/models/campus_solutions/new_admit_resources_spec.rb
@@ -5,6 +5,7 @@ describe CampusSolutions::NewAdmitResources do
   let(:link_api_response) { {url: true} }
   before(:each) do
     allow_any_instance_of(LinkFetcher).to receive(:fetch_link).and_return link_api_response
+    CampusSolutions::MyAidYears.stub_chain(:new, :get_feed).and_return aid_years_response
   end
 
   let(:sir_statuses_incomplete_base_response) {
@@ -113,6 +114,16 @@ describe CampusSolutions::NewAdmitResources do
     }
   }
 
+  let(:aid_years_response) {
+    {
+      feed: {
+        finaidSummary: {
+          finaidYears: [{ id: 2018 }, { id: 2017 }, { id: 2016 }, { id:2009 }, { id: 2065 }]
+        }
+      }
+    }
+  }
+
   let(:evaluator_response) {
     {
       'evaluator_name' => 'James P. Sullivan',
@@ -192,8 +203,8 @@ describe CampusSolutions::NewAdmitResources do
           expect(subject[:links][:firstYearPathways][:selectionForm][:url]).to be_truthy
           expect(subject[:links][:firstYearPathways][:pathwaysFinAid][:url]).to be_truthy
         end
-        it 'shows the fall-admit first-year-pathway financial aid link' do
-          expect(subject[:links][:firstYearPathways][:pathwaysFinAid][:url]).to eq '/finances'
+        it 'shows the fall-admit first-year-pathway financial aid link attached to the latest aid year' do
+          expect(subject[:links][:firstYearPathways][:pathwaysFinAid][:url]).to eq '/finances/finaid/2065'
         end
         it 'does not contain admissions evaluator information' do
           expect(subject[:admissionsEvaluator][:name]).to be_nil


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-38224

* Link to latest-aid-year financial aid details page if aid years exist, otherwise, link to the "My Finances" page.