### PR TITLE
CLC-7125 Try enabling the ActiveRecord Reaper for Oracle connections

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -50,6 +50,7 @@ edodb:
   password: <%=Settings.edodb.password %>
   pool: <%=Settings.edodb.pool %>
   timeout: <%=Settings.edodb.timeout %>
+  reaping_frequency: <%=Settings.edodb.reaping_frequency %>
 
 edw_db:
   adapter: <%= Settings.edw_db.adapter %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -51,6 +51,9 @@ edodb:
   username: sa
   password: sa
   pool: 95
+  # Frequency in seconds to periodically run the ActiveRecord Reaper.
+  # The default is nil, which means do not schedule any runs.
+  reaping_frequency: 600
 
 campusdb:
   fake: false


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7125

Rails 4 keeps this off by default due to stability issues in some DB implementations. It's been useful for some shops; disastrous for some others.