### PR TITLE
NOJIRA - Fixes academic records error and updates SISEDO view checker

### DIFF
--- a/app/models/edo_oracle/view_checker.rb
+++ b/app/models/edo_oracle/view_checker.rb
@@ -134,6 +134,14 @@ class EdoOracle::ViewChecker
       ]
     },
     {
+      :id => 'SISEDO.STUCAR_TERMV00_VW',
+      :columns => [
+        'STUDENT_ID',
+        'PNP_TOT_UNITS_TAKEN',
+        'PNP_TOT_UNITS_PASSED'
+      ]
+    },
+    {
       :id => 'SISEDO.STUDENT_REGISTRATIONV00_VW',
       :columns => [
         'STUDENT_ID',
@@ -150,6 +158,22 @@ class EdoOracle::ViewChecker
     {
       :id => 'SISEDO.API_COURSEIDENTIFIERSV00_VW',
       :columns => ['subjectArea']
+    },
+    {
+      :id => 'SISEDO.APPLICANT_ADMIT_DATA_UGV00_VW',
+      :columns => [
+        'ACAD_PROG',
+        'ACAD_PROG_DESCR',
+        'ADMIT_TERM',
+        'ADMIT_TYPE',
+        'ADMIT_TYPE_DESCR',
+        'ATHLETE',
+        'PROG_STATUS',
+        'STUDENT_ID',
+        'APPLICATION_NBR',
+        'EVALUATOR_NAME',
+        'EVALUATOR_EMAIL'
+      ]
     }
   ]
 

--- a/app/models/my_academics/academic_records.rb
+++ b/app/models/my_academics/academic_records.rb
@@ -15,7 +15,7 @@ module MyAcademics
       cs_official_transcript = CampusSolutions::CsOfficialTranscript.new(user_id: @uid).get
       return {errored: true} if (cs_official_transcript[:statusCode] != 200)
       filtered_keys = [:debugDbname, :debugJavaString1, :debugJavaString2]
-      transcript_data = cs_official_transcript.try(:[], :feed).try(:[], :transcriptOrder)
+      transcript_data = cs_official_transcript.try(:[], :feed).try(:[], :transcriptOrder) || {}
       transcript_post_url = transcript_data.delete(:credSolLink).to_s.strip
       transcript_post_params = transcript_data.except(*filtered_keys)
       {


### PR DESCRIPTION
1.  Fixes the following error by replacing `nil` with an empty Hash.
```[2018-01-30 10:23:08] [FATAL] 
NoMethodError (undefined method `delete' for nil:NilClass):
  app/models/my_academics/academic_records.rb:19:in `get_official_transcript_request_data'
  app/models/my_academics/academic_records.rb:8:in `get_feed_internal'
```

2.  Adds some new views to the SISEDO view testing script.