### PR TITLE
CLC-7575, compile lti.html same as index.html (vue-cli)

### DIFF
--- a/public/lti.html
+++ b/public/lti.html
@@ -1,4 +1,8 @@
 <div class="cc-off-canvas-container bc-canvas-embedded" data-bc-iframe-resize>
+  <!--
+  TODO: We need an equivalent to 'data-bc-iframe-resize'. Will that logic live in App.vue?
+  TODO: See src/assets/javascripts/angular/services/utilService.js:92
+  -->
   <div
   class="row cc-container-main"
   role="main">

--- a/vue.config.js
+++ b/vue.config.js
@@ -8,5 +8,15 @@ module.exports = {
   	  	additionalData: `@import "~@/assets/styles/colors.scss"; @import "~@/assets/styles/_canvas_colors.scss"; @import "~@/assets/styles/_canvas_base.scss"; @import "~@/assets/styles/_bootstrap_variables.scss";`
   	  }
   	}
+  },
+  pages: {
+    index: {
+      entry: 'src/main.ts',
+      template: 'public/index.html'
+    },
+    lti: {
+      entry: 'src/main.ts',
+      template: 'public/lti.html'
+    }
   }
 }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7575

I'm using 'pages' feature in vue-cli: https://cli.vuejs.org/config/#pages

Unlike index.html, `lti.html` is not top-level HTML; it's a fragment. However, _vue-cli_ treats it as top-level HTML and injects 'head' element as shown below. 
```
<head><link ...></head>
<div class="cc-off-canvas-container bc-canvas-embedded" data-bc-iframe-resize>...</div><script type=module src=/static/js/chunk-vendors.425a010b.js></script>...
```

This might not render nicely in iFrame but let's see. We'll tweak it.
