### PR TITLE
CLC-7551, screen-readers have access to roster-view-mode toggle

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -62,22 +62,30 @@
         </div>
       </b-col>
     </b-row>
-    <b-row v-if="$currentUser.isLoggedIn && !$currentUser.isDirectlyAuthenticated" class="border-top pl-3 pt-3 text-secondary w-100">
-      <b-col class="pt-1" sm="10">
+    <b-row v-if="$currentUser.isLoggedIn && !$currentUser.isDirectlyAuthenticated" class="border-top pl-3 pt-3 text-secondary w-100" no-gutters>
+      <b-col class="pt-1" sm="8">
         You are viewing as {{ $currentUser.fullName }} ({{ $currentUser.uid }}),
         <span v-if="$currentUser.firstLoginAt">first logged in on {{ $currentUser.firstLoginAt | moment('M/D/YY') }}</span>
         <span v-if="!$currentUser.firstLoginAt">who has never logged in to CalCentral</span>
       </b-col>
-      <b-col class="pb-3 pr-0" sm="2">
+      <b-col sm="4">
         <div class="float-right">
           <b-button
             id="stop-viewing-as"
+            class="btn-stop-viewing-as cc-button-blue text-nowrap"
             size="sm"
-            variant="primary"
+            variant="outline-secondary"
             @click="stopActAs"
           >
             Stop viewing as
           </b-button>
+        </div>
+      </b-col>
+    </b-row>
+    <b-row v-if="$config.isVueAppDebugMode" class="pl-3 w-100">
+      <b-col sm="12">
+        <div class="text-secondary">
+          <span class="font-weight-bolder">Screen-reader alert:</span> {{ screenReaderAlert }}
         </div>
       </b-col>
     </b-row>
@@ -86,11 +94,13 @@
 
 <script>
 import BuildSummary from '@/components/util/BuildSummary'
+import Context from '@/mixins/Context'
 import DevAuth from '@/components/util/DevAuth'
 import {stopActAs} from '@/api/act'
 
 export default {
   name: 'Footer',
+  mixins: [Context],
   components: {DevAuth, BuildSummary},
   props: {
     includeBuildSummary: {
@@ -110,11 +120,16 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 h4 {
   font-size: 18px;
 }
+.btn-stop-viewing-as {
+  height: 25px;
+  width: 110px;
+}
 .fixed {
+  border-top: 2px solid $cc-color-dark-tangerine;
   bottom: 0;
   left: 0;
   position: fixed;

--- a/src/components/bcourses/roster/RosterList.vue
+++ b/src/components/bcourses/roster/RosterList.vue
@@ -1,0 +1,68 @@
+<template>
+  <div>
+    <b-table
+      :fields="[
+        {
+          key: 'student_id',
+          label: 'SID',
+          sortable: true
+        },
+        {
+          key: 'last_name',
+          label: 'Name',
+          sortable: true
+        },
+        {
+          key: 'email',
+          sortable: true
+        },
+        {
+          key: 'sections',
+          sortable: false
+        }
+      ]"
+      hover
+      :items="students"
+      :sort-by.sync="sortBy"
+      striped
+    >
+      <template v-slot:cell(last_name)="data">
+        {{ data.item.last_name }}, {{ data.item.first_name }}
+      </template>
+      <template v-slot:cell(sections)="data">
+        <div v-for="section in data.item.sections" :key="section.ccn">
+          {{ section.name }} ({{ section.ccn }})
+        </div>
+      </template>
+    </b-table>
+  </div>
+</template>
+
+<script>
+import Context from '@/mixins/Context'
+import Util from '@/mixins/Utils'
+
+export default {
+  name: 'RosterList',
+  mixins: [Context, Util],
+  props: {
+    courseId: {
+      required: true,
+      type: Number
+    },
+    students: {
+      required: true,
+      type: Array
+    }
+  },
+  data: () => ({
+    context: 'canvas',
+    sortBy: undefined
+  }),
+  watch: {
+    sortBy(value) {
+      this.alertScreenReader(`Sorted by ${value}`)
+    }
+  }
+}
+</script>

--- a/src/components/bcourses/roster/RosterPhotos.vue
+++ b/src/components/bcourses/roster/RosterPhotos.vue
@@ -1,0 +1,68 @@
+<template>
+  <ul v-if="students.length" class="align-content-start d-flex flex-wrap">
+    <li v-for="student in students" :key="student.student_id" class="pl-5 pr-5 text-center">
+      <div v-if="student.profile_url">
+        <a :id="`student-profile-url-${student.student_id}`" :href="student.profile_url" target="_top">
+          <RosterPhoto :student="student" />
+        </a>
+      </div>
+      <div v-if="!student.profile_url">
+        <a :id="`student-profile-url-${student.student_id}`" :href="`/${context}/${courseId}/profile/${student.login_id}`" target="_top">
+          <RosterPhoto :student="student" />
+        </a>
+      </div>
+      <div v-if="!student.email">
+        <div class="cc-page-roster-student-name">{{ student.first_name }}</div>
+        <div class="cc-page-roster-student-name font-weight-bolder">
+          {{ student.last_name }}
+        </div>
+      </div>
+      <div v-if="student.email">
+        <div class="cc-page-roster-student-name">
+          <a :href="`mailto:${student.email}`">
+            {{ student.first_name }}
+          </a>
+        </div>
+        <div class="cc-page-roster-student-name font-weight-bolder">
+          <a :id="`student-email-${student.student_id}`" :href="`mailto:${student.email}`">{{ student.last_name }}</a>
+        </div>
+      </div>
+      <div :id="`student-id-${student.student_id}`" class="cc-print-hide">
+        <span class="sr-only">Student ID: </span>
+        {{ student.student_id }}
+      </div>
+      <div v-if="student.terms_in_attendance" class="cc-page-roster-student-terms cc-print-hide">
+        Terms: {{ student.terms_in_attendance }}
+      </div>
+      <div v-if="student.majors" class="cc-page-roster-student-majors cc-print-hide">
+        {{ $_.truncate(student.majors.join(', '), {length: 50}) }}
+      </div>
+    </li>
+  </ul>
+</template>
+
+<script>
+import RosterPhoto from '@/components/bcourses/roster/RosterPhoto'
+
+export default {
+  name: 'RosterPhotos',
+  components: {RosterPhoto},
+  props: {
+    courseId: {
+      required: true,
+      type: Number
+    },
+    students: {
+      required: true,
+      type: Array
+    }
+  },
+  data: () => ({
+    context: 'canvas'
+  })
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/toolbox/ToolboxHeader.vue
+++ b/src/components/toolbox/ToolboxHeader.vue
@@ -1,14 +1,14 @@
 <template>
-  <b-row class="bg-header p-3 cc-masthead" no-gutters>
+  <b-row class="bg-header cc-masthead" no-gutters>
     <b-col sm="8">
-      <div class="header-text pt-1">
+      <div class="header-text mt-1 pl-3 pt-2">
         ETS bCourses Utilities
       </div>
     </b-col>
-    <b-col sm="4">
+    <b-col cols="auto" sm="4">
       <b-button
         id="log-out"
-        class="float-right p-0 text-white"
+        class="float-right text-white"
         variant="link"
         @click="exit"
       >


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7551

In local env:
* Developers see this toggle by default because `VUE_APP_DEBUG=true` in `.env.development`. You can override that value with `.env.development.local`, which is git-ignored. Article: [how-to-use-environment-variables-in-vue-js](https://medium.com/js-dojo/how-to-use-environment-variables-in-vue-js-273eba0102b0)
* Screen-reader alert shows in footer, as in BOA.
