### PR TITLE
SISRP-42744 - CalCentral Access Fringe Case Review & Analysis

### DIFF
--- a/app/models/berkeley/user_roles.rb
+++ b/app/models/berkeley/user_roles.rb
@@ -8,7 +8,6 @@ module Berkeley
         advisor: false,
         applicant: false,
         concurrentEnrollmentStudent: false,
-        confidential: false,
         expiredAccount: false,
         exStudent: false,
         faculty: false,
@@ -25,7 +24,7 @@ module Berkeley
 
     def roles_from_affiliations(affiliations)
       affiliations ||= []
-      {
+      base_roles.merge({
         :student => affiliations.index {|a| (a.start_with? 'STUDENT-TYPE-')}.present?,
         :registered => affiliations.include?('STUDENT-TYPE-REGISTERED'),
         # TODO Remove '-STATUS-EXPIRED' logic once CalNet transition is complete.
@@ -33,7 +32,7 @@ module Berkeley
         :faculty => affiliations.include?('EMPLOYEE-TYPE-ACADEMIC'),
         :staff => affiliations.include?('EMPLOYEE-TYPE-STAFF'),
         :guest => (affiliations & ['GUEST-TYPE-COLLABORATOR', 'GUEST-TYPE-SOCIAL']).present?
-      }
+      })
     end
 
     def roles_from_ldap_affiliations(ldap_record)
@@ -135,7 +134,7 @@ module Berkeley
           result[:exStudent] = true
         end
       end
-      result
+      base_roles.merge(result)
     end
 
     def find_matching_roles(ldap_groups, group_to_role)

--- a/app/models/user/authentication_validator.rb
+++ b/app/models/user/authentication_validator.rb
@@ -7,12 +7,17 @@ module User
 
     attr_reader :auth_uid
 
-    def initialize(auth_uid)
+    def initialize(auth_uid, auth_handler=nil)
+      @auth_handler = auth_handler
       @auth_uid = auth_uid
     end
 
     def feature_enabled?
       Settings.features.authentication_validator
+    end
+
+    def slate_auth_handler
+      @slate_handler ||= Settings.authentication_handlers.slate.to_s.downcase
     end
 
     def validated_user_id
@@ -47,34 +52,30 @@ module User
       cs_student = cs_feed.try(:[], :feed).try(:[], 'student')
       if affiliations = cs_student.try(:[], 'affiliations')
         affiliations = HashConverter.symbolize affiliations
-        held = unreleased_applicant?(affiliations)
-        has_ldap_affiliations = held ? has_ldap_affiliations? : nil
-        is_graduate = held && (!has_ldap_affiliations.nil? && !has_ldap_affiliations) ? is_graduate_applicant? : nil
-        held && (!has_ldap_affiliations.nil? && !has_ldap_affiliations) && (!is_graduate.nil? && !is_graduate)
+        cs_roles = roles_from_cs_affiliations(affiliations)
+        user_auth_handler = @auth_handler.to_s.downcase
+        if user_auth_handler.include?(slate_auth_handler)
+          return !cs_roles[:releasedAdmit]
+        else
+          unreleased = unreleased_applicant?(cs_roles)
+          has_ldap_affiliations = unreleased ? has_ldap_affiliations? : nil
+          return unreleased && (!has_ldap_affiliations.nil? && !has_ldap_affiliations)
+        end
       else
         # We don't know much about this person, but they're not a held applicant.
         false
       end
     end
 
-    def unreleased_applicant?(cs_affiliations)
-      roles = roles_from_cs_affiliations(cs_affiliations)
-      is_applicant = roles.delete(:applicant)
-      !!is_applicant && roles.empty?
+    def unreleased_applicant?(cs_roles)
+      is_applicant = cs_roles.delete(:applicant)
+      !!is_applicant && !cs_roles.has_value?(true)
     end
 
     def has_ldap_affiliations?
       ldap_attributes = CalnetLdap::UserAttributes.new(user_id: @auth_uid).get_feed
       ldap_roles = ldap_attributes.try(:[], :roles) || {}
       ldap_roles.has_value?(true)
