### PR TITLE
CLC-7599, No need for store-user-as-recent on client-side. And avoid CORs error on re-auth?

### DIFF
--- a/src/components/toolbox/ActAs.vue
+++ b/src/components/toolbox/ActAs.vue
@@ -68,7 +68,7 @@ import {
   getMyStoredUsers,
   removeAllRecentUsers,
   removeAllSavedUsers,
-  removeSavedUser, storeUserAsRecent,
+  removeSavedUser,
   storeUserAsSaved
 } from '@/api/act'
 
@@ -120,10 +120,8 @@ export default {
       })
     },
     actAsUser(uid) {
-      actAs(uid).then(() => {
-        this.alertScreenReader(`Prepare to act as user ${uid}.`)
-        storeUserAsRecent(uid).then(() => window.location.href = '/')
-      })
+      this.alertScreenReader(`Prepare to act as user ${uid}.`)
+      actAs(uid).then(() => window.location.href = '/')
     }
   }
 }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7599

Store-as-recent happens server-side when act-as session starts:
https://github.com/ets-berkeley-edu/calcentral/blob/bf11e27068c8b3b3e3a9780e62da076066125446/app/controllers/act_as_controller.rb#L49