### PR TITLE
SISRP-38331 - CalCentral: Hide Pathways Selection Link from GEP Waitlist

### DIFF
--- a/app/models/campus_solutions/sir/sir_statuses.rb
+++ b/app/models/campus_solutions/sir/sir_statuses.rb
@@ -127,11 +127,12 @@ module CampusSolutions
         return { errored: true } unless status.is_a?(Hash)
         first_year_freshman = status.try(:[], 'admit_type') == 'FYR'
         is_athlete = status.try(:[], 'athlete') == 'Y'
+        is_global_edge = status.try(:[], 'global_edge_program') == 'Y'
         admit_term_code = from_edo_id(status.try(:[], 'admit_term'))
         roles = {
           athlete: is_athlete,
           firstYearFreshman: first_year_freshman,
-          firstYearPathway: first_year_freshman && !is_athlete && ['UCLS', 'UCNR'].include?(status.try(:[], 'applicant_program')),
+          firstYearPathway: first_year_freshman && !is_athlete && !is_global_edge && ['UCLS', 'UCNR'].include?(status.try(:[], 'applicant_program')),
           preMatriculated: ['AD', 'PM'].include?(status.try(:[], 'admit_status')),
           transfer: status.try(:[], 'admit_type') == 'TRN'
         }

--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -502,6 +502,7 @@ module EdoOracle
           ADMIT_TERM as admit_term,
           ADMIT_TYPE as admit_type,
           ADMIT_TYPE_DESCR as admit_type_desc,
+          ADMITTED_GEP as global_edge_program,
           ATHLETE as athlete,
           PROG_STATUS as admit_status
         FROM

--- a/app/models/edo_oracle/view_checker.rb
+++ b/app/models/edo_oracle/view_checker.rb
@@ -167,6 +167,7 @@ class EdoOracle::ViewChecker
         'ADMIT_TERM',
         'ADMIT_TYPE',
         'ADMIT_TYPE_DESCR',
+        'ADMITTED_GEP',
         'ATHLETE',
         'PROG_STATUS',
         'STUDENT_ID',

--- a/spec/models/campus_solutions/sir/sir_statuses_spec.rb
+++ b/spec/models/campus_solutions/sir/sir_statuses_spec.rb
@@ -116,7 +116,21 @@ describe CampusSolutions::Sir::SirStatuses do
       'admit_term' => '2185',
       'admit_type' => 'FYR',
       'admit_type_desc' => 'First Year Student',
-      'athlete' => 'N'
+      'athlete' => 'N',
+      'global_edge_program' => 'N'
+    }
+  }
+
+  let(:new_admit_attributes_freshman_pathway_gep) {
+    {
+      'applicant_program' => 'UCLS',
+      'applicant_program_descr' => 'College of Letters and Science',
+      'admit_status' => 'AD',
+      'admit_term' => '2185',
+      'admit_type' => 'FYR',
+      'admit_type_desc' => 'First Year Student',
+      'athlete' => 'N',
+      'global_edge_program' => 'Y'
     }
   }
 
@@ -128,7 +142,8 @@ describe CampusSolutions::Sir::SirStatuses do
       'admit_term' => '2165',
       'admit_type' => 'TRN',
       'admit_type_desc' => 'Transfer',
-      'athlete' => 'N'
+      'athlete' => 'N',
+      'global_edge_program' => 'Y'
     }
   }
 
@@ -336,11 +351,26 @@ describe CampusSolutions::Sir::SirStatuses do
         end
       end
 
+      context 'as a freshman eligible for first year pathway admitted to the Global Edge Program' do
+        before do
+          EdoOracle::Queries.stub(:get_new_admit_status) {new_admit_attributes_freshman_pathway_gep}
+        end
+        subject { (proxy.new(uid).get_feed)[:sirStatuses] }
+        it 'denies first year pathway status due to GEP' do
+          expect(subject[0][:newAdmitAttributes][:roles][:firstYearPathway]).to be_falsey
+        end
+        it 'adds the correct links to the status' do
+          expect(subject[0][:newAdmitAttributes][:links][:coaFreshmanLink][:url]).to be_truthy
+          expect(subject[0][:newAdmitAttributes][:links][:firstYearPathwayLink]).to be_falsey
+          expect(subject[0][:newAdmitAttributes][:links][:coaTransferLink]).to be_falsey
+        end
+      end
+
       context 'as a transfer student' do
         before do
           EdoOracle::Queries.stub(:get_new_admit_status) { new_admit_attributes_transfer }
         end
-        subject { (proxy.new(uid).get_feed)[:sirStatuses]}
+        subject { (proxy.new(uid).get_feed)[:sirStatuses] }
         it 'adds the correct links to the status' do
           expect(subject[0][:newAdmitAttributes][:links][:coaFreshmanLink]).to be_falsey
           expect(subject[0][:newAdmitAttributes][:links][:firstYearPathwayLink]).to be_falsey


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-38331

"gep" stands for "Global Edge Program"