### PR TITLE
SISRP-38837 - Moves career filtering logic to the Semesters model

### DIFF
--- a/app/models/edo_oracle/queries.rb
+++ b/app/models/edo_oracle/queries.rb
@@ -147,7 +147,7 @@ module EdoOracle
       SQL
     end
 
-    def self.get_enrolled_sections(person_id, academic_careers, terms)
+    def self.get_enrolled_sections(person_id, terms)
       # The push_pred hint below alerts Oracle to use indexes on SISEDO.API_COURSEV00_VW, aka crs.
       in_term_where_clause = "enr.\"TERM_ID\" IN (#{terms_query_list terms}) AND " if Settings.features.hub_term_api
       safe_query <<-SQL
@@ -176,7 +176,6 @@ module EdoOracle
         #{JOIN_SECTION_TO_COURSE}
         WHERE  #{in_term_where_clause}
           enr."CAMPUS_UID" = '#{person_id}'
-          #{and_academic_career('enr', academic_careers)}
           #{and_institution('enr')}
           AND enr."STDNT_ENRL_STATUS_CODE" != 'D'
           #{where_course_term_updated_date}

--- a/app/models/edo_oracle/user_courses/all.rb
+++ b/app/models/edo_oracle/user_courses/all.rb
@@ -4,13 +4,13 @@ module EdoOracle
 
       include Cache::UserCacheExpiry
 
-      def get_all_campus_courses(academic_careers = nil)
+      def get_all_campus_courses()
         # Because this data structure is used by multiple top-level feeds, it's essential
         # that it be cached efficiently.
         self.class.fetch_from_cache @uid do
           campus_classes = {}
           merge_instructing campus_classes
-          merge_enrollments(campus_classes, academic_careers)
+          merge_enrollments campus_classes
           sort_courses campus_classes
 
           # Sort the hash in descending order of semester.
@@ -27,7 +27,7 @@ module EdoOracle
       def get_enrollments_summary(academic_careers = nil)
         self.class.fetch_from_cache "summary-#{@uid}" do
           campus_classes = {}
-          merge_enrollments(campus_classes, academic_careers)
+          merge_enrollments campus_classes
           sort_courses campus_classes
           campus_classes = Hash[campus_classes.sort.reverse]
           remove_duplicate_sections(campus_classes)

--- a/app/models/edo_oracle/user_courses/base.rb
+++ b/app/models/edo_oracle/user_courses/base.rb
@@ -12,11 +12,11 @@ module EdoOracle
         !uid.blank?
       end
 
-      def merge_enrollments(campus_classes, academic_careers = nil)
+      def merge_enrollments(campus_classes)
         return if @non_legacy_academic_terms.empty?
         previous_item = {}
 
-        EdoOracle::Queries.get_enrolled_sections(@uid, academic_careers, @non_legacy_academic_terms).each do |row|
+        EdoOracle::Queries.get_enrolled_sections(@uid, @non_legacy_academic_terms).each do |row|
           if (item = row_to_feed_item(row, previous_item))
             item[:role] = 'Student'
             # Cross-listed courses may lack descriptive names. Students, unlike instructors, will

--- a/spec/models/edo_oracle/queries_spec.rb
+++ b/spec/models/edo_oracle/queries_spec.rb
@@ -89,10 +89,9 @@ describe EdoOracle::Queries do
   end
 
   describe '#get_enrolled_sections', testext: false do
-    subject { described_class.get_enrolled_sections(uid, careers, terms) }
+    subject { described_class.get_enrolled_sections(uid, terms) }
     let(:uid) { 799934 }
     let(:terms) { nil }
-    let(:careers) { nil }
 
     it_behaves_like 'a successful query'
 
@@ -163,15 +162,6 @@ describe EdoOracle::Queries do
         expect(subject.count).to eq 2
         expect(subject[0]['term_id']).to eq '2178'
         expect(subject[1]['term_id']).to eq '2178'
-      end
-    end
-    context 'when constrained by careers' do
-      let(:uid) { 300216 }
-      let(:careers) { ['GRAD'] }
-      it_behaves_like 'a successful query'
-      it 'returns only enrollments associated with the specified careers' do
-        expect(subject.count).to eq 1
-        expect(subject[0]['acad_career']).to eq 'GRAD'
       end
     end
     context 'when no UID provided' do

--- a/spec/models/edo_oracle/user_courses/base_spec.rb
+++ b/spec/models/edo_oracle/user_courses/base_spec.rb
@@ -10,11 +10,10 @@ describe EdoOracle::UserCourses::Base do
 
     subject do
       feed = {}
-      described_class.new(user_id: user_id).merge_enrollments(feed, academic_careers)
+      described_class.new(user_id: user_id).merge_enrollments(feed)
       feed
     end
     let(:user_id) { 799934 }
-    let(:academic_careers) { nil }
 
     it 'assembles the enrollments feed' do
       expect(subject).to be
@@ -49,7 +48,7 @@ describe EdoOracle::UserCourses::Base do
 
     it 'should query non-legacy terms only' do
       allow(Settings.terms).to receive(:legacy_cutoff).and_return 'summer-2013'
-      expect(EdoOracle::Queries).to receive(:get_enrolled_sections).with(anything, nil, terms_following_and_including_cutoff('2135')).and_return []
+      expect(EdoOracle::Queries).to receive(:get_enrolled_sections).with(anything, terms_following_and_including_cutoff('2135')).and_return []
       described_class.new(user_id: random_id).merge_enrollments({})
     end
 

--- a/spec/models/my_academics/semesters_spec.rb
+++ b/spec/models/my_academics/semesters_spec.rb
@@ -1,40 +1,20 @@
 describe MyAcademics::Semesters do
 
-  describe '#academic_careers', testext: false do
-    subject { described_class.new(uid).academic_careers }
-
-    before do
-      allow_any_instance_of(MyAcademics::MyAcademicRoles).to receive(:get_feed).and_return academic_roles
-    end
+  describe '#find_academic_careers', testext: false do
+    subject { described_class.new(uid).find_academic_careers }
     let(:uid) { 300216 }
-    let(:academic_roles) do
-      {
-        'law'=> has_law_role
-      }
-    end
 
-    context 'when user is not a Law student' do
-      let(:has_law_role) { false }
-      it 'returns nil' do
-        expect(subject).to be nil
+    context 'with an active career' do
+      it 'returns a list of active careers' do
+        expect(subject).to contain_exactly('GRAD', 'LAW')
       end
     end
-    context 'when user is a Law student' do
-      let(:has_law_role) { true }
-
-      context 'with an active career' do
-        it 'returns a list of active careers' do
-          expect(subject).to contain_exactly('GRAD', 'LAW')
-        end
-      end
-      context 'with no active career' do
-        let(:uid) { 790833 }
-        it 'returns a list of all careers' do
-          expect(subject).to contain_exactly('UGRD', 'UCBX')
-        end
+    context 'with no active career' do
+      let(:uid) { 790833 }
+      it 'returns a list of all careers' do
+        expect(subject).to contain_exactly('UGRD', 'UCBX')
       end
     end
-
   end
 
   describe '#semester_feed', testext: false do


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-38837

Since the query is shared by multiple callers, I had to move the filtering to the view model layer - otherwise, the filtering would sometimes get skipped because of caching.