### PR TITLE
SISRP-39586 - Prevents specs that hit H2 from running on bamboo

### DIFF
--- a/spec/models/edo_oracle/career_term_spec.rb
+++ b/spec/models/edo_oracle/career_term_spec.rb
@@ -1,4 +1,4 @@
-describe EdoOracle::CareerTerm do
+describe EdoOracle::CareerTerm, testext: false do
 
   describe '#term_summary' do
     subject { described_class.new({user_id: uid}).term_summary(academic_careers, term_id) }

--- a/spec/models/edo_oracle/queries_spec.rb
+++ b/spec/models/edo_oracle/queries_spec.rb
@@ -28,7 +28,7 @@ describe EdoOracle::Queries do
     expect(described_class.settings).to be Settings.edodb
   end
 
-  describe '#get_term_unit_totals' do
+  describe '#get_term_unit_totals', testext: false do
     subject { described_class.get_term_unit_totals(uid, academic_careers, term_id) }
     let(:uid) { 799934 }
     let(:academic_careers) { ['UGRD'] }
@@ -44,7 +44,7 @@ describe EdoOracle::Queries do
     end
   end
 
-  describe '#get_term_law_unit_totals' do
+  describe '#get_term_law_unit_totals', testext: false do
     subject { described_class.get_term_law_unit_totals(uid, academic_careers, term_id) }
     let(:uid) { 300216 }
     let(:academic_careers) { %w(GRAD LAW) }
@@ -59,7 +59,7 @@ describe EdoOracle::Queries do
     end
   end
 
-  describe '#get_enrolled_sections' do
+  describe '#get_enrolled_sections', testext: false do
     subject { described_class.get_enrolled_sections uid }
     let(:uid) { 799934 }
 
@@ -108,7 +108,7 @@ describe EdoOracle::Queries do
     end
   end
 
-  describe '#get_law_enrollment' do
+  describe '#get_law_enrollment', testext: false do
     subject { described_class.get_law_enrollment(uid, academic_career, term, section, require_desig_code) }
     let (:uid) { 490452 }
     let (:academic_career) { 'LAW' }

--- a/spec/models/edo_oracle/user_courses/base_spec.rb
+++ b/spec/models/edo_oracle/user_courses/base_spec.rb
@@ -1,13 +1,13 @@
 describe EdoOracle::UserCourses::Base do
 
-  context '#merge_enrollments' do
+  describe '#merge_enrollments', testext: false do
     before do
       allow(Settings.edodb).to receive(:fake).and_return false
       allow(Settings.terms).to receive(:fake_now).and_return nil
       allow(Settings.terms).to receive(:use_term_definitions_json_file).and_return true
       allow(Settings.features).to receive(:hub_term_api).and_return false
     end
-    
+
     subject do
       feed = {}
       described_class.new(user_id: user_id).merge_enrollments(feed)

--- a/spec/models/my_academics/semesters_spec.rb
+++ b/spec/models/my_academics/semesters_spec.rb
@@ -1,6 +1,6 @@
 describe MyAcademics::Semesters do
 
-  describe '#semester_feed' do
+  describe '#semester_feed', testext: false do
 
     before do
       allow(Settings.edodb).to receive(:fake).and_return false


### PR DESCRIPTION
Specs introduced under #7100 that run against a fake H2 database fail on Bamboo when they try to run against the real SISEDO database.

For now, we'll skip these tests when running in `testext`.