### PR TITLE
CLC-7459 Work around JRuby 9.2 DateTime serialization issue

### DIFF
--- a/app/models/berkeley/term.rb
+++ b/app/models/berkeley/term.rb
@@ -58,8 +58,8 @@ module Berkeley
       @year = term_yr.to_i
       @slug = TermCodes.to_slug(@year, @code)
       @name = Berkeley::TermCodes.codes[@code.to_sym]
-      @start = term_feed['beginDate'].to_date.in_time_zone.to_datetime
-      @end = term_feed['endDate'].to_date.in_time_zone.to_datetime.end_of_day
+      @start = parse_date(term_feed['beginDate'])
+      @end = parse_date(term_feed['endDate']).end_of_day
       @is_sis_current_term = term_feed['temporalPosition'] == 'Current'
       if @code == 'C'
         @is_summer = true
@@ -70,8 +70,8 @@ module Berkeley
       else
         @is_summer = false
         session = term_feed['sessions'].first
-        @classes_start = session['beginDate'].to_date.in_time_zone.to_datetime
-        @instruction_end = session['endDate'].to_date.in_time_zone.to_datetime.end_of_day
+        @classes_start = parse_date(session['beginDate'])
+        @instruction_end = parse_date(session['endDate']).end_of_day
         @classes_end = @instruction_end.advance(days: -7)
         if (timePeriods = session['timePeriods']).present?
           timePeriods.each do |timePeriod|
@@ -89,8 +89,8 @@ module Berkeley
       @year = term['year'].to_i
       @slug = term['slug']
       @name = term['name']
-      @start = term['start'].to_date.in_time_zone.to_datetime
-      @end = term['end'].to_date.in_time_zone.to_datetime
+      @start = parse_date(term['start'])
+      @end = parse_date(term['end'])
       (_, @code) = TermCodes.from_edo_id(@campus_solutions_id).values
       if @code == 'C'
         @is_summer = true
@@ -100,10 +100,10 @@ module Berkeley
         @end_drop_add = false
       else
         @is_summer = false
-        @classes_start = term['classes_start'].to_date.in_time_zone.to_datetime
-        @instruction_end = term['instruction_end'].to_date.in_time_zone.to_datetime
-        @classes_end = term['classes_end'].to_date.in_time_zone.to_datetime
-        @end_drop_add =term['end_drop_add'] if term['end_drop_add'].present?
+        @classes_start = parse_date(term['classes_start'])
+        @instruction_end = parse_date(term['instruction_end'])
+        @classes_end = parse_date(term['classes_end'])
+        @end_drop_add = term['end_drop_add'] if term['end_drop_add'].present?
       end
       self
     end
@@ -114,8 +114,8 @@ module Berkeley
       @year = db_row['term_year'].to_i
       @slug = TermCodes.to_slug(@year, @code)
       @name = db_row['term_type']
-      @start = db_row['term_begin_date'].to_date.in_time_zone.to_datetime
-      @end = db_row['term_end_date'].to_date.in_time_zone.to_datetime
+      @start = parse_date(db_row['term_begin_date'])
+      @end = parse_date(db_row['term_end_date'])
       if @code == 'C'
         @is_summer = true
         @classes_start = @start
@@ -124,10 +124,10 @@ module Berkeley
         @end_drop_add = false
       else
         @is_summer = false
-        @classes_start = db_row['class_begin_date'].to_date.in_time_zone.to_datetime  if db_row['class_begin_date'].present?
-        @instruction_end = db_row['instruction_end_date'].to_date.in_time_zone.to_datetime if db_row['instruction_end_date'].present?
-        @classes_end = db_row['class_end_date'].to_date.in_time_zone.to_datetime if db_row['class_end_date'].present?
-        @end_drop_add =db_row['end_drop_add_date'] if db_row['end_drop_add_date'].present?
+        @classes_start = parse_date(db_row['class_begin_date']) if db_row['class_begin_date'].present?
+        @instruction_end = parse_date(db_row['instruction_end_date']) if db_row['instruction_end_date'].present?
+        @classes_end = parse_date(db_row['class_end_date']) if db_row['class_end_date'].present?
+        @end_drop_add = db_row['end_drop_add_date'] if db_row['end_drop_add_date'].present?
       end
       self
     end
