### PR TITLE
CLC-7213, in prod, Ops might need to deploy same knob-id more than once

### DIFF
--- a/script/deploy/deploy-to-current-node.sh
+++ b/script/deploy/deploy-to-current-node.sh
@@ -32,20 +32,12 @@ function log_info {
   echo "$(date): [INFO] ${1}" | ${LOGIT}
 }
 
-if [ "$(./script/deploy/_is_deploy_necessary.sh)" == "true" ]; then
+./script/init.d/calcentral maint
 
-  ./script/init.d/calcentral maint
+./script/deploy/_download-knob-for-torquebox.sh || { log_error "download-knob-for-torquebox failed"; exit 1; }
 
-  ./script/deploy/_download-knob-for-torquebox.sh || { log_error "download-knob-for-torquebox failed"; exit 1; }
-
-  if [[ "$(uname -n)" = *-01\.ist.berkeley.edu ]]; then
-    ./script/migrate.sh
-  fi
-
-else
-
-  log_info "No deployment necessary. Requested knob file is already running on ${HOSTNAME}."
-
+if [[ "$(uname -n)" = *-01\.ist.berkeley.edu ]]; then
+  ./script/migrate.sh
 fi
 
 log_info "Done."

--- a/script/migrate.sh
+++ b/script/migrate.sh
@@ -12,7 +12,7 @@ VERSION=${1}
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
 
-if [ -z ${1} ]; then
+if [ -z "${1}" ]; then
   # Default db version is the latest one in our code tree
   if [ ! -d "deploy/db/migrate" ]
   then


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7213

prod deploys will use `deploy-to-current-node.sh`, which tolerates same-knob-id deploys. Other environments use the more restrictive `deploy-to-all-nodes.sh`. Use `?w=1` to review.