### PR TITLE
SISRP-40732: Allows advisors to look up released admits

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -142,7 +142,7 @@ class ApplicationController < ActionController::Base
     else
       require_advisor current_user.user_id
       {
-        roles: [:applicant, :student, :exStudent],
+        roles: [:applicant, :releasedAdmit, :student, :exStudent],
         except: [:confidential]
       }
     end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-40732

When we created the `releaseAdmit` role, we inadvertently removed the ability for advisors to do student lookup on people with the ADMT_UX affiliation.

Please merge #7202 before this one.