### PR TITLE
SISRP-34988 - CalCentral application does not connect to Postgres via SSL

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -19,6 +19,7 @@ production:
   password: <%= Settings.postgres.password %>
   host: <%= Settings.postgres.host %>
   port: <%= Settings.postgres.port %>
+  sslmode: <%= Settings.postgres.sslmode %>
 
 test:
   adapter: sqlite3

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -40,6 +40,7 @@ postgres:
   host: <%= ENV['DB_PORT_5432_TCP_ADDR'] || 'localhost' %>
   port: <%= ENV['DB_PORT_5432_TCP_PORT'] || '5432' %>
   pool: 95
+  sslmode: <%= ENV['DB_ENV_POSTGRESQL_SSLMODE'] || 'prefer' %>
 
 edodb:
   fake: false


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-34988

Makes it possible for SIS admins to configure production.local.yml (or other environment specific config files) to specify an SSL mode value.
```yaml
postgres:
  sslmode: 'require'
```

See [PostgreSQL SSL Mode statements](https://www.postgresql.org/docs/9.1/static/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS)