### PR TITLE
CLC-7135 Whitelist to block inactivation of bCourses accounts

### DIFF
--- a/app/models/canvas_csv/base.rb
+++ b/app/models/canvas_csv/base.rb
@@ -34,7 +34,8 @@ module CanvasCsv
       return nil unless campus_user
       if Settings.canvas_proxy.mixed_sis_user_id
         if campus_user[:student_id].present? &&
-          (campus_user[:roles][:student] || campus_user[:roles][:concurrentEnrollmentStudent])
+          (campus_user[:roles][:student] || campus_user[:roles][:concurrentEnrollmentStudent]) &&
+          !campus_user[:roles][:expiredAccount]
           campus_user[:student_id].to_s
         else
           "UID:#{campus_user[:ldap_uid]}"

--- a/app/models/user/auth.rb
+++ b/app/models/user/auth.rb
@@ -5,13 +5,13 @@ module User
     self.table_name = 'user_auths'
 
     after_initialize :log_access
-    attr_accessible :uid, :is_superuser, :is_author, :is_viewer, :active
+    attr_accessible :uid, :is_superuser, :is_viewer, :is_canvas_whitelisted, :active
 
     def self.get(uid)
       user_auth = uid.nil? ? nil : User::Auth.where(:uid => uid.to_s).first
       if user_auth.blank?
         # user's anonymous, or is not in the user_auth table, so give them an active status with zero permissions.
-        user_auth = User::Auth.new(uid: uid, is_superuser: false, is_author: false, is_viewer: false, active: true)
+        user_auth = User::Auth.new(uid: uid, is_superuser: false, is_viewer: false, is_canvas_whitelisted: false, active: true)
       end
       user_auth
     end
@@ -20,12 +20,17 @@ module User
       use_pooled_connection {
         Retriable.retriable(:on => ActiveRecord::RecordNotUnique, :tries => 5) do
           user = self.where(uid: uid).first_or_initialize
-          #super-user and test-user flags should probably be mutually exclusive...
           user.is_superuser = true
           user.active = true
           user.save
         end
       }
+    end
+
+    def self.canvas_whitelist
+      use_pooled_connection do
+        self.where(is_canvas_whitelisted: true, active: true).select(:uid).collect {|r| r[:uid]}
+      end
     end
 
   end

--- a/app/policies/authentication_state_policy.rb
+++ b/app/policies/authentication_state_policy.rb
@@ -30,14 +30,6 @@ class AuthenticationStatePolicy
     @user.directly_authenticated? && (can_administrate? || Oec::Administrator.is_admin?(@user.user_id))
   end
 
-  def can_author?
-    @user.real_user_auth.active? && (@user.real_user_auth.is_superuser? || @user.real_user_auth.is_author?)
-  end
-
-  def can_clear_campus_links_cache?
-    can_clear_cache? || can_author?
-  end
-
   def can_clear_cache?
     # Only super-users are allowed to clear caches in production, but in development mode, anyone can.
     !Rails.env.production? || can_administrate?

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -34,7 +34,7 @@ RailsAdmin.config do |config|
   config.authenticate_with {
     if cookies[:reauthenticated] || !!Settings.features.reauthentication == false
       policy = AuthenticationState.new(session).policy
-      redirect_to main_app.root_path unless policy.can_author?
+      redirect_to main_app.root_path unless policy.can_administrate?
     else
       redirect_to main_app.reauth_admin_path
     end
@@ -95,10 +95,10 @@ RailsAdmin.config do |config|
       field :is_superuser do
         column_width 20
       end
-      field :is_author do
+      field :is_viewer do
         column_width 20
       end
-      field :is_viewer do
+      field :is_canvas_whitelisted do
         column_width 20
       end
       field :active do

--- a/db/developer-seed-data.sql
+++ b/db/developer-seed-data.sql
@@ -156,7 +156,6 @@ CREATE TABLE user_auths (
     active boolean DEFAULT false NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    is_author boolean DEFAULT false NOT NULL,
     is_viewer boolean DEFAULT false NOT NULL
 );
 

--- a/db/migrate/20191101190708_add_canvas_whitelist.rb
+++ b/db/migrate/20191101190708_add_canvas_whitelist.rb
@@ -1,0 +1,6 @@
+class AddCanvasWhitelist < ActiveRecord::Migration
+  def change
+    remove_column :user_auths, :is_author
+    add_column :user_auths, :is_canvas_whitelisted, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190909202711) do
+ActiveRecord::Schema.define(version: 20191101190708) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,13 +99,13 @@ ActiveRecord::Schema.define(version: 20190909202711) do
   end
 
   create_table "user_auths", force: :cascade do |t|
