### PR TITLE
SISRP-38229 - Adds validation to address posting proxy

### DIFF
--- a/app/controllers/campus_solutions/address_controller.rb
+++ b/app/controllers/campus_solutions/address_controller.rb
@@ -1,5 +1,6 @@
 module CampusSolutions
   class AddressController < CampusSolutionsController
+    rescue_from Errors::ClientError, with: :handle_client_error
 
     before_filter :exclude_acting_as_users
 

--- a/app/models/campus_solutions/address.rb
+++ b/app/models/campus_solutions/address.rb
@@ -32,6 +32,10 @@ module CampusSolutions
       )
     end
 
+    def self.valid?(params)
+      %w(DIPL LOCL MAIL HOME).include? params[:addressType]
+    end
+
     def request_root_xml_node
       'UC_CC_ADDR_UPD_REQ'
     end

--- a/app/models/campus_solutions/person_data_updating_model.rb
+++ b/app/models/campus_solutions/person_data_updating_model.rb
@@ -2,7 +2,7 @@ module CampusSolutions
   module PersonDataUpdatingModel
     def passthrough(model_name, params)
       proxy = model_name.new({user_id: @uid, params: params})
-      result = proxy.get
+      result = proxy.post
       PersonDataExpiry.expire @uid
       result
     end

--- a/app/models/campus_solutions/posting_proxy.rb
+++ b/app/models/campus_solutions/posting_proxy.rb
@@ -1,5 +1,6 @@
 module CampusSolutions
   class PostingProxy < Proxy
+    include ClassLogger
 
     attr_reader :params
 
@@ -11,6 +12,18 @@ module CampusSolutions
 
     def mock_request
       super.merge(method: :post)
+    end
+
+    def post
+      if self.class.valid? params
+        get
+      else
+        raise Errors::BadRequestError, "Invalid request: #{params}"
+      end
+    end
+
+    def self.valid?(params)
+      true
     end
 
     def request_options

--- a/spec/controllers/campus_solutions/address_controller_spec.rb
+++ b/spec/controllers/campus_solutions/address_controller_spec.rb
@@ -31,6 +31,17 @@ describe CampusSolutions::AddressController do
         expect(json['feed']).to be
         expect(json['feed']['address']).to be
       end
+      it 'should reject a post that fails validation' do
+        post :post,
+             {
+               addressType: 'DORM',
+               address1: '1 Test Lane'
+             }
+        expect(response.status).to eq 400
+        json = JSON.parse(response.body)
+        expect(json['feed']).not_to be
+        expect(json['error']).to be
+      end
     end
   end
 

--- a/spec/models/campus_solutions/address_spec.rb
+++ b/spec/models/campus_solutions/address_spec.rb
@@ -7,14 +7,14 @@ describe CampusSolutions::Address do
     let(:params) { {} }
     let(:proxy) { CampusSolutions::Address.new(fake: true, user_id: user_id, params: params) }
 
-    context 'filtering out fields not on the whitelist' do
+    context 'when given params not on the whitelist' do
       let(:params) { {
         bogus: 1,
         invalid: 2,
         address1: '1 Test Lane'
       } }
       subject { proxy.filter_updateable_params(params) }
-      it 'should strip out invalid fields' do
+      it 'should filter out the invalid params' do
         expect(subject.keys.length).to eq 16
         expect(subject[:bogus]).to be_nil
         expect(subject[:invalid]).to be_nil
@@ -22,7 +22,7 @@ describe CampusSolutions::Address do
       end
     end
 
-    context 'converting params to Campus Solutions field names' do
+    context 'when converting params to Campus Solutions field names' do
       let(:params) { {
         addressType: 'HOME',
         address1: '1 Test Lane'
@@ -37,13 +37,29 @@ describe CampusSolutions::Address do
       end
     end
 
-    context 'performing a post' do
+    context 'when posting a param with invalid values' do
+      let(:params) { {
+        addressType: 'DORM',
+        address1: '1 Test Lane'
+      } }
+      subject {
+        proxy.post
+      }
+      it 'raises an error and aborts' do
+        expect{
+          subject
+        }.to raise_error Errors::BadRequestError, /Invalid request: {:addressType=>"DORM", :address1=>"1 Test Lane"}/
+        expect(CampusSolutions::Proxy).to receive(:get).never
+      end
+    end
+
+    context 'when posting valid params' do
       let(:params) { {
         addressType: 'HOME',
         address1: '1 Test Lane'
       } }
       subject {
-        proxy.get
+        proxy.post
       }
       it_should_behave_like 'a simple proxy that returns errors'
       it_behaves_like 'a proxy that properly observes the profile feature flag'

--- a/src/assets/javascripts/angular/controllers/widgets/profile/profileAddressController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/profile/profileAddressController.js
@@ -167,7 +167,8 @@ angular.module('calcentral.controllers').controller('ProfileAddressController', 
 
     apiService.profile
       .save($scope, profileFactory.postAddress, merge)
-      .then(saveCompleted);
+      .then(saveCompleted)
+      .catch(saveCompleted);
   };
 
   $scope.showAdd = function() {

--- a/src/assets/javascripts/angular/services/profileService.js
+++ b/src/assets/javascripts/angular/services/profileService.js
@@ -8,7 +8,7 @@ angular.module('calcentral.services').service('profileService', function() {
    * Fired after an action (delete / save) has been completed
    */
   var actionCompleted = function($scope, response, callback) {
-    if (response.data.errored) {
+    if (response.data.error || response.data.errored) {
       $scope.errorMessage = _.get(response, 'data.feed.errmsgtext') || 'An error occurred while saving your data.';
     } else {
       $scope.closeEditor();


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-38229

New `valid?` method can be overridden to do specific validation in any class inheriting from `PostingProxy`.  I imagine we'll only need to do validation on POST requests.  In this case, we validate the address type against a whitelist because CS apparently does not do this type of validation, nor does the API.