### PR TITLE
CLC-6775 Remove empty object from OEC controller scope

### DIFF
--- a/src/assets/javascripts/angular/controllers/pages/oecController.js
+++ b/src/assets/javascripts/angular/controllers/pages/oecController.js
@@ -16,9 +16,6 @@ angular.module('calcentral.controllers').controller('OecController', function(ap
         $scope.oecTaskStatus = null;
         $scope.participatingDepartments = _.filter(response.data.oecDepartments, 'participating');
         $scope.taskParameters = {
-          selectedTask: {
-            name: null
-          },
           options: {
             term: response.data.currentTerm
           }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6775

Why was it ever in there? Why did it work?