### PR TITLE
CLC-7325 bCourses recent-update job takes previous job results into account

### DIFF
--- a/app/models/canvas_csv/base.rb
+++ b/app/models/canvas_csv/base.rb
@@ -114,5 +114,9 @@ module CanvasCsv
         nil
     end
 
+    def timestamp_from_filepath(filepath)
+      filepath.gsub(@export_dir, '').gsub(/\D/, '')
+    end
+
   end
 end

--- a/app/models/canvas_csv/refresh_campus_data_base.rb
+++ b/app/models/canvas_csv/refresh_campus_data_base.rb
@@ -43,8 +43,6 @@ module CanvasCsv
       end
     end
 
-    # TODO The 'recent' job needs not only to look at cached MaintainUsers output for the day, but also to loop through results for any
-    # recent incremental user exports (or SIS ID changes).
     def generate_users_csv(uid_filter=nil, opts={})
       users_csv = make_users_csv(@users_csv_filename)
       sis_ids_csv = make_sis_ids_csv(@sis_ids_csv_filename) if @sis_ids_csv_filename

--- a/app/models/canvas_csv/site_memberships_maintainer.rb
+++ b/app/models/canvas_csv/site_memberships_maintainer.rb
@@ -202,10 +202,10 @@ module CanvasCsv
       # Note: old_canvas_enrollments may originate from CanvasCsv::TermEnrollments
       # Make sure to update this class to include fields this logic depends on from the Canvas Enrollments API
       if (user_enrollments = old_canvas_enrollments[login_uid])
-        logger.debug "#{user_enrollments.count} Enrollments found for UID #{login_uid}"
+        logger.debug "#{user_enrollments.count} Enrollments found for UID #{login_uid} in section #{sis_section_id}"
         # If the user already has the same role, remove the old enrollment from the cleanup list.
-        if (matching_enrollment = user_enrollments.select{|e| e['role'] == canvas_api_role}.first)
-          logger.debug "Matching enrollment found for UID #{login_uid} in role #{canvas_api_role}"
+        if (matching_enrollment = user_enrollments.find { |e| e['role'] == canvas_api_role })
+          logger.debug "Matching enrollment found for UID #{login_uid} in section #{sis_section_id}, role #{canvas_api_role}"
           sis_imported = matching_enrollment['sis_import_id'].present?
           user_enrollments.delete(matching_enrollment)
           # If the user's membership was due to an earlier SIS import, no action is needed.
@@ -216,10 +216,9 @@ module CanvasCsv
       else
         add_user_if_new login_uid
       end
-      logger.debug "Adding UID #{login_uid} to SIS Section: #{sis_section_id} as role: #{canvas_api_role}"
 
-      sis_user_id = get_sis_user_id(login_uid)
-      if sis_user_id
+      if (sis_user_id = get_sis_user_id(login_uid))
+        logger.debug "Adding UID #{login_uid} to SIS Section: #{sis_section_id} as role: #{canvas_api_role}"
         append_enrollment_update(sis_section_id, canvas_api_role, sis_user_id)
         return true
       end
@@ -238,25 +237,25 @@ module CanvasCsv
     end
 
     def add_user_if_new(uid)
-      unless @known_users[uid].present?
-        logger.debug "Adding UID #{uid} as new user"
-        user_attributes = User::BasicAttributes.attributes_for_uids([uid]).first
-        unless user_attributes
+      if @known_users[uid].blank?
+        unless (canvas_user = canvas_user_for_uid(uid))
           logger.error "No user attributes found for LDAP UID #{uid}; skipping this account"
           return
         end
-        canvas_user = canvas_user_from_campus_attributes(user_attributes)
-        @users_csv_output << canvas_user
         @known_users[uid] = canvas_user['user_id']
+        logger.debug "Adding UID #{uid} as new user"
+        @users_csv_output << canvas_user
       end
     end
 
-    def get_sis_user_id(ldap_uid)
-      if @known_users[ldap_uid].blank?
-        user_attributes = User::BasicAttributes.attributes_for_uids([ldap_uid]).first
-        @known_users[ldap_uid] = derive_sis_user_id(user_attributes)
+    def canvas_user_for_uid(uid)
+      if (user_attributes = User::BasicAttributes.attributes_for_uids([uid]).first)
+        canvas_user_from_campus_attributes(user_attributes)
       end
-      @known_users[ldap_uid]
+    end
+
+    def get_sis_user_id(uid)
+      @known_users[uid] || canvas_user_for_uid(uid).try(:[], 'user_id')
     end
 
     # For certain built-in enrollment roles, the Canvas enrollments API shows the


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7325

The main thing here is that the job looks at CSV exports from previous jobs so it doesn't attempt to redo their work. Also some general code cleanup and streamlining.