### PR TITLE
CLC-7072 Continue to support pre-CS Course Captures in bCourses

### DIFF
--- a/app/models/webcast/recordings.rb
+++ b/app/models/webcast/recordings.rb
@@ -12,57 +12,21 @@ module Webcast
         courses: {}
       }
       response = get_json_data['courses']
-      migrated_response = handle_legacy_ccns response
-      migrated_response.each do |course|
+      # This code works for bCourses integration, but for SIS CalCentral some extra mapping was necessary to
+      # support pre-CS Course Captures: https://github.com/ets-berkeley-edu/calcentral/pull/6630 and 7533
+      response.each do |course|
         year = course['year']
         semester = course['semester']
         ccn = course['ccn']
         if year && semester && ccn
-          key = Webcast::CourseMedia.id_per_ccn(year, semester, ccn)
+          key = Webcast::CourseMedia.id_per_ccn(year, semester, course['ccn'])
           recordings[:courses][key] = {
-            legacy_ccn: course['legacy_ccn'],
             recordings: course['recordings'],
             youtube_playlist: course['youTubePlaylist']
           }
-        elsif course['legacy_ccn']
-          logger.warn "No CS Section ID found for class with recordings: #{year} #{semester} #{course['deptName']} #{course['catalogId']} CCN #{course['legacy_ccn']}"
         end
       end
       recordings
-    end
-
-    # Which "ccn" value we need to match depends on whether the application is using the CS-era DB (which is missing
-    # "legacy CCNs") or the application is using bCourses sites or the legacy DB2-era DB (both of which include the
-    # original section Course Control Numbers).
-    # To support a match against CS-era-only data, we need to take the extra step of merging CS Section IDs
-    # into the basic Recordings list.
-
-    def handle_legacy_ccns(recordings)
-      return recordings if Settings.features.allow_legacy_fallback
-      legacy_terms = Hash.new {|h, k| h[k] = []}
-      cs_era_courses = recordings.reject do |course|
-        term_yr, term_cd = course['year'], Berkeley::TermCodes.to_code(course['semester'])
-        if Berkeley::TermCodes.legacy?(term_yr, term_cd)
-          legacy_terms[Berkeley::TermCodes.to_edo_id(term_yr, term_cd)] << course
-        end
-      end
-      if legacy_terms.present?
-        legacy_courses = []
-        legacy_terms.each do |term_id, term_courses|
-          ccns = term_courses.map {|c| c['ccn'].to_s}
-          legacy_to_cs = Berkeley::LegacyTerms.legacy_ccns_to_section_ids(term_id, ccns)
-          term_courses.each do |course|
-            legacy_ccn = course['ccn'].to_s
-            course['legacy_ccn'] = legacy_ccn
-            # The CS Section ID will be nil if the section wasn't migrated.
-            course['ccn'] = legacy_to_cs[legacy_ccn]
-            legacy_courses << course
-          end
-        end
-        legacy_courses + cs_era_courses
-      else
-        cs_era_courses
-      end
     end
 
   end

--- a/spec/models/webcast/recordings_spec.rb
+++ b/spec/models/webcast/recordings_spec.rb
@@ -16,31 +16,5 @@ describe Webcast::Recordings do
         expect(law_2723[:recordings]).to have(12).items
       end
     end
-    context 'when integrating with a CS-only SIS source which lacks legacy CCNs' do
-      let(:use_legacy_ccns) { false }
-      # Currently, only 3 of the 25 courses in the fake JSON feed are CS-era.
-      # This test code only stubs legacy-CCN translations for 2 courses,
-      # which means the other 23 legacy courses should have nil CS Section ID
-      # values and be stripped out of the final parsed feed.
-      before do
-        allow(Berkeley::LegacyTerms).to receive(:legacy_ccns_to_section_ids) do |cs_term_id, legacy_ccns|
-          expect(cs_term_id).to be < '2168'
-          if cs_term_id == '2142'
-            expect(legacy_ccns).to include('71859', '74163')
-            {'71859' => '66671859', '74163' => '66674163'}
-          else
-            {}
-          end
-        end
-      end
-      it 'returns CS-mapped playlists' do
-        expect(recordings[:courses]).to have(5).items
-        ['2014-B-66671859', '2014-B-66671859'].each do |legacy_key|
-          course_captures = recordings[:courses][legacy_key]
-          expect(course_captures[:youtube_playlist]).to be_present
-          expect(course_captures[:recordings]).to be_present
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7072

... dropping a bit of CalCentral-specific support code on the way.