### PR TITLE
CLC-6899, OEC sis-import fix; google-drive gem update and better session mgmt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'httparty', '~> 0.13.3'
 # OAuth2 support
 gem 'signet', '~> 0.7.2'
 gem 'google-api-client', '~> 0.8.6'
-gem 'google_drive', '~> 1.0.1'
+gem 'google_drive', '~> 1.0.6'
 
 # LTI support
 gem 'ims-lti', :git => 'https://github.com/instructure/ims-lti.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,8 +195,8 @@ GEM
       multi_json (~> 1.10)
       retriable (~> 1.4)
       signet (~> 0.6)
-    google_drive (1.0.1)
-      google-api-client (>= 0.7.0)
+    google_drive (1.0.6)
+      google-api-client (>= 0.7.0, < 0.9)
       nokogiri (>= 1.4.4, != 1.5.2, != 1.5.1)
       oauth (>= 0.3.6)
       oauth2 (>= 0.5.0)
@@ -297,12 +297,12 @@ GEM
       net-ssh (>= 2.6.5)
     nokogiri (1.8.2-java)
     oauth (0.4.7)
-    oauth2 (1.0.0)
-      faraday (>= 0.8, < 0.10)
+    oauth2 (1.4.0)
+      faraday (>= 0.8, < 0.13)
       jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
-      rack (~> 1.2)
+      rack (>= 1.2, < 3)
     omniauth (1.2.2)
       hashie (>= 1.2, < 4)
       rack (~> 1.0)
@@ -535,7 +535,7 @@ DEPENDENCIES
   faraday (~> 0.9.0)
   faraday_middleware (~> 0.9.1)
   google-api-client (~> 0.8.6)
-  google_drive (~> 1.0.1)
+  google_drive (~> 1.0.6)
   guard-livereload (~> 2.4.0)
   guard-spork
   headless (~> 1.0.2)
@@ -586,4 +586,4 @@ DEPENDENCIES
   webmock (~> 1.20.4)
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/app/models/google_apps/sheets_manager.rb
+++ b/app/models/google_apps/sheets_manager.rb
@@ -21,17 +21,16 @@ module GoogleApps
 
     def initialize(app_id, uid, opts={})
       super(app_id, uid, opts)
-      auth = google_api.authorization
       # See https://github.com/gimite/google-drive-ruby
-      @session = GoogleDrive::Session.login_with_oauth auth.access_token
+      @session = GoogleDrive::Session.login_with_oauth google_api
     end
 
     def export_csv(file)
       csv_export_uri = if file.respond_to? :csv_export_url
-                     file.csv_export_url
-                   elsif file.exportLinks && file.exportLinks['text/csv']
-                     file.exportLinks['text/csv']
-                   end
+                         file.csv_export_url
+                       elsif file.exportLinks && file.exportLinks['text/csv']
+                         file.exportLinks['text/csv']
+                       end
       raise Errors::ProxyError, "No CSV export path found for file ID: #{file.id}" unless csv_export_uri
       result = @session.execute!(uri: csv_export_uri)
       log_response result


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6899

My latest comment in the Jira describes the change.

I ran this on my laptop and it hummed along for 4+ hours until crashing on `Timeout error; url: https://apis.berkeley.edu/uat/sis/v1/terms`.  38 dept sheets were created in course-eval's `2018-D/Step 1: SIS Import` folder. The sis-data in those 38 looks legit. I would like to get this change on `junction-qa` and give it a proper run.  cc: @raydavis 