### PR TITLE
CLC-7488 Condense Oracle configs across environments

### DIFF
--- a/app/models/edo_oracle/connection.rb
+++ b/app/models/edo_oracle/connection.rb
@@ -7,13 +7,8 @@ module EdoOracle
 
     # WARNING: Default Rails SQL query caching (done for the lifetime of a controller action) apparently does not apply
     # to anything but the primary DB connection. Any Oracle query caching needs to be handled explicitly.
-    if self.fake?
-      establish_connection :edodb_test
-      Rails.logger.info 'Established fake EDODB connection'
-    else
-      establish_connection :edodb
-      Rails.logger.info 'Established non-fake EDODB connection'
-    end
+    establish_connection :edodb
+    Rails.logger.info "Established EDODB connection (fake=#{fake?})"
 
     def self.query(sql, opts={})
       result = use_pooled_connection do

--- a/app/models/edw_oracle/connection.rb
+++ b/app/models/edw_oracle/connection.rb
@@ -9,13 +9,8 @@ module EdwOracle
 
     # WARNING: Default Rails SQL query caching (done for the lifetime of a controller action) apparently does not apply
     # to anything but the primary DB connection. Any Oracle query caching needs to be handled explicitly.
-    if self.fake?
-      establish_connection :edwdb_test
-      Rails.logger.info 'Established fake EDWDB connection'
-    else
-      establish_connection :edwdb
-      Rails.logger.info 'Established non-fake EDWDB connection'
-    end
+    establish_connection :edwdb
+    Rails.logger.info "Established EDWDB connection (fake=#{fake?})"
 
     def self.query(sql, opts={})
       result = []

--- a/config/database.yml
+++ b/config/database.yml
@@ -41,35 +41,12 @@ edodb:
   pool: <%=Settings.edodb.pool %>
   timeout: <%=Settings.edodb.timeout %>
 
-edodb_test:
-  adapter: postgresql
-  database: <%= Settings.fake_oracle.database %>
-  encoding: unicode
-  pool: <%= Settings.postgres.pool %>
-  timeout: 5000
-  username: <%= Settings.postgres.username %>
-  password: <%= Settings.postgres.password %>
-  host: <%= Settings.postgres.host %>
-  port: <%= Settings.postgres.port %>
-  sslmode: <%= Settings.postgres.sslmode %>
-
 edwdb:
   adapter: <%= Settings.edwdb.adapter %>
-  driver: <%=Settings.edwdb.driver %>
-  url: <%=Settings.edwdb.url %>
+  host: <%=Settings.edwdb.host %>
+  port: <%=Settings.edwdb.port %>
+  database: <%=Settings.edwdb.database %>
   username: <%=Settings.edwdb.username %>
   password: <%=Settings.edwdb.password %>
   pool: <%=Settings.edwdb.pool %>
   timeout: <%=Settings.edwdb.timeout %>
-
-edwdb_test:
-  adapter: postgresql
-  database: <%= Settings.fake_oracle.database %>
-  encoding: unicode
-  pool: <%= Settings.postgres.pool %>
-  timeout: 5000
-  username: <%= Settings.postgres.username %>
-  password: <%= Settings.postgres.password %>
-  host: <%= Settings.postgres.host %>
-  port: <%= Settings.postgres.port %>
-  sslmode: <%= Settings.postgres.sslmode %>

--- a/config/initializers/populate_sisedo_test_data.rb
+++ b/config/initializers/populate_sisedo_test_data.rb
@@ -3,7 +3,7 @@ class PopulateSisedoTestData < ApplicationRecord
   Rails.application.config.after_initialize do
     if Settings.edodb.adapter == 'postgresql'
       logger.warn('Initializing mock SISEDO test data')
-      establish_connection :edodb_test
+      establish_connection :edodb
       sql = <<-SQL
 
       DROP SCHEMA IF EXISTS SISEDO CASCADE;

--- a/config/initializers/populate_sysadm_test_data.rb
+++ b/config/initializers/populate_sysadm_test_data.rb
@@ -3,7 +3,7 @@ class PopulateSysadmTestData < ApplicationRecord
   Rails.application.config.after_initialize do
     if Settings.edodb.adapter == 'postgresql'
       logger.warn('Initializing mock SYSADM test data')
-      establish_connection :edodb_test
+      establish_connection :edodb
       sql = <<-SQL
 
       DROP SCHEMA IF EXISTS SYSADM CASCADE;

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -48,9 +48,6 @@ edodb:
   adapter: postgresql
   pool: 95
 
-fake_oracle:
-  database: edodb_test
-
 terms:
   # Limit how far back our academic history goes.
   oldest: spring-2010

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -31,4 +31,3 @@ background_threads:
   min: 10,
   max: 10,
   max_queue: 0  # unbounded work queue
-

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -14,9 +14,23 @@ canvas_proxy:
 
 edodb:
   fake: true
+  adapter: postgresql
+  database: edodb_test
+  username: calcentral_test
+  password: secret
+  host: localhost
+  port: 5432
+  pool: 3
 
 edwdb:
   fake: true
+  adapter: postgresql
+  database: edodb_test
+  username: calcentral_test
+  password: secret
+  host: localhost
+  port: 5432
+  pool: 3
 
 ldap:
   fake: 'true'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7488

The oracle_enhanced adapter uses the same config pattern as Postgres, so no more need for distinct `edodb_test` and `edwdb_test` config groups.