### PR TITLE
CLC-7130, if document.readyState is acceptable then load canvas-customization

### DIFF
--- a/public/canvas/index.js
+++ b/public/canvas/index.js
@@ -24,6 +24,10 @@
     $('head').append(css);
   };
 
-  document.addEventListener('load', loadCanvasCustomization);
+  if (document.readyState === 'complete' || (document.readyState !== 'loading' && !document.documentElement.doScroll)) {
+    loadCanvasCustomization();
+  } else {
+    document.addEventListener('DOMContentLoaded', loadCanvasCustomization);
+  }
 
 })(window, window.$);


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7130

The QA dept ran Teena against this change in canvas-beta. See "Plain JavaScript ready() Alternative" at https://www.sitepoint.com/jquery-document-ready-plain-javascript/  to understand this diff.