-    end
-
-    def is_graduate_applicant?
-      sir_feed = CampusSolutions::Sir::SirStatuses.new(@auth_uid).get_feed
-      sir_statuses = sir_feed.try(:[], :sirStatuses) || []
-      sir_statuses.any? do |sir_status|
-        !sir_status.try(:[], :isUndergraduate)
-      end
     end
 
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,6 +17,9 @@ application:
   # The default is to support all CalCentral/Junction services.
   provided_services: ['calcentral', 'bcourses', 'oec']
 
+authentication_handlers:
+  slate: 'slateAuthenticationHandler'
+
 logger:
   level: <%= ENV['LOGGER_LEVEL'] || WARN %>
   stdout: <%= ENV['LOGGER_STDOUT'] %>

--- a/spec/models/hub_edos/user_attributes_spec.rb
+++ b/spec/models/hub_edos/user_attributes_spec.rb
@@ -24,7 +24,7 @@ describe HubEdos::UserAttributes do
     expect(subject[:official_bmail_address]).to eq 'oski@berkeley.edu'
     expect(subject[:names]).to be
     expect(subject[:addresses]).to be
-    expect(subject[:roles]).to eq({applicant: true, releasedAdmit: true})
+    expect(subject[:roles]).to include(:applicant => true, :releasedAdmit => true)
   end
 
   describe 'student_id depends on role' do
@@ -72,7 +72,7 @@ describe HubEdos::UserAttributes do
   context 'Contacts feed contains all necessary data' do
     it 'does not bother calling the Affiliations API' do
       expect(HubEdos::Affiliations).to receive(:new).never
-      expect(subject[:roles]).to eq({applicant: true, releasedAdmit: true})
+      expect(subject[:roles]).to include({applicant: true, releasedAdmit: true})
     end
   end
   context 'Contacts feed is unexpectedly reticent' do
@@ -84,7 +84,7 @@ describe HubEdos::UserAttributes do
     end
     it 'reluctantly falls back on the Affiliations API' do
       expect(HubEdos::Affiliations).to receive(:new).and_return fake_affiliations_proxy
-      expect(subject[:roles]).to eq({applicant: true, releasedAdmit: true})
+      expect(subject[:roles]).to include({applicant: true, releasedAdmit: true})
     end
   end
 

--- a/spec/models/user/authentication_validator_spec.rb
+++ b/spec/models/user/authentication_validator_spec.rb
@@ -1,8 +1,10 @@
 describe User::AuthenticationValidator do
   let(:auth_uid) { random_id }
+  let(:auth_handler) { 'DuoAuthenticationHandlerJaasAuthenticationHandler' } # Default authentication handler
   let(:feature_flag) { true }
   before do
     allow(Settings.features).to receive(:authentication_validator).and_return feature_flag
+    allow(described_class).to receive(:new).with(auth_uid, auth_handler).and_call_original
   end
 
   describe '#held_applicant?' do
@@ -17,24 +19,7 @@ describe User::AuthenticationValidator do
         }
       }
     end
-    let(:applicant_applied_cs_affiliation) do
-      {
-        statusCode: 200,
-        feed: {
-          'student'=>
-            {'affiliations'=>
-               [{'type'=>{'code'=>'APPLICANT', 'description'=>'Applicant'},
-                 'detail'=> 'Applied',
-                 'status'=> {
-                   'code'=>'ACT',
-                   'description'=>'Active'},
-                 'fromDate'=>'2016-01-06'}]
-            }
-        },
-        studentNotFound: nil
-      }
-    end
-    let(:held_cs_affiliations) do
+    let(:applicant_admitted_cs_affiliation) do
       {
         statusCode: 200,
         feed: {
@@ -74,6 +59,32 @@ describe User::AuthenticationValidator do
         studentNotFound: nil
       }
     end
+    let(:reverted_cs_affiliations) do
+      {
+        statusCode: 200,
+        feed:
+          {'student'=>
+             {'affiliations'=>
+                [{'type'=>
+                    {'code'=>'ADMT_UX',
+                     'description'=>'Admitted Students CalCentral Access'},
+                  'status'=> {
+                    'code'=>'ACT',
+                    'description'=>'Active'},
+                  'fromDate'=>'2016-01-11'},
+                  {'type'=>{'code'=>'STUDENT', 'description'=>''},
+                  'status'=> {
+                    'code'=>'ACT',
+                    'description'=>'Active'},
+                  'fromDate'=>'2015-12-14'},
+                 {'type'=>{'code'=>'UNDERGRAD', 'description'=>'Undergraduate Student'},
+                  'status'=> {
+                    'code'=>'INA',
+                    'description'=>'Inactive'},
+                  'fromDate'=>'2015-12-14'}]}},
+        studentNotFound: nil
+      }
+    end
     let(:nil_ldap_roles) do
       {
         roles: {}
@@ -86,143 +97,139 @@ describe User::AuthenticationValidator do
         }
       }
     end
