### PR TITLE
CLC-7146, aws s3 cp ojdbc7.jar to local lib, during package phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,16 @@ rvm: jruby-9.1.14.0
 
 env:
   global:
-    - JRUBY_OPTS="--dev -J-Xmx900m"
-    - DISPLAY=:99.0
-    - LOGGER_LEVEL=WARN
-    - DEPLOY_S3_FOLDER="${TRAVIS_BRANCH}_$(date +%F_%T)"
+    # Travis CI makes encrypted variables available ONLY to pull requests coming from the same repository. Read more:
+    # https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions
     - ARTIFACTS_PATHS="./calcentral.knob"
+    - AWS_ACCESS_KEY_ID=${ARTIFACTS_KEY}
+    - AWS_SECRET_ACCESS_KEY=${ARTIFACTS_SECRET}
+    - DEPLOY_S3_FOLDER="${TRAVIS_BRANCH}_$(date +%F_%T)"
+    - DISPLAY=:99.0
+    - JRUBY_OPTS="--dev -J-Xmx900m"
+    - LOGGER_LEVEL=WARN
+    - PATH="${HOME}/.local/bin:$PATH"
 
 before_install:
   - gem uninstall bundler --force -x
@@ -38,17 +43,21 @@ jobs:
       script:
         - RAILS_ENV=test bundle exec rspec
     - stage: Deploy
-      if: type = push OR env(DEPLOY_CALCENTRAL_KNOB) = 'true'
+      if: type = push OR env(DEPLOY_CALCENTRAL_KNOB) = true
       script:
+        - pip install --user awscli
+        - aws configure list
+        - aws s3 cp s3://rtl-travis-junction/third-party-dependencies/ojdbc7.jar .
+        - mv ./ojdbc7.jar ./lib
         - bundle install --deployment --local --retry 3
         - bundle package --all
         - bundle exec rake assets:precompile
         - bundle exec rake fix_assets
         - bundle exec rake torquebox:archive NAME=calcentral 2>&1 1>/dev/null
 
+# Note: the artifacts add-on does not run on pull request builds. Read https://docs.travis-ci.com/user/uploading-artifacts/
 addons:
   artifacts:
-    if: type = push OR env(DEPLOY_CALCENTRAL_KNOB) = 'true'
     s3_region: 'us-west-2'
     debug: true
     target_paths:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7146

We use the "artifacts" add-on to upload to s3: https://docs.travis-ci.com/user/uploading-artifacts

The strategy: When a PR is merged, Travis will run another build to (1) build the knob and (2) upload it to s3. This strategy is controlled by conditionals in `.travis.yml`. For example, `if: type = push`. Again, building of knob and s3 upload will not happen when PR is first submitted.   