@@ -144,8 +144,8 @@ module Berkeley
       # TODO Remove this embarrassment as soon as we switch to Campus Solutions for source of record on term dates.
       db_row.merge! FALL_2016_DATES if @slug == 'fall-2016'
 
-      @classes_start = db_row['term_start_date'].to_date.in_time_zone.to_datetime
-      @instruction_end = db_row['term_end_date'].to_date.in_time_zone.to_datetime.end_of_day
+      @classes_start = parse_date(db_row['term_start_date'])
+      @instruction_end = parse_date(db_row['term_end_date']).end_of_day
       @legacy_sis_term_status = db_row['term_status']
       if term_cd == 'C'
         @start = @classes_start
@@ -191,6 +191,10 @@ module Berkeley
 
     def to_s
       "#<Berkeley::Term> #{to_h}"
+    end
+
+    def parse_date(str)
+      Cache::CacheableDateTime.new(str.to_date.in_time_zone.to_datetime)
     end
   end
 end

--- a/app/models/berkeley/terms.rb
+++ b/app/models/berkeley/terms.rb
@@ -73,7 +73,7 @@ module Berkeley
     end
 
     def initialize(options)
-      @current_date = options[:fake_now] || DateTime.now
+      @current_date = options[:fake_now] || Cache::CacheableDateTime.new(DateTime.now)
       @oldest = options[:oldest]
       @hub_api_disabled = options[:hub_api_disabled]
     end

--- a/lib/cache/cacheable_date_time.rb
+++ b/lib/cache/cacheable_date_time.rb
@@ -1,0 +1,25 @@
+module Cache
+
+  # This wrapper class for DateTime works around a marshal/unmarshal issue in JRuby 9.2
+  # (https://github.com/jruby/jruby/issues/6385) so that we can store datetime objects in
+  # the Rails cache.
+
+  class CacheableDateTime < SimpleDelegator
+    def marshal_dump
+      iso8601(9)
+    end
+
+    def marshal_load(serialized)
+      __setobj__(DateTime.iso8601(serialized))
+    end
+
+    def advance(opts)
+      self.class.new(__getobj__.advance(opts))
+    end
+
+    def end_of_day
+      self.class.new(__getobj__.end_of_day)
+    end
+  end
+
+end

--- a/spec/lib/cache/cacheable_date_time_spec.rb
+++ b/spec/lib/cache/cacheable_date_time_spec.rb
@@ -1,0 +1,28 @@
+describe Cache::CacheableDateTime do
+
+  let(:cacheable_now) { described_class.new(Time.now.in_time_zone.to_datetime) }
+
+  shared_examples 'a cacheable datetime' do
+    it 'survives dehydration and rehydration intact' do
+      duplicate_datetime = Marshal.load(Marshal.dump cacheable_datetime)
+      expect(duplicate_datetime).to eq cacheable_datetime
+      expect(duplicate_datetime.offset).to eq cacheable_datetime.offset
+    end
+  end
+
+  context 'up to the moment' do
+    let(:cacheable_datetime) { cacheable_now }
+    it_should_behave_like 'a cacheable datetime'
+  end
+
+  context 'the news from next week' do
+    let(:cacheable_datetime) { cacheable_now.advance(days: 7) }
+    it_should_behave_like 'a cacheable datetime'
+  end
+
+  context 'when the day is done' do
+    let(:cacheable_datetime) { cacheable_now.end_of_day }
+    it_should_behave_like 'a cacheable datetime'
+  end
+
+end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7459

Devs who have noticed a slew of “invalid offset is ignored” warnings in our recent spec runs might be interested in https://github.com/jruby/jruby/issues/6385. It hits us whenever we try to stash term dates in the Rails cache, and we can work around it with a simple wrapper class using Ruby delegation.