### PR TITLE
CLC-7071 Update paths for temp directories in configs

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -28,12 +28,12 @@ edodb:
   timeout: 5000
 
 canvas_proxy:
-  export_directory: '/home/app_calcentral/calcentral/tmp/canvas'
+  export_directory: '/home/app_junction/calcentral/tmp/canvas'
   # Set to "true" when Canvas allows it.
   delete_bad_emails: false
 
 data_loch:
-  staging_directory: '/home/app_calcentral/calcentral/tmp/data_loch'
+  staging_directory: '/home/app_junction/calcentral/tmp/data_loch'
 
 background_threads:
   min: 10,


### PR DESCRIPTION
Adjusts the data_loch path added in #7615, and the canvas_proxy path it was presumably copied from (which is already getting overridden in local configs, but no need to have a confusing default hanging around).