### PR TITLE
CLC-6963 Google finally drops the misleading "Google-Plus" API

### DIFF
--- a/app/models/google_apps/userinfo.rb
+++ b/app/models/google_apps/userinfo.rb
@@ -9,7 +9,7 @@ module GoogleApps
     def mock_request
       super.merge(
         method: :get,
-        uri_matching: 'https://www.googleapis.com/plus/v1/people/me'
+        uri_matching: 'https://people.googleapis.com/v1/people/me'
       )
     end
 
@@ -19,7 +19,7 @@ module GoogleApps
 
     def user_info
       request(
-        api: 'plus',
+        api: 'people',
         api_version: 'v1',
         resource: 'people',
         method: 'get',
@@ -27,7 +27,8 @@ module GoogleApps
           'Content-Type' => 'application/json'
         },
         params: {
-          'userId' => 'me'
+          'resourceName' => 'people/me',
+          'personFields' => 'emailAddresses'
         }
       ).first
     end

--- a/app/models/user/oauth2_data.rb
+++ b/app/models/user/oauth2_data.rb
@@ -51,8 +51,8 @@ module User
         authenticated_entry = self.where(uid: user_id, app_id: GoogleApps::Proxy::APP_ID).first
         return unless authenticated_entry
         userinfo = GoogleApps::Userinfo.new(user_id: user_id).user_info
-        return unless userinfo && userinfo.response.status == 200 && userinfo.data["emails"].present? && userinfo.data["emails"].length > 0
-        authenticated_entry.app_data["email"] = userinfo.data["emails"].first["value"]
+        return unless userinfo && userinfo.response.status == 200 && userinfo.data["emailAddresses"].present? && userinfo.data["emailAddresses"].length > 0
+        authenticated_entry.app_data["email"] = userinfo.data["emailAddresses"].first["value"]
         authenticated_entry.save
       }
     end

--- a/fixtures/json/google_userinfo.json
+++ b/fixtures/json/google_userinfo.json
@@ -1,27 +1,8 @@
 {
-  "kind": "plus#person",
-  "etag": "AtDvFRdo1nr9guODqwfbgdIwgiE/_rO2os0jeRUzCd-Q00uxeeX0XQY",
-  "gender": "female",
-  "emails": [
+  "emailAddresses": [
     {
       "value": "tammi.chang.clc@gmail.com",
       "type": "account"
     }
-  ],
-  "objectType": "person",
-  "id": "114856790171836979104",
-  "displayName": "Tammi Chang",
-  "name": {
-    "familyName": "Chang",
-    "givenName": "Tammi"
-  },
-  "url": "https://plus.google.com/114856790171836979104",
-  "image": {
-    "url": "https://lh3.googleusercontent.com/-XdUIqdMkCWA/AAAAAAAAAAI/AAAAAAAAAAA/4252rscbv5M/photo.jpg?sz=50",
-    "isDefault": true
-  },
-  "isPlusUser": true,
-  "language": "en",
-  "circledByCount": 1,
-  "verified": false
+  ]
 }

--- a/spec/models/google_apps/userinfo_spec.rb
+++ b/spec/models/google_apps/userinfo_spec.rb
@@ -3,9 +3,6 @@ describe GoogleApps::Userinfo do
     userinfo_proxy = GoogleApps::Userinfo.new :fake => true
     userinfo_proxy.class.api.should == 'userinfo'
     response = userinfo_proxy.user_info
-    %w(emails name id).each do |key|
-      response.data[key].blank?.should_not be_truthy
-    end
-    response.data['emails'].first['value'].should eq 'tammi.chang.clc@gmail.com'
+    response.data['emailAddresses'].first['value'].should eq 'tammi.chang.clc@gmail.com'
   end
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6963

It never made sense that they made places that never enabled G+ go through a G+ branded API to access account info.

The bad news is that customers have to explicitly enable the more sensibly branded API before using it. Which means...

DO NOT MERGE UNTIL SIS CALCENTRAL HAS CONFIRMED ACCESS TO THE PEOPLE API!