### PR TITLE
SISRP-43490 - favicon missing on CalCentral prod nodes 01-08

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -678,11 +678,6 @@
         "uri-js": "4.2.2"
       }
     },
-    "ajv-errors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.0.tgz",
-      "integrity": "sha1-7PAh+hCP0X37Xms4Py3SM+Mf/Fk="
-    },
     "ajv-keywords": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
@@ -9187,7 +9182,8 @@
     "mime": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
+      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.36.0",
@@ -16020,28 +16016,6 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
       "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=",
       "dev": true
-    },
-    "url-loader": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.1.2.tgz",
-      "integrity": "sha512-dXHkKmw8FhPqu8asTc1puBfe3TehOCo2+RmOOev5suNCIYBcT626kxiWg1NBVkwc4rO8BGa7gP70W7VXuqHrjg==",
-      "requires": {
-        "loader-utils": "1.1.0",
-        "mime": "2.3.1",
-        "schema-utils": "1.0.0"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-          "requires": {
-            "ajv": "6.5.4",
-            "ajv-errors": "1.0.0",
-            "ajv-keywords": "3.2.0"
-          }
-        }
-      }
     },
     "url-parse-lax": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "raven-js": "~3.18.1",
     "sass-loader": "^7.1.0",
     "style-loader": "^0.21.0",
-    "url-loader": "^1.0.1",
     "webpack": "~4.16.2",
     "webpack-cli": "~3.1.0",
     "webpack-merge": "^4.1.4"

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -57,20 +57,15 @@ module.exports = {
         ]
       },
       { test: /\.(png|svg|jpg|gif|ico)$/,
-        loader: 'url-loader',
+        loader: 'file-loader',
         options: {
-          fallback: 'file-loader',
-          // sets our base64 encoding threshold at 8KB
-          limit: 8 * 1024,
           name: '[name].[ext]',
           outputPath: 'assets/images/'
         }
       },
       { test: /\.(woff|woff2|eot|ttf|otf)$/,
-        loader: 'url-loader',
+        loader: 'file-loader',
         options: {
-          fallback: 'file-loader',
-          limit: 8 * 1024,
           name: '[name].[ext]',
           outputPath: 'assets/fonts/'
         }


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-43490

- Removes `url-loader` in favor of `file-loader`, to stop encoding smaller files within the JS and return to doing it the old fashioned way (copy and paste files)