### PR TITLE
CLC-7573, 'public' dir does not belong in WAR file

### DIFF
--- a/config/warble.rb
+++ b/config/warble.rb
@@ -1,6 +1,6 @@
 Warbler::Config.new do |config|
   config.override_gem_home = false
-  config.dirs = %w(app bin config db dist lib log public script vendor versions tmp)
+  config.dirs = %w(app bin config db dist lib log script vendor versions tmp)
   config.init_contents << StringIO.new("\nGem.clear_paths\nGem.path\n")
   config.jrubyc_options = "--javac"
   config.war_name = "junction"

--- a/script/deploy/_start-tomcat.sh
+++ b/script/deploy/_start-tomcat.sh
@@ -53,12 +53,6 @@ cp -Rvf ${TOMCAT_DEPLOY}/ROOT/WEB-INF/dist ${DOC_ROOT} | ${LOGIT}
 log_info "Deleting old assets from ${DOC_ROOT}/assets"
 find ${DOC_ROOT}/assets -type f -mtime +${MAX_ASSET_AGE_IN_DAYS} -delete | ${LOGIT}
 
-log_info "Copying bCourses static files into ${DOC_ROOT}"
-cp -Rvf ${TOMCAT_DEPLOY}/ROOT/WEB-INF/public/canvas ${DOC_ROOT} | ${LOGIT}
-
-log_info "Copying OAuth static files into ${DOC_ROOT}"
-cp -Rvf ${TOMCAT_DEPLOY}/ROOT/WEB-INF/config/oauth ${DOC_ROOT} | ${LOGIT}
-
 # Fix file permissions for Tomcat deploys
 cd ${DOC_ROOT}
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7573

During the build, all front-end assets are "compiled" into the `dist/` directory. The `public/` dir is essential for that build step but it does not need to be in the WAR file. Let's not cause confusion, down the road, by having unused stuff in the deployment.  