### PR TITLE
SISRP-44440 - Removes unused link details

### DIFF
--- a/src/assets/javascripts/angular/controllers/widgets/financesLinksController.js
+++ b/src/assets/javascripts/angular/controllers/widgets/financesLinksController.js
@@ -48,10 +48,6 @@ angular.module('calcentral.controllers').controller('FinancesLinksController', f
     taxFormLink: {
       url: 'http://studentbilling.berkeley.edu/taxpayer.htm',
       title: 'Reduce your federal income tax based upon qualified tuition and fees paid'
-    },
-    viewFormLink: {
-      url: 'https://www.1098t.com/',
-      title: 'Start here to access your 1098-T form'
     }
   };
 


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-44440

Removes left-over hard coded link details, after CS Link API was implemented for this link in #7454