### PR TITLE
CLC-7587, remove 'oauth' copy in _start_tomcat.sh

### DIFF
--- a/script/deploy/_start-tomcat.sh
+++ b/script/deploy/_start-tomcat.sh
@@ -51,9 +51,6 @@ cat ${TOMCAT_DEPLOY}/ROOT/WEB-INF/versions/git.txt | ${LOGIT}
 log_info "Copying assets into ${DOC_ROOT}"
 cp -Rvf ${TOMCAT_DEPLOY}/ROOT/WEB-INF/dist ${DOC_ROOT} | ${LOGIT}
 
-log_info "Copying oauth to ${DOC_ROOT}"
-cp -Rvf ${TOMCAT_DEPLOY}/ROOT/oauth ${DOC_ROOT} | ${LOGIT}
-
 log_info "Move compiled 'index.html' into ${TOMCAT_DEPLOY}/ROOT"
 cp -vf "${TOMCAT_DEPLOY}/ROOT/WEB-INF/dist/static/index.html" "${TOMCAT_DEPLOY}/ROOT/" | ${LOGIT}
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7587

I'd like to use Apache config to serve `/oauth` instead of copying files around at deploy time.