### PR TITLE
CLC-6896 Make Junction's data available to multiple Nessie environments

### DIFF
--- a/app/models/data_loch/s3.rb
+++ b/app/models/data_loch/s3.rb
@@ -2,28 +2,37 @@ module DataLoch
   class S3
     include ClassLogger
 
-    def initialize
-      @settings = Settings.data_loch
+    def initialize(target=nil)
+      settings = Settings.data_loch
+      if target
+        s3_config = settings.targets.find {|c| c.name == target}
+        raise ArgumentError, "Could not find data_loch target #{target}" unless s3_config
+      else
+        # TODO Remove support for old one-S3-target-only configurations in next release.
+        s3_config = settings
+      end
+      @bucket = s3_config.bucket
+      @prefix = s3_config.prefix
       @resource = Aws::S3::Resource.new(
-        credentials: Aws::Credentials.new(@settings.aws_key, @settings.aws_secret),
-        region: @settings.aws_region
+        credentials: Aws::Credentials.new(s3_config.aws_key, s3_config.aws_secret),
+        region: s3_config.aws_region
       )
     end
 
     def upload(subfolder, local_path, is_historical=false)
       if is_historical
-        key = "#{@settings.prefix}/historical/#{subfolder}/#{File.basename local_path}"
+        key = "#{@prefix}/historical/#{subfolder}/#{File.basename local_path}"
       else
         today = (Settings.terms.fake_now || DateTime.now).in_time_zone.strftime('%Y-%m-%d')
         digest = Digest::MD5.hexdigest today
-        key = "#{@settings.prefix}/daily/#{digest}-#{today}/#{subfolder}/#{File.basename local_path}"
+        key = "#{@prefix}/daily/#{digest}-#{today}/#{subfolder}/#{File.basename local_path}"
       end
       begin
-        @resource.bucket(@settings.bucket).object(key).upload_file local_path, server_side_encryption: 'AES256'
-        logger.info("S3 upload complete (bucket=#{@settings.bucket}, key=#{key}")
+        @resource.bucket(@bucket).object(key).upload_file local_path, server_side_encryption: 'AES256'
+        logger.info("S3 upload complete (bucket=#{@bucket}, key=#{key}")
         key
       rescue => e
-        logger.error("Error on S3 upload (bucket=#{@settings.bucket}, key=#{key}: #{e.message}")
+        logger.error("Error on S3 upload (bucket=#{@bucket}, key=#{key}: #{e.message}")
         nil
       end
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -418,12 +418,15 @@ calnet_crosswalk_proxy:
 
 data_loch:
   fake: true
-  aws_key: 'key'
-  aws_secret: 'secret'
-  aws_region: 'region'
-  bucket: 'bucket'
-  prefix: 'exports/go/here'
   staging_directory: 'tmp/data_loch'
+  targets:
+    - name: 's3_test'
+      aws_key: 'key'
+      aws_secret: 'secret'
+      aws_region: 'region'
+      bucket: 'bucket'
+      prefix: 'exports/go/here'
+
 
 # A feature will be disabled if the corresponding feature-flag is false or nil.
 features:

--- a/lib/tasks/data_loch.rake
+++ b/lib/tasks/data_loch.rake
@@ -6,23 +6,33 @@ namespace :data_loch do
     if term_ids.blank?
       Rails.logger.error 'Must specify TERM_ID as four-digit Campus Solutions id. Separate multiple term ids with commas.'
     else
+      s3s = []
+      targets = ENV['TARGETS']
+      if targets.blank?
+        Rails.logger.warn 'Should specify TARGETS as names of S3 configurations. Separate multiple target names with commas.'
+        Rails.logger.warn 'Defaulting to deprecated single-target configuration.'
+        s3s << DataLoch::S3.new
+      else
+        targets.split(',').each do |target|
+          s3s << DataLoch::S3.new(target)
+        end
+      end
+
       is_historical = ENV['HISTORICAL']
       data_type = is_historical ? 'historical' : 'daily'
       Rails.logger.warn "Starting #{data_type} course and enrollment data snapshot for term ids #{term_ids}."
       Rails.logger.warn 'Disabling slow query logger for this task.'
       ActiveSupport::Notifications.unsubscribe 'sql.active_record'
 
-      s3 = DataLoch::S3.new
-
       term_ids.split(',').each do |term_id|
         Rails.logger.info "Starting snapshots for term #{term_id}."
 
         courses_path = DataLoch::Zipper.zip_courses term_id
-        s3.upload('courses', courses_path, is_historical)
+        s3s.each {|s3| s3.upload('courses', courses_path, is_historical) }
         FileUtils.rm courses_path
 
         enrollments_path = DataLoch::Zipper.zip_enrollments term_id
-        s3.upload('enrollments', enrollments_path, is_historical)
+        s3s.each {|s3| s3.upload('enrollments', enrollments_path, is_historical) }
         FileUtils.rm enrollments_path
 
         Rails.logger.info "Snapshots complete for term #{term_id}."

--- a/spec/models/data_loch/s3_spec.rb
+++ b/spec/models/data_loch/s3_spec.rb
@@ -1,5 +1,5 @@
 describe DataLoch::S3 do
-  subject {described_class.new}
+  subject {described_class.new('s3_test')}
 
   let(:local_path) { '/tmp/data_loch/analytics_a_la_carte.gz' }
   before do


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6896

To reduce the pain of configuration + crontab + potential-rollback transitions across environments, the new code is backwards compatible. If it tests out OK, I'll create a follow-up JIRA to remove the backwards-facing code.