### PR TITLE
SISRP-39773 - Hides cumulative transfer credits from Law students

### DIFF
--- a/app/models/my_academics/transfer_credit.rb
+++ b/app/models/my_academics/transfer_credit.rb
@@ -1,12 +1,14 @@
 module MyAcademics
   class TransferCredit < UserSpecificModel
     include ClassLogger
+    include Cache::CachedFeed
+    include Cache::UserCacheExpiry
 
     def merge(data)
-      data[:transferCredit] = transfer_credit
+      data[:transferCredit] = get_feed
     end
 
-    def transfer_credit
+    def get_feed_internal
       response = CampusSolutions::TransferCredit.new(user_id: @uid).get
       response = response.try(:[], :feed).try(:[], :root).try(:[], :ucTransferCredits).try(:[], :transferCredit)
       if (credit = response.try(:[], :ucTransferCrseSch))

--- a/src/assets/javascripts/angular/controllers/pages/academicSummaryController.js
+++ b/src/assets/javascripts/angular/controllers/pages/academicSummaryController.js
@@ -29,16 +29,6 @@ angular.module('calcentral.controllers').controller('AcademicSummaryController',
     });
   };
 
-  var parseGpaUnits = function() {
-    // Testing units are lumped in with Transfer Units on the academic summary
-    if ($scope.gpaUnits && !$scope.gpaUnits.errored) {
-      var unitsAdjusted = _.get($scope, 'transferCredit.ucTransferCrseSch.unitsAdjusted');
-      var totalTestUnits = _.get($scope, 'transferCredit.ucTestComponent.totalTestUnits');
-      var totalTransferAndTestingUnits = academicsService.totalTransferUnits(unitsAdjusted, totalTestUnits);
-      _.set($scope.gpaUnits, 'testingAndTransferUnits', totalTransferAndTestingUnits);
-    }
-  };
-
   var parseTransferCredit = function() {
     $scope.showTransferCredit = showTransferCredit();
     if (!showTransferCredit) {
@@ -63,7 +53,6 @@ angular.module('calcentral.controllers').controller('AcademicSummaryController',
     angular.extend($scope, _.get(response, 'data'));
     $scope.showSemesters = showSemesters();
     parseTermHonors();
-    parseGpaUnits();
     parseTransferCredit();
   };
 

--- a/src/assets/templates/widgets/academic_summary/academic_summary_student_profile.html
+++ b/src/assets/templates/widgets/academic_summary/academic_summary_student_profile.html
@@ -113,14 +113,14 @@
       <tr>
         <th class="cc-academic-summary-row-title"><h4>Units</h4></th>
         <th class="cc-academic-summary-row-header">Cumulative</th>
-        <th data-ng-if="gpaUnits.testingAndTransferUnits" class="cc-academic-summary-row-header">Transfer</th>
+        <th data-ng-if="gpaUnits.totalTransferAndTestingUnits" class="cc-academic-summary-row-header">Transfer</th>
         <th data-ng-if="gpaUnits.totalUnitsTakenNotForGpa" class="cc-academic-summary-row-header">P/NP Total</th>
         <th data-ng-if="gpaUnits.totalUnitsPassedNotForGpa" class="cc-academic-summary-row-header">P/NP Passed</th>
       </tr>
       <tr>
         <td></td>
         <td><span data-ng-bind="gpaUnits.totalUnits"></span></td>
-        <td data-ng-if="gpaUnits.testingAndTransferUnits"><span data-ng-bind="gpaUnits.testingAndTransferUnits"></span></td>
+        <td data-ng-if="gpaUnits.totalTransferAndTestingUnits"><span data-ng-bind="gpaUnits.totalTransferAndTestingUnits"></span></td>
         <td data-ng-if="gpaUnits.totalUnitsTakenNotForGpa"><span data-ng-bind="gpaUnits.totalUnitsTakenNotForGpa"></span></td>
         <td data-ng-if="gpaUnits.totalUnitsPassedNotForGpa"><span data-ng-bind="gpaUnits.totalUnitsPassedNotForGpa"></span></td>
       </tr>


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-39773

Changes made to the `GpaUnits` feed:
- Merge the `TransferCredit` data into the feed on the back-end instead of in the UI code
- Cache the `TransferCredit` feed since we're using it in two places now
- Include all the keys in the `GpaUnits` response object, whether they have a value or they are nil