### PR TITLE
Revert SISRP-41586

### DIFF
--- a/app/models/edo_oracle/user_courses/base.rb
+++ b/app/models/edo_oracle/user_courses/base.rb
@@ -125,14 +125,14 @@ module EdoOracle
       #   "course_code" : the short course name as displayed in the UX
       def class_from_row(row)
         dept_name, dept_code, catalog_id = parse_course_code row
-        slug = [dept_code, catalog_id].map { |str| normalize_to_slug str }.join '-'
+        slug = [dept_name, catalog_id].map { |str| normalize_to_slug str }.join '-'
         term_code = Berkeley::TermCodes.edo_id_to_code row['term_id']
         session_code = Berkeley::TermCodes::SUMMER_SESSIONS[row['session_id']]
         course_id =  session_code.present? ? "#{slug}-#{term_code}-#{session_code}" : "#{slug}-#{term_code}"
         {
           catid: catalog_id,
           course_catalog: catalog_id,
-          course_code: "#{dept_code} #{catalog_id}",
+          course_code: "#{dept_name} #{catalog_id}",
           dept: dept_name,
           dept_code: dept_code,
           id: course_id,

--- a/app/models/rosters/campus.rb
+++ b/app/models/rosters/campus.rb
@@ -178,7 +178,7 @@ module Rosters
           feed[:sections] << {
             ccn: section[:ccn],
             course_name: "#{course[:dept]} #{course[:catid]}",
-            name: "#{course[:dept_code]} #{course[:catid]} #{section[:section_label]}",
+            name: "#{course[:dept]} #{course[:catid]} #{section[:section_label]}",
             section_label: section[:section_label].to_s,
             section_number: section[:section_number].to_s,
             instruction_format: section[:instruction_format].to_s,

--- a/spec/models/edo_oracle/user_courses/base_spec.rb
+++ b/spec/models/edo_oracle/user_courses/base_spec.rb
@@ -23,13 +23,12 @@ describe EdoOracle::UserCourses::Base do
         'course_title' => 'Introduction to Selected Musics of the World',
         'course_title_short' => 'INTR MUSICS WORLD',
         'dept_name' => 'MUSIC',
-        'dept_code' => 'MUSIC',
         'section_display_name' => 'MUSIC 74',
         'term_id' => '2168',
       }
     end
 
-    let(:subject_areas) { ['MECENG', 'MUSIC'] }
+    let(:subject_areas) { ['MEC ENG', 'MUSIC'] }
     before do
       allow(EdoOracle::Queries).to receive(:get_subject_areas).and_return subject_areas.map { |area| {'subjectarea' => area} }
     end
@@ -196,7 +195,6 @@ describe EdoOracle::UserCourses::Base do
             'course_title' => 'The Stooges in Context',
             'course_title_short' => 'STGS CNTXT',
             'dept_name' => 'MUSIC',
-            'dept_code' => 'MUSIC',
             'enroll_limit' => 40,
             'instruction_format' => 'LEC',
             'primary' => 'true',
@@ -215,7 +213,6 @@ describe EdoOracle::UserCourses::Base do
             'course_title' => 'Einstuerzende Neubauten and Structural Failure',
             'course_title_short' => 'KOLLAPS',
             'dept_name' => 'MUSIC',
-            'dept_code' => 'MUSIC',
             'enroll_limit' => 35,
             'instruction_format' => 'LEC',
             'primary' => 'true',
@@ -230,15 +227,14 @@ describe EdoOracle::UserCourses::Base do
             'catalog_prefix' => 'C',
             'catalog_root' => '112',
             'catalog_suffix' => nil,
-            'course_display_name' => 'MECENG C112',
+            'course_display_name' => 'MEC ENG C112',
             'course_title' => 'Einstuerzende Neubauten and Structural Failure',
             'course_title_short' => 'KOLLAPS',
             'dept_name' => 'MEC ENG',
-            'dept_code' => 'MECENG',
             'enroll_limit' => 35,
             'instruction_format' => 'LEC',
             'primary' => 'true',
-            'section_display_name' => 'MECENG C112',
+            'section_display_name' => 'MEC ENG C112',
             'section_id' => '54807',
             'section_num' => '001',
             'waitlist_limit' => 9
@@ -319,7 +315,7 @@ describe EdoOracle::UserCourses::Base do
           expect(get_sections 'MUSIC 74').to have(4).items
           expect(get_sections 'MUSIC 99C').to have(1).items
           expect(get_sections 'MUSIC C105').to have(1).items
-          expect(get_sections 'MECENG C112').to have(1).items
+          expect(get_sections 'MEC ENG C112').to have(1).items
         end
       end
       include_examples 'proper section sorting'
@@ -330,11 +326,11 @@ describe EdoOracle::UserCourses::Base do
         shared_examples 'compensation for bad formatting' do
           include_examples 'proper section sorting'
           it 'deduces correct course codes' do
-            mec_eng_course = subject.find { |course| course[:course_code] == 'MECENG C112' }
+            mec_eng_course = subject.find { |course| course[:course_code] == 'MEC ENG C112' }
             expect(mec_eng_course).to include({
               catid: 'C112',
               course_catalog: 'C112',
-              dept: 'MECENG'
+              dept: 'MEC ENG'
             })
           end
         end
@@ -384,20 +380,20 @@ describe EdoOracle::UserCourses::Base do
         expect(get_course('MUSIC 99C')[:waitlist_limit]).to eq 10
         expect(get_course('MUSIC C105')[:enroll_limit]).to eq 35
         expect(get_course('MUSIC C105')[:waitlist_limit]).to eq 9
-        expect(get_course('MECENG C112')[:enroll_limit]).to eq 35
-        expect(get_course('MECENG C112')[:waitlist_limit]).to eq 9
+        expect(get_course('MEC ENG C112')[:enroll_limit]).to eq 35
+        expect(get_course('MEC ENG C112')[:waitlist_limit]).to eq 9
       end
 
       it 'assigns cross-listing hashes to matching cs_course_id and section only' do
         expect(get_sections('MUSIC 74').first).not_to include(:cross_listing_hash)
         expect(get_sections('MUSIC 99C').first).not_to include(:cross_listing_hash)
-        expect(get_sections('MUSIC C105').first[:cross_listing_hash]).to eq get_sections('MECENG C112').first[:cross_listing_hash]
+        expect(get_sections('MUSIC C105').first[:cross_listing_hash]).to eq get_sections('MEC ENG C112').first[:cross_listing_hash]
       end
 
       describe 'canonical course ordering' do
         before { EdoOracle::UserCourses::Base.new(user_id: random_id).sort_courses feed }
         it 'should order courses by code' do
-          expect(subject.map { |c| c[:course_code] }).to eq ['MECENG C112', 'MUSIC 74', 'MUSIC 99C', 'MUSIC C105']
+          expect(subject.map { |c| c[:course_code] }).to eq ['MEC ENG C112', 'MUSIC 74', 'MUSIC 99C', 'MUSIC C105']
         end
       end
 
@@ -432,7 +428,7 @@ describe EdoOracle::UserCourses::Base do
           expect(get_sections('MUSIC 74').first[:instructors].first[:name]).to eq 'minuscule bear'
         end
         it 'uses name from database when no directory entry found' do
-          expect(get_sections('MECENG C112').first[:instructors].first[:name]).to eq 'Professor Plum'
+          expect(get_sections('MEC ENG C112').first[:instructors].first[:name]).to eq 'Professor Plum'
         end
       end
     end
@@ -440,9 +436,9 @@ describe EdoOracle::UserCourses::Base do
     describe '#course_ids_from_row' do
       subject { EdoOracle::UserCourses::Base.new(user_id: random_id).class_from_row row }
       shared_examples 'a well-parsed id set' do
-        its([:slug]) { should eq 'mecengires-0109al' }
-        its([:id])  {should eq 'mecengires-0109al-2016-D' }
-        its([:course_code]) { should eq 'MECENGIRES 0109AL' }
+        its([:slug]) { should eq 'mec_eng_i_res-0109al' }
+        its([:id])  {should eq 'mec_eng_i_res-0109al-2016-D' }
+        its([:course_code]) { should eq 'MEC ENG/I,RES 0109AL' }
         its([:dept]) { should eq 'MEC ENG/I,RES' }
         its([:dept_code]) { should eq 'MECENGIRES' }
       end

--- a/spec/models/rosters/campus_spec.rb
+++ b/spec/models/rosters/campus_spec.rb
@@ -26,7 +26,6 @@ describe Rosters::Campus do
           term_cd: term_cd,
           catid: catid,
           dept: 'INFO',
-          dept_code: 'INFO',
           course_code: "INFO #{catid}",
           emitter: 'Campus',
           name: 'Data Rules Everything Around Me',


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-41586

Decision is to pull this work due to a bug with the SISEDO views until 12/05. See QA PR #7408

* Revert "SISRP-41586 - Updates course section name format"
  * This reverts commit 6067324385e3a0a981e111e5ca595a9f33509ce4.
  * See #7401
* Revert "SISRP-41586 - Course Name Differs on Final Exam Schedule"
  * This reverts commit 1528999bee8542ce02291764f72e6dcf306a06a3.
  * See #7367