### PR TITLE
[QA] CLC-7036 Work around order-dependent Oracle issue in WHERE clause

### DIFF
--- a/app/models/edo_oracle/bulk.rb
+++ b/app/models/edo_oracle/bulk.rb
@@ -59,8 +59,10 @@ module EdoOracle
           TRIM(crs."title") AS course_title,
           cls."allowedUnitsMaximum" AS allowed_units
         FROM
-          SISEDO.CLASSSECTIONALLV01_MVW sec,
-          SISEDO.EXTENDED_TERM_MVW term
+          SISEDO.CLASSSECTIONALLV01_MVW sec
+        JOIN SISEDO.EXTENDED_TERM_MVW term1 ON (
+          term1.STRM = sec."term-id" AND
+          term1.ACAD_CAREER = 'UGRD')
         LEFT OUTER JOIN SISEDO.DISPLAYNAMEXLATV01_MVW xlat ON (xlat."classDisplayName" = sec."displayName")
         LEFT OUTER JOIN SISEDO.API_COURSEV01_MVW crs ON (xlat."courseDisplayName" = crs."displayName")
         LEFT OUTER JOIN SISEDO.CLASSV00_VW cls ON (
@@ -81,10 +83,8 @@ module EdoOracle
         WHERE
           sec."term-id" = '#{term_id}'
           AND sec."status-code" IN ('A','S')
-          AND term.ACAD_CAREER = 'UGRD'
-          AND term.STRM = sec."term-id"
-          AND CAST(crs."fromDate" AS DATE) <= term.TERM_END_DT
-          AND CAST(crs."toDate" AS DATE) >= term.TERM_END_DT
+          AND CAST(crs."fromDate" AS DATE) <= term1.TERM_END_DT
+          AND CAST(crs."toDate" AS DATE) >= term1.TERM_END_DT
           AND crs."updatedDate" = (
             SELECT MAX(crs2."updatedDate")
             FROM SISEDO.API_COURSEV01_MVW crs2, SISEDO.EXTENDED_TERM_MVW term2


### PR DESCRIPTION
QA-first workaround for https://jira.ets.berkeley.edu/jira/browse/CLC-7036

It's hard to interpret this as anything other than an Oracle bug, although it would be nice to get DBA confirmation. (Oracle has recently had at least one other bug relating to old-style WHERE-clause implicit joins.)