### PR TITLE
SISRP-40537: Allows former Law students to see non-Law transcript links

### DIFF
--- a/src/assets/templates/widgets/academics/academic_records.html
+++ b/src/assets/templates/widgets/academics/academic_records.html
@@ -3,7 +3,6 @@
     <h2>Academic Records</h2>
   </div>
   <div>
-    <!-- If Law true, show law links, do not show general or concurrent -->
     <div class="cc-list-link-container" data-cc-spinner-directive="officialTranscript.isLoading">
       <ul class="cc-list-links">
         <li data-ng-if="api.user.profile.academicRoles.historical.law">
@@ -17,13 +16,13 @@
           <a data-ng-href="{{lawTranscriptLink.link}}" data-ng-attr-title="{{lawTranscriptLink.title}}">Transcript - Law (Printed)</a>
           <div class="cc-list-links-sub-text">Printed for pick up or mailing at no charge</div>
         </li>
-        <li data-ng-if="api.user.profile.roles.exStudent || (!api.user.profile.academicRoles.historical.law && (api.user.profile.academicRoles.current.ugrd || api.user.profile.academicRoles.current.grad))">
+        <li data-ng-if="!api.user.profile.roles.law && (api.user.profile.academicRoles.historical.ugrd || api.user.profile.academicRoles.historical.grad)">
           <a data-ng-class="{'cc-academics-link-disabled':(api.user.profile.delegateActingAsUid)}"
             data-ng-click="requestTranscript()"
             data-ng-disabled="api.user.profile.delegateActingAsUid"
             data-ng-attr-title="{{officialTranscript.postUrlHover}}">Transcript - Undergraduate or Graduate Students</a>
         </li>
-        <li data-ng-if="api.user.profile.roles.exStudent || (!api.user.profile.academicRoles.historical.law && api.user.profile.academicRoles.current.concurrent)">
+        <li data-ng-if="!api.user.profile.roles.law && api.user.profile.academicRoles.historical.concurrent">
           <a data-ng-href="{{ucbxTranscriptLink.link}}" data-ng-attr-title="{{ucbxTranscriptLink.title}}">Transcript - Concurrent Enrollment (UC Extension)</a>
         </li>
         <li data-ng-if="api.user.profile.features.enrollmentVerification && (api.user.profile.isDirectlyAuthenticated || api.user.profile.actingAsUid || api.user.profile.advisorActingAsUid)">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-40537

Changes logic around showing/hiding transcript links based on feedback from campus partner.