### PR TITLE
CLC-7540 Initial routing + template for standalone User Provision

### DIFF
--- a/src/components/bcourses/UserProvision.vue
+++ b/src/components/bcourses/UserProvision.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="bc-canvas-application cc-page-user-provision">
+    <b-container fluid>
+      <b-row>
+        <h1 class="cc-page-user-provision-heading">Add Users to bCourses</h1>
+      </b-row>
+      <b-row>
+        <form name="userImportForm" :submit="importUsers(rawUids)">
+          <b-col cols="10">
+            <div class="row">
+              <div class="small-2 columns">
+                <label for="cc-page-user-provision-uid-list" class="bc-form-label">
+                  <span aria-hidden="true">UID</span>
+                  <span class="sr-only">U I D</span>
+                  List
+                </label>
+              </div>
+              <div class="small-10 columns">
+                <textarea
+                  id="cc-page-user-provision-uid-list"
+                  class="cc-page-user-provision-uid-list-input"
+                  rows="4"
+                  name="uids"
+                  :value="rawUids"
+                  placeholder="Paste your list of UIDs here organized one UID per a line, or separated by spaces or commas."
+                >
+                </textarea>
+                <small v-if="checkPerformed && validationErrors.required" class="error">
+                  You must provide at least one
+                  <span aria-hidden="true">UID</span>
+                  <span class="sr-only">U I D</span>
+                  .
+                </small>
+                <small v-if="validationErrors.ccNumericList" class="error">
+                  The following items in your list are not numeric: {{ invalidValues.join(', ') }}
+                </small>
+                <small v-if="validationErrors.ccListLimit" class="error">
+                  Maximum IDs: 200. {{ listLength }} IDs found in list.
+                </small>
+              </div>
+            </div>
+            <div class="row">
+              <div class="small-2 small-offset-2 columns">
+                <button type="submit" class="bc-canvas-button bc-canvas-button-primary" data-ng-disabled="importButtonDisabled()">Import Users</button>
+              </div>
+              <div v-if="displayImportResult" class="small-8 columns">
+                <div data-cc-spinner-directive>
+                  <div class="row">
+                    <div class="small-11 small-offset-1 columns">
+                      <div class="cc-page-user-provision-feedback" role="alert">
+                        <div v-if="status === 'error'">
+                          <i class="cc-left fa fa-exclamation-circle cc-icon-red"></i>
+                          <strong>Error : {{ error }}</strong>
+                        </div>
+                        <div v-if="status === 'success'">
+                          <i class="cc-left fa fa-check-circle cc-icon-green"></i>
+                          Success : The users specified were imported into bCourses.
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </b-col>
+        </form>
+      </b-row>
+    </b-container>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'UserProvision',
+  data: () => ({
+    checkPerformed: false,
+    error: null,
+    importUsers: () => {},
+    invalidValues: [],
+    rawUids: [],
+    status: null,
+    validationErrors: {}
+  }),
+}
+</script>
+
+<style scoped>
+.cc-page-user-provision {
+  color: #333;
+  font-family: "Lato","Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: 300;
+  padding: 10px 20px;
+}
+</style>

--- a/src/router.ts
+++ b/src/router.ts
@@ -5,7 +5,9 @@ import Login from '@/views/Login.vue'
 import NotFound from '@/views/NotFound.vue'
 import Oec from '@/views/Oec.vue'
 import Router from 'vue-router'
+import StandaloneLti from '@/views/StandaloneLti.vue'
 import Toolbox from '@/views/Toolbox.vue'
+import UserProvision from '@/components/bcourses/UserProvision.vue'
 import Vue from 'vue'
 
 Vue.use(Router)
@@ -61,6 +63,19 @@ const router = new Router({
           meta: {
             title: 'Toolbox'
           }
+        },
+        {
+          component: StandaloneLti,
+          path: '/canvas',
+          children: [
+            {
+              component: UserProvision,
+              path: '/canvas/user_provision',
+              meta: {
+                title: 'bCourses User Provision'
+              }
+            }
+          ]
         }
       ]
     },

--- a/src/views/StandaloneLti.vue
+++ b/src/views/StandaloneLti.vue
@@ -1,0 +1,29 @@
+<template>
+  <b-container fluid>
+    <b-row>
+      <b-col>
+        <ToolboxHeader />
+      </b-col>
+    </b-row>
+    <b-row>
+      <b-col class="text-center">
+        <router-view />
+      </b-col>
+    </b-row>
+    <b-row>
+      <b-col>
+        <Footer />
+      </b-col>
+    </b-row>
+  </b-container>
+</template>
+
+<script>
+import Footer from '@/components/Footer'
+import ToolboxHeader from '@/components/toolbox/ToolboxHeader'
+
+export default {
+  name: 'StandaloneLti',
+  components: {Footer, ToolboxHeader}
+}
+</script>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7540

This is just to get the /canvas/user_provision routing in place - styling and function calls don’t work. The idea is that StandaloneLti.vue is a simple wrapper view that can load the bCourses tools outside the LTI context, as in the old Angular setup.