### PR TITLE
BOAC-3314 Add academic standing to nightly loch jobs

### DIFF
--- a/app/models/data_loch/stocker.rb
+++ b/app/models/data_loch/stocker.rb
@@ -115,6 +115,10 @@ module DataLoch
               job_paths[job] = DataLoch::Zipper.zip_query_sliced_matches(job, sids) do |subset|
                 EdoOracle::Bulk.get_demographics subset
               end
+            elsif job == 'academic_standing'
+              job_paths[job] = DataLoch::Zipper.zip_query_sliced_matches(job, sids) do |subset|
+                EdoOracle::Bulk.get_latest_academic_standing subset
+              end
             else
               job_paths[job] = DataLoch::Zipper.zip_query job do
                 case job

--- a/app/models/edo_oracle/bulk.rb
+++ b/app/models/edo_oracle/bulk.rb
@@ -161,6 +161,26 @@ module EdoOracle
       safe_query(sql, do_not_stringify: true)
     end
 
+    def self.get_latest_academic_standing(advisee_sids)
+      sids_in = advisee_sids.map {|sid| "'#{sid}'"}.join ','
+      sql = <<-SQL
+        SELECT
+          sas.STUDENT_ID, sas.TERM_ID,
+          sas.ACAD_STANDING_ACTION, sas.ACAD_STANDING_ACTION_DESCR,
+          sas.ACAD_STANDING_STATUS, sas.ACAD_STANDING_STATUS_DESCR,
+          sas.ACTION_DATE
+        FROM SISEDO.STUDENT_ACAD_STNDNGV00_VW sas
+        JOIN (
+          SELECT STUDENT_ID, MAX(ACTION_DATE) AS ACTION_DATE
+          FROM SISEDO.STUDENT_ACAD_STNDNGV00_VW
+          WHERE STUDENT_ID IN (#{sids_in})
+          GROUP BY STUDENT_ID
+        ) ugrd_latest_actions
+        ON sas.STUDENT_ID = ugrd_latest_actions.STUDENT_ID AND sas.ACTION_DATE = ugrd_latest_actions.ACTION_DATE;
+      SQL
+      safe_query(sql, do_not_stringify: true)
+    end
+
     def self.get_advising_notes()
       sql = <<-SQL
         SELECT

--- a/lib/tasks/data_loch.rake
+++ b/lib/tasks/data_loch.rake
@@ -21,6 +21,7 @@ namespace :data_loch do
     targets = s3_targets
     term_ids = ENV['TERM_ID']
     advisee_data = []
+    advisee_data.concat ['academic_standing'] if ENV['ACADEMIC_STANDING']
     advisee_data.concat ['demographics'] if ENV['DEMOGRAPHICS']
     advisee_data.concat ['edw_demographics'] if ENV['EDW_DEMOGRAPHICS']
     advisee_data.concat ['intended_majors'] if ENV['INTENDED_MAJORS']


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3314

Though academic standing entries come with a term attached, the BOA UX won't be thinking of them as per-term values and the update schedule doesn't fit with the rest of our per-term data. Accordingly we'll just grab the most recent standing available per SID and treat it as non-term-specific data.