### PR TITLE
SISRP-38366 - New admits admission offer acceptance - improve validation (fix testext)

### DIFF
--- a/spec/models/campus_solutions/sir/sir_response_spec.rb
+++ b/spec/models/campus_solutions/sir/sir_response_spec.rb
@@ -84,18 +84,4 @@ describe CampusSolutions::Sir::SirResponse do
     end
   end
 
-  context 'with a real external service', testext: true do
-    let(:proxy) { CampusSolutions::Sir::SirResponse.new(fake: false, user_id: user_id, params: params) }
-    subject { proxy.post }
-
-    context 'an invalid post' do
-      let(:params) { {
-        'studentCarNbr' => ''
-      } }
-      context 'performing a real but invalid post' do
-        it_should_behave_like 'a simple proxy that returns errors'
-        it_should_behave_like 'a proxy that responds to user error gracefully'
-      end
-    end
-  end
 end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-38366

* Previous PR broke these testext tests
* This test isn't really valid anymore, because "an invalid post" will never pass our server-side validation to reach an actual proxy call, and that piece is already being tested elsewhere in the spec.