### PR TITLE
CLC-7577 Allow individual LTI components to handle errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -78,7 +78,11 @@ axios.interceptors.response.use(
       // Refresh user in case his/her session expired.
       return axios.get(`${apiBaseUrl}/api/my/status`).then(response => {
         Vue.prototype.$currentUser = response.data
-        axiosErrorHandler(error)
+        const errorUrl = _.get(error, 'response.config.url')
+        // Auth errors from the academics API should be handled by individual LTI components.
+        if (!(errorUrl && errorUrl.includes('/api/academics'))) {
+          axiosErrorHandler(error)
+        }
         return Promise.reject(error)
       })
     } else {

--- a/src/views/Roster.vue
+++ b/src/views/Roster.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="cc-page-roster">
-    <b-container v-if="roster" fluid>
+    <b-container v-if="roster && !error" fluid>
       <b-row align-v="start" class="cc-page-roster cc-print-hide cc-roster-search" no-gutters>
         <b-col class="pb-2 pr-2" sm="3">
           <b-input
@@ -82,13 +82,22 @@
         </b-col>
       </b-row>
     </b-container>
-    <div v-if="!roster">
+    <div v-if="!roster & !error">
       <b-alert aria-live="polite" role="alert" show>Downloading rosters. This may take a minute for larger classes.</b-alert>
       <b-card>
         <b-skeleton animation="fade" width="85%"></b-skeleton>
         <b-skeleton animation="fade" width="55%"></b-skeleton>
         <b-skeleton animation="fade" width="70%"></b-skeleton>
       </b-card>
+    </div>
+    <div v-if="error" role="alert">
+      <fa icon="exclamation-triangle" class="cc-icon-red"></fa> You must be a teacher in this bCourses course to view official student rosters.
+    </div>
+    <div v-if="!error && roster && !roster.sections" role="alert">
+      <fa icon="exclamation-circle" class="cc-icon-gold"></fa> There are no currently maintained official sections in this course site.
+    </div>
+    <div v-if="!error && roster && roster.sections && !roster.students" role="alert">
+      <fa icon="exclamation-circle" class="cc-icon-gold"></fa> Students have not yet signed up for this class.
     </div>
   </div>
 </template>
@@ -115,6 +124,7 @@ export default {
   },
   data: () => ({
     canvasCourseId: undefined,
+    error: null,
     search: undefined,
     roster: undefined,
     section: null,
@@ -133,6 +143,9 @@ export default {
         students.push(student)
       })
       this.studentsFiltered = this.sort(students)
+      this.$ready('Roster')
+    }, error => {
+      this.error = error
       this.$ready('Roster')
     })
   },


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7577

If they’re auth errors from the academics API, anyhow. Additional special cases can be worked in as needed.