-    let(:undergrad_sir_admit) do
-      {
-        sirStatuses: [
-          { isUndergraduate: true }
-        ]
-      }
-    end
-    let(:multiple_sir_admit) do
-      {
-        sirStatuses: [
-          { isUndergraduate: true },
-          {}
-        ]
-      }
-    end
-    let(:graduate_sir_admit) do
-      {
-        sirStatuses: [
-          { isUndergraduate: false }
-        ]
-      }
-    end
     let(:ldap_affiliations) { nil }
-    let(:sir_statuses) { nil }
+    let(:slate_auth_handler) { 'slateAuthenticationHandler' }
+
+    shared_examples 'it should not request data from LDAP' do
+      it 'does not request data from LDAP' do
+        expect(CalnetLdap::UserAttributes).not_to receive(:new)
+      end
+    end
     before do
       HubEdos::Affiliations.stub_chain(:new, :get).and_return cs_affiliations
       CalnetLdap::UserAttributes.stub_chain(:new, :get_feed).and_return ldap_affiliations
-      CampusSolutions::Sir::SirStatuses.stub_chain(:new, :get_feed).and_return sir_statuses
+      Settings.stub_chain(:authentication_handlers, :slate).and_return slate_auth_handler
     end
-    subject { User::AuthenticationValidator.new(auth_uid).held_applicant? }
-    context 'nil affiliations from all' do
+    subject { User::AuthenticationValidator.new(auth_uid, auth_handler).held_applicant? }
+
+    context 'no CS affiliations' do
       let(:cs_affiliations) { nil_cs_affiliations }
-      it 'should return false without requesting data from LDAP or SirStatuses' do
-        expect(subject).to eql(false)
-        expect(CalnetLdap::UserAttributes).not_to receive(:new)
-        expect(CampusSolutions::Sir::SirStatuses).not_to receive(:new)
-      end
-    end
-    context 'no CS affiliations, existing LDAP affiliations' do
-      let(:cs_affiliations) { nil }
-      let(:ldap_affiliations) { staff_ldap_roles }
-      it 'should return false without requesting data from LDAP or SirStatuses' do
-        expect(subject).to eql(false)
-        expect(CalnetLdap::UserAttributes).not_to receive(:new)
-        expect(CampusSolutions::Sir::SirStatuses).not_to receive(:new)
-      end
-    end
-    context 'pending-admit CS affiliation, no LDAP affiliations, undergraduate new admit' do
-      let(:cs_affiliations) { held_cs_affiliations }
-      let(:sir_statuses) { undergrad_sir_admit }
-      it 'should return true' do
-        expect(subject).to eql(true)
-      end
-    end
-    context 'pending-admit CS affiliation, existing LDAP affiliations, undergraduate new admit' do
-      let(:cs_affiliations) { held_cs_affiliations }
-      let(:ldap_affiliations) { staff_ldap_roles }
-      it 'should return false without requesting data from SirStatuses' do
-        expect(subject).to eql(false)
-        expect(CampusSolutions::Sir::SirStatuses).not_to receive(:new)
-      end
-    end
-    context 'pending-admit CS affiliation, no LDAP affiliations, multiple new admit' do
-      let(:cs_affiliations) { held_cs_affiliations }
-      let(:sir_statuses) { multiple_sir_admit }
       it 'should return false' do
         expect(subject).to eql(false)
       end
+      include_examples 'it should not request data from LDAP'
     end
