### PR TITLE
[JQA] CLC-7392, webcast/recordings init fix: 'fake' false in non-test env

### DIFF
--- a/app/models/webcast/recordings.rb
+++ b/app/models/webcast/recordings.rb
@@ -5,8 +5,8 @@ module Webcast
 
     attr_accessor :fake
 
-    def initialize(fake = false)
-      @fake = fake
+    def initialize(options={})
+      @fake = options[:fake]
     end
 
     def get


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7392

`fixtures/course_capture/legacy_recordings.json` is being used in non-test envs. We _should_ be using the file under `~/.calcentral_config/`