### PR TITLE
SISRP-38227 - Adds validation to Terms & Conditions

### DIFF
--- a/app/controllers/campus_solutions/terms_and_conditions_controller.rb
+++ b/app/controllers/campus_solutions/terms_and_conditions_controller.rb
@@ -1,5 +1,6 @@
 module CampusSolutions
   class TermsAndConditionsController < CampusSolutionsController
+    rescue_from Errors::ClientError, with: :handle_client_error
 
     before_filter :exclude_acting_as_users
 

--- a/app/models/campus_solutions/my_terms_and_conditions.rb
+++ b/app/models/campus_solutions/my_terms_and_conditions.rb
@@ -5,7 +5,7 @@ module CampusSolutions
       proxy = CampusSolutions::TermsAndConditions.new({user_id: @uid, params: params})
       ChecklistDataExpiry.expire @uid
       FinancialAidExpiry.expire @uid
-      proxy.get
+      proxy.post
     end
 
   end

--- a/app/models/campus_solutions/terms_and_conditions.rb
+++ b/app/models/campus_solutions/terms_and_conditions.rb
@@ -18,6 +18,15 @@ module CampusSolutions
       )
     end
 
+    def self.valid?(params)
+      aid_years = []
+      aid_years_feed = CampusSolutions::MyAidYears.new(@uid).get_feed
+      aid_years_feed.try(:[], :feed).try(:[], :finaidSummary).try(:[], :finaidYears).try(:each) do |aid_year|
+        aid_years.push(aid_year.try(:[], :id).try(:to_i))
+      end
+      aid_years.include?(params[:aidYear].try(:to_i))
+    end
+
     def request_root_xml_node
       'Terms_Conditions'
     end

--- a/spec/controllers/campus_solutions/terms_and_conditions_controller_spec.rb
+++ b/spec/controllers/campus_solutions/terms_and_conditions_controller_spec.rb
@@ -26,6 +26,17 @@ describe CampusSolutions::TermsAndConditionsController do
         expect(json['feed']).to be
         expect(json['feed']['institution']).to eq 'UCB01'
       end
+      it 'should reject a post that fails validation' do
+        post :post,
+            {
+              response: 'Y',
+              aidYear: '2018'
+            }
+        expect(response.status).to eq 400
+        json = JSON.parse(response.body)
+        expect(json['feed']).not_to be
+        expect(json['error']).to be
+      end
     end
   end
 end

--- a/src/assets/javascripts/angular/controllers/pages/finaidController.js
+++ b/src/assets/javascripts/angular/controllers/pages/finaidController.js
@@ -42,7 +42,7 @@ angular.module('calcentral.controllers').controller('FinaidController', function
   var getFinaidSummary = function(options) {
     return finaidFactory.getSummary(options).then(
       function successCallback(response) {
-        combinationExists(response.data.feed, _.get($scope, 'finaidYear.id'));
+        combinationExists(response.data.feed, $routeParams.finaidYearId);
         setFinaidYear(response.data.feed, $routeParams.finaidYearId);
         $scope.finaidSummary = response.data.feed.finaidSummary;
         $scope.finaid.isLoading = false;


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-38227

Prevents a user from accepting the terms and conditions for an aid year that isn't available.  For example, if they can only see data for aid years 2017 and 2018, they shouldn't be able to accept for 2019.

Also fixes a bug in FinaidController.