### PR TITLE
CLC-7204 Update secure_headers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'omniauth-cas', '~> 1.1.0', git: 'https://github.com/ets-berkeley-edu/omniau
 gem 'net-ldap', '~> 0.16.0'
 
 # secure_headers provides x-frame, csp and other http headers
-gem 'secure_headers', '~> 1.4.0'
+gem 'secure_headers', '~> 3.9.0'
 
 gem 'faraday', '~> 0.9.0'
 gem 'faraday_middleware', '~> 0.9.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,7 +431,8 @@ GEM
     sassc (2.0.1)
       ffi (~> 1.9)
       rake
-    secure_headers (1.4.1)
+    secure_headers (3.9.0)
+      useragent
     selenium-webdriver (2.53.4)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
@@ -509,6 +510,7 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     user_agent_parser (2.5.1)
+    useragent (0.16.10)
     warbler (2.0.5)
       jruby-jars (>= 9.0.0.0)
       jruby-rack (>= 1.1.1, < 1.3)
@@ -592,7 +594,7 @@ DEPENDENCIES
   ruby-debug-ide (~> 0.6.0)
   rubyzip (~> 1.3.0)
   rvm-capistrano (~> 1.3.1)
-  secure_headers (~> 1.4.0)
+  secure_headers (~> 3.9.0)
   selenium-webdriver (~> 2.53.4)
   signet (~> 0.7.2)
   simplecov (~> 0.14.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,12 +6,6 @@ class ApplicationController < ActionController::Base
   after_filter :access_log
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
-  # Disable most of the default headers provided by secure_headers gem, leaving just x-frame for now
-  # http://rubydoc.info/gems/secure_headers/0.5.0/frames
-  # Rails 4 will DENY X-Frame by default
-  ensure_security_headers
-  skip_before_filter :set_csp_header, :set_hsts_header, :set_x_content_type_options_header, :set_x_xss_protection_header
-
   def authenticate(force = false)
     redirect_to url_for_path('/auth/cas') unless !force && session['user_id']
   end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -5,11 +5,17 @@
 module Calcentral
   class Application < Rails::Application
     config.before_initialize do
-      ::SecureHeaders::Configuration.configure do |config|
+      SecureHeaders::Configuration.default do |config|
+        # Disable most of the default headers provided by secure_headers gem, leaving x_frame and x_xss.
         config.x_frame_options = 'DENY'
-        config.x_xss_protection = {:value => 1, :mode => 'block'}
+        config.x_xss_protection = '1; mode=block'
+        config.csp = SecureHeaders::OPT_OUT
+        config.hsts = SecureHeaders::OPT_OUT
+        config.x_content_type_options = SecureHeaders::OPT_OUT
+        config.x_download_options = SecureHeaders::OPT_OUT
+        config.x_permitted_cross_domain_policies = SecureHeaders::OPT_OUT
+        config.referrer_policy = SecureHeaders::OPT_OUT
       end
-
     end
   end
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7204

The gem API has substantially changed. See https://github.com/github/secure_headers/blob/master/docs/upgrading-to-3-0.md: "secure_headers 3.0 is a near-complete rewrite."