### PR TITLE
SISRP-38360 - Add link to Summer Aid Estimator in CalCentral

### DIFF
--- a/app/controllers/campus_solutions/financial_resources_controller.rb
+++ b/app/controllers/campus_solutions/financial_resources_controller.rb
@@ -1,0 +1,22 @@
+module CampusSolutions
+  class FinancialResourcesController < ApplicationController
+
+    before_action :api_authenticate
+
+    def get_general
+      render json: CampusSolutions::FinancialResourcesGeneral.new().get_feed
+    end
+
+    def get_parameterized
+      aid_year = aid_year_param
+      render json: CampusSolutions::FinancialResourcesParameterized.new({aid_year: aid_year}).get_feed
+    end
+
+    private
+
+    def aid_year_param
+      params.require 'aid_year'
+    end
+
+  end
+end

--- a/app/models/campus_solutions/financial_resources_general.rb
+++ b/app/models/campus_solutions/financial_resources_general.rb
@@ -1,0 +1,15 @@
+module CampusSolutions
+  class FinancialResourcesGeneral
+
+    def get_feed
+      get_general_cs_links
+    end
+
+    def get_general_cs_links
+      link_config = { cs_link_key: 'UC_CX_EMERGENCY_LOAN_FORM' }
+      link = LinkFetcher.fetch_link(link_config[:cs_link_key])
+      { emergencyLoan: link }
+    end
+
+  end
+end

--- a/app/models/campus_solutions/financial_resources_parameterized.rb
+++ b/app/models/campus_solutions/financial_resources_parameterized.rb
@@ -1,0 +1,23 @@
+module CampusSolutions
+  class FinancialResourcesParameterized < UserSpecificModel
+    include Cache::CachedFeed
+    include Cache::UserCacheExpiry
+
+    def initialize(options = {})
+      super options
+      @aid_year = options.try(:[], :aid_year)
+    end
+
+    def get_feed_internal
+      get_summer_estimator_link
+    end
+
+    def get_summer_estimator_link
+      return {} if @aid_year.nil?
+      link_config = { cs_link_key: 'UC_FA_SUMMR_EST_FLU', cs_link_params: { :AID_YEAR => @aid_year } }
+      link = LinkFetcher.fetch_link(link_config[:cs_link_key], link_config[:cs_link_params])
+      { summerEstimator: link }
+    end
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,52 +140,54 @@ Calcentral::Application.routes.draw do
     post '/api/campus_solutions/delegate_access' => 'campus_solutions/delegate_access#post', :defaults => { :format => 'json' }
 
     # Campus Solutions general purpose endpoints
-    get '/api/campus_solutions/higher_one_url' => 'campus_solutions/higher_one_url#get', :defaults => { :format => 'json' }
-    get '/api/campus_solutions/country' => 'campus_solutions/country#get', :defaults => { :format => 'json' }
-    get '/api/campus_solutions/state' => 'campus_solutions/state#get', :defaults => { :format => 'json' }
-    get '/api/campus_solutions/ethnicity_setup' => 'campus_solutions/ethnicity_setup#get', :defaults => { :format => 'json' }
     get '/api/campus_solutions/address_label' => 'campus_solutions/address_label#get', :defaults => { :format => 'json' }
     get '/api/campus_solutions/address_type' => 'campus_solutions/address_type#get', :defaults => { :format => 'json' }
-    get '/api/campus_solutions/name_type' => 'campus_solutions/name_type#get', :defaults => { :format => 'json' }
-    get '/api/campus_solutions/currency_code' => 'campus_solutions/currency_code#get', :defaults => { :format => 'json' }
-    get '/api/campus_solutions/language_code' => 'campus_solutions/language_code#get', :defaults => { :format => 'json' }
-    get '/api/campus_solutions/translate' => 'campus_solutions/translate#get', :defaults => { :format => 'json' }
+    get '/api/campus_solutions/advising_resources' => 'campus_solutions/advising_resources#get', :defaults => { :format => 'json' }
     get '/api/campus_solutions/aid_years' => 'campus_solutions/aid_years#get', :defaults => { :format => 'json' }
