### PR TITLE
CLC-7130, load canvas-customization when 'load' event is fired

### DIFF
--- a/public/canvas/index.js
+++ b/public/canvas/index.js
@@ -1,25 +1,29 @@
 (function(window, $) {
   'use strict';
 
-  window.CALCENTRAL = 'https://junction.berkeley.edu';
+  var loadCanvasCustomization = function() {
+    window.CALCENTRAL = 'https://junction.berkeley.edu';
 
-  // Ensure the bCourses development and test servers are pointing to the correct
-  // CalCentral instance when a copy of production is made
-  if (window.location.origin === 'https://ucberkeley.beta.instructure.com') {
-    window.CALCENTRAL = 'https://junction-dev.berkeley.edu';
-  } else if (window.location.origin === 'https://ucberkeley.test.instructure.com') {
-    window.CALCENTRAL = 'https://junction-qa.berkeley.edu';
-  }
+    // Ensure the bCourses development and test servers are pointing to the correct
+    // CalCentral instance when a copy of production is made
+    if (window.location.origin === 'https://ucberkeley.beta.instructure.com') {
+      window.CALCENTRAL = 'https://junction-dev.berkeley.edu';
+    } else if (window.location.origin === 'https://ucberkeley.test.instructure.com') {
+      window.CALCENTRAL = 'https://junction-qa.berkeley.edu';
+    }
 
-  // Load the JavaScript customizations
-  $.getScript(window.CALCENTRAL + '/canvas/canvas-customization.js');
+    // Load the JavaScript customizations
+    $.getScript(window.CALCENTRAL + '/canvas/canvas-customization.js');
 
-  // Load the CSS customizations
-  var css = $('<link>', {
-    'rel': 'stylesheet',
-    'type': 'text/css',
-    'href': window.CALCENTRAL + '/canvas/canvas-customization.css'
-  });
-  $('head').append(css);
+    // Load the CSS customizations
+    var css = $('<link>', {
+      'rel': 'stylesheet',
+      'type': 'text/css',
+      'href': window.CALCENTRAL + '/canvas/canvas-customization.css'
+    });
+    $('head').append(css);
+  };
+
+  document.addEventListener('load', loadCanvasCustomization);
 
 })(window, window.$);


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7130

In regard to issue above, R1 peer says, "...you should be able to fix it by wrapping in function: window.addEventListener('load', () => { ... })".  This PR follows that recommendation.

I suggest you append `?w=1` to URL of this page.

Note: The `DOMContentLoaded` approach described in https://github.com/instructure/canvas-lms/commit/48c055ed0e3c4b8e11a1103566e86ae99b03e54e is "not reliable".