### PR TITLE
CLC-7572, 'public/assets' is no longer in the mix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ public/styleguide
 
 # Ignore precompiled assets
 /dist
-/public/assets
 
 # Ignore the coverage directory (for checking in, otherwise useful)
 /coverage

--- a/script/deploy/_start-tomcat.sh
+++ b/script/deploy/_start-tomcat.sh
@@ -48,7 +48,6 @@ echo "Last commit in junction.war deployed:" | ${LOGIT}
 cat ${TOMCAT_DEPLOY}/ROOT/WEB-INF/versions/git.txt | ${LOGIT}
 
 log_info "Copying assets into ${DOC_ROOT}"
-cp -Rvf ${TOMCAT_DEPLOY}/ROOT/WEB-INF/public/assets ${DOC_ROOT} | ${LOGIT}
 cp -Rvf ${TOMCAT_DEPLOY}/ROOT/WEB-INF/dist ${DOC_ROOT} | ${LOGIT}
 
 log_info "Deleting old assets from ${DOC_ROOT}/assets"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7572

`public/assets` belongs to old Angular days. It's in the `qa` WAR files but not those built in `dev`. Devs should remove the dir locally, if present.