### PR TITLE
CLC-7147, Travis build uploads 'latest.txt' to reduce work for deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ env:
     - ARTIFACTS_PATHS="./calcentral.knob"
     - AWS_ACCESS_KEY_ID=${ARTIFACTS_KEY}
     - AWS_SECRET_ACCESS_KEY=${ARTIFACTS_SECRET}
-    - DEPLOY_S3_FOLDER="${TRAVIS_BRANCH}_$(date +%F_%T)"
     - DISPLAY=:99.0
     - JRUBY_OPTS="--dev -J-Xmx900m"
     - LOGGER_LEVEL=WARN
     - PATH="${HOME}/.local/bin:$PATH"
+    - S3_PATH="/${TRAVIS_BRANCH}/$(date -u +%Y%m%d_%H%M%SZ)"
 
 before_install:
   - gem uninstall bundler --force -x
@@ -47,13 +47,15 @@ jobs:
       script:
         - pip install --user awscli
         - aws configure list
-        - aws s3 cp s3://rtl-travis-junction/third-party-dependencies/ojdbc7.jar .
+        - aws s3 cp s3://${ARTIFACTS_BUCKET}/third-party-dependencies/ojdbc7.jar .
         - mv ./ojdbc7.jar ./lib
         - bundle install --deployment --local --retry 3
         - bundle package --all
         - bundle exec rake assets:precompile
         - bundle exec rake fix_assets
         - bundle exec rake torquebox:archive NAME=calcentral 2>&1 1>/dev/null
+        - echo -n "${S3_PATH}/calcentral.knob" > latest.txt
+        - aws s3 cp latest.txt "s3://${ARTIFACTS_BUCKET}/${TRAVIS_BRANCH}/"
 
 # Note: the artifacts add-on does not run on pull request builds. Read https://docs.travis-ci.com/user/uploading-artifacts/
 addons:
@@ -61,4 +63,4 @@ addons:
     s3_region: 'us-west-2'
     debug: true
     target_paths:
-      - /$TRAVIS_BRANCH/$(date -u +%Y%m%d_%H%M%SZ)
+      - ${S3_PATH}


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7147

The deploy script will download `s3://${bucket}/${branch}/latest.txt`, grab info, and download the specified knob file. 