### PR TITLE
CLC-7525, break CreateCourseSite.vue into components per 'workflowStep'

### DIFF
--- a/src/api/canvas.ts
+++ b/src/api/canvas.ts
@@ -106,7 +106,7 @@ export function getCourseSections(canvasCourseId) {
 
 export function getSections(
   adminActingAs: string,
-  adminByCcns: string[],
+  adminByCcns: string,
   adminMode: string,
   currentAdminSemester: string,
   isAdmin: boolean

--- a/src/components/bcourses/create/ConfirmationStep.vue
+++ b/src/components/bcourses/create/ConfirmationStep.vue
@@ -1,0 +1,115 @@
+<template>
+  <div>
+    <div>
+      <div class="medium-12 columns">
+        <div class="bc-alert bc-alert-info" role="alert">
+          <!-- TODO: data-cc-focus-reset-directive -->
+          <h2 class="cc-visuallyhidden" data-cc-focus-reset-directive="confirmFocus">Confirm Course Site Details</h2>
+          <strong>
+            You are about to create a {{ currentSemesterName }} course site with
+            {{ selectedSections(coursesList).length }}
+            {{ pluralize(section, selectedSections(coursesList).length) }}:
+          </strong>
+          <ul class="bc-page-create-course-site-section-list">
+            <li v-for="section in selectedSections(coursesList)" :key="section.ccn">
+              {{ section.courseTitle }} - {{ section.courseCode }}
+              {{ section.section_label }} ({{ section.ccn }})
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div>
+      <div class="medium-12 columns">
+        <form
+          name="createCourseSiteForm"
+          class="bc-canvas-page-form"
+          @submit="createCourseSiteJob"
+        >
+          <div>
+            <div class="small-12 medium-6 end">
+              <div class="bc-page-create-course-site-form-fields-container">
+                <div>
+                  <div class="medium-offset-1 medium-4 columns">
+                    <label for="siteName" class="right">Site Name:</label>
+                  </div>
+                  <div class="medium-7 columns">
+                    <b-form-input
+                      id="siteName"
+                      v-model="siteName"
+                      type="text"
+                      name="siteName"
+                      :required="true"
+                    />
+                    <div v-if="createCourseSiteForm.siteName.$error.required" class="bc-alert bc-notice-error">
+                      <fa icon="exclamation-circle" class="cc-left cc-icon-red bc-canvas-notice-icon"></fa>
+                      Please fill out a site name.
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div class="medium-offset-1 medium-4 columns">
+                    <label for="siteAbbreviation" class="right">Site Abbreviation:</label>
+                  </div>
+                  <div class="medium-7 columns">
+                    <b-form-input
+                      id="siteAbbreviation"
+                      v-model="siteAbbreviation"
+                      type="text"
+                      name="siteAbbreviation"
+                      :required="true"
+                    />
+                    <div v-if="createCourseSiteForm.siteAbbreviation.$error.required" class="bc-alert bc-notice-error">
+                      <fa icon="exclamation-circle" class="cc-left cc-icon-red bc-canvas-notice-icon"></fa>
+                      Please fill out a site abbreviation.
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="medium-12 columns">
+              <div class="bc-form-actions">
+                <button
+                  :disabled="createCourseSiteForm.$invalid"
+                  class="bc-canvas-button bc-canvas-button-primary"
+                  type="submit"
+                  role="button"
+                  aria-label="Create Course Site"
+                  aria-controls="bc-page-create-course-site-steps-container"
+                >
+                  Create Course Site
+                </button>
+                <button class="bc-canvas-button" type="button" @click="showSelecting">Go Back</button>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ConfirmationStep',
+  props: {
+    selectedSections: {
+      required: true,
+      type: Array
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.bc-page-create-course-site-section-list {
+  list-style-type: disc;
+  margin: 10px 0 0 39px;
+}
+
+.bc-page-create-course-site-form-fields-container {
+  margin: 10px 0;
+}
+</style>

--- a/src/components/bcourses/create/CreateCourseSiteHeader.vue
+++ b/src/components/bcourses/create/CreateCourseSiteHeader.vue
@@ -1,0 +1,204 @@
+<template>
+  <div class="d-flex flex-column">
+    <div class="order-3">
+      <h1 class="bc-page-create-course-site-header bc-page-create-course-site-header1">Create a Course Site</h1>
+    </div>
+    <div class="order-2">
+      <div v-if="showMaintenanceNotice" role="alert">
+        <MaintenanceNotice />
+      </div>
+    </div>
+    <div class="order-1">
+      <div>
+        <div v-if="isAdmin" class="bc-page-create-course-site-admin-options">
+          <h1 class="cc-visuallyhidden">Administrator Options</h1>
+          <button
+            aria-controls="bc-page-create-course-site-admin-section-loader-form"
+            class="bc-canvas-button bc-canvas-button-small bc-page-create-course-site-admin-mode-switch p-2"
+            @click="adminMode = adminMode === 'act_as' ? 'by_ccn' : 'act_as'"
+          >
+            Switch to {{ adminMode === 'act_as' ? 'CCN input' : 'acting as instructor' }}
+          </button>
+          <div id="bc-page-create-course-site-admin-section-loader-form">
+            <div v-if="adminMode === 'act_as'" class="pt-3">
+              <h2 class="cc-visuallyhidden">Load Sections By Instructor UID</h2>
+              <form class="bc-canvas-page-form bc-page-create-course-site-act-as-form d-flex" @submit="fetchFeed">
+                <label for="instructor-uid" class="cc-visuallyhidden">Instructor UID</label>
+                <b-form-input
+                  id="instructor-uid"
+                  v-model="uid"
+                  placeholder="Instructor UID"
+                  role="search"
+                ></b-form-input>
+                <div>
+                  <b-button
+                    id="sections-by-uid-button"
+                    class="bc-canvas-button bc-canvas-button-primary"
+                    :disabled="!toInt(uid)"
+                    aria-label="Load official sections for instructor"
+                    aria-controls="bc-page-create-course-site-steps-container"
+                    @click="fetchFeed"
+                  >
+                    As instructor
+                  </b-button>
+                </div>
+              </form>
+            </div>
+            <div v-if="adminMode === 'by_ccn'">
+              <h2 class="cc-visuallyhidden">Load Sections By Course Control Numbers (CCN)</h2>
+              <form class="bc-canvas-page-form" @submit="fetchFeed">
+                <div v-if="$_.size(adminSemesters)">
+                  <div class="bc-buttonset">
+                    <span v-for="(semester, index) in adminSemesters" :key="index">
+                      <input
+                        :id="`semester${index}`"
+                        type="radio"
+                        name="adminSemester"
+                        class="cc-visuallyhidden"
+                        :aria-selected="currentAdminSemester === semester.slug"
+                        role="tab"
+                        @click="switchAdminSemester(semester)"
+                      />
+                      <label
+                        :for="`semester${index}`"
+                        class="bc-buttonset-button"
+                        role="button"
+                        aria-disabled="false"
+                        :class="{
+                          'bc-buttonset-button-active': currentAdminSemester === semester.slug,
+                          'bc-buttonset-corner-left': index === 0,
+                          'bc-buttonset-corner-right': index === ($_.size(adminSemesters) - 1)
+                        }"
+                      >
+                        {{ semester.name }}
+                      </label>
+                    </span>
+                  </div>
+                  <label
+                    for="bc-page-create-course-site-ccn-list"
+                    class="cc-visuallyhidden"
+                  >
+                    Provide CCN List Separated by Commas or Spaces
+                  </label>
+                  <textarea
+                    id="bc-page-create-course-site-ccn-list"
+                    v-model="adminByCcns"
+                    placeholder="Paste your list of CCNs here, separated by commas or spaces"
+                  >
+                </textarea>
+                  <b-button
+                    id="sections-by-ids-button"
+                    class="bc-canvas-button bc-canvas-button-primary"
+                    :disabled="!$_.trim(adminByCcns)"
+                    type="submit"
+                    aria-controls="bc-page-create-course-site-steps-container"
+                  >
+                    Review matching CCNs
+                  </b-button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import MaintenanceNotice from '@/components/bcourses/shared/MaintenanceNotice'
+import Utils from '@/mixins/Utils'
+
+export default {
+  name: 'CreateCourseSiteHeader',
+  mixins: [Utils],
+  components: {MaintenanceNotice},
+  watch: {
+    uid() {
+      this.setAdminActingAs(this.uid)
+    }
+  },
+  props: {
+    setAdminActingAs: {
+      required: true,
+      type: Function
+    },
+    adminByCcns: {
+      default: undefined,
+      required: false,
+      type: String
+    },
+    adminMode: {
+      required: true,
+      type: String
+    },
+    adminSemesters: {
+      required: true,
+      type: Array
+    },
+    currentAdminSemester: {
+      default: undefined,
+      required: false,
+      type: String
+    },
+    isAdmin: {
+      required: true,
+      type: Boolean
+    },
+    fetchFeed: {
+      required: true,
+      type: Function
+    },
+    showMaintenanceNotice: {
+      required: true,
+      type: Boolean
+    },
+    switchAdminSemester: {
+      required: true,
+      type: Function
+    }
+  },
+  data: () => ({
+    uid: undefined
+  })
+}
+</script>
+
+<style scoped lang="scss">
+.bc-page-create-course-site-act-as-form {
+  margin: 5px 0;
+  input[type="text"] {
+    font-family: $bc-base-font-family;
+    font-size: 14px;
+    margin: 2px 10px 0 0;
+    padding: 8px 12px;
+    width: 140px;
+  }
+}
+
+.bc-page-create-course-site-admin-options {
+  margin-bottom: 15px;
+}
+
+.bc-page-create-course-site-header {
+  color: $bc-color-headers;
+  font-family: $bc-base-font-family;
+  font-weight: normal;
+  line-height: 40px;
+  margin: 5px 0;
+}
+
+.bc-page-create-course-site-header1 {
+  font-size: 23px;
+}
+
+.bc-page-create-course-site-header2 {
+  font-size: 18px;
+  margin: 10px 0;
+}
+
+.bc-page-create-course-site-admin-mode-switch {
+  margin-bottom: 5px;
+  outline: none;
+}
+</style>

--- a/src/components/bcourses/create/MonitoringJob.vue
+++ b/src/components/bcourses/create/MonitoringJob.vue
@@ -1,0 +1,92 @@
+<template>
+  <div>
+    <!-- TODO: data-cc-focus-reset-directive -->
+    <h2 class="cc-visuallyhidden" data-cc-focus-reset-directive="confirmFocus">Course Site Creation</h2>
+    <div aria-live="polite">
+      <div v-show="!jobStatus" class="bc-page-create-course-site-pending-request">
+        <fa icon="spinner" spin></fa>
+        Sending request...
+      </div>
+      <div v-if="jobStatus === 'New'" class="bc-page-create-course-site-pending-request">
+        <fa icon="spinner" spin></fa>
+        Course provisioning request sent. Awaiting processing....
+      </div>
+      <div v-if="jobStatus">
+        <div>
+          <ProgressBar :percent-complete-rounded="50" />
+        </div>
+        <div v-if="jobStatus === 'Error'">
+          <BackgroundJobError :error-config="errorConfig" :errors="errors" />
+          <div class="bc-page-create-course-site-step-options">
+            <div class="medium-12 columns">
+              <div class="bc-form-actions">
+                <button
+                  class="bc-canvas-button bc-canvas-button-primary"
+                  type="button"
+                  aria-control="bc-page-create-course-site-selecting-step"
+                  aria-label="Start over course site creation process"
+                  @click="fetchFeed"
+                >
+                  Start Over
+                </button>
+                <button
+                  class="cc-button cc-page-button-grey"
+                  type="button"
+                  aria-control="bc-page-create-course-site-confirmation-step"
+                  aria-label="Go Back to Site Details Confirmation"
+                  @click="showConfirmation"
+                >
+                  Back
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div v-if="jobStatus === 'Completed'" :aria-expanded="jobStatus === 'Completed'">
+      <!-- TODO: data-cc-spinner-directive -->
+      <div data-cc-spinner-directive></div>
+      <div class="cc-visuallyhidden" role="alert">
+        Redirecting to new course site.
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import BackgroundJobError from '@/components/bcourses/shared/BackgroundJobError'
+import ProgressBar from '@/components/bcourses/shared/ProgressBar'
+
+export default {
+  name: 'MonitoringJob',
+  components: {
+    BackgroundJobError,
+    ProgressBar
+  },
+  props: {
+    fetchFeed: {
+      required: true,
+      type: Function
+    },
+    jobStatus: {
+      required: true,
+      type: String
+    },
+    showConfirmation: {
+      required: true,
+      type: Function
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.bc-page-create-course-site-pending-request {
+  margin: 15px auto;
+}
+
+.bc-page-create-course-site-step-options {
+  padding: 20px 0;
+}
+</style>

--- a/src/components/bcourses/create/SelectSectionsStep.vue
+++ b/src/components/bcourses/create/SelectSectionsStep.vue
@@ -1,0 +1,231 @@
+<template>
+  <div>
+    <!-- TODO: data-cc-spinner-directive -->
+    <div data-cc-spinner-directive></div>
+    <div v-if="!$_.size(teachingSemesters)" role="alert">
+      <p>You are currently not listed as the instructor of record for any courses, so you cannot create a course site in bCourses.</p>
+    </div>
+    <div v-if="$_.size(teachingSemesters)">
+      <div class="medium-5 columns">
+        <div class="bc-buttonset">
+          <!-- TODO: data-cc-focus-reset-directive -->
+          <h2
+            class="bc-page-create-course-site-header bc-page-create-course-site-header2 bc-accessibility-no-outline"
+            data-cc-focus-reset-directive="selectFocus"
+          >
+            Term
+          </h2>
+          <span v-for="(semester, index) in teachingSemesters" :key="index">
+            <input
+              :id="`semester${index}`"
+              type="radio"
+              name="semester"
+              class="cc-visuallyhidden"
+              :aria-selected="currentSemester === semester.slug"
+              role="tab"
+              @click="switchSemester(semester)"
+            />
+            <label
+              :for="`semester${index}`"
+              class="bc-buttonset-button"
+              aria-disabled="false"
+              :class="{
+                'bc-buttonset-button-active': currentSemester === semester.slug,
+                'bc-buttonset-corner-left': !index,
+                'bc-buttonset-corner-right': (index === $_.size(teachingSemesters) - 1)
+              }"
+            >
+              {{ semester.name }}
+            </label>
+          </span>
+        </div>
+      </div>
+      <div class="medium-12 columns">
+        <h2 class="bc-page-create-course-site-header bc-page-create-course-site-header2">Official Sections</h2>
+        <p>All official sections you select below will be put in ONE, single course site.</p>
+        <div class="bc-page-help-notice bc-page-create-course-site-help-notice">
+          <fa icon="question-circle" class="cc-left bc-page-help-notice-icon"></fa>
+          <div class="bc-page-help-notice-left-margin pl-1">
+            <button
+              class="bc-button-link"
+              aria-haspopup="true"
+              aria-controls="section-selection-help"
+              :aria-expanded="toggle.displayHelp"
+              @click="toggle.displayHelp = !toggle.displayHelp"
+            >
+              Need help deciding which official sections to select?
+            </button>
+            <div aria-live="polite">
+              <div
+                v-if="toggle.displayHelp"
+                id="section-selection-help"
+                class="bc-page-help-notice-content"
+              >
+                <p>If you have a course with multiple sections, you will need to decide whether you want to:</p>
+                <ol class="bc-page-create-course-site-help-notice-ordered-list">
+                  <li>
+                    Create one, single course site which includes official sections for both your primary and secondary sections, or
+                  </li>
+                  <li>
+                    Create multiple course sites, perhaps with one for each section, or
+                  </li>
+                  <li>
+                    Create separate course sites based on instruction mode.
+                    <a target="_blank" href="https://berkeley.service-now.com/kb_view.do?sysparm_article=KB0010732#instructionmode">
+                      Learn more about instruction modes in bCourses.
+                    </a>
+                  </li>
+                </ol>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="medium-12 columns">
+        <form class="bc-canvas-page-form" @submit="showConfirmation">
+          <ul class="bc-page-create-course-site-section-margin">
+            <li v-for="course in coursesList" :key="course.course_id" class="bc-sections-course-container bc-sections-course-container-bottom-margin">
+              <div class="d-flex">
+                <div>
+                  <b-button
+                    :aria-expanded="course.visible"
+                    class="pb-0 pt-0"
+                    variant="link"
+                    @click="course.visible = !course.visible"
+                  >
+                    <fa :icon="course.visible ? 'caret-down' : 'caret-right'" />
+                    <span class="sr-only">Toggle course sections list for {{ course.course_code }} {{ course.title }}</span>
+                  </b-button>
+                </div>
+                <div>
+                  <h3 class="bc-sections-course-title">{{ course.course_code }}<span v-if="course.title">: {{ course.title }}</span></h3>
+                </div>
+                <div v-if="$_.size(course.sections)" class="ml-1">
+                  ({{ pluralize('section', course.sections.length, {0: 'No', 1: 'One'}) }})
+                </div>
+              </div>
+              <b-collapse :id="course.course_id" visible>
+                <div v-if="course.sections.length > 1" class="bc-page-create-course-site-form-select-all-option">
+                  Select:
+                  <button
+                    :aria-label="`Select ${course.selectToggleText} of the course sections`"
+                    class="bc-button-link bc-page-create-course-site-form-select-all-option-button"
+                    type="button"
+                    @click="toggleCourseSectionsWithUpdate(course)"
+                  >
+                    {{ course.selectToggleText }}
+                  </button>
+                </div>
+                <CourseSectionsTable
+                  mode="createCourseForm"
+                  :sections="course.sections"
+                  :update-selected="updateSelected"
+                />
+              </b-collapse>
+            </li>
+          </ul>
+          <div class="bc-form-actions">
+            <button
+              class="bc-canvas-button bc-canvas-button-primary"
+              type="submit"
+              :disabled="!selectedSectionsList.length"
+              aria-controls="bc-page-create-course-site-steps-container"
+              aria-label="Continue to next step"
+              role="button"
+            >
+              Next
+            </button>
+            <a
+              :href="linkToSiteOverview"
+              class="bc-canvas-button"
+              type="reset"
+              aria-label="Cancel and return to Site Creation Overview"
+            >
+              Cancel
+            </a>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import CourseSectionsTable from '@/components/bcourses/CourseSectionsTable'
+import Utils from '@/mixins/Utils'
+
+export default {
+  name: 'SelectSectionsStep',
+  mixins: [Utils],
+  components: {CourseSectionsTable},
+  props: {
+    coursesList: {
+      required: true,
+      type: Array
+    },
+    currentSemester: {
+      required: true,
+      type: String
+    },
+    selectedSectionsList: {
+      required: true,
+      type: Array
+    },
+    showConfirmation: {
+      required: true,
+      type: Function
+    },
+    switchSemester: {
+      required: true,
+      type: Function
+    },
+    teachingSemesters: {
+      required: true,
+      type: Array
+    },
+    toggleCourseSectionsWithUpdate: {
+      required: true,
+      type: Function
+    },
+    updateSelected: {
+      required: true,
+      type: Function
+    }
+  },
+  data: () => ({
+    linkToSiteOverview: undefined,
+    toggle: {
+      displayHelp: false
+    }
+  })
+}
+</script>
+
+<style scoped lang="scss">
+.bc-page-create-course-site-help-notice {
+  margin-bottom: 20px;
+  .bc-page-create-course-site-help-notice-ordered-list {
+    margin-bottom: 10px;
+    margin-left: 20px;
+  }
+
+  .bc-page-create-course-site-help-notice-paragraph {
+    margin-bottom: 7px;
+  }
+}
+
+.bc-page-create-course-site-form-select-all-option {
+  font-size: 12px;
+  font-weight: normal;
+  margin: 6px 0 4px 2px;
+}
+
+.bc-page-create-course-site-form-select-all-option-button {
+  outline: none;
+}
+
+.bc-page-create-course-site-section-margin {
+  margin: 0;
+  overflow: hidden;
+}
+</style>

--- a/src/views/CreateCourseSite.vue
+++ b/src/views/CreateCourseSite.vue
@@ -1,402 +1,47 @@
 <template>
   <div class="bc-canvas-application bc-page-create-course-site p-5">
     <div v-if="!loading && !error" class="bc-accessibility-no-outline">
-      <div v-if="isAdmin" class="bc-page-create-course-site-admin-options">
-        <h1 class="cc-visuallyhidden">Administrator Options</h1>
-        <button
-          aria-controls="bc-page-create-course-site-admin-section-loader-form"
-          class="bc-canvas-button bc-canvas-button-small bc-page-create-course-site-admin-mode-switch p-2"
-          @click="adminMode = adminMode === 'act_as' ? 'by_ccn' : 'act_as'"
-        >
-          Switch to {{ adminMode === 'act_as' ? 'CCN input' : 'acting as instructor' }}
-        </button>
-        <div id="bc-page-create-course-site-admin-section-loader-form">
-          <div v-if="adminMode === 'act_as'" class="pt-3">
-            <h2 class="cc-visuallyhidden">Load Sections By Instructor UID</h2>
-            <form class="bc-canvas-page-form bc-page-create-course-site-act-as-form d-flex" @submit="fetchFeed">
-              <label for="instructor-uid" class="cc-visuallyhidden">Instructor UID</label>
-              <b-form-input
-                id="instructor-uid"
-                v-model="adminActingAs"
-                placeholder="Instructor UID"
-                role="search"
-              ></b-form-input>
-              <div>
-                <b-button
-                  id="sections-by-uid-button"
-                  class="bc-canvas-button bc-canvas-button-primary"
-                  aria-label="Load official sections for instructor"
-                  aria-controls="bc-page-create-course-site-steps-container"
-                  @click="fetchFeed"
-                >
-                  As instructor
-                </b-button>
-              </div>
-            </form>
-          </div>
-          <div v-if="adminMode === 'by_ccn'">
-            <h2 class="cc-visuallyhidden">Load Sections By Course Control Numbers (CCN)</h2>
-            <form class="bc-canvas-page-form" @submit="fetchFeed">
-              <div v-if="$_.size(adminSemesters)">
-                <div class="bc-buttonset">
-                  <span v-for="(semester, index) in adminSemesters" :key="index">
-                    <input
-                      :id="`semester${index}`"
-                      type="radio"
-                      name="adminSemester"
-                      class="cc-visuallyhidden"
-                      :aria-selected="currentAdminSemester === semester.slug"
-                      role="tab"
-                      @click="switchAdminSemester(semester)"
-                    />
-                    <label
-                      :for="`semester${index}`"
-                      class="bc-buttonset-button"
-                      role="button"
-                      aria-disabled="false"
-                      :class="{
-                        'bc-buttonset-button-active': currentAdminSemester === semester.slug,
-                        'bc-buttonset-corner-left': index === 0,
-                        'bc-buttonset-corner-right': index === ($_.size(adminSemesters) - 1)
-                      }"
-                    >
-                      {{ semester.name }}
-                    </label>
-                  </span>
-                </div>
-                <label
-                  for="bc-page-create-course-site-ccn-list"
-                  class="cc-visuallyhidden"
-                >
-                  Provide CCN List Separated by Commas or Spaces
-                </label>
-                <textarea
-                  id="bc-page-create-course-site-ccn-list"
-                  v-model="adminByCcns"
-                  placeholder="Paste your list of CCNs here, separated by commas or spaces"
-                >
-                </textarea>
-                <b-button
-                  id="sections-by-ids-button"
-                  class="bc-canvas-button bc-canvas-button-primary"
-                  type="submit"
-                  aria-controls="bc-page-create-course-site-steps-container"
-                >
-                  Review matching CCNs
-                </b-button>
-              </div>
-            </form>
-          </div>
-        </div>
-      </div>
-      <div v-if="showMaintenanceNotice" role="alert">
-        <MaintenanceNotice />
-      </div>
-      <h1 class="bc-page-create-course-site-header bc-page-create-course-site-header1">Create a Course Site</h1>
-      <div id="bc-page-create-course-site-steps-container" class="bc-page-create-course-site-steps-container">
+      <CreateCourseSiteHeader
+        :set-admin-acting-as="setAdminActingAs"
+        :admin-by-ccns="adminByCcns"
+        :admin-mode="adminMode"
+        :admin-semesters="adminSemesters"
+        :current-admin-semester="currentAdminSemester"
+        :is-admin="isAdmin"
+        :fetch-feed="fetchFeed"
+        :show-maintenance-notice="showMaintenanceNotice"
+        :switch-admin-semester="switchAdminSemester"
+      />
+      <div id="bc-page-create-course-site-steps-container" class="p-0">
         <div
           v-if="currentWorkflowStep === 'selecting'"
           id="bc-page-create-course-site-selecting-step"
           :aria-expanded="currentWorkflowStep === 'selecting'"
         >
-          <!-- TODO: data-cc-spinner-directive -->
-          <div data-cc-spinner-directive></div>
-          <div v-if="!$_.size(teachingSemesters)" role="alert">
-            <p>You are currently not listed as the instructor of record for any courses, so you cannot create a course site in bCourses.</p>
-          </div>
-          <div v-if="$_.size(teachingSemesters)">
-            <div class="medium-5 columns">
-              <div class="bc-buttonset">
-                <!-- TODO: data-cc-focus-reset-directive -->
-                <h2
-                  class="bc-page-create-course-site-header bc-page-create-course-site-header2 bc-accessibility-no-outline"
-                  data-cc-focus-reset-directive="selectFocus"
-                >
-                  Term
-                </h2>
-                <span v-for="(semester, index) in teachingSemesters" :key="index">
-                  <input
-                    :id="`semester${index}`"
-                    type="radio"
-                    name="semester"
-                    class="cc-visuallyhidden"
-                    :aria-selected="currentSemester === semester.slug"
-                    role="tab"
-                    @click="switchSemester(semester)"
-                  />
-                  <label
-                    :for="`semester${index}`"
-                    class="bc-buttonset-button"
-                    aria-disabled="false"
-                    :class="{
-                      'bc-buttonset-button-active': currentSemester === semester.slug,
-                      'bc-buttonset-corner-left': !index,
-                      'bc-buttonset-corner-right': (index === $_.size(teachingSemesters) - 1)
-                    }"
-                  >
-                    {{ semester.name }}
-                  </label>
-                </span>
-              </div>
-            </div>
-            <div class="medium-12 columns">
-              <h2 class="bc-page-create-course-site-header bc-page-create-course-site-header2">Official Sections</h2>
-              <p>All official sections you select below will be put in ONE, single course site.</p>
-              <div class="bc-page-help-notice bc-page-create-course-site-help-notice">
-                <fa icon="question-circle" class="cc-left bc-page-help-notice-icon"></fa>
-                <div class="bc-page-help-notice-left-margin pl-1">
-                  <button
-                    class="bc-button-link"
-                    aria-haspopup="true"
-                    aria-controls="section-selection-help"
-                    :aria-expanded="toggle.displayHelp"
-                    @click="toggle.displayHelp = !toggle.displayHelp"
-                  >
-                    Need help deciding which official sections to select?
-                  </button>
-                  <div aria-live="polite">
-                    <div
-                      v-if="toggle.displayHelp"
-                      id="section-selection-help"
-                      class="bc-page-help-notice-content"
-                    >
-                      <p>If you have a course with multiple sections, you will need to decide whether you want to:</p>
-                      <ol class="bc-page-create-course-site-help-notice-ordered-list">
-                        <li>
-                          Create one, single course site which includes official sections for both your primary and secondary sections, or
-                        </li>
-                        <li>
-                          Create multiple course sites, perhaps with one for each section, or
-                        </li>
-                        <li>
-                          Create separate course sites based on instruction mode.
-                          <a target="_blank" href="https://berkeley.service-now.com/kb_view.do?sysparm_article=KB0010732#instructionmode">
-                            Learn more about instruction modes in bCourses.
-                          </a>
-                        </li>
-                      </ol>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="medium-12 columns">
-              <form class="bc-canvas-page-form" @submit="showConfirmation">
-                <ul class="bc-page-create-course-site-section-margin">
-                  <li v-for="course in coursesList" :key="course.course_id" class="bc-sections-course-container bc-sections-course-container-bottom-margin">
-                    <div class="d-flex">
-                      <div>
-                        <b-button
-                          :aria-expanded="course.visible"
-                          class="pb-0 pt-0"
-                          variant="link"
-                          @click="course.visible = !course.visible"
-                        >
-                          <fa :icon="course.visible ? 'caret-down' : 'caret-right'" />
-                          <span class="sr-only">Toggle course sections list for {{ course.course_code }} {{ course.title }}</span>
-                        </b-button>
-                      </div>
-                      <div>
-                        <h3 class="bc-sections-course-title">{{ course.course_code }}<span v-if="course.title">: {{ course.title }}</span></h3>
-                      </div>
-                      <div v-if="$_.size(course.sections)" class="ml-1">
-                        ({{ pluralize('section', course.sections.length, {0: 'No', 1: 'One'}) }})
-                      </div>
-                    </div>
-                    <b-collapse :id="course.course_id" visible>
-                      <div v-if="course.sections.length > 1" class="bc-page-create-course-site-form-select-all-option">
-                        Select:
-                        <button
-                          :aria-label="`Select ${course.selectToggleText} of the course sections`"
-                          class="bc-button-link bc-page-create-course-site-form-select-all-option-button"
-                          type="button"
-                          @click="toggleCourseSectionsWithUpdate(course)"
-                        >
-                          {{ course.selectToggleText }}
-                        </button>
-                      </div>
-                      <CourseSectionsTable
-                        mode="createCourseForm"
-                        :sections="course.sections"
-                        :update-selected="updateSelected"
-                      />
-                    </b-collapse>
-                  </li>
-                </ul>
-                <div class="bc-form-actions">
-                  <button
-                    class="bc-canvas-button bc-canvas-button-primary"
-                    type="submit"
-                    :disabled="!selectedSectionsList.length"
-                    aria-controls="bc-page-create-course-site-steps-container"
-                    aria-label="Continue to next step"
-                    role="button"
-                  >
-                    Next
-                  </button>
-                  <a
-                    :href="linkToSiteOverview"
-                    class="bc-canvas-button"
-                    type="reset"
-                    aria-label="Cancel and return to Site Creation Overview"
-                  >
-                    Cancel
-                  </a>
-                </div>
-              </form>
-            </div>
-          </div>
+          <SelectSectionsStep
+            :courses-list="coursesList"
+            :current-semester="currentSemester"
+            :selected-sections-list="selectedSectionsList"
+            :show-confirmation="showConfirmation"
+            :switch-semester="switchSemester"
+            :teaching-semesters="teachingSemesters"
+            :toggle-course-sections-with-update="toggleCourseSectionsWithUpdate"
+            :update-selected="updateSelected"
+          />
         </div>
         <div
           v-if="currentWorkflowStep === 'confirmation'"
           id="bc-page-create-course-site-confirmation-step"
           :aria-expanded="currentWorkflowStep === 'confirmation'"
         >
-          <div>
-            <div class="medium-12 columns">
-              <div class="bc-alert bc-alert-info" role="alert">
-                <!-- TODO: data-cc-focus-reset-directive -->
-                <h2 class="cc-visuallyhidden" data-cc-focus-reset-directive="confirmFocus">Confirm Course Site Details</h2>
-                <strong>
-                  You are about to create a {{ currentSemesterName }} course site with
-                  {{ selectedSections(coursesList).length }}
-                  {{ pluralize(section, selectedSections(coursesList).length) }}:
-                </strong>
-                <ul class="bc-page-create-course-site-section-list">
-                  <li v-for="section in selectedSections(coursesList)" :key="section.ccn">
-                    {{ section.courseTitle }} - {{ section.courseCode }}
-                    {{ section.section_label }} ({{ section.ccn }})
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </div>
-          <div>
-            <div class="medium-12 columns">
-              <form
-                name="createCourseSiteForm"
-                class="bc-canvas-page-form"
-                @submit="createCourseSiteJob"
-              >
-                <div>
-                  <div class="small-12 medium-6 end">
-                    <div class="bc-page-create-course-site-form-fields-container">
-                      <div>
-                        <div class="medium-offset-1 medium-4 columns">
-                          <label for="siteName" class="right">Site Name:</label>
-                        </div>
-                        <div class="medium-7 columns">
-                          <b-form-input
-                            id="siteName"
-                            v-model="siteName"
-                            type="text"
-                            name="siteName"
-                            :required="true"
-                          />
-                          <div v-if="createCourseSiteForm.siteName.$error.required" class="bc-alert bc-notice-error">
-                            <fa icon="exclamation-circle" class="cc-left cc-icon-red bc-canvas-notice-icon"></fa>
-                            Please fill out a site name.
-                          </div>
-                        </div>
-                      </div>
-                      <div>
-                        <div class="medium-offset-1 medium-4 columns">
-                          <label for="siteAbbreviation" class="right">Site Abbreviation:</label>
-                        </div>
-                        <div class="medium-7 columns">
-                          <b-form-input
-                            id="siteAbbreviation"
-                            v-model="siteAbbreviation"
-                            type="text"
-                            name="siteAbbreviation"
-                            :required="true"
-                          />
-                          <div v-if="createCourseSiteForm.siteAbbreviation.$error.required" class="bc-alert bc-notice-error">
-                            <fa icon="exclamation-circle" class="cc-left cc-icon-red bc-canvas-notice-icon"></fa>
-                            Please fill out a site abbreviation.
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div>
-                  <div class="medium-12 columns">
-                    <div class="bc-form-actions">
-                      <button
-                        :disabled="createCourseSiteForm.$invalid"
-                        class="bc-canvas-button bc-canvas-button-primary"
-                        type="submit"
-                        role="button"
-                        aria-label="Create Course Site"
-                        aria-controls="bc-page-create-course-site-steps-container"
-                      >
-                        Create Course Site
-                      </button>
-                      <button class="bc-canvas-button" type="button" @click="showSelecting">Go Back</button>
-                    </div>
-                  </div>
-                </div>
-              </form>
-            </div>
-          </div>
+          <ConfirmationStep :selected-sections="selectedSections" />
         </div>
         <div
           v-if="currentWorkflowStep === 'monitoring_job'"
           id="bc-page-create-course-site-monitor-step"
           :aria-expanded="currentWorkflowStep === 'monitoring_job'"
         >
-          <!-- TODO: data-cc-focus-reset-directive -->
-          <h2 class="cc-visuallyhidden" data-cc-focus-reset-directive="confirmFocus">Course Site Creation</h2>
-          <div aria-live="polite">
-            <div v-show="!jobStatus" class="bc-page-create-course-site-pending-request">
-              <fa icon="spinner" spin></fa>
-              Sending request...
-            </div>
-            <div v-if="jobStatus === 'New'" class="bc-page-create-course-site-pending-request">
-              <fa icon="spinner" spin></fa>
-              Course provisioning request sent. Awaiting processing....
-            </div>
-            <div v-if="jobStatus">
-              <div>
-                <ProgressBar :percent-complete-rounded="50" />
-              </div>
-              <div v-if="jobStatus === 'Error'">
-                <BackgroundJobError :error-config="errorConfig" :errors="errors" />
-                <div class="bc-page-create-course-site-step-options">
-                  <div class="medium-12 columns">
-                    <div class="bc-form-actions">
-                      <button
-                        class="bc-canvas-button bc-canvas-button-primary"
-                        type="button"
-                        aria-control="bc-page-create-course-site-selecting-step"
-                        aria-label="Start over course site creation process"
-                        @click="fetchFeed"
-                      >
-                        Start Over
-                      </button>
-                      <button
-                        class="cc-button cc-page-button-grey"
-                        type="button"
-                        aria-control="bc-page-create-course-site-confirmation-step"
-                        aria-label="Go Back to Site Details Confirmation"
-                        @click="showConfirmation"
-                      >
-                        Back
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div v-if="jobStatus === 'Completed'" :aria-expanded="jobStatus === 'Completed'">
-            <!-- TODO: data-cc-spinner-directive -->
-            <div data-cc-spinner-directive></div>
-            <div class="cc-visuallyhidden" role="alert">
-              Redirecting to new course site.
-            </div>
-          </div>
+          <MonitoringJob fetch-feed="fetchFeed" job-status="jobStatus" show-confirmation="showConfirmation" />
         </div>
       </div>
     </div>
@@ -408,19 +53,25 @@
 
 <script>
 import Accessibility from '@/mixins/Accessibility'
-import BackgroundJobError from '@/components/bcourses/shared/BackgroundJobError'
 import CanvasErrors from '@/components/bcourses/CanvasErrors'
+import ConfirmationStep from '@/components/bcourses/create/ConfirmationStep'
 import Context from '@/mixins/Context'
-import CourseSectionsTable from '@/components/bcourses/CourseSectionsTable'
-import MaintenanceNotice from '@/components/bcourses/shared/MaintenanceNotice'
-import ProgressBar from '@/components/bcourses/shared/ProgressBar'
+import CreateCourseSiteHeader from '@/components/bcourses/create/CreateCourseSiteHeader'
+import MonitoringJob from '@/components/bcourses/create/MonitoringJob'
+import SelectSectionsStep from '@/components/bcourses/create/SelectSectionsStep'
 import Utils from '@/mixins/Utils'
 import {getCourseProvisioningMetadata, getSections} from '@/api/canvas'
 
 export default {
   name: 'CreateCourseSite',
   mixins: [Accessibility, Context, Utils],
-  components: {BackgroundJobError, CanvasErrors, CourseSectionsTable, MaintenanceNotice, ProgressBar},
+  components: {
+    CanvasErrors,
+    ConfirmationStep,
+    CreateCourseSiteHeader,
+    MonitoringJob,
+    SelectSectionsStep
+  },
   data: () => ({
     adminActingAs: undefined,
     adminByCcns: undefined,
@@ -445,15 +96,11 @@ export default {
     isTeacher: undefined,
     isUidInputMode: true,
     jobStatus: undefined,
-    linkToSiteOverview: undefined,
     selectedSectionsList: undefined,
     semester: undefined,
     showMaintenanceNotice: true,
     siteName: undefined,
-    teachingSemesters: undefined,
-    toggle: {
-      displayHelp: false
-    }
+    teachingSemesters: undefined
   }),
   created() {
     this.$loading()
@@ -624,6 +271,9 @@ export default {
       this.coursesList = newSelectedCourses
       this.updateSelected()
     },
+    setAdminActingAs(uid) {
+      this.adminActingAs = uid
+    },
     showConfirmation() {
       // TODO
       return []
@@ -636,7 +286,6 @@ export default {
       this.currentAdminSemester = semester.slug
       this.selectedSectionsList = []
       this.updateSelected()
-
     },
     switchSemester(semester) {
       this.currentSemester = semester.slug
@@ -664,47 +313,10 @@ export default {
     padding: 10px;
   }
 
-  .bc-page-create-course-site-header {
-    color: $bc-color-headers;
-    font-family: $bc-base-font-family;
-    font-weight: normal;
-    line-height: 40px;
-    margin: 5px 0;
-  }
-
-  .bc-page-create-course-site-header1 {
-    font-size: 23px;
-  }
-
-  .bc-page-create-course-site-header2 {
-    font-size: 18px;
-    margin: 10px 0;
-  }
-
-  .bc-page-create-course-site-admin-options {
-    margin-bottom: 15px;
-  }
-
   .cc-page-button-grey {
     background: linear-gradient($bc-color-button-grey-gradient-1, $bc-color-button-grey-gradient-2);
     border: 1px solid $bc-color-button-grey-border;
     color: $bc-color-button-grey-text;
-  }
-
-  .bc-page-create-course-site-act-as-form {
-    margin: 5px 0;
-    input[type="text"] {
-      font-family: $bc-base-font-family;
-      font-size: 14px;
-      margin: 2px 10px 0 0;
-      padding: 8px 12px;
-      width: 140px;
-    }
-  }
-
-  .bc-page-create-course-site-admin-mode-switch {
-    margin-bottom: 5px;
-    outline: none;
   }
 
   .bc-page-create-course-site-choices {
@@ -721,66 +333,12 @@ export default {
     }
   }
 
-  .bc-page-create-course-site-section-list {
-    list-style-type: disc;
-    margin: 10px 0 0 39px;
-  }
-
-  .bc-page-create-course-site-help-notice {
-    margin-bottom: 20px;
-    .bc-page-create-course-site-help-notice-ordered-list {
-      margin-bottom: 10px;
-      margin-left: 20px;
-    }
-
-    .bc-page-create-course-site-help-notice-paragraph {
-      margin-bottom: 7px;
-    }
-  }
-
-  .bc-page-create-course-site-form-fields-container {
-    margin: 10px 0;
-  }
-
-  .bc-page-create-course-site-pending-request {
-    margin: 15px auto;
-  }
-
-  .bc-page-create-course-site-steps-container {
-    padding: 0;
-  }
-
-  .bc-page-create-course-site-step-options {
-    padding: 20px 0;
-  }
-
-  .bc-page-create-course-site-success-intro {
-    margin: 15px 0 0;
-  }
-
-  // Form with Expandable Courses & Sections
-
-  .bc-page-create-course-site-section-margin {
-    margin: 0;
-    overflow: hidden;
-  }
-
   .bc-page-create-course-site-form-course-button {
     color: $bc-color-body-black;
 
     &:focus, &:hover {
       text-decoration: none;
     }
-  }
-
-  .bc-page-create-course-site-form-select-all-option {
-    font-size: 12px;
-    font-weight: normal;
-    margin: 6px 0 4px 2px;
-  }
-
-  .bc-page-create-course-site-form-select-all-option-button {
-    outline: none;
   }
 }
 </style>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7525

An all-in-one `CreateCourseSite` component is unwieldy. Breaking up its template code based on steps in workflow makes sense, methinks.