### PR TITLE
SISRP-37550 - Remove leftover dependent code from LiveUpdates

### DIFF
--- a/public/dummy/json/activities.json
+++ b/public/dummy/json/activities.json
@@ -417,13 +417,5 @@
       "type": "message",
       "status": "No action required, document reviewed and processed"
     }
-  ],
-  "lastModified": {
-    "hash": "af8f7132a5d2efdf8bd3d88c2d1fa5d37086c389",
-    "timestamp": {
-      "epoch": 1383947240,
-      "dateTime": "2013-11-08T13:47:20-08:00",
-      "dateString": "11/08"
-    }
-  }
+  ]
 }

--- a/public/dummy/json/advising_student_academics.json
+++ b/public/dummy/json/advising_student_academics.json
@@ -829,13 +829,5 @@
       ]
     }
   ],
-  "updatePlanUrl" : "https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SCI_PLNR_FL.SCI_PLNR_FL.GBL?ucInstitution=UCB01",
-  "lastModified":{
-    "hash":"ffabb092eb078bba9c5717705bfb543166b3305e",
-    "timestamp":{
-      "epoch":1459449726,
-      "dateTime":"2016-03-31T11:42:06-07:00",
-      "dateString":"3/31"
-    }
-  }
+  "updatePlanUrl" : "https://bcs-web-dev-03.is.berkeley.edu:8443/psc/bcsdev/EMPLOYEE/HRMS/c/SCI_PLNR_FL.SCI_PLNR_FL.GBL?ucInstitution=UCB01"
 }

--- a/public/dummy/json/badges.json
+++ b/public/dummy/json/badges.json
@@ -529,13 +529,5 @@
         }
       ]
     }
-  },
-  "lastModified": {
-    "hash": "af8f7132a5d2efdf8bd3d88c2d1fa5d37086c389",
-    "timestamp": {
-      "epoch": 1383947240,
-      "dateTime": "2013-11-08T13:47:20-08:00",
-      "dateString": "11/08"
-    }
   }
 }

--- a/public/dummy/json/cal1card.json
+++ b/public/dummy/json/cal1card.json
@@ -6,14 +6,5 @@
   "mealpoints": null,
   "mealpointsMessage": "OK",
   "mealpointsPlan": null,
-  "statusCode": 200,
-  "lastModified": {
-    "hash": "e5569fb761838b28150bf0f5d7536707be4c829b",
-    "timestamp": {
-      "epoch": 1397610967,
-      "dateTime": "2014-04-15T18:16:07-07:00",
-      "dateString": "4/15"
-    }
-  },
-  "feedName": "Cal1card::MyCal1card"
+  "statusCode": 200
 }

--- a/public/dummy/json/classes.json
+++ b/public/dummy/json/classes.json
@@ -356,13 +356,5 @@
       ]
     }
   ],
-  "current_term": "Summer 2013",
-  "lastModified": {
-    "hash": "af8f7132a5d2efdf8bd3d88c2d1fa5d37086c389",
-    "timestamp": {
-      "epoch": 1383947240,
-      "dateTime": "2013-11-08T13:47:20-08:00",
-      "dateString": "11/08"
-    }
-  }
+  "current_term": "Summer 2013"
 }

--- a/public/dummy/json/cs_address.json
+++ b/public/dummy/json/cs_address.json
@@ -85,14 +85,5 @@
         "isRequired": false
       }
     }
-  },
-  "lastModified": {
-    "hash": "a2f654e13a274b144ab40a280e2cb7c43cdaccf4",
-    "timestamp": {
-      "epoch": 1433190149,
-      "dateTime": "2015-06-01T13:22:29-07:00",
-      "dateString": "6/01"
-    }
-  },
-  "feedName": "CampusSolutions::MyAddress"
+  }
 }

--- a/public/dummy/json/finaid.json
+++ b/public/dummy/json/finaid.json
@@ -163,14 +163,5 @@
       "type": "alert",
       "status": "Action required, missing document"
     }
-  ],
-  "lastModified": {
-    "hash": "c78afd5ef7549973e02d230ec3c30b3cc3cd7c08",
-    "timestamp": {
-      "epoch": 1397756074,
-      "dateTime": "2014-04-17T10:34:34-07:00",
-      "dateString": "4/17"
-    }
-  },
-  "feedName": "Finaid::MyFinAid"
+  ]
 }

--- a/public/dummy/json/finaid_summary.json
+++ b/public/dummy/json/finaid_summary.json
@@ -48,14 +48,5 @@
         "shortTitle": "You have not selected a Title IV Release option."
       }
     }
-  },
-  "lastModified": {
-    "hash": "b2496bed80547289819e442821e83df043166ac3",
-    "timestamp": {
-      "epoch": 1438643912,
-      "dateTime": "2015-08-03T16:18:32-07:00",
-      "dateString": "8/03"
-    }
-  },
-  "feedName": "CampusSolutions::MyAidYears"
+  }
 }

