### PR TITLE
CLC-6998 Disable E-Grades, Roster Photos, Official Sections for pre-CS Canvas sites

### DIFF
--- a/app/models/canvas/course.rb
+++ b/app/models/canvas/course.rb
@@ -24,6 +24,13 @@ module Canvas
       }
     end
 
+    def official_courses(term_id)
+      account_id = Settings.canvas_proxy.official_courses_account_id
+      paged_get "accounts/#{account_id}/courses", {
+        'enrollment_term_id' => term_id
+      }
+    end
+
     def to_s
       "Canvas Course ID #{@canvas_course_id}"
     end

--- a/app/models/canvas/course_sections.rb
+++ b/app/models/canvas/course_sections.rb
@@ -17,7 +17,10 @@ module Canvas
         course_sections.each do |s|
           next if s['sis_section_id'].blank?
           section_hash = Canvas::Terms.sis_section_id_to_ccn_and_term s['sis_section_id']
-          identifiers << s.merge(section_hash) if section_hash
+          if section_hash &&
+            "#{section_hash[:term_yr]}-#{section_hash[:term_cd]}" >= Settings.canvas_proxy.oldest_official_term
+            identifiers << s.merge(section_hash)
+          end
         end
       end
       identifiers

--- a/app/models/canvas_lti/toggle_sis_lti_tools.rb
+++ b/app/models/canvas_lti/toggle_sis_lti_tools.rb
@@ -1,0 +1,73 @@
+module CanvasLti
+  class ToggleSisLtiTools
+    include ClassLogger
+
+    def initialize(options = {})
+      settings = {
+        to_term: '2016-C',
+        from_term: '2013-C',
+        hide_them: true
+      }.merge options
+      @newest_term = settings[:to_term]
+      @oldest_term = settings[:from_term]
+      @hide_them = settings[:hide_them]
+    end
+
+    def run
+      @tool_ids = get_sis_dependent_tool_ids
+      total_sites_changed = 0
+      logger.warn "Will change tools hidden=#{@hide_them} for terms from #{@oldest_term} to #{@newest_term}"
+      get_canvas_term_ids(@newest_term, @oldest_term).each do |canvas_term_id|
+        sites_changed = loop_sites_in_term canvas_term_id
+        total_sites_changed += sites_changed
+      end
+      logger.warn "Set tools hidden=#{@hide_them} in #{total_sites_changed} sites"
+    end
+
+    def get_sis_dependent_tool_ids
+      official_course_tools = Canvas::ExternalTools.public_list[:officialCourseTools]
+      official_course_tools.slice('Official Sections', 'Roster Photos').values
+    end
+
+    def get_canvas_term_ids(newest_term_code, oldest_term_code)
+      canvas_term_ids = []
+      Canvas::Terms.fetch.each do |canvas_term|
+        if (term = Canvas::Terms.sis_term_id_to_term canvas_term['sis_term_id'])
+          term_code = "#{term[:term_yr]}-#{term[:term_cd]}"
+          if term_code <= newest_term_code && term_code >= oldest_term_code
+            canvas_term_ids << canvas_term['id']
+          end
+        end
+      end
+      canvas_term_ids
+    end
+
+    def loop_sites_in_term(canvas_term_id)
+      response = Canvas::Course.new.official_courses canvas_term_id
+      courses = response[:body]
+      logger.warn "Will loop around #{courses.length} course sites for Canvas term #{canvas_term_id}"
+      updates = 0
+      courses.each do |course|
+        if update_course_site_tabs course['id']
+          updates += 1
+        end
+      end
+      updates
+    end
+
+    def update_course_site_tabs(canvas_course_id)
+      updated = false
+      proxy = Canvas::ExternalTools.new(canvas_course_id: canvas_course_id)
+      tab_list = proxy.course_site_tab_list
+      @tool_ids.each do |tool_id|
+        tab = tab_list.find { |tab| tab['id'].end_with? "_#{tool_id}" }
+        if !!tab['hidden'] != @hide_them
+          proxy.update_course_site_tab_hidden(tab, @hide_them)
+          updated = true
+        end
+      end
+      updated
+    end
+
+  end
+end

--- a/app/models/rosters/canvas.rb
+++ b/app/models/rosters/canvas.rb
@@ -19,7 +19,7 @@ module Rosters
 
       # Look up Canvas course sections associated with official campus sections.
       official_sections = ::Canvas::CourseSections.new(course_id: @canvas_course_id).official_section_identifiers
