### PR TITLE
CLC-7208, add git commit hash to identifier of build artifact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - JRUBY_OPTS="--dev -J-Xmx900m"
     - LOGGER_LEVEL=WARN
     - PATH="${HOME}/.local/bin:$PATH"
-    - S3_PATH="/${TRAVIS_BRANCH}/$(date -u +%Y%m%d_%H%M%SZ)"
+    - S3_PATH="/${TRAVIS_BRANCH}/$(date -u +%Y%m%d_%H%M%SZ)_${TRAVIS_COMMIT}"
 
 before_install:
   - gem uninstall bundler --force -x


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7208

This PR appends the full commit hash, not the seven char abbreviation. This might be more convenient.