### PR TITLE
CLC-6957 Short-circuit bCourses refresh on DB errors

### DIFF
--- a/app/models/canvas_lti/sis_adapter.rb
+++ b/app/models/canvas_lti/sis_adapter.rb
@@ -7,7 +7,7 @@ module CanvasLti
       if Berkeley::Terms.legacy?(term_year, term_code) && Settings.features.allow_legacy_fallback
         CampusOracle::Queries.get_enrolled_students(section_id, term_year, term_code)
       else
-        EdoOracle::Queries.get_enrolled_students(section_id, term_id(term_year, term_code)).each do |enrollment|
+        EdoOracle::Bcourses.get_enrolled_students(section_id, term_id(term_year, term_code)).each do |enrollment|
           adapt_pnp_flag enrollment
         end
       end
@@ -17,7 +17,7 @@ module CanvasLti
       if Berkeley::Terms.legacy?(term_year, term_code) && Settings.features.allow_legacy_fallback
         CampusOracle::Queries.get_section_instructors(term_year, term_code, section_id)
       else
-        EdoOracle::Queries.get_section_instructors(term_id(term_year, term_code), section_id).each do |instructor|
+        EdoOracle::Bcourses.get_section_instructors(term_id(term_year, term_code), section_id).each do |instructor|
           adapt_instructor_func instructor
         end
       end

--- a/app/models/edo_oracle/bcourses.rb
+++ b/app/models/edo_oracle/bcourses.rb
@@ -1,0 +1,52 @@
+module EdoOracle
+  class Bcourses < Connection
+    include ActiveRecordHelper
+
+    def self.get_enrolled_students(section_id, term_id)
+      fallible_query <<-SQL
+        SELECT DISTINCT
+          enroll."CAMPUS_UID" AS ldap_uid,
+          enroll."STUDENT_ID" AS student_id,
+          enroll."STDNT_ENRL_STATUS_CODE" AS enroll_status,
+          enroll."WAITLISTPOSITION" AS waitlist_position,
+          enroll."UNITS_TAKEN" AS units,
+          TRIM(enroll."GRADING_BASIS_CODE") AS grading_basis
+        FROM SISEDO.ETS_ENROLLMENTV00_VW enroll
+        WHERE
+          enroll."CLASS_SECTION_ID" = '#{section_id}'
+          AND enroll."TERM_ID" = '#{term_id}'
+          AND enroll."STDNT_ENRL_STATUS_CODE" != 'D'
+      SQL
+    end
+
+    def self.get_section_instructors(term_id, section_id)
+      fallible_query <<-SQL
+        SELECT DISTINCT
+          TRIM(instr."formattedName") AS person_name,
+          TRIM(instr."givenName") AS first_name,
+          TRIM(instr."familyName") AS last_name,
+          instr."campus-uid" AS ldap_uid,
+          instr."role-code" AS role_code,
+          instr."role-descr" AS role_description,
+          instr."gradeRosterAccess" AS grade_roster_access,
+          instr."printInScheduleOfClasses" AS print_in_schedule
+        FROM
+          SISEDO.ASSIGNEDINSTRUCTORV00_VW instr
+        JOIN SISEDO.CLASSSECTIONALLV01_MVW sec ON (
+          instr."cs-course-id" = sec."cs-course-id" AND
+          instr."term-id" = sec."term-id" AND
+          instr."session-id" = sec."session-id" AND
+          instr."offeringNumber" = sec."offeringNumber" AND
+          instr."number" = sec."sectionNumber"
+        )
+        WHERE
+          sec."id" = '#{section_id.to_s}' AND
+          sec."term-id" = '#{term_id.to_s}' AND
+          TRIM(instr."instructor-id") IS NOT NULL
+        ORDER BY
+          role_code
+      SQL
+    end
+
+  end
+end

--- a/app/models/edo_oracle/connection.rb
+++ b/app/models/edo_oracle/connection.rb
@@ -24,6 +24,13 @@ module EdoOracle
       []
     end
 