+    get '/api/campus_solutions/billing' => 'campus_solutions/billing#get', :defaults => { :format => 'json' }
+    get '/api/campus_solutions/confidential_student_message' => 'campus_solutions/confidential_student#get_message', :defaults => { :format => 'json' }
+    get '/api/campus_solutions/country' => 'campus_solutions/country#get', :defaults => { :format => 'json' }
+    get '/api/campus_solutions/currency_code' => 'campus_solutions/currency_code#get', :defaults => { :format => 'json' }
+    get '/api/campus_solutions/emergency_contacts' => 'campus_solutions/emergency_contacts#get', :defaults => { :format => 'json' }
+    get '/api/campus_solutions/ethnicity_setup' => 'campus_solutions/ethnicity_setup#get', :defaults => { :format => 'json' }
     get '/api/campus_solutions/financial_aid_compare_awards_current' => 'campus_solutions/financial_aid_compare_awards_current#get', :defaults => { :format => 'json' }
     get '/api/campus_solutions/financial_aid_compare_awards_list' => 'campus_solutions/financial_aid_compare_awards_list#get', :defaults => { :format => 'json' }
     get '/api/campus_solutions/financial_aid_compare_awards_prior' => 'campus_solutions/financial_aid_compare_awards_prior#get', :defaults => { :format => 'json' }
     get '/api/campus_solutions/financial_aid_data' => 'campus_solutions/financial_aid_data#get', :defaults => { :format => 'json' }
     get '/api/campus_solutions/financial_aid_funding_sources' => 'campus_solutions/financial_aid_funding_sources#get', :defaults => { :format => 'json' }
     get '/api/campus_solutions/financial_aid_funding_sources_term' => 'campus_solutions/financial_aid_funding_sources_term#get', :defaults => { :format => 'json' }
-    get '/api/campus_solutions/holds' => 'campus_solutions/holds#get', :defaults => { :format => 'json' }
-    get '/api/campus_solutions/advising_resources' => 'campus_solutions/advising_resources#get', :defaults => { :format => 'json' }
-    get '/api/campus_solutions/billing' => 'campus_solutions/billing#get', :defaults => { :format => 'json' }
-    get '/api/campus_solutions/slr_deeplink' => 'campus_solutions/slr_deeplink#get', :defaults => { :format => 'json' }
+    get '/api/campus_solutions/financial_resources_general' => 'campus_solutions/financial_resources#get_general', :defaults => { :format => 'json' }
+    get '/api/campus_solutions/financial_resources_parameterized/summer_estimator/:aid_year' => 'campus_solutions/financial_resources#get_parameterized', :defaults => { :format => 'json' }
     get '/api/campus_solutions/fpp_enrollment' => 'campus_solutions/fpp_enrollment#get', :defaults => { :format => 'json' }
-    get '/api/campus_solutions/emergency_contacts' => 'campus_solutions/emergency_contacts#get', :defaults => { :format => 'json' }
+    get '/api/campus_solutions/higher_one_url' => 'campus_solutions/higher_one_url#get', :defaults => { :format => 'json' }
+    get '/api/campus_solutions/holds' => 'campus_solutions/holds#get', :defaults => { :format => 'json' }
+    get '/api/campus_solutions/language_code' => 'campus_solutions/language_code#get', :defaults => { :format => 'json' }
     get '/api/campus_solutions/link' => 'campus_solutions/link#get', :defaults => { :format => 'json' }
+    get '/api/campus_solutions/name_type' => 'campus_solutions/name_type#get', :defaults => { :format => 'json' }
+    get '/api/campus_solutions/slr_deeplink' => 'campus_solutions/slr_deeplink#get', :defaults => { :format => 'json' }
+    get '/api/campus_solutions/state' => 'campus_solutions/state#get', :defaults => { :format => 'json' }
     get '/api/campus_solutions/student_resources' => 'campus_solutions/student_resources#get', :defaults => { :format => 'json' }
-    get '/api/campus_solutions/confidential_student_message' => 'campus_solutions/confidential_student#get_message', :defaults => { :format => 'json' }
+    get '/api/campus_solutions/translate' => 'campus_solutions/translate#get', :defaults => { :format => 'json' }
     post '/api/campus_solutions/address' => 'campus_solutions/address#post', :defaults => { :format => 'json' }
     post '/api/campus_solutions/email' => 'campus_solutions/email#post', :defaults => { :format => 'json' }
