### PR TITLE
SISRP-39127 - Update CalCentral roster queries to use SISEDO.CC_ENROLLMENTV00_VW

### DIFF
--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -343,7 +343,7 @@ module EdoOracle
           enroll."WAITLISTPOSITION" AS waitlist_position,
           enroll."UNITS_TAKEN" AS units,
           TRIM(enroll."GRADING_BASIS_CODE") AS grading_basis
-        FROM SISEDO.ENROLLMENTV00_VW enroll
+        FROM SISEDO.CC_ENROLLMENTV00_VW enroll
         WHERE
           enroll."CLASS_SECTION_ID" = '#{section_id}'
           AND enroll."TERM_ID" = '#{term_id}'
@@ -372,7 +372,7 @@ module EdoOracle
           plan."STATUSINPLAN_STATUS_CODE",
           stdgroup."HIGHEST_STDNT_GROUP" AS terms_in_attendance_group
           #{email_col}
-        FROM SISEDO.ENROLLMENTV00_VW enroll
+        FROM SISEDO.CC_ENROLLMENTV00_VW enroll
         LEFT OUTER JOIN
           SISEDO.STUDENT_PLAN_CC_V00_VW plan ON enroll."STUDENT_ID" = plan."STUDENT_ID" AND
           plan."ACADPLAN_TYPE_CODE" IN ('CRT', 'HS', 'MAJ', 'SP', 'SS')


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-39127

@raydavis @paulkerschen - I've notified @dkawase and @yoshers about this update as this will affect the Canvas/bCourses enrollment query in EdoOracle::Queries.get_enrolled_students

See other `master` PR #7012 
See QA PR in #7018