+    def self.fallible_query(sql, opts={})
+      query(sql, opts)
+    rescue => e
+      logger.fatal "Query failed: #{e.class}: #{e.message}\n #{e.backtrace.join("\n ")}"
+      raise RuntimeError, "Fatal database failure"
+    end
+
     def self.stringified_columns
       %w(campus-uid meeting_num section_id)
     end

--- a/spec/models/canvas_lti/sis_adapter_spec.rb
+++ b/spec/models/canvas_lti/sis_adapter_spec.rb
@@ -11,13 +11,13 @@ describe CanvasLti::SisAdapter do
 
     it 'provides enrolled students from legacy source' do
       expect(CampusOracle::Queries).to receive(:get_enrolled_students).with(ccn, term_year, term_code)
-      expect(EdoOracle::Queries).to_not receive(:get_enrolled_students)
+      expect(EdoOracle::Bcourses).to_not receive(:get_enrolled_students)
       CanvasLti::SisAdapter.get_enrolled_students(ccn, term_year, term_code)
     end
 
     it 'provides instructors for section from sisedo source' do
       expect(CampusOracle::Queries).to receive(:get_section_instructors).with(term_year, term_code, ccn)
-      expect(EdoOracle::Queries).to_not receive(:get_section_instructors)
+      expect(EdoOracle::Bcourses).to_not receive(:get_section_instructors)
       CanvasLti::SisAdapter.get_section_instructors(ccn, term_year, term_code)
     end
 
@@ -42,9 +42,9 @@ describe CanvasLti::SisAdapter do
           {'ldap_uid' => '1237', 'student_id' => 'PI', 'enroll_status' => 'W', 'grading_basis' => 'PNP'}
         ]
       }
-      before { allow(EdoOracle::Queries).to receive(:get_enrolled_students).and_return(dummy_enrollments) }
+      before { allow(EdoOracle::Bcourses).to receive(:get_enrolled_students).and_return(dummy_enrollments) }
       it 'provides enrolled students from sisedo source' do
-        expect(EdoOracle::Queries).to receive(:get_enrolled_students).with(section_id, expected_term_id)
+        expect(EdoOracle::Bcourses).to receive(:get_enrolled_students).with(section_id, expected_term_id)
         expect(CampusOracle::Queries).to_not receive(:get_enrolled_students)
         CanvasLti::SisAdapter.get_enrolled_students(section_id, term_year, term_code)
       end
@@ -64,9 +64,9 @@ describe CanvasLti::SisAdapter do
           {'ldap_uid' => '1237', 'role_code' => 'INVT'},  # Teaching with Invalid Title
         ]
       }
-      before { allow(EdoOracle::Queries).to receive(:get_section_instructors).and_return(dummy_instructors) }
+      before { allow(EdoOracle::Bcourses).to receive(:get_section_instructors).and_return(dummy_instructors) }
       it 'provides instructors for section from sisedo source' do
-        expect(EdoOracle::Queries).to receive(:get_section_instructors).with(expected_term_id, section_id)
+        expect(EdoOracle::Bcourses).to receive(:get_section_instructors).with(expected_term_id, section_id)
         expect(CampusOracle::Queries).to_not receive(:get_section_instructors)
         CanvasLti::SisAdapter.get_section_instructors(section_id, term_year, term_code)
       end

--- a/src/assets/templates/canvas_embedded/_shared/background_job_error.html
+++ b/src/assets/templates/canvas_embedded/_shared/background_job_error.html
@@ -13,6 +13,11 @@
     <li data-ng-repeat="info in errorConfig.supportInfo">
       <span data-ng-bind="info"></span>
     </li>
-    <li>The following error message: &quot;<span data-ng-bind="error"></span>&quot;</li>
+    <li data-ng-if="errors">The following error messages:</li>
+    <ul>
+      <li data-ng-repeat="msg in errors">
+        "<span data-ng-bind="msg"></span>"
+      </li>
+    </ul>
   </ul>
 </div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6957

These two queries play too central a role for the show to go on without them.

The PR also fixes end-user reporting of background job errors.
