### PR TITLE
[QA] Revert "SISRP-42655: Update gems to fix security vulnerabilities"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,7 @@ gem 'net-ssh', '~>2.9.2' # v3 requires Ruby 2.0
 
 gem 'icalendar', '~> 2.2.2'
 
-gem 'rubyzip', '~> 1.2.2'
+gem 'rubyzip', '~> 1.2.0'
 
 # Data Loch integration
 gem 'aws-sdk-s3', '~> 1.8.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,12 +6,12 @@ GIT
 
 GIT
   remote: https://github.com/ets-berkeley-edu/omniauth-cas.git
-  revision: 56926d0602cc1b3554bf7bd7e14d2a7bb9533c92
+  revision: f6704c97bd0741413510d4dd85e0f2709cadbb0e
   specs:
     omniauth-cas (1.1.0)
       addressable (~> 2.3)
       nokogiri (~> 1.5)
-      omniauth (~> 1.3.2)
+      omniauth (~> 1.2.0)
 
 GIT
   remote: https://github.com/instructure/ims-lti.git
@@ -157,7 +157,7 @@ GEM
     concurrent-ruby (1.0.5-java)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
-    crass (1.0.4)
+    crass (1.0.3)
     dalli (2.7.2)
     data_magic (0.22)
       faker (>= 1.1.2)
@@ -179,7 +179,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.9.1)
       faraday (>= 0.7.4, < 0.10)
-    ffi (1.9.25-java)
+    ffi (1.9.14-java)
     font-awesome-rails (4.7.0.0)
       railties (>= 3.2, < 5.1)
     formatador (0.2.5)
@@ -226,7 +226,7 @@ GEM
       spork (>= 0.8.4)
     haml (4.0.5)
       tilt
-    hashie (3.6.0)
+    hashie (3.5.5)
     headless (1.0.2)
     highline (1.6.21)
     hike (1.2.3)
@@ -269,7 +269,7 @@ GEM
     logging (2.0.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    loofah (2.2.3)
+    loofah (2.1.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.9)
@@ -284,7 +284,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    multi_json (1.12.2)
+    multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nested_form (0.3.2)
@@ -296,7 +296,7 @@ GEM
     net-ssh (2.9.2)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
-    nokogiri (1.8.5-java)
+    nokogiri (1.8.2-java)
     oauth (0.4.7)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)
@@ -304,9 +304,9 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.3.2)
+    omniauth (1.2.2)
       hashie (>= 1.2, < 4)
-      rack (>= 1.0, < 3)
+      rack (~> 1.0)
     page-object (1.2.0)
       page_navigation (>= 0.9)
       selenium-webdriver (>= 2.44.0)
@@ -324,7 +324,7 @@ GEM
       spoon (~> 0.0)
     pundit (0.3.0)
       activesupport (>= 3.0.0)
-    rack (1.6.11)
+    rack (1.6.8)
     rack-pjax (0.8.0)
       nokogiri (~> 1.5)
       rack (~> 1.1)
@@ -347,8 +347,8 @@ GEM
       activesupport (>= 4.2.0, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.4)
-      loofah (~> 2.2, >= 2.2.2)
+    rails-html-sanitizer (1.0.3)
+      loofah (~> 2.0)
     rails-observers (0.1.2)
       activemodel (~> 4.0)
     rails-perftest (0.0.5)
@@ -410,7 +410,7 @@ GEM
     ruby-debug-ide (0.6.0)
       rake (>= 0.8.1)
     ruby-progressbar (1.7.0)
-    rubyzip (1.2.2)
+    rubyzip (1.2.0)
     rvm-capistrano (1.3.4)
       capistrano (>= 2.0.0)
     safe_yaml (1.0.4)
@@ -442,7 +442,7 @@ GEM
     spork-rails (4.0.0)
       rails (>= 3.0.0, < 5)
       spork (>= 1.0rc0)
-    sprockets (2.12.5)
+    sprockets (2.12.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
@@ -573,7 +573,7 @@ DEPENDENCIES
   rspec_junit_formatter!
   ruby-debug (>= 0.10.5.rc9)
   ruby-debug-ide (~> 0.6.0)
-  rubyzip (~> 1.2.2)
+  rubyzip (~> 1.2.0)
   rvm-capistrano (~> 1.3.1)
   secure_headers (~> 1.4.0)
   selenium-webdriver (~> 2.53.4)


### PR DESCRIPTION
Original JIRA: https://jira.berkeley.edu/browse/SISRP-42655

This reverts commit 5a755e7b724e5640043ed772844ae17420e53971.

This is being reverted because it is a culprit for: 
https://jira.berkeley.edu/browse/SISRP-45121

Following this merge, we will retest and see if it is safe to include back in the `qa` branch.