### PR TITLE
SISRP-38829 - Adds APR link to My Academics > Grad Degree Progress

### DIFF
--- a/app/models/concerns/academic_roles.rb
+++ b/app/models/concerns/academic_roles.rb
@@ -4,13 +4,19 @@ module Concerns
 
     # Role(s) assigned to a user if they are in an academic plan associated with that role.
     ACADEMIC_PLAN_ROLES = [
+      {role_code: 'doctorScienceLaw', match: ['842C1JSDG']},
       {role_code: 'fpf', match: ['25000FPFU']},
+      {role_code: 'haasBusinessAdminMasters', match: ['70141MSG']},
+      {role_code: 'haasBusinessAdminPhD', match: ['70141PHDG']},
       {role_code: 'haasFullTimeMba', match: ['70141MBAG']},
       {role_code: 'haasEveningWeekendMba', match: ['701E1MBAG']},
       {role_code: 'haasExecMba', match: ['70364MBAG']},
       {role_code: 'haasMastersFinEng', match: ['701F1MFEG']},
       {role_code: 'haasMbaPublicHealth', match: ['70141BAPHG']},
       {role_code: 'haasMbaJurisDoctor', match: ['70141BAJDG']},
+      {role_code: 'jurisSocialPolicyMasters', match: ['84485MAG']},
+      {role_code: 'jurisSocialPolicyPhC', match: ['84485CPHLG']},
+      {role_code: 'jurisSocialPolicyPhD', match: ['84485PHDG']},
       {role_code: 'ugrdUrbanStudies', match: ['19912U']},
       {
         role_code: 'summerVisitor',

--- a/app/models/degree_progress/my_graduate_milestones.rb
+++ b/app/models/degree_progress/my_graduate_milestones.rb
@@ -8,16 +8,48 @@ module DegreeProgress
     include MilestonesModule
     include LinkFetcher
 
+    APR_LINK_ID_HAAS = 'UC_CX_APR_RPT_GRD_STDNT_HAAS'
+    APR_LINK_ID_LAW = 'UC_CX_APR_RPT_GRD_STDNT_LAW'
+    APR_LINK_ID_GRAD = 'UC_CX_APR_RPT_GRD_STDNT'
+
     def get_feed_internal
       return {} unless is_feature_enabled? && target_audience?
       response = CampusSolutions::DegreeProgress::GraduateMilestones.new(user_id: @uid).get
-      response[:feed] = HashConverter.camelize({
-        degree_progress: process(response)
-      })
-      response
+      if response[:errored] || response[:noStudentId]
+        response[:feed] = {}
+      else
+        response[:feed] = {
+          degree_progress: process(response)
+        }
+        response[:feed][:links] = get_links
+      end
+      HashConverter.camelize response
     end
 
     private
+
+    def get_links
+      roles = MyAcademics::MyAcademicRoles.new(@uid).get_feed
+      student_empl_id = User::Identifiers.lookup_campus_solutions_id @uid
+      links = {}
+
+      links[:academic_progress_report_haas] = fetch_link(APR_LINK_ID_HAAS, { :EMPLID => student_empl_id }) if haas_student?(roles)
+      links[:academic_progress_report_law] = fetch_link(APR_LINK_ID_LAW, { :EMPLID => student_empl_id }) if law_student?(roles)
+      links[:academic_progress_report_grad] = fetch_link(APR_LINK_ID_GRAD, { :EMPLID => student_empl_id }) if non_haas_grad_student?(roles)
+      links
+    end
+
+    def haas_student?(roles)
+      !!roles['haasBusinessAdminMasters'] || !!roles['haasBusinessAdminPhD']
+    end
+
+    def law_student?(roles)
+      !!roles['doctorScienceLaw'] || !!roles['jurisSocialPolicyMasters'] || !!roles['jurisSocialPolicyPhC'] || !!roles['jurisSocialPolicyPhD']
+    end
+
+    def non_haas_grad_student?(roles)
+      !!roles['grad'] && (!roles['haasBusinessAdminMasters'] && !roles['haasBusinessAdminPhD'] && !roles['haasFullTimeMba'] && !roles['haasEveningWeekendMba'] && !roles['haasExecMba'] && !roles['haasMastersFinEng'] && !roles['haasMbaPublicHealth'] && !roles['haasMbaJurisDoctor'])
+    end
 
     def target_audience?
       User::SearchUsersByUid.new(id: @uid, roles: [:graduate, :law, :exStudent]).search_users_by_uid.present?

--- a/fixtures/xml/campus_solutions/link_api_multiple.xml
+++ b/fixtures/xml/campus_solutions/link_api_multiple.xml
@@ -191,9 +191,7 @@
         <value>PL</value>
       </PROPERTY>
     </PROPERTIES>
-    <URL>
-      https://bcswebqat.is.berkeley.edu/psp/bcsdev/EMPLOYEE/HRMS/c/G3FRAME.G3SEARCH.GBL?&amp;G3FORM_FAMILY=STUDENT&amp;G3FORM_TYPE=AAQEAPPLIC&amp;G3FORM_CONDITION=Default&amp;G3FORM_TASK=VWS
-    </URL>
+    <URL>https://bcswebqat.is.berkeley.edu/psp/bcsdev/EMPLOYEE/HRMS/c/G3FRAME.G3SEARCH.GBL?&amp;G3FORM_FAMILY=STUDENT&amp;G3FORM_TYPE=AAQEAPPLIC&amp;G3FORM_CONDITION=Default&amp;G3FORM_TASK=VWS</URL>
     <COMMENTS></COMMENTS>
   </Link>
   <Link>
@@ -760,6 +758,93 @@ This link should take an instructor to the Grade Roster in BCS of the identified
     </PROPERTIES>
     <URL>https://bcswebqat.is.berkeley.edu/psp/bcsqat/EMPLOYEE/PSFT_CS/c/SA_LEARNER_SERVICES.SAA_SS_DPR_ADB.GBL?EMPLID={EMPLID}</URL>
     <COMMENTS>This should take a student to page where they can see their newly generated Academic Progress Report in CS.</COMMENTS>
+  </Link>
+  <Link>
+    <URL_ID>UC_CX_APR_RPT_GRD_STDNT</URL_ID>
+    <DESCRIPTION>View Academic Progress Report</DESCRIPTION>
+    <HOVER_OVER_TEXT>View Academic Progress Report</HOVER_OVER_TEXT>
+    <PROPERTIES type="array">
+      <PROPERTY>
+        <NAME>CALCENTRAL</NAME>
+        <value>GENERIC</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>UCFROM</NAME>
+        <value>CalCentral</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>UCFROMLINK</NAME>
+        <value>https://calcentral-sis-dev.berkeley.edu</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>UCFROMTEXT</NAME>
+        <value>CalCentral</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>URI_TYPE</NAME>
+        <value>PL</value>
+      </PROPERTY>
+    </PROPERTIES>
+    <URL>https://bcswebqat.is.berkeley.edu/psp/bcsqat/EMPLOYEE/PSFT_CS/c/SA_LEARNER_SERVICES.SAA_SS_DPR_ADB.GBL?EMPLID={EMPLID}</URL>
+    <COMMENTS></COMMENTS>
+  </Link>
+  <Link>
+    <URL_ID>UC_CX_APR_RPT_GRD_STDNT_HAAS</URL_ID>
+    <DESCRIPTION>View Academic Progress Report</DESCRIPTION>
+    <HOVER_OVER_TEXT>View Academic Progress Report</HOVER_OVER_TEXT>
+    <PROPERTIES type="array">
+      <PROPERTY>
+        <NAME>CALCENTRAL</NAME>
+        <value>GENERIC</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>UCFROM</NAME>
+        <value>CalCentral</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>UCFROMLINK</NAME>
+        <value>https://calcentral-sis-dev.berkeley.edu</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>UCFROMTEXT</NAME>
+        <value>CalCentral</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>URI_TYPE</NAME>
+        <value>PL</value>
+      </PROPERTY>
+    </PROPERTIES>
+    <URL>https://bcswebqat.is.berkeley.edu/psp/bcsqat/EMPLOYEE/PSFT_CS/c/SA_LEARNER_SERVICES.SAA_SS_DPR_ADB.GBL?EMPLID={EMPLID}</URL>
+    <COMMENTS></COMMENTS>
+  </Link>
+  <Link>
+    <URL_ID>UC_CX_APR_RPT_GRD_STDNT_LAW</URL_ID>
+    <DESCRIPTION>View Academic Progress Report</DESCRIPTION>
+    <HOVER_OVER_TEXT>View Academic Progress Report</HOVER_OVER_TEXT>
+    <PROPERTIES type="array">
+      <PROPERTY>
+        <NAME>CALCENTRAL</NAME>
+        <value>GENERIC</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>UCFROM</NAME>
+        <value>CalCentral</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>UCFROMLINK</NAME>
+        <value>https://calcentral-sis-dev.berkeley.edu</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>UCFROMTEXT</NAME>
+        <value>CalCentral</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>URI_TYPE</NAME>
+        <value>PL</value>
+      </PROPERTY>
+    </PROPERTIES>
+    <URL>https://bcswebqat.is.berkeley.edu/psp/bcsqat/EMPLOYEE/PSFT_CS/c/SA_LEARNER_SERVICES.SAA_SS_DPR_ADB.GBL?EMPLID={EMPLID}</URL>
+    <COMMENTS></COMMENTS>
   </Link>
   <Link>
     <URL_ID>UC_CX_AA_MILESTONE</URL_ID>

--- a/spec/models/concerns/academic_roles_spec.rb
+++ b/spec/models/concerns/academic_roles_spec.rb
@@ -74,19 +74,25 @@ describe Concerns::AcademicRoles do
   describe '#role_defaults' do
     subject { described_class.role_defaults }
     it 'returns all possible roles set to false' do
-      expect(subject.keys.count).to eq (15)
+      expect(subject.keys.count).to eq (21)
       expect(subject['ugrd']).to eq false
       expect(subject['grad']).to eq false
       expect(subject['law']).to eq false
       expect(subject['concurrent']).to eq false
       expect(subject['lettersAndScience']).to eq false
+      expect(subject['doctorScienceLaw']).to eq false
       expect(subject['fpf']).to eq false
+      expect(subject['haasBusinessAdminMasters']).to eq false
+      expect(subject['haasBusinessAdminPhD']).to eq false
       expect(subject['haasFullTimeMba']).to eq false
       expect(subject['haasEveningWeekendMba']).to eq false
       expect(subject['haasExecMba']).to eq false
       expect(subject['haasMastersFinEng']).to eq false
       expect(subject['haasMbaPublicHealth']).to eq false
       expect(subject['haasMbaJurisDoctor']).to eq false
+      expect(subject['jurisSocialPolicyMasters']).to eq false
+      expect(subject['jurisSocialPolicyPhC']).to eq false
+      expect(subject['jurisSocialPolicyPhD']).to eq false
       expect(subject['ugrdUrbanStudies']).to eq false
       expect(subject['summerVisitor']).to eq false
       expect(subject['courseworkOnly']).to eq false

--- a/spec/models/degree_progress/my_graduate_milestones_spec.rb
+++ b/spec/models/degree_progress/my_graduate_milestones_spec.rb
@@ -1,15 +1,73 @@
 describe DegreeProgress::MyGraduateMilestones do
 
+  shared_examples 'a proxy that returns a link to the Grad Academic Progress Report' do
+    it 'includes said link in the response' do
+      expect(subject[:feed][:links]).to be
+      puts subject[:feed][:links].pretty_inspect
+      expect(subject[:feed][:links][:academicProgressReportGrad]).to be
+      expect(subject[:feed][:links][:academicProgressReportGrad][:urlId]).to eq 'UC_CX_APR_RPT_GRD_STDNT'
+      expect(subject[:feed][:links][:academicProgressReportGrad][:url]).to eq 'https://bcswebqat.is.berkeley.edu/psp/bcsqat/EMPLOYEE/PSFT_CS/c/SA_LEARNER_SERVICES.SAA_SS_DPR_ADB.GBL?EMPLID=25738808'
+    end
+  end
+  shared_examples 'a proxy that returns a link to the Haas Academic Progress Report' do
+    it 'includes said link in the response' do
+      expect(subject[:feed][:links]).to be
+      expect(subject[:feed][:links][:academicProgressReportHaas]).to be
+      expect(subject[:feed][:links][:academicProgressReportHaas][:urlId]).to eq 'UC_CX_APR_RPT_GRD_STDNT_HAAS'
+      expect(subject[:feed][:links][:academicProgressReportHaas][:url]).to eq 'https://bcswebqat.is.berkeley.edu/psp/bcsqat/EMPLOYEE/PSFT_CS/c/SA_LEARNER_SERVICES.SAA_SS_DPR_ADB.GBL?EMPLID=25738808'
+    end
+  end
+  shared_examples 'a proxy that returns a link to the Law Academic Progress Report' do
+    it 'includes said link in the response' do
+      expect(subject[:feed][:links]).to be
+      expect(subject[:feed][:links][:academicProgressReportLaw]).to be
+      expect(subject[:feed][:links][:academicProgressReportLaw][:urlId]).to eq 'UC_CX_APR_RPT_GRD_STDNT_LAW'
+      expect(subject[:feed][:links][:academicProgressReportLaw][:url]).to eq 'https://bcswebqat.is.berkeley.edu/psp/bcsqat/EMPLOYEE/PSFT_CS/c/SA_LEARNER_SERVICES.SAA_SS_DPR_ADB.GBL?EMPLID=25738808'
+    end
+  end
+  shared_examples 'a proxy that returns two links' do
+    it 'include exactly two links in the response' do
+      expect(subject[:feed][:links].count).to eq 2
+    end
+  end
+  shared_examples 'a proxy that returns one link' do
+    it 'include exactly link in the response' do
+      expect(subject[:feed][:links].count).to eq 1
+    end
+  end
+  shared_examples 'a proxy that does not return links' do
+    it 'does not include a link in the response' do
+      expect(subject[:feed][:links].count).to eq 0
+    end
+  end
+
   let(:model) { described_class.new(user_id) }
   let(:user_id) { '12345' }
+  let(:link_proxy) { CampusSolutions::Link.new(fake: true) }
   let(:user_attributes) do
     {
       roles: {student: true, graduate: graduate_student, law: law_student}
     }
   end
+  let(:academic_roles) do
+    {
+      'jurisSocialPolicyMasters' => whitelisted_law_student,
+      'haasBusinessAdminMasters' => whitelisted_haas_student,
+      'haasExecMba' => blacklisted_haas_student,
+      'grad' => graduate_student,
+      'law' => law_student,
+    }
+  end
+  let(:graduate_student) { false }
+  let(:law_student) { false }
+  let(:whitelisted_law_student) { false }
+  let(:whitelisted_haas_student) { false }
+  let(:blacklisted_haas_student) { false }
 
   before do
     allow(User::AggregatedAttributes).to receive(:new).with(user_id).and_return double(get_feed: user_attributes)
+    allow(CampusSolutions::Link).to receive(:new).and_return link_proxy
+    allow_any_instance_of(MyAcademics::MyAcademicRoles).to receive(:get_feed).and_return(academic_roles)
   end
 
   describe '#get_feed_internal' do
@@ -17,18 +75,65 @@ describe DegreeProgress::MyGraduateMilestones do
 
     context 'when user is a graduate student' do
       let(:graduate_student) { true }
-      let(:law_student) { false }
 
       it_behaves_like 'a proxy that returns graduate milestone data'
       it_behaves_like 'a proxy that properly observes the graduate degree progress for student feature flag'
+      it_behaves_like 'a proxy that returns one link'
+      it_behaves_like 'a proxy that returns a link to the Grad Academic Progress Report'
+
+      context 'when student is active in an APR-ready Haas plan' do
+        let(:whitelisted_haas_student) { true }
+
+        it_behaves_like 'a proxy that returns graduate milestone data'
+        it_behaves_like 'a proxy that properly observes the graduate degree progress for student feature flag'
+        it_behaves_like 'a proxy that returns one link'
+        it_behaves_like 'a proxy that returns a link to the Haas Academic Progress Report'
+      end
+
+      context 'when student is active in a Haas plan that doesn\t use the APR' do
+        let(:blacklisted_haas_student) { true }
+
+        it_behaves_like 'a proxy that returns graduate milestone data'
+        it_behaves_like 'a proxy that properly observes the graduate degree progress for student feature flag'
+        it_behaves_like 'a proxy that does not return links'
+      end
     end
 
     context 'when user is a law student' do
-      let(:graduate_student) { false }
       let(:law_student) { true }
 
       it_behaves_like 'a proxy that returns graduate milestone data'
       it_behaves_like 'a proxy that properly observes the graduate degree progress for student feature flag'
+      it_behaves_like 'a proxy that does not return links'
+
+      context 'when student is active in an APR-ready law plan' do
+        let(:whitelisted_law_student) { true }
+
+        it_behaves_like 'a proxy that returns graduate milestone data'
+        it_behaves_like 'a proxy that properly observes the graduate degree progress for student feature flag'
+        it_behaves_like 'a proxy that returns one link'
+        it_behaves_like 'a proxy that returns a link to the Law Academic Progress Report'
+      end
+    end
+
+    context 'when user has both Graduate and Law careers' do
+      let(:graduate_student) { true }
+      let(:law_student) { true }
+
+      it_behaves_like 'a proxy that returns graduate milestone data'
+      it_behaves_like 'a proxy that properly observes the graduate degree progress for student feature flag'
+      it_behaves_like 'a proxy that returns one link'
+      it_behaves_like 'a proxy that returns a link to the Grad Academic Progress Report'
+
+      context 'when student is active in an APR-ready law plan' do
+        let(:whitelisted_law_student) { true }
+
+        it_behaves_like 'a proxy that returns graduate milestone data'
+        it_behaves_like 'a proxy that properly observes the graduate degree progress for student feature flag'
+        it_behaves_like 'a proxy that returns two links'
+        it_behaves_like 'a proxy that returns a link to the Law Academic Progress Report'
+        it_behaves_like 'a proxy that returns a link to the Grad Academic Progress Report'
+      end
     end
 
     context 'when user is neither Graduate nor Law' do

--- a/spec/models/my_academics/my_academic_roles_spec.rb
+++ b/spec/models/my_academics/my_academic_roles_spec.rb
@@ -11,19 +11,25 @@ describe MyAcademics::MyAcademicRoles do
     subject { described_class_instance.get_feed_internal }
     it 'provides a set of roles based on the user\'s academic status' do
       expect(subject).to be
-      expect(subject.keys.count).to eq 15
+      expect(subject.keys.count).to eq 21
       expect(subject['ugrd']).to eq true
       expect(subject['grad']).to eq false
       expect(subject['fpf']).to eq false
       expect(subject['law']).to eq false
       expect(subject['concurrent']).to eq false
+      expect(subject['doctorScienceLaw']).to eq false
       expect(subject['lettersAndScience']).to eq true
+      expect(subject['haasBusinessAdminMasters']).to eq false
+      expect(subject['haasBusinessAdminPhD']).to eq false
       expect(subject['haasFullTimeMba']).to eq false
       expect(subject['haasEveningWeekendMba']).to eq false
       expect(subject['haasExecMba']).to eq false
       expect(subject['haasMastersFinEng']).to eq false
       expect(subject['haasMbaPublicHealth']).to eq false
       expect(subject['haasMbaJurisDoctor']).to eq false
+      expect(subject['jurisSocialPolicyMasters']).to eq false
+      expect(subject['jurisSocialPolicyPhC']).to eq false
+      expect(subject['jurisSocialPolicyPhD']).to eq false
       expect(subject['ugrdUrbanStudies']).to eq false
       expect(subject['summerVisitor']).to eq false
       expect(subject['courseworkOnly']).to eq false

--- a/src/assets/templates/widgets/academics/degree_progress_graduate.html
+++ b/src/assets/templates/widgets/academics/degree_progress_graduate.html
@@ -4,6 +4,29 @@
   </div>
   <div class="cc-widget-padding">
     <div data-ng-if="degreeProgress.graduate.errored">There was an error retrieving graduate degree progress data.</div>
+    <div data-ng-if="!api.user.profile.roles.advisor">
+      <div data-ng-if="degreeProgress.graduate.links.academicProgressReportLaw.url">
+        <a data-cc-campus-solutions-link-directive="degreeProgress.graduate.links.academicProgressReportLaw"
+           data-cc-campus-solutions-link-directive-cc-page-name="currentPage.name"
+           data-cc-campus-solutions-link-directive-cc-page-url="currentPage.url"
+        ></a>
+        <span data-ng-bind="degreeProgress.graduate.links.academicProgressReportLaw.linkDescription"></span>
+      </div>
+      <div data-ng-if="degreeProgress.graduate.links.academicProgressReportGrad.url">
+        <a data-cc-campus-solutions-link-directive="degreeProgress.graduate.links.academicProgressReportGrad"
+           data-cc-campus-solutions-link-directive-cc-page-name="currentPage.name"
+           data-cc-campus-solutions-link-directive-cc-page-url="currentPage.url"
+        ></a>
+        <span data-ng-bind="degreeProgress.graduate.links.academicProgressReportGrad.linkDescription"></span>
+      </div>
+      <div data-ng-if="degreeProgress.graduate.links.academicProgressReportHaas.url">
+        <a data-cc-campus-solutions-link-directive="degreeProgress.graduate.links.academicProgressReportHaas"
+           data-cc-campus-solutions-link-directive-cc-page-name="currentPage.name"
+           data-cc-campus-solutions-link-directive-cc-page-url="currentPage.url"
+        ></a>
+        <span data-ng-bind="degreeProgress.graduate.links.academicProgressReportHaas.linkDescription"></span>
+      </div>
+    </div>
     <div data-ng-if="!degreeProgress.graduate.progresses.length && !api.user.profile.roles.advisor">
       You have not completed any Graduate Division Milestones. Please contact your department if you believe this is an error.
     </div>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-38587

Three versions of the link to run the APR were created specifically for Grad, Law, and Haas students.  Each of those three links can be enabled/disabled independently of the others.

- Adds two new Haas plan-based roles. 
-- Only these 2 Haas roles should see the Haas link - other Haas roles will not see a link.
-- I did not update the other places in the code that use Haas roles to take these new roles into account.
- Adds 4 new plan-based roles for Law students