### PR TITLE
SISRP-37023 - Hide My Academics Page from New Admits

### DIFF
--- a/app/models/user/api.rb
+++ b/app/models/user/api.rb
@@ -139,7 +139,7 @@ module User
         return !!authentication_state.delegated_privileges[:viewEnrollments] || !!authentication_state.delegated_privileges[:viewGrades]
       end
       roles = @user_attributes[:roles]
-      roles[:student] || roles[:faculty] || roles[:applicant] || has_instructor_history || has_student_history
+      roles[:student] || roles[:faculty] || has_instructor_history || has_student_history
     end
 
     def has_badges?

--- a/spec/models/user/api_spec.rb
+++ b/spec/models/user/api_spec.rb
@@ -383,8 +383,8 @@ describe User::Api do
 
     context 'when user is an applicant' do
       let(:has_applicant_role) { true }
-      let(:expected_can_view_academics) { true }
-      let(:expected_can_view_grades) { true }
+      let(:expected_can_view_academics) { false }
+      let(:expected_can_view_grades) { false }
       let(:expected_has_badges) { true }
       let(:expected_has_campus_tab) { true }
       let(:expected_has_dashboard_tab) { true }


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-37023

* Originally, we gave applicants access to My Academics so that they can see their holds (#5478), but now we are only showing holds *after* matriculation, so we can remove that access.