### PR TITLE
CLC-7587, 'terms.term_definitions_json_file' exists in settings; let's override in prod.yml

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -33,4 +33,5 @@ background_threads:
   max_queue: 0  # unbounded work queue
 
 terms:
-  legacy_ccn_mappings_file: "csv/legacy_ccn_mappings.csv"
+  legacy_ccn_mappings_file: "dist/static/csv/legacy_ccn_mappings.csv"
+  term_definitions_json_file: "dist/static/json/terms.json"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7587

I believe `~/tomcat9/webapps/ROOT/WEB-INF` is Rails.root. I tested the legacy_ccn_mappings config value in `~/.calcentral_config/production.local.yml` and Junction no longer complains about file not found.