### PR TITLE
CLC-6928 Allow concurrent-ruby in place of Torquebox Backgroundable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,9 @@ gem 'rails_admin', '1.3.0'
 
 gem 'bootstrap-sass', '~> 3.3.1.0'
 
+# Background jobs without TorqueBox
+gem 'concurrent-ruby', '~> 1.0.5'
+
 # TorqueBox app server
 gem 'torquebox', '~> 3.2.0'
 gem 'torquebox-server', '~> 3.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,7 @@ GEM
       execjs
     coffee-script-source (1.8.0)
     columnize (0.3.6)
+    concurrent-ruby (1.0.5-java)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     crass (1.0.3)
@@ -531,6 +532,7 @@ DEPENDENCIES
   capistrano (~> 2.15.4)
   capybara (~> 2.4.4)
   closure-compiler (~> 1.1.11)
+  concurrent-ruby (~> 1.0.5)
   dalli (~> 2.7.2)
   faraday (~> 0.9.0)
   faraday_middleware (~> 0.9.1)

--- a/app/models/oec/api_task_wrapper.rb
+++ b/app/models/oec/api_task_wrapper.rb
@@ -1,6 +1,6 @@
 module Oec
   class ApiTaskWrapper
-    include TorqueBox::Messaging::Backgroundable
+    include BackgroundableShim
     include ClassLogger
 
     TASK_LIST = [
@@ -89,7 +89,7 @@ module Oec
     private
 
     def background_correlate(backgroundable_future, task_id)
-      torquebox_correlation_id = backgroundable_future.correlation_id
+      torquebox_correlation_id = backgroundable_future.try(:correlation_id, nil)
       logger.warn "#{@task_class.name} task_id = #{task_id}, Torquebox correlation_id = #{torquebox_correlation_id}"
       backgroundable_future
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -333,6 +333,13 @@ developer_auth:
   enabled: false
   password: topsecret!
 
+# If false, background jobs are handled without Torquebox.
+background_torquebox: false
+background_threads:
+  min: 2,
+  max: 2,
+  max_queue: 0  # unbounded work queue
+
 background_jobs_check:
   time_between_pings: <%= 5.minutes %>
 

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -31,3 +31,9 @@ canvas_proxy:
   export_directory: '/home/app_calcentral/calcentral/tmp/canvas'
   # Set to "true" when Canvas allows it.
   delete_bad_emails: false
+
+background_torquebox: true
+background_threads:
+  min: 10,
+  max: 10,
+  max_queue: 0  # unbounded work queue

--- a/lib/background_job.rb
+++ b/lib/background_job.rb
@@ -33,7 +33,7 @@ module BackgroundJob
   #   worker.background_job_initialize(:job_type => 'special_job', :total_steps => 3)
   #   worker.background_correlate(worker.background.perform_work)
   #
-  include TorqueBox::Messaging::Backgroundable
+  include BackgroundableShim
   include ClassLogger
 
   attr_reader :background_job_id
@@ -100,7 +100,7 @@ module BackgroundJob
   end
 
   def background_correlate(backgroundable_future)
-    torquebox_correlation_id = backgroundable_future.correlation_id
+    torquebox_correlation_id = backgroundable_future.try(:correlation_id, nil)
     logger.warn "background_job_id = #{@background_job_id}, Torquebox correlation_id = #{torquebox_correlation_id}"
     Rails.cache.write(correlation_cache_key, torquebox_correlation_id, expires_in: Settings.cache.expiration.CanvasBackgroundJobs)
     backgroundable_future

--- a/lib/background_thread.rb
+++ b/lib/background_thread.rb
@@ -1,0 +1,73 @@
+require 'concurrent'
+
+module BackgroundThread
+
+  def background(options = { })
+    BackgroundThread::Proxy.new(self, options)
+  end
+
+  def bg_run
+    Pool.bg_run do
+      yield
+    end
+  end
+
+  class Proxy
+    def initialize(receiver, options)
+      @receiver = receiver
+      @options = options
+    end
+
+    def method_missing(method, *args)
+      @receiver.method_missing(method, *args) unless @receiver.respond_to?(method)
+      reply = Pool.bg_run do
+        @receiver.send method, *args
+      end
+      return reply
+    end
+  end
+
+  class Pool
+    include ClassLogger
+
+    @inner = nil
+
+    def self.get_pool
+      if !@inner
+        logger.info "No Background Thread Pool found - will create one now."
+        @inner = Concurrent::ThreadPoolExecutor.new(
+          min_threads: Settings.background_threads.min,
+          max_threads: Settings.background_threads.max,
+          max_queue: Settings.background_threads.max_queue
+        )
+      end
+      @inner
+    end
+
+    def self.bg_run
+      logger.debug "About to add task: #{describe}"
+      is_queued = get_pool.post do
+        result = error_message = nil
+        begin
+          result = yield
+          logger.debug "Background task returned '#{result}'"
+        rescue => ex
+          error_message = "#{ex.class} #{ex.message}"
+          message_lines = [error_message]
+          message_lines << ex.backtrace.join("\n ") unless Rails.env == "test"
+          logger.error message_lines.join("\n")
+        end
+      end
+      logger.warn "Task was not successfully queued to pool" if !is_queued
+      return is_queued
+    end
+
+
+    def self.describe
+      pool = get_pool
+      return "#{pool.length} threads in pool of max #{pool.max_length}; #{pool.queue_length} tasks on queue"
+    end
+  end
+
+
+end

--- a/lib/backgroundable_shim.rb
+++ b/lib/backgroundable_shim.rb
@@ -1,0 +1,11 @@
+module BackgroundableShim
+
+  def self.included(base)
+    if Settings.background_torquebox
+      base.send :include, TorqueBox::Messaging::Backgroundable
+    else
+      base.send :include, BackgroundThread
+    end
+  end
+
+end

--- a/spec/lib/background_thread_spec.rb
+++ b/spec/lib/background_thread_spec.rb
@@ -1,0 +1,38 @@
+describe BackgroundThread do
+  class TestClass
+    include BackgroundThread
+    def fiddle(stick, suffix)
+      Rails.cache.write("fiddle_#{stick}", "#{self.class.name}-#{suffix}")
+      return 'Not a future'
+    end
+    def time_bomb(seconds)
+      bg_run do
+        sleep seconds
+        raise ArgumentError.new('Snark must not be Boojum')
+      end
+    end
+  end
+
+  subject { TestClass.new }
+
+  it 'does not directly return if backgrounded' do
+    report = subject.fiddle('foreground', 1)
+    expect(report).to eq 'Not a future'
+    expect(Rails.cache.read('fiddle_foreground')).to eq 'TestClass-1'
+    report = subject.background.fiddle('background', 2)
+    expect(report).to eq true
+    sleep(1)
+    expect(Rails.cache.read('fiddle_background')).to eq 'TestClass-2'
+  end
+
+  it 'logs uncaught exceptions instead of silently dropping the task' do
+    expect(Rails.logger).to receive(:error) do |error_message|
+      lines = error_message.lines.to_a
+      expect(lines[0]).to match(/Boojum/)
+    end
+    report = subject.time_bomb 1
+    expect(report).to eq true
+    sleep 2
+  end
+
+end

--- a/spec/lib/backgroundable_shim_spec.rb
+++ b/spec/lib/backgroundable_shim_spec.rb
@@ -1,0 +1,28 @@
+describe BackgroundableShim do
+
+  before do
+    allow(Settings).to receive(:background_torquebox).and_return(use_torquebox)
+  end
+  context 'with Torquebox' do
+    let(:use_torquebox) { true }
+    it 'supports Torquebox background jobs' do
+      class Toxed
+        include BackgroundableShim
+      end
+      shimmed = Toxed.new
+      expect(shimmed.background.class).to eq TorqueBox::Messaging::Backgroundable::BackgroundProxy
+      expect(Toxed.respond_to? :always_background).to be_truthy
+    end
+  end
+  context 'without Torquebox' do
+    let(:use_torquebox) { false }
+    it 'still backgrounds' do
+      class Detoxed
+        include BackgroundableShim
+      end
+      shimmed = Detoxed.new
+      expect(shimmed.is_a? BackgroundThread).to be_truthy
+    end
+  end
+
+end

--- a/spec/support/canvas_shared_examples.rb
+++ b/spec/support/canvas_shared_examples.rb
@@ -118,10 +118,6 @@ shared_examples 'a background job worker' do
     subject.background_job_initialize(:total_steps => 3)
   end
 
-  it 'supports Torquebox background jobs' do
-    expect(subject.background.class).to eq TorqueBox::Messaging::Backgroundable::BackgroundProxy
-  end
-
   it 'provides consistent background job id' do
     allow(BackgroundJob).to receive(:unique_job_id).and_return('generated.cache.key1','generated.cache.key2')
     subject.background_job_initialize(:total_steps => 3)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6928

By default, "production" environments (the clusters) will continue to rely on Torquebox, but "development" and "test" will exercise the new Torquebox-free code.