### PR TITLE
SISRP-40517 Bamboo should not run integration tests by default

### DIFF
--- a/script/bamboo-tests.sh
+++ b/script/bamboo-tests.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-# Script to install necessary dependencies and then run testext tests, for use on Bamboo CI
+# Script to install necessary dependencies and then run either unit tests or testext tests, for use on Bamboo CI
 
 # set up environment
-export RAILS_ENV=${RAILS_ENV:="testext"}
+# In the Bamboo job, configure the RAILS_ENV environment variable to "testext" to test against a set of real APIs.
+export RAILS_ENV=${RAILS_ENV:="test"}
 export DISPLAY=":99"
 export JRUBY_OPTS="-Xcompile.invokedynamic=false -J-Xmx900m -J-Djruby.compile.mode=OFF"
 
@@ -34,6 +35,9 @@ if [ "$2" == "uitest" ]; then
   echo "Running UI tests with RAILS_ENV=$RAILS_ENV"
   export UI_TEST=true
   bundle exec rake spec:xml
+elif [ $RAILS_ENV == "test" ]; then
+  echo "Running tests with fixtures"
+  bundle exec rake assets:clean spec:xml
 else
   # run regular testext tests
   echo "Running testext tests"


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-40517

I've tested this out on a personal-branch build on ETS Bamboo.

* By default, a test-and-build will only run Travis-CI-style unit tests. 12 minutes, no quarantines.
* If you pine for the full "testext" experience, you can go to "Configuration" / "Tasks" / "Command bamboo-tests.sh", and add `RAILS_ENV=testext` to the "Environment variables" property. 22 minutes, no shortage of quarantines.