-    context 'pending-admit CS affiliation, no LDAP affiliations, graduate new admit' do
-      let(:cs_affiliations) { held_cs_affiliations }
-      let(:sir_statuses) { graduate_sir_admit }
-      it 'should return false' do
-        expect(subject).to eql(false)
+
+    context 'pending-admit CS affiliations' do
+      let(:cs_affiliations) { applicant_admitted_cs_affiliation }
+
+      context 'no LDAP affiliations' do
+        context 'authenticated via CAS' do
+          it 'should return true' do
+            expect(subject).to eql(true)
+          end
+        end
+        context 'authenticated via SSO from Slate' do
+          let(:auth_handler) { slate_auth_handler }
+          it 'should return true' do
+            expect(subject).to eql(true)
+          end
+          include_examples 'it should not request data from LDAP'
+        end
+      end
+
+      context 'existing LDAP affiliations' do
+        let(:ldap_affiliations) { staff_ldap_roles }
+        context 'authenticated via CAS' do
+          it 'should return false' do
+            expect(subject).to eql(false)
+          end
+        end
+        context 'authenticated via SSO from Slate' do
+          let(:auth_handler) { slate_auth_handler }
+          it 'should return true' do
+            expect(subject).to eql(true)
+          end
+          include_examples 'it should not request data from LDAP'
+        end
       end
     end
-    context 'released-admit CS affiliation, no LDAP affiliations, undergraduate new admit' do
+
+    context 'released-admit CS affiliations' do
       let(:cs_affiliations) { released_cs_affiliations }
-      it 'should return false without requesting data from LDAP or SirStatuses' do
-        expect(subject).to eql(false)
-        expect(CalnetLdap::UserAttributes).not_to receive(:new)
-        expect(CampusSolutions::Sir::SirStatuses).not_to receive(:new)
+
+      context 'no LDAP affiliations' do
+        context 'authenticated via CAS' do
+          it 'should return false' do
+            expect(subject).to eql(false)
+          end
+          include_examples 'it should not request data from LDAP'
+        end
+
+        context 'authenticated via SSO from Slate' do
+          let(:auth_handler) { slate_auth_handler }
+          it 'should return false' do
+            expect(subject).to eql(false)
+          end
+          include_examples 'it should not request data from LDAP'
+        end
+      end
+
+      context 'existing LDAP affiliations' do
+        let(:ldap_affiliations) { staff_ldap_roles }
+        context 'authenticated via CAS' do
+          it 'should return false' do
+            expect(subject).to eql(false)
+          end
+          include_examples 'it should not request data from LDAP'
+        end
+
+        context 'authenticated via SSO from Slate' do
+          let(:auth_handler) { slate_auth_handler }
+          it 'should return false' do
+            expect(subject).to eql(false)
+          end
+          include_examples 'it should not request data from LDAP'
+        end
       end
     end
-    context 'multiple CS affiliations, no LDAP affiliations, undergraduate new admit' do
-      let(:cs_affiliations) do
-        {
-          statusCode: 200,
-          feed:
-            {'student'=>
-              {'affiliations'=>
-                [{'type'=>{'code'=>'STUDENT', 'description'=>''},
-                  'status'=> {
-                    'code'=>'ACT',
-                    'description'=>'Active'},
-                  'fromDate'=>'2015-12-14'},
-                  {'type'=>{'code'=>'UNDERGRAD', 'description'=>'Undergraduate Student'},
-                    'status'=> {
-                      'code'=>'INA',
-                      'description'=>'Inactive'},
-                    'fromDate'=>'2015-12-14'}]}},
-          studentNotFound: nil
-        }
+
+    context 'reverted admit CS affiliations' do
+      let(:cs_affiliations) { reverted_cs_affiliations }
+
+      context 'no LDAP affiliations' do
+        context 'authenticated via CAS' do
+          it 'should return false' do
+            expect(subject).to eql(false)
+          end
+          include_examples 'it should not request data from LDAP'
+        end
+
+        context 'authenticated via SSO from Slate' do
+          let(:auth_handler) { slate_auth_handler }
+          it 'should return false' do
+            expect(subject).to eql(false)
+          end
+          include_examples 'it should not request data from LDAP'
+        end
       end
