### PR TITLE
SISRP-38358 - Allows Housing card to display to advisors and delegates

### DIFF
--- a/app/models/campus_solutions/my_financial_aid_data.rb
+++ b/app/models/campus_solutions/my_financial_aid_data.rb
@@ -3,7 +3,6 @@ module CampusSolutions
 
     include ClassLogger
     include Cache::CachedFeed
-    include Cache::JsonifiedFeed
     include Cache::UserCacheExpiry
     include Cache::RelatedCacheKeyTracker
     include CampusSolutions::FinaidFeatureFlagged

--- a/app/models/campus_solutions/my_financial_aid_filtered_for_advisor.rb
+++ b/app/models/campus_solutions/my_financial_aid_filtered_for_advisor.rb
@@ -15,11 +15,9 @@ module CampusSolutions
     end
 
     def get_feed_internal
-      if is_feature_enabled && (self.aid_year ||= CampusSolutions::MyAidYears.new(@uid).default_aid_year)
-        apply_filter CampusSolutions::FinancialAidData.new(user_id: @uid, aid_year: aid_year).get
-      else
-        {}
-      end
+      model = CampusSolutions::MyFinancialAidData.new(@uid)
+      model.aid_year = aid_year
+      apply_filter model.get_feed
     end
 
     def apply_filter(feed)

--- a/spec/models/campus_solutions/my_financial_aid_data_spec.rb
+++ b/spec/models/campus_solutions/my_financial_aid_data_spec.rb
@@ -11,7 +11,7 @@ describe CampusSolutions::MyFinancialAidData do
 
   context 'mock proxy' do
     let(:state) { { 'fake' => true, 'user_id' => random_id } }
-    let(:feed) { JSON.parse(subject.get_feed) }
+    let(:feed) { subject.get_feed }
     context 'no aid year provided' do
       it 'should return empty' do
         expect(feed).to be_empty
@@ -22,16 +22,14 @@ describe CampusSolutions::MyFinancialAidData do
       it 'should return feed' do
         expect(feed).to_not be_empty
       end
-      context 'housing data' do
-        it 'should include housing data' do
-          expect(feed['feed']['housing']['title']).to eq 'Housing'
-          expect(feed['feed']['housing']['values']).to be
-          expect(feed['feed']['housing']['link']).to be
-        end
-        it 'should append housing messaging and links' do
-          expect(feed['feed']['housing']['instruction']).to eq 'mock instructions'
-        end
+      it 'should include housing data' do
+        expect(feed[:feed][:housing][:title]).to eq 'Housing'
+        expect(feed[:feed][:housing][:values]).to be
+        expect(feed[:feed][:housing][:link]).to be
       end
-    end
+      it 'should append housing messaging and links' do
+        expect(feed[:feed][:housing][:instruction]).to eq 'mock instructions'
+      end
+  end
   end
 end

--- a/spec/models/campus_solutions/my_financial_aid_filtered_for_advisor_spec.rb
+++ b/spec/models/campus_solutions/my_financial_aid_filtered_for_advisor_spec.rb
@@ -4,24 +4,29 @@ describe CampusSolutions::MyFinancialAidFilteredForAdvisor do
 
   context 'mock proxy' do
     let(:state) { { 'fake' => true, 'user_id' => random_id } }
-    context 'no aid year provided' do
-      it 'should return empty' do
-        expect(subject.get_feed).to be_empty
+
+    context 'no advisor session' do
+      it 'should deny access' do
+        expect{
+          subject.get_feed
+        }.to raise_exception /Only advisors have access/
       end
     end
-    context 'aid year provided' do
-      before { subject.aid_year = '2016' }
-      context 'no advisor session' do
-        it 'should deny access' do
-          expect{
-            subject.get_feed
-          }.to raise_exception /Only advisors have access/
+    context 'advisor session' do
+      let(:state) { { 'fake' => true, 'user_id' => random_id, SessionKey.original_advisor_user_id => random_id } }
+      let(:feed) { subject.get_feed }
+      let(:json) { feed.to_json }
+
+      context 'no aid year provided' do
+        it 'should indicate feed as filtered for advisor' do
+          expect(feed[:filteredForAdvisor]).to be true
+        end
+        it 'should return an empty feed' do
+          expect(subject.get_feed[:feed]).not_to be
         end
       end
