### PR TITLE
SISRP-38366 - New admits admission offer acceptance - improve validation

### DIFF
--- a/app/controllers/campus_solutions/sir_response_controller.rb
+++ b/app/controllers/campus_solutions/sir_response_controller.rb
@@ -1,5 +1,6 @@
 module CampusSolutions
   class SirResponseController < CampusSolutionsController
+    rescue_from Errors::ClientError, with: :handle_client_error
 
     before_filter :exclude_acting_as_users
 

--- a/app/models/campus_solutions/address.rb
+++ b/app/models/campus_solutions/address.rb
@@ -32,7 +32,7 @@ module CampusSolutions
       )
     end
 
-    def self.valid?(params)
+    def valid?(params)
       %w(DIPL LOCL MAIL HOME).include? params[:addressType]
     end
 

--- a/app/models/campus_solutions/checklist_data_updating_model.rb
+++ b/app/models/campus_solutions/checklist_data_updating_model.rb
@@ -1,0 +1,10 @@
+module CampusSolutions
+  module ChecklistDataUpdatingModel
+    def passthrough(model_name, params)
+      proxy = model_name.new({user_id: @uid, params: params})
+      result = proxy.post
+      ChecklistDataExpiry.expire @uid
+      result
+    end
+  end
+end

--- a/app/models/campus_solutions/email.rb
+++ b/app/models/campus_solutions/email.rb
@@ -19,7 +19,7 @@ module CampusSolutions
       )
     end
 
-    def self.valid?(params)
+    def valid?(params)
       %w(HOME OTHR).include? params[:type]
     end
 

--- a/app/models/campus_solutions/posting_proxy.rb
+++ b/app/models/campus_solutions/posting_proxy.rb
@@ -15,14 +15,14 @@ module CampusSolutions
     end
 
     def post
-      if self.class.valid? params
+      if valid? params
         get
       else
         raise Errors::BadRequestError, "Invalid request: #{params}"
       end
     end
 
-    def self.valid?(params)
+    def valid?(params)
       true
     end
 

--- a/app/models/campus_solutions/sir/my_sir_response.rb
+++ b/app/models/campus_solutions/sir/my_sir_response.rb
@@ -2,10 +2,9 @@ module CampusSolutions
   module Sir
     class MySirResponse < UserSpecificModel
 
-      include CampusSolutions::PersonDataUpdatingModel
+      include CampusSolutions::ChecklistDataUpdatingModel
 
       def update(params = {})
-        CampusSolutions::ChecklistDataExpiry.expire @uid
         passthrough(CampusSolutions::Sir::SirResponse, params)
       end
 

--- a/app/models/campus_solutions/terms_and_conditions.rb
+++ b/app/models/campus_solutions/terms_and_conditions.rb
@@ -18,7 +18,7 @@ module CampusSolutions
       )
     end
 
-    def self.valid?(params)
+    def valid?(params)
       aid_years = []
       aid_years_feed = CampusSolutions::MyAidYears.new(@uid).get_feed
       aid_years_feed.try(:[], :feed).try(:[], :finaidSummary).try(:[], :finaidYears).try(:each) do |aid_year|

--- a/spec/controllers/campus_solutions/sir_response_controller_spec.rb
+++ b/spec/controllers/campus_solutions/sir_response_controller_spec.rb
@@ -1,6 +1,26 @@
 describe CampusSolutions::SirResponseController do
 
   let(:user_id) { '12350' }
+  let(:sir_statuses_feed) {
+    {
+      sirStatuses: [
+        {
+          itemStatusCode: 'I',
+          chklstItemCd: 'AUSIRF',
+          checkListMgmtAdmp: {
+            admApplNbr: '00123456'
+          }
+        }
+      ]
+    }
+  }
+  let(:post_response) {
+    {
+      feed: {
+        status: 200
+      }
+    }
+  }
 
   context 'updating sir response' do
     it 'should not let an unauthenticated user post' do
@@ -12,18 +32,32 @@ describe CampusSolutions::SirResponseController do
       before do
         session['user_id'] = user_id
         User::Auth.stub(:where).and_return([User::Auth.new(uid: user_id, is_superuser: false, active: true)])
+        CampusSolutions::Sir::SirStatuses.stub_chain(:new, :get_feed).and_return sir_statuses_feed
+        CampusSolutions::Proxy.stub(:get).and_return post_response
       end
       it 'should let an authenticated user post' do
         post :post,
              {
-               bogus_field: 'abc',
-               studentCarNbr: '1234'
+               'chklstItemCd' => 'AUSIRF',
+               'admApplNbr' => '00123456'
              }
         expect(response.status).to eq 200
         json = JSON.parse(response.body)
         expect(json['statusCode']).to eq 200
         expect(json['feed']).to be
         expect(json['feed']['status']).to be
+      end
+      it 'should reject a post that fails validation' do
+        post :post,
+             {
+               'studentCarNbr' => '1234',
+               'admApplNbr' => '12345678',
+               'chklstItemCd' => 'let-me-in-please'
+             }
+        expect(response.status).to eq 400
+        json = JSON.parse(response.body)
+        expect(json['feed']).not_to be
+        expect(json['error']).to be
       end
     end
   end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-38366

* Adds validation to the SIR response POST
* Also creates `ChecklistDataUpdatingModel` because `PersonDataUpdatingModel` really had nothing to do with SIR
* Changes `valid?` from a class method to an instance method.  I believe that it needed to be an instance method so that classes outside of the `CampusSolutions` module (in this PR, `SirStatuses` is under `CampusSolutions::Sir::SirStatuses`) could access inherited instance variables
* For that reason, changes `valid?` to an instance method on all the other models it was already defined in
