### PR TITLE
SISRP-38837 - hides non-Law enrollments from active Law students

### DIFF
--- a/app/models/concerns/careers.rb
+++ b/app/models/concerns/careers.rb
@@ -1,0 +1,14 @@
+module Concerns
+  module Careers
+    extend self
+
+    def active? career
+      :AC == career.try(:[], 'program_status').try(:intern)
+    end
+
+    def active_or_all careers
+      active_careers = careers.try(:select){|career| active? career}
+      active_careers.present? ? active_careers : careers
+    end
+  end
+end

--- a/app/models/edo_oracle/career.rb
+++ b/app/models/edo_oracle/career.rb
@@ -1,0 +1,13 @@
+module EdoOracle
+  class Career < BaseProxy
+    include ClassLogger
+
+    def initialize(options = {})
+      super(Settings.edodb, options)
+    end
+
+    def fetch
+      EdoOracle::Queries.get_careers(@uid)
+    end
+  end
+end

--- a/app/models/edo_oracle/user_courses/all.rb
+++ b/app/models/edo_oracle/user_courses/all.rb
@@ -4,13 +4,13 @@ module EdoOracle
 
       include Cache::UserCacheExpiry
 
-      def get_all_campus_courses
+      def get_all_campus_courses(academic_careers = nil)
         # Because this data structure is used by multiple top-level feeds, it's essential
         # that it be cached efficiently.
         self.class.fetch_from_cache @uid do
           campus_classes = {}
           merge_instructing campus_classes
-          merge_enrollments campus_classes
+          merge_enrollments(campus_classes, academic_careers)
           sort_courses campus_classes
 
           # Sort the hash in descending order of semester.
@@ -24,10 +24,10 @@ module EdoOracle
         end
       end
 
-      def get_enrollments_summary
+      def get_enrollments_summary(academic_careers = nil)
         self.class.fetch_from_cache "summary-#{@uid}" do
           campus_classes = {}
-          merge_enrollments campus_classes
+          merge_enrollments(campus_classes, academic_careers)
           sort_courses campus_classes
           campus_classes = Hash[campus_classes.sort.reverse]
           remove_duplicate_sections(campus_classes)

--- a/app/models/edo_oracle/user_courses/base.rb
+++ b/app/models/edo_oracle/user_courses/base.rb
@@ -12,11 +12,11 @@ module EdoOracle
         !uid.blank?
       end
 
-      def merge_enrollments(campus_classes)
+      def merge_enrollments(campus_classes, academic_careers = nil)
         return if @non_legacy_academic_terms.empty?
         previous_item = {}
 
-        EdoOracle::Queries.get_enrolled_sections(@uid, @non_legacy_academic_terms).each do |row|
+        EdoOracle::Queries.get_enrolled_sections(@uid, academic_careers, @non_legacy_academic_terms).each do |row|
           if (item = row_to_feed_item(row, previous_item))
             item[:role] = 'Student'
             # Cross-listed courses may lack descriptive names. Students, unlike instructors, will

--- a/app/models/my_academics/gpa_units.rb
+++ b/app/models/my_academics/gpa_units.rb
@@ -3,6 +3,7 @@ module MyAcademics
     include ClassLogger
     include User::Identifiers
     include Concerns::AcademicStatus
+    include Concerns::Careers
 
     def merge(data)
       data[:gpaUnits] = gpa_units
@@ -68,23 +69,16 @@ module MyAcademics
     end
 
     def get_cumulative_units
-      unit_totals = EdoOracle::Queries.get_career_unit_totals(@uid)
-      has_active_career = unit_totals.any? do |career|
-        active? career
-      end
+      careers = active_or_all EdoOracle::Career.new(user_id: @uid).fetch
       result = {
         totalUnits: 0,
         totalLawUnits: 0
       }
-      unit_totals.each do |career|
-        result[:totalUnits] += (career['total_cumulative_units'] if active?(career) || !has_active_career).to_f
-        result[:totalLawUnits] += (career['total_cumulative_law_units'] if active?(career) || !has_active_career).to_f
+      careers.each do |career|
+        result[:totalUnits] += (career['total_cumulative_units']).to_f
+        result[:totalLawUnits] += (career['total_cumulative_law_units']).to_f
       end
       result
-    end
-
-    def active?(career)
-      :AC == career['program_status'].try(:intern)
     end
 
     def parse_total_transfer_units(status)