-      context 'advisor session' do
-        let(:state) { { 'fake' => true, 'user_id' => random_id, SessionKey.original_advisor_user_id => random_id } }
-        let(:feed) { subject.get_feed }
-        let(:json) { feed.to_json }
+      context 'aid year provided' do
+        before { subject.aid_year = '2016' }
         it 'should indicate feed as filtered for advisor' do
           expect(feed[:filteredForAdvisor]).to be true
         end

--- a/spec/models/campus_solutions/my_financial_aid_filtered_for_delegate_spec.rb
+++ b/spec/models/campus_solutions/my_financial_aid_filtered_for_delegate_spec.rb
@@ -1,28 +1,32 @@
 describe CampusSolutions::MyFinancialAidFilteredForDelegate do
 
   subject { CampusSolutions::MyFinancialAidFilteredForDelegate.from_session state }
-  let(:state) { { 'fake' => true, 'user_id' => random_id } }
 
   context 'mock proxy' do
-    context 'no aid year provided' do
-      it 'should return empty' do
-        expect(subject.get_feed).to be_empty
+    let(:state) { { 'fake' => true, 'user_id' => random_id } }
+
+    context 'no delegate session' do
+      it 'should deny access' do
+        expect{
+          subject.get_feed
+        }.to raise_exception /Only delegate users have access/
       end
     end
-    context 'aid year provided' do
-      before { subject.aid_year = '2016' }
-      context 'no delegate session' do
-        it 'should deny access' do
-          expect{
-            subject.get_feed
-          }.to raise_exception /Only delegate users have access/
+    context 'delegate session' do
+      let(:state) { { 'fake' => true, 'user_id' => random_id, SessionKey.original_delegate_user_id => random_id } }
+      let(:feed) { subject.get_feed }
+      let(:json) { feed.to_json }
+
+      context 'no aid year provided' do
+        it 'should indicate feed as filtered for delegate' do
+          expect(feed[:filteredForDelegate]).to be true
+        end
+        it 'should return empty' do
+          expect(subject.get_feed[:feed]).not_to be
         end
       end
-      context 'delegate session' do
-        let(:state) { { 'fake' => true, 'user_id' => random_id, SessionKey.original_delegate_user_id => random_id } }
-        let(:feed) { subject.get_feed }
-        let(:json) { feed.to_json }
-
+      context 'aid year provided' do
+        before { subject.aid_year = '2016' }
         it 'should indicate feed as filtered for delegate' do
           expect(feed[:filteredForDelegate]).to be true
         end

--- a/src/assets/javascripts/angular/controllers/widgets/finaid/finaidHousingController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/finaid/finaidHousingController.js
@@ -13,7 +13,7 @@ angular.module('calcentral.controllers').controller('FinaidHousingController', f
   linkService.addCurrentRouteSettings($scope);
 
   var processHousingData = function(response) {
-    angular.extend($scope.housing, _.get(response, 'data.feed.housing'))
+    angular.extend($scope.housing, _.get(response, 'data.feed.housing'));
     $scope.housing.errored = _.get(response, 'data.errored');
   };
 

--- a/src/assets/javascripts/angular/controllers/widgets/finaid/finaidHousingController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/finaid/finaidHousingController.js
@@ -7,10 +7,13 @@ var angular = require('angular');
  * Finaid Housing controller
  */
 angular.module('calcentral.controllers').controller('FinaidHousingController', function($scope, finaidFactory, finaidService, linkService) {
+  $scope.housing = {
+    isLoading: true
+  };
   linkService.addCurrentRouteSettings($scope);
 
   var processHousingData = function(response) {
-    $scope.housing = _.get(response, 'data.feed.housing');
+    angular.extend($scope.housing, _.get(response, 'data.feed.housing'))
     $scope.housing.errored = _.get(response, 'data.errored');
   };
 

--- a/src/assets/templates/widgets/finaid_housing.html
+++ b/src/assets/templates/widgets/finaid_housing.html
@@ -31,6 +31,7 @@
                   </tr>
                 </tbody>
               </thead>
+            </table>
         </div>
         <div data-ng-if="housing.instruction">
           <hr aria-hidden="true">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-38358

I address two separate bugs here - thus the two commits.

1.  The housing card showed an infinite spinner
2.  The `CampusSolutions::FinancialAidHousing` data wasn't being added to the `MyFinancialAidFilteredForAdvisor` or `MyFinancialAidFilteredForDelegate` feeds