-    t.string   "uid",          limit: 255,                 null: false
-    t.boolean  "is_superuser",             default: false, null: false
-    t.boolean  "active",                   default: false, null: false
-    t.datetime "created_at",                               null: false
-    t.datetime "updated_at",                               null: false
-    t.boolean  "is_author",                default: false, null: false
-    t.boolean  "is_viewer",                default: false, null: false
+    t.string   "uid",                   limit: 255,                 null: false
+    t.boolean  "is_superuser",                      default: false, null: false
+    t.boolean  "active",                            default: false, null: false
+    t.datetime "created_at",                                        null: false
+    t.datetime "updated_at",                                        null: false
+    t.boolean  "is_viewer",                         default: false, null: false
+    t.boolean  "is_canvas_whitelisted",             default: false, null: false
   end
 
   add_index "user_auths", ["uid"], name: "index_user_auths_on_uid", unique: true, using: :btree

--- a/spec/models/berkeley/course_policy_spec.rb
+++ b/spec/models/berkeley/course_policy_spec.rb
@@ -142,7 +142,6 @@ describe Berkeley::CoursePolicy do
     context 'when webcast content is served to a non-superuser' do
       before do
         allow_any_instance_of(User::Auth).to receive(:active?).and_return true
-        allow_any_instance_of(User::Auth).to receive(:is_author?).and_return true
       end
       it 'returns false' do
         expect(subject.can_view_webcast_sign_up?).to be false

--- a/spec/models/user/auth_spec.rb
+++ b/spec/models/user/auth_spec.rb
@@ -16,7 +16,6 @@ describe "User::Auth" do
   it "anonymous user should have no permissions but still be active" do
     anon = User::Auth.get nil
     anon.is_superuser?.should be_falsey
-    anon.is_author?.should be_falsey
     anon.is_viewer?.should be_falsey
     anon.active?.should be_truthy
   end

--- a/spec/policies/authentication_state_policy_spec.rb
+++ b/spec/policies/authentication_state_policy_spec.rb
@@ -18,14 +18,13 @@ describe AuthenticationStatePolicy do
   let(:inactive_superuser_uid) {random_id}
   let(:auth_map) do
     {
-      superuser_uid => {uid: superuser_uid, is_superuser: true, is_author: false, is_viewer: false, active: true},
-      author_uid => {uid: author_uid, is_superuser: false, is_author: true, is_viewer: false, active: true},
-      viewer_uid => {uid: viewer_uid, is_superuser: false, is_author: false, is_viewer: true, active: true},
-      inactive_viewer_uid => {uid: inactive_viewer_uid, is_superuser: false, is_author: false, is_viewer: true, active: false},
-      average_joe_uid => {uid: average_joe_uid, is_superuser: false, is_author: false, is_viewer: false, active: true},
-      inactive_average_joe_uid => {uid: average_joe_uid, is_superuser: false, is_author: false, is_viewer: false, active: false},
-      inactive_superuser_uid => {uid: inactive_superuser_uid, is_superuser: true, is_author: false, is_viewer: false, active: false},
-      oec_administrator_uid => {uid: oec_administrator_uid, is_superuser: false, is_author: false, is_viewer: false, active: true}
+      superuser_uid => {uid: superuser_uid, is_superuser: true, is_viewer: false, active: true},
+      viewer_uid => {uid: viewer_uid, is_superuser: false, is_viewer: true, active: true},
+      inactive_viewer_uid => {uid: inactive_viewer_uid, is_superuser: false, is_viewer: true, active: false},
+      average_joe_uid => {uid: average_joe_uid, is_superuser: false, is_viewer: false, active: true},
+      inactive_average_joe_uid => {uid: average_joe_uid, is_superuser: false, is_viewer: false, active: false},
+      inactive_superuser_uid => {uid: inactive_superuser_uid, is_superuser: true, is_viewer: false, active: false},
+      oec_administrator_uid => {uid: oec_administrator_uid, is_superuser: false, is_viewer: false, active: true}
     }
   end
   before do
@@ -67,10 +66,6 @@ describe AuthenticationStatePolicy do
       let(:user_id) {viewer_uid}
       its(:can_administrate?) { is_expected.to be false }
     end
-    context 'author as self' do
-      let(:user_id) {author_uid}
-      its(:can_administrate?) { is_expected.to be false }
-    end
     context 'superuser as someone else' do
       let(:user_id) {average_joe_uid}
       let(:original_user_id) {superuser_uid}
@@ -107,30 +102,6 @@ describe AuthenticationStatePolicy do
         let(:original_user_id) {viewer_uid}
         its(:can_administer_oec?) { is_expected.to be false }
       end
-    end
-  end
-
-  describe '#can_author?' do
-    context 'superuser as self' do
-      let(:user_id) {superuser_uid}
-      its(:can_author?) { is_expected.to be true }
-    end
-    context 'inactive superuser' do
-      let(:user_id) {inactive_superuser_uid}
-      its(:can_author?) { is_expected.to be false }
-    end
-    context 'viewer as self' do
-      let(:user_id) {viewer_uid}
-      its(:can_author?) { is_expected.to be false }
-    end
-    context 'author as self' do
-      let(:user_id) {author_uid}
-      its(:can_author?) { is_expected.to be true }
-    end
-    context 'in embedded app' do
-      let(:user_id) {author_uid}
-      let(:lti_authenticated_only) {true}
-      its(:can_author?) { is_expected.to be false }
     end
   end
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7135

This PR also removes the obsolete `author` account type, which was originally used to support campus-link-list editing.