### PR TITLE
CLC-6919 Use zip archive for daily SIS Imports to bCourses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,8 @@ gem 'net-ssh', '~>2.9.2' # v3 requires Ruby 2.0
 
 gem 'icalendar', '~> 2.2.2'
 
+gem 'rubyzip', '~> 1.2.0'
+
 # Data Loch integration
 gem 'aws-sdk-s3', '~> 1.8.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -571,6 +571,7 @@ DEPENDENCIES
   rspec_junit_formatter!
   ruby-debug (>= 0.10.5.rc9)
   ruby-debug-ide (~> 0.6.0)
+  rubyzip (~> 1.2.0)
   rvm-capistrano (~> 1.3.1)
   secure_headers (~> 1.4.0)
   selenium-webdriver (~> 2.53.4)

--- a/app/models/canvas_csv/maintain_users.rb
+++ b/app/models/canvas_csv/maintain_users.rb
@@ -69,7 +69,7 @@ module CanvasCsv
     # Makes any necessary changes to SIS user IDs.
     def refresh_existing_user_accounts
       check_all_user_accounts
-      if Settings.canvas_proxy.sis_id_changes_csv.present?
+      if Settings.canvas_proxy.import_zipped_csvs.present?
         change_sis_user_ids_by_csv
       else
         change_sis_user_ids_by_api

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -117,8 +117,8 @@ canvas_proxy:
   inactivate_expired_users: true
   # Set to false if Canvas permissions block our ability to delete an invalid email address.
   delete_bad_emails: true
-  # Set to false to use an API loop to change SIS User IDs.
-  sis_id_changes_csv: true
+  # Set to false to use an API loop to change SIS User IDs and upload SIS Import files one at a time.
+  import_zipped_csvs: true
   # URL for scripts to point to CalCentral/Junction
   app_provider_host: 'http://localhost:3000'
   test_admin_id:

--- a/lib/zipper.rb
+++ b/lib/zipper.rb
@@ -1,0 +1,26 @@
+require 'zip'
+
+module Zipper
+  extend self
+
+  def zip_flattened(input_file_paths, output_zip_path)
+    count = 0
+    if File.file? output_zip_path
+      Rails.logger.warn "Zipper output path #{output_zip_path} already exists and will be added to"
+    end
+    Zip::File.open(output_zip_path, Zip::File::CREATE) do |zipfile|
+      input_file_paths.each do |file_path|
+        if File.file? file_path
+          basefile = File.basename file_path
+          zipfile.add(basefile, file_path)
+          count += 1
+        else
+          Rails.logger.warn "Zipper received bad input file path #{file_path}"
+        end
+      end
+    end
+    Rails.logger.info "Zipper added #{count} files to #{output_zip_path}"
+    output_zip_path
+  end
+
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6919

Also takes care of CLC-6920, since `canvas_proxy.import_zipped_csvs` can be configured `false` to restore the old loop-APIs-then-loop-CSV-imports behavior. 