-    post '/api/campus_solutions/person_name' => 'campus_solutions/person_name#post', :defaults => { :format => 'json' }
-    post '/api/campus_solutions/phone' => 'campus_solutions/phone#post', :defaults => { :format => 'json' }
     post '/api/campus_solutions/emergency_contact' => 'campus_solutions/emergency_contact#post', :defaults => { :format => 'json' }
     post '/api/campus_solutions/emergency_phone' => 'campus_solutions/emergency_phone#post', :defaults => { :format => 'json' }
-    post '/api/campus_solutions/language' => 'campus_solutions/language#post', :defaults => { :format => 'json' }
-    post '/api/campus_solutions/work_experience' => 'campus_solutions/work_experience#post', :defaults => { :format => 'json' }
     post '/api/campus_solutions/ethnicity' => 'campus_solutions/ethnicity#post', :defaults => { :format => 'json' }
+    post '/api/campus_solutions/language' => 'campus_solutions/language#post', :defaults => { :format => 'json' }
+    post '/api/campus_solutions/person_name' => 'campus_solutions/person_name#post', :defaults => { :format => 'json' }
+    post '/api/campus_solutions/phone' => 'campus_solutions/phone#post', :defaults => { :format => 'json' }
+    post '/api/campus_solutions/sir_response' => 'campus_solutions/sir_response#post', :defaults => { :format => 'json' }
     post '/api/campus_solutions/terms_and_conditions' => 'campus_solutions/terms_and_conditions#post', :defaults => { :format => 'json' }
     post '/api/campus_solutions/title4' => 'campus_solutions/title4#post', :defaults => { :format => 'json' }
-    post '/api/campus_solutions/sir_response' => 'campus_solutions/sir_response#post', :defaults => { :format => 'json' }
+    post '/api/campus_solutions/work_experience' => 'campus_solutions/work_experience#post', :defaults => { :format => 'json' }
     delete '/api/campus_solutions/address/:type' => 'campus_solutions/address#delete', :defaults => { :format => 'json' }
     delete '/api/campus_solutions/email/:type' => 'campus_solutions/email#delete', :defaults => { :format => 'json' }
     delete '/api/campus_solutions/emergency_contact/:contactName' => 'campus_solutions/emergency_contact#delete', :defaults => { :format => 'json' }
     delete '/api/campus_solutions/emergency_phone/:contactName/:phoneType' => 'campus_solutions/emergency_phone#delete', :defaults => { :format => 'json' }
+    delete '/api/campus_solutions/ethnicity/:ethnicGroupCode/:regRegion' => 'campus_solutions/ethnicity#delete', :defaults => { :format => 'json' }
     delete '/api/campus_solutions/language/:languageCode' => 'campus_solutions/language#delete', :defaults => { :format => 'json' }
     delete '/api/campus_solutions/person_name/:type' => 'campus_solutions/person_name#delete', :defaults => { :format => 'json' }
     delete '/api/campus_solutions/phone/:type' => 'campus_solutions/phone#delete', :defaults => { :format => 'json' }
-    delete '/api/campus_solutions/ethnicity/:ethnicGroupCode/:regRegion' => 'campus_solutions/ethnicity#delete', :defaults => { :format => 'json' }
     delete '/api/campus_solutions/work_experience/:sequenceNbr' => 'campus_solutions/work_experience#delete', :defaults => { :format => 'json' }
 
     # Redirect to College Scheduler

--- a/spec/models/campus_solutions/financial_resources_parameterized_spec.rb
+++ b/spec/models/campus_solutions/financial_resources_parameterized_spec.rb
@@ -1,0 +1,27 @@
+describe CampusSolutions::FinancialResourcesParameterized do
+  let(:uid) { 61889 }
+  let(:model) { described_class }
+  let(:link_api_response) { { url: true } }
+
+  describe 'attempting to get CS links' do
+    before do
+      allow_any_instance_of(LinkFetcher).to receive(:fetch_link).and_return link_api_response
+    end
+
+    context 'while passing the aid_year parameter' do
+      subject { model.new({ aid_year: 2018 }).get_feed_internal }
+      it 'returns a valid summer estimator link' do
+        expect(subject[:summerEstimator][:url]).to be_truthy
+      end
+    end
+
+    context 'while not passing the aid_year paramter' do
+      subject {model.new().get_feed_internal}
+      it 'does not return a summer estimator link' do
+        expect(subject.has_key?(:summerEstimator)).to be_falsey
+      end
+    end
+
+  end
+
+end

