### PR TITLE
SISRP-44236 - Some cc-dev/cc-sis-test logins are not recognizing staff affiliations

### DIFF
--- a/app/models/user/aggregated_attributes.rb
+++ b/app/models/user/aggregated_attributes.rb
@@ -47,7 +47,8 @@ module User
         edo_roles = (@edo_attributes && @edo_attributes[:roles]) || {}
         # Do not introduce conflicts if CS is more up-to-date on active student status.
         campus_roles.except!(:exStudent) if edo_roles[:student]
-        campus_roles.merge edo_roles
+        # If there is a conflict between LDAP roles and EDO roles, keep the role as true
+        campus_roles.merge(edo_roles) { |key, r1, r2| r1 || r2 }
       else
         campus_roles
       end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-44236

This bug was created with the merge of #7420 (SISRP-42744 - CalCentral Access Fringe Case Review & Analysis), so if that ticket for any reason needs to be reverted, this one does as well.