--- a/public/dummy/json/financials.json
+++ b/public/dummy/json/financials.json
@@ -55,14 +55,5 @@
     }
   ],
   "currentTerm": "Spring 2014",
-  "apiVersion": "1.0.7",
-  "lastModified": {
-    "hash": "5487ad7f77a8309af55dae6671bc87b706ee3d12",
-    "timestamp": {
-      "epoch": 1399590141,
-      "dateTime": "2014-05-08T16:02:21-07:00",
-      "dateString": "5/08"
-    }
-  },
-  "feedName": "Financials::MyFinancials"
+  "apiVersion": "1.0.7"
 }

--- a/public/dummy/json/status.json
+++ b/public/dummy/json/status.json
@@ -45,14 +45,5 @@
   "delegateActingAsUid": false,
   "canSeeCSLinks": true,
   "canActOnFinances": true,
-  "lastModified": {
-    "hash": "c7e1f3df2ddb1dbf46b0d285185b1af03d20089e",
-    "timestamp": {
-      "epoch": 1394747903,
-      "dateTime": "2014-03-13T22:58:23+01:00",
-      "dateString": "3/13"
-    }
-  },
-  "feedName": "User::Api",
   "youtubeSplashId": "Yc3z0TIl_Fc"
 }

--- a/public/dummy/json/up_next.json
+++ b/public/dummy/json/up_next.json
@@ -81,13 +81,5 @@
       "isAllDay": false,
       "emitter": "Google Calendar"
     }
-  ],
-  "lastModified": {
-    "hash": "af8f7132a5d2efdf8bd3d88c2d1fa5d37086c389",
-    "timestamp": {
-      "epoch": 1383947240,
-      "dateTime": "2013-11-08T13:47:20-08:00",
-      "dateString": "11/08"
-    }
-  }
+  ]
 }

--- a/spec/ui_selenium/pages/my_dashboard_up_next_card.rb
+++ b/spec/ui_selenium/pages/my_dashboard_up_next_card.rb
@@ -6,8 +6,6 @@ module CalCentralPages
     include CalCentralPages
     include ClassLogger
 
-    span(:day, :xpath => '//span[@data-ng-bind="lastModifiedDate | date:\'EEEE\'"]')
-    span(:date, :xpath => '//span[@data-ng-bind="lastModifiedDate | date:\'MMM d\'"]')
     unordered_list(:events_list, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]')
     elements(:event_time, :div, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]/li//div[@class="cc-widget-mycalendar-datelist-time cc-left"]')
     elements(:event_summary, :div, :xpath => '//ul[@class="cc-widget-list cc-widget-mycalendar-datelist"]/li//strong[@data-ng-bind="item.summary"]')

--- a/src/assets/javascripts/angular/controllers/widgets/upNextController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/upNextController.js
@@ -7,16 +7,6 @@ var _ = require('lodash');
  * My Up Next controller
  */
 angular.module('calcentral.controllers').controller('UpNextController', function(apiService, upNextFactory, $scope) {
-  /**
-   * Make sure that we're not showing wrong date information to the user.
-   * This will make sure that the date that is shown in the UI is the
-   * same as the last modified date of the feed.
-   * @param {Integer} epoch Last modified date epoch
-   */
-  var setLastModifiedDate = function(epoch) {
-    $scope.lastModifiedDate = new Date(epoch * 1000);
-  };
-
   var getUpNext = function(options) {
     upNextFactory.getUpNext(options).then(
       function successCallback(response) {
@@ -24,7 +14,6 @@ angular.module('calcentral.controllers').controller('UpNextController', function
           return;
         }
         angular.extend($scope, response.data);
-        setLastModifiedDate(response.data.lastModified.timestamp.epoch);
       }
     );
   };

--- a/src/assets/templates/widgets/up_next.html
+++ b/src/assets/templates/widgets/up_next.html
@@ -1,10 +1,6 @@
 <div class="cc-widget cc-widget-mycalendar" data-ng-controller="UpNextController">
   <div class="cc-widget-title">
-    <h2>
-      <span data-ng-if="!lastModifiedDate">Up Next</span>
-      <span data-ng-bind="lastModifiedDate | date:'EEEE'"></span>
-      <span data-ng-bind="lastModifiedDate | date:'MMM d'" class="cc-widget-title-sub"></span>
-    </h2>
+    <h2>Up Next</h2>
   </div>
   <div class="cc-widget-mycalendar-container" data-cc-spinner-directive>
     <ul class="cc-widget-list cc-widget-mycalendar-datelist">


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-37550

Removes `feedName` and `lastModified` timestamp data from dummy feeds. Removes code from [Up Next card](https://wikihub.berkeley.edu/display/SIS/CalCentral+Up+Next+Card) that is no longer needed.