--- a/spec/models/concerns/careers_spec.rb
+++ b/spec/models/concerns/careers_spec.rb
@@ -1,0 +1,81 @@
+describe Concerns::Careers do
+
+  let(:active_career) do
+    {
+      'program_status' => 'AC'
+    }
+  end
+  let(:inactive_career) do
+    {
+      'program_status' => nil
+    }
+  end
+
+  describe '#active?' do
+    subject { described_class.active? career }
+
+    context 'when career is active' do
+      let(:career) { active_career }
+      it 'returns true' do
+        expect(subject).to eq true
+      end
+    end
+    context 'when career is inactive' do
+      let(:career) { inactive_career }
+      it 'returns false' do
+        expect(subject).to eq false
+      end
+    end
+    context 'when career is missing' do
+      let(:career) { nil }
+      it 'returns false' do
+        expect(subject).to eq false
+      end
+    end
+    context 'when career is malformed' do
+      let(:career) do
+        {
+          foo: 'bar'
+        }
+      end
+      it 'returns false' do
+        expect(subject).to eq false
+      end
+    end
+  end
+
+  describe '#active_or_all' do
+    subject { described_class.active_or_all careers }
+
+    context 'when no careers are active' do
+      let(:careers) { [inactive_career, inactive_career] }
+      it 'returns all careers' do
+        expect(subject).to contain_exactly(inactive_career, inactive_career)
+      end
+    end
+    context 'when all careers are active' do
+      let(:careers) { [active_career, active_career] }
+      it 'returns all careers' do
+        expect(subject).to contain_exactly(active_career, active_career)
+      end
+    end
+    context 'when some careers are active' do
+      let(:careers) { [inactive_career, active_career] }
+      it 'returns only active careers' do
+        expect(subject).to contain_exactly(active_career)
+      end
+    end
+    context 'when careers is nil' do
+      let(:careers) { nil }
+      it 'returns nil' do
+        expect(subject).to be nil
+      end
+    end
+    context 'when careers is empty' do
+      let(:careers) { [] }
+      it 'returns empty' do
+        expect(subject).to eq []
+      end
+    end
+  end
+end

--- a/spec/models/edo_oracle/career_spec.rb
+++ b/spec/models/edo_oracle/career_spec.rb
@@ -1,0 +1,23 @@
+describe EdoOracle::Career, testext: false do
+
+  describe '#fetch' do
+    subject { described_class.new({user_id: uid}).fetch }
+    let(:uid) { 790833 }
+    it 'returns the expected result' do
+      expect(subject).to be
+      expect(subject.count).to be 2
+
+      expect(subject[0].count).to eq 4
+      expect(subject[0]).to have_key('acad_career')
+      expect(subject[0]).to have_key('program_status')
+      expect(subject[0]).to have_key('total_cumulative_units')
+      expect(subject[0]).to have_key('total_cumulative_law_units')
+
+      expect(subject[1].count).to eq 4
+      expect(subject[1]).to have_key('acad_career')
+      expect(subject[1]).to have_key('program_status')
+      expect(subject[1]).to have_key('total_cumulative_units')
+      expect(subject[1]).to have_key('total_cumulative_law_units')
+    end
+  end
+end

--- a/spec/models/edo_oracle/user_courses/base_spec.rb
+++ b/spec/models/edo_oracle/user_courses/base_spec.rb
@@ -10,10 +10,11 @@ describe EdoOracle::UserCourses::Base do
 
     subject do
       feed = {}
-      described_class.new(user_id: user_id).merge_enrollments(feed)
+      described_class.new(user_id: user_id).merge_enrollments(feed, academic_careers)
       feed
     end
     let(:user_id) { 799934 }
+    let(:academic_careers) { nil }
 
     it 'assembles the enrollments feed' do
       expect(subject).to be
@@ -48,7 +49,7 @@ describe EdoOracle::UserCourses::Base do
 
     it 'should query non-legacy terms only' do
       allow(Settings.terms).to receive(:legacy_cutoff).and_return 'summer-2013'
-      expect(EdoOracle::Queries).to receive(:get_enrolled_sections).with(anything, terms_following_and_including_cutoff('2135')).and_return []
+      expect(EdoOracle::Queries).to receive(:get_enrolled_sections).with(anything, nil, terms_following_and_including_cutoff('2135')).and_return []
       described_class.new(user_id: random_id).merge_enrollments({})
     end
 

--- a/spec/models/my_academics/semesters_spec.rb
+++ b/spec/models/my_academics/semesters_spec.rb
@@ -1,6 +1,44 @@
 describe MyAcademics::Semesters do
 
+  describe '#academic_careers', testext: false do
+    subject { described_class.new(uid).academic_careers }
+
+    before do
+      allow_any_instance_of(MyAcademics::MyAcademicRoles).to receive(:get_feed).and_return academic_roles
+    end
+    let(:uid) { 300216 }
+    let(:academic_roles) do
+      {
+        'law'=> has_law_role
+      }
+    end
+
+    context 'when user is not a Law student' do
+      let(:has_law_role) { false }
+      it 'returns nil' do
+        expect(subject).to be nil
+      end
+    end
+    context 'when user is a Law student' do
+      let(:has_law_role) { true }
+
+      context 'with an active career' do
+        it 'returns a list of active careers' do
+          expect(subject).to contain_exactly('GRAD', 'LAW')
+        end
+      end
+      context 'with no active career' do
+        let(:uid) { 790833 }
+        it 'returns a list of all careers' do
+          expect(subject).to contain_exactly('UGRD', 'UCBX')
+        end
+      end
+    end
+
+  end
+
   describe '#semester_feed', testext: false do
+    subject { described_class.new(uid).semester_feed(enrollment_terms, reg_status_data) }
 
     before do
       allow(Settings.edodb).to receive(:fake).and_return false
@@ -9,7 +47,6 @@ describe MyAcademics::Semesters do
       allow(Settings.features).to receive(:hub_term_api).and_return false
     end
 
-    subject { described_class.new(uid).semester_feed(enrollment_terms, reg_status_data) }
     let(:enrollment_terms) { EdoOracle::UserCourses::All.new(user_id: uid, fake: false).get_all_campus_courses }
     let(:reg_status_data) { [] }
     let(:uid) { 790833 }


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-38837

- Non-Law students can see all past and present enrollments.
- Active Law students can only see their active career enrollments.
- A dual career law student (active in 2 careers) can see enrollments in both active careers