-      it 'should return false without requesting data from LDAP or SirStatuses' do
-        expect(subject).to eql(false)
-        expect(CalnetLdap::UserAttributes).not_to receive(:new)
-        expect(CampusSolutions::Sir::SirStatuses).not_to receive(:new)
-      end
-    end
-    context 'Reverted released-admit, no LDAP affiliations, undergraduate new admit' do
-      let(:cs_affiliations) do
-        {
-          statusCode: 200,
-          feed:
-            {'student'=>
-              {'affiliations'=>
-                [{'type'=>
-                  {'code'=>'ADMT_UX',
-                    'description'=>'Admitted Students CalCentral Access'},
-                  'status'=> {
-                    'code'=>'INA',
-                    'description'=>'Inactive'},
-                  'fromDate'=>'2016-01-11'},
-                  {'type'=>{'code'=>'APPLICANT', 'description'=>'Applicant'},
-                    'detail' => 'Admitted',
-                    'status'=> {
-                      'code'=>'ACT',
-                      'description'=>'Active'},
-                    'fromDate'=>'2016-01-06'}]}},
-          studentNotFound: nil
-        }
-      end
-      let(:ldap_affiliations) { nil_ldap_roles }
-      let(:sir_statuses) { undergrad_sir_admit }
-      it 'should return true' do
-        expect(subject).to eql(true)
+
+      context 'existing LDAP affiliations' do
+        let(:ldap_affiliations) { staff_ldap_roles }
+        context 'authenticated via CAS' do
+          it 'should return false' do
+            expect(subject).to eql(false)
+          end
+          include_examples 'it should not request data from LDAP'
+        end
+
+        context 'authenticated via SSO from Slate' do
+          let(:auth_handler) { slate_auth_handler }
+          it 'should return false' do
+            expect(subject).to eql(false)
+          end
+          include_examples 'it should not request data from LDAP'
+        end
       end
     end
   end
@@ -231,7 +238,7 @@ describe User::AuthenticationValidator do
     before do
       allow_any_instance_of(User::AuthenticationValidator).to receive(:held_applicant?).and_return(is_held)
     end
-    subject { User::AuthenticationValidator.new(auth_uid) }
+    subject { User::AuthenticationValidator.new(auth_uid, auth_handler) }
     context 'user is only known as a held applicant' do
       let(:is_held) { true }
       it 'does not accept the session user_id' do
@@ -251,7 +258,7 @@ describe User::AuthenticationValidator do
     it 'should not waste time checking affiliations' do
       expect(CampusOracle::Queries).to receive(:get_basic_people_attributes).never
       expect(HubEdos::Affiliations).to receive(:new).never
-      expect(User::AuthenticationValidator.new(auth_uid).validated_user_id).to eq auth_uid
+      expect(User::AuthenticationValidator.new(auth_uid, auth_handler).validated_user_id).to eq auth_uid
     end
   end
 
@@ -264,7 +271,7 @@ describe User::AuthenticationValidator do
         'User::AuthenticationValidator::short'.to_sym => 1.second
       })
     end
-    subject { User::AuthenticationValidator.new(auth_uid) }
+    subject { User::AuthenticationValidator.new(auth_uid, auth_handler) }
     context 'in a stable institutional relationship' do
       let(:is_held) { false }
       it 'remembers the good times' do


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-42744

Changes Authentication Validator logic to accommodate users utilizing Single Sign-On from Slate. To sum it up:
- if you are an undergraduate student/applicant,
  - check to see if you've authenticated via Slate SSO
    - if so, deny if the `ADMT_UX` affiliation has not been provisioned
    - continue login if otherwise
- if you are not an undergraduate student/applicant,
  - use current login logic

cc @raydavis - Wanted to ping you since this functionality is a dependency of `CanvasLtiController`. This will change the way undergraduates are handled - the assumption was that if you are able to authenticate via CAS (as opposed to Slate), then you belong in CalCentral (line 64 in `authentication_validator.rb`). I hope this doesn't conflict with the Canvas Authentication process - if so, let's talk it through!