### PR TITLE
CLC-7028: Removes leftover (obsolete) job

### DIFF
--- a/lib/tasks/data_loch.rake
+++ b/lib/tasks/data_loch.rake
@@ -41,7 +41,7 @@ namespace :data_loch do
 
   desc 'Upload advising notes, topics, and attachment data to data loch S3'
   task :notes => :environment do
-    DataLoch::Stocker.new().upload_advising_notes_data(s3_targets, ['notes', 'note-topics', 'note-attachments'])
+    DataLoch::Stocker.new().upload_advising_notes_data(s3_targets, ['notes', 'note-attachments'])
   end
 
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7028

In my excitement yesterday I forgot to remove this reference to the 'note-topics' job.