--- a/src/assets/javascripts/angular/factories/financesLinksFactory.js
+++ b/src/assets/javascripts/angular/factories/financesLinksFactory.js
@@ -8,6 +8,8 @@ var angular = require('angular');
 angular.module('calcentral.factories').factory('financesLinksFactory', function(apiService) {
   var urlEftEnrollment = '/api/my/eft_enrollment';
   var urlFppEnrollment = '/api/campus_solutions/fpp_enrollment';
+  var urlGeneralCsLinks = '/api/campus_solutions/financial_resources_general';
+  var urlSummerEstimator = '/api/campus_solutions/financial_resources_parameterized/summer_estimator/';
 
   var getEftEnrollment = function(options) {
     return apiService.http.request(options, urlEftEnrollment);
@@ -17,8 +19,19 @@ angular.module('calcentral.factories').factory('financesLinksFactory', function(
     return apiService.http.request(options, urlFppEnrollment);
   };
 
+  var getGeneralCsLinks = function(options) {
+    return apiService.http.request(options, urlGeneralCsLinks);
+  };
+
+  var getSummerEstimator = function(options) {
+    urlSummerEstimator = options && options.aidYear ? urlSummerEstimator + options.aidYear : urlSummerEstimator;
+    return apiService.http.request(options, urlSummerEstimator);
+  };
+
   return {
+    getGeneralCsLinks: getGeneralCsLinks,
     getEftEnrollment: getEftEnrollment,
-    getFppEnrollment: getFppEnrollment
+    getFppEnrollment: getFppEnrollment,
+    getSummerEstimator: getSummerEstimator
   };
 });

--- a/src/assets/templates/widgets/finances_links.html
+++ b/src/assets/templates/widgets/finances_links.html
@@ -75,6 +75,13 @@
             data-cc-campus-solutions-link-directive-cc-page-url="currentPage.url"
           ></a>
         </li>
+        <li data-ng-if="subcategory === 'Summer Sessions' && summerEstimatorLink.url && canViewSummerEstimatorLink">
+          <a data-cc-campus-solutions-link-directive="summerEstimatorLink"
+            data-cc-campus-solutions-link-directive-cc-page-name="currentPage.name"
+            data-cc-campus-solutions-link-directive-cc-page-url="currentPage.url"
+          ></a>
+          <p class="cc-list-links-text" data-ng-bind="summerEstimatorLink.linkDescription"></p>
+        </li>
       </ul>
     </div>
     <div class="cc-widget-text" data-ng-if="campuslinks.data.links.length === 0">There are no links available.</div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-38360

* In addition to adding a link to Summer Aid Estimator, this also lays the groundwork to move the work done in [financesLinksController.js](https://github.com/davidlimcheng/calcentral/blob/master/src/assets/javascripts/angular/controllers/widgets/financesLinksController.js) to the back-end, specifically to `CampusSolutions::FinancialResourcesGeneral` and `CampusSolutions::FinancialResourcesParameterized`.
* Why two models?  `FinancialResourcesGeneral` was made for all general all-purpose links that aren't user-specific and don't need any special parameters.  Since this is only serving one link at the moment, which is already cached in `Links`, I did not put any caching mechanisms on this model.
* `FinancialResourcesParameterized` was made for all links that may be user-specific and need parameters passed in.  At the moment it's only the Summer Aid Estimator, but in the future it will also serve the EFT Enrollment data that is currently being served via `MyEftEnrollment`.
* I also reordered the Campus Solutions endpoints because they were annoying out-of-order.
* Also refactored the front-end controller to be a bit more performant.  It needs a bigger refactor, which we don't have time for at the moment.