### PR TITLE
CLC-7479, Junction is a bit too sassy

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,13 +30,6 @@ Rails.application.configure do
   # Expands the lines which load the assets
   config.assets.debug = false
 
-  # We need to leave this to false since otherwise it takes 25 seconds to compile
-  # https://jira.media.berkeley.edu/jira/browse/CLC-1585
-  config.sass.debug_info = false
-
-  # source maps don't get output if this is true
-  config.sass.line_comments = false
-
   # Turn off all page, action, fragment caching
   config.action_controller.perform_caching = false
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7479

Previous PR removed `sass` but not all sassiness. Error at startup: `NoMethodError: undefined method `sass' for Rails::Application::Configuration` 