### PR TITLE
CLC-7059: Increases heap size for advisor data upload

### DIFF
--- a/script/data-loch-snapshot.sh
+++ b/script/data-loch-snapshot.sh
@@ -17,7 +17,7 @@ source .rvmrc
 export RAILS_ENV=${RAILS_ENV:-production}
 export LOGGER_STDOUT=only
 export LOGGER_LEVEL=INFO
-export JRUBY_OPTS="--dev"
+export JRUBY_OPTS="--dev -J-Xmx1024m"
 
 echo | $LOGIT
 echo "------------------------------------------" | $LOGIT


### PR DESCRIPTION
When I tried to run the script on junction-dev, I ran into the old `Java::JavaLang::OutOfMemoryError`. Increasing the heap size resolved this.

https://jira.ets.berkeley.edu/jira/browse/CLC-7059