### PR TITLE
SISRP-37214: Fixes OpenSSL deprecation warning

### DIFF
--- a/app/models/user/oauth2_data.rb
+++ b/app/models/user/oauth2_data.rb
@@ -115,7 +115,7 @@ module User
 
     def self.encrypt_with_iv(value)
       return value if value.blank?
-      cipher = OpenSSL::Cipher::Cipher.new(@@encryption_algorithm)
+      cipher = OpenSSL::Cipher.new(@@encryption_algorithm)
       cipher.encrypt
       iv = cipher.random_iv
       cipher.key = @@encryption_key


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-37214

One usage of the deprecated class was already cleaned up during the JRuby/Rails upgrade (https://github.com/ets-berkeley-edu/calcentral/commit/dc24345764d06adc818ec0a0631e40d91bdd0975).  I must have missed this other one.  