### PR TITLE
SISRP-38355 - Error navigating back to calcentral from 'Add a Withdrawal request' efrom from New Admit Resource card

### DIFF
--- a/src/assets/templates/widgets/new_admit_resources.html
+++ b/src/assets/templates/widgets/new_admit_resources.html
@@ -16,7 +16,11 @@
             data-ng-click="api.widget.toggleShow($event, null, newAdmitResources.admissionsSection, 'Dashboard - New Admit Resources')">Admissions Changes</h3>
         <ul data-ng-if="newAdmitResources.admissionsSection.show" class="cc-list-bullets">
           <li data-ng-repeat="(linkName, link) in newAdmitResources.links.admissions">
-            <a data-cc-campus-solutions-link-directive="link"></a>
+            <a data-ng-if="linkName != 'withdrawAfterMatric'" data-cc-campus-solutions-link-directive="link"></a>
+            <a data-ng-if="linkName == 'withdrawAfterMatric'"
+               data-cc-campus-solutions-link-directive="link"
+               data-cc-campus-solutions-link-directive-cc-page-name="currentPage.name"
+               data-cc-campus-solutions-link-directive-cc-page-url="currentPage.url"></a>
             <p data-ng-bind="link.linkDescription"></p>
           </li>
         </ul>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-38355

Dynamic link that goes to CS only if student has matriculated, it's also the only CS-centric link in the card, so we don't have to worry about this happening for the other links.