-      return feed unless official_sections
+      return feed unless official_sections.present?
 
       term_yr, term_cd = official_sections.first.values_at(:term_yr, :term_cd)
       ccns = official_sections.map { |section| section[:ccn] }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -133,6 +133,8 @@ canvas_proxy:
   test_cas_url: 'https://auth-test.berkeley.edu/cas'
   # If reports are provided through Google Drive, this is the UID that creates them.
   reporter_uid:
+  # Course sites before this term will not be linked to campus SIS data.
+  oldest_official_term: 2016-D
 
 ldap:
   host: 'ldap.berkeley.edu'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -10,6 +10,7 @@ logger:
 canvas_proxy:
   fake: true
   app_provider_host: 'https://cc-dev.example.com'
+  oldest_official_term: 2013-D
 
 edodb:
   fake: true

--- a/lib/tasks/canvas.rake
+++ b/lib/tasks/canvas.rake
@@ -131,4 +131,20 @@ namespace :canvas do
     CanvasCsv::LtiUsageReporter.new(ENV["TERM_ID"]).run
   end
 
+  desc 'Manage visibility of SIS-integrated LTI tools for a range of terms (TO_TERM="2016-C" FROM_TERM="2013-C" HIDE_THEM=true)'
+  task :toggle_sis_lti_tools => :environment do
+    to_term = ENV['TO_TERM']
+    hide_them = ENV['HIDE_THEM']
+    if to_term.blank? || hide_them.blank?
+      Rails.logger.error 'Must specify TO_TERM="yyyy-B" HIDE_THEM=true_or_false'
+    else
+      hide_them = ('true'.casecmp(hide_them.to_s) == 0)
+      options = {to_term: to_term, hide_them: hide_them}
+      if ENV['FROM_TERM']
+        options[:from_term] = ENV['FROM_TERM']
+      end
+      CanvasLti::ToggleSisLtiTools.new(options).run
+    end
+  end
+
 end

--- a/spec/models/canvas/course_sections_spec.rb
+++ b/spec/models/canvas/course_sections_spec.rb
@@ -69,6 +69,13 @@ describe Canvas::CourseSections do
         expect(sis_section_ids[1]).to eq course_sections[1].merge({:term_yr=>'2014', :term_cd=>'C', :ccn=>'06211'})
       end
 
+      context 'course site is too old to link to campus SIS' do
+        before { allow(Settings.canvas_proxy).to receive(:oldest_official_term).and_return '2016-D' }
+        it 'returns an empty list of official sections' do
+          expect(subject.official_section_identifiers).to eq []
+        end
+      end
+
       context 'when course sections returned includes invalid section ids' do
         let(:course_sections) do
           [

--- a/src/assets/javascripts/angular/controllers/pages/canvasCourseGradeExportController.js
+++ b/src/assets/javascripts/angular/controllers/pages/canvasCourseGradeExportController.js
@@ -216,7 +216,7 @@ angular.module('calcentral.controllers').controller('CanvasCourseGradeExportCont
       }
     } else {
       $scope.appState = 'error';
-      $scope.errorStatus = 'No sections found in this course representing an official campus term.';
+      $scope.errorStatus = 'No sections found in this course representing a currently maintained campus term.';
       $scope.unexpectedContactSupport = true;
     }
   };

--- a/src/assets/templates/canvas_embedded/_shared/sections_table.html
+++ b/src/assets/templates/canvas_embedded/_shared/sections_table.html
@@ -76,7 +76,7 @@
     </tbody>
     <tbody data-ng-if="listMode === 'preview' && sectionsList.length < 1">
       <tr>
-        <td colspan="7">There are no official sections in this course site</td>
+        <td colspan="7">There are no currently maintained official sections in this course site</td>
       </tr>
     </tbody>
     <tbody data-ng-if="listMode === 'currentStaging' && noCurrentSections()">

--- a/src/assets/templates/widgets/roster.html
+++ b/src/assets/templates/widgets/roster.html
@@ -90,7 +90,11 @@
         <i class="fa fa-exclamation-triangle cc-icon-red"></i> You must be a teacher in this bCourses course to view official student rosters.
       </p>
 
-      <p data-ng-hide="students.length || errorStatus">
+      <p data-ng-hide="sections.length || errorStatus">
+        <i class="fa fa-exclamation-circle cc-icon-gold"></i> There are no currently maintained official sections in this course site.
+      </p>
+
+      <p data-ng-hide="students.length || !sections.length || errorStatus">
         <i class="fa fa-exclamation-circle cc-icon-gold"></i> Students have not yet signed up for this class.
       </p>
     </div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6998

The final step in achieving ODS independence. (Along with more attempts to deal with Canvas's buggy Tabs API.)

See JIRA comments for more background.