### PR TITLE
CLC-7615 Fix keyboard navigation in Vue forms

### DIFF
--- a/src/components/bcourses/CourseAddUser.vue
+++ b/src/components/bcourses/CourseAddUser.vue
@@ -79,7 +79,7 @@
 
       <b-row v-if="showSearchForm" no-gutters>
         <b-col md="6">
-          <form class="bc-canvas-page-form">
+          <form class="bc-canvas-page-form" @submit.prevent="searchUsers">
             <b-row class="bc-horizontal-form" no-gutters>
               <b-col md="4">
                 <label for="search-text" class="cc-visuallyhidden">Search users</label>
@@ -113,10 +113,9 @@
               <b-col md="2" class="bc-column-align-center">
                 <button
                   id="submit-search"
-                  type="button"
+                  type="submit"
                   class="bc-canvas-button bc-canvas-button-primary bc-full-wide"
                   aria-label="Perform User Search"
-                  @click="searchUsers"
                 >
                   Go
                 </button>

--- a/src/components/bcourses/SiteMailingList.vue
+++ b/src/components/bcourses/SiteMailingList.vue
@@ -33,15 +33,14 @@
         members. Students and people not in the site cannot send messages through Mailing Lists.
       </p>
 
-      <form v-if="!listCreated" class="bc-canvas-page-form bc-canvas-form">
+      <form v-if="!listCreated" class="bc-canvas-page-form bc-canvas-form" @submit.prevent="createMailingList">
         <div class="bc-form-actions">
           <button
             id="btn-create-mailing-list"
-            type="button"
+            type="submit"
             class="bc-canvas-button bc-canvas-button-primary"
             aria-controls="cc-page-reader-alert"
             :disabled="errorMessages"
-            @click="createMailingList"
           >
             <span v-if="!isCreating">Create mailing list</span>
             <span v-if="isCreating"><fa icon="spinner" class="mr-2 fa-spin"></fa> Creating ...</span>

--- a/src/components/bcourses/SiteMailingLists.vue
+++ b/src/components/bcourses/SiteMailingLists.vue
@@ -20,7 +20,7 @@
     </div>
 
     <div v-if="!siteSelected">
-      <form class="bc-page-site-mailing-list-form">
+      <form class="bc-page-site-mailing-list-form" @submit.prevent="findSiteMailingList">
         <b-row no-gutters>
           <b-col sm="12" md="3">
             <label for="bc-page-site-mailing-list-site-id" class="bc-page-site-mailing-list-form-label">Course Site ID:</label>
@@ -37,10 +37,9 @@
             >
             <button 
               id="btn-get-mailing-list"
-              type="button"
+              type="submit"
               class="bc-canvas-button bc-canvas-button-primary"
               :disabled="isProcessing || !canvasSite.canvasCourseId"
-              @click="findSiteMailingList"
             >
               <span v-if="!isProcessing">Get Mailing List</span>
               <span v-if="isProcessing"><i class="fa fa-spinner fa-spin"></i> Finding ...</span>

--- a/src/components/bcourses/create/ConfirmationStep.vue
+++ b/src/components/bcourses/create/ConfirmationStep.vue
@@ -15,7 +15,7 @@
       <form
         name="createCourseSiteForm"
         class="bc-canvas-page-form"
-        @submit="create"
+        @submit.prevent="create"
       >
         <b-container>
           <b-row>
@@ -60,11 +60,11 @@
           <div>
             <b-button
               id="create-course-site-button"
+              type="submit"
               aria-controls="bc-page-create-course-site-steps-container"
               aria-label="Create Course Site"
               class="bc-canvas-button bc-canvas-button-primary"
               :disabled="!$_.trim(siteName) || !$_.trim(siteAbbreviation)"
-              @click="create"
             >
               Create Course Site
             </b-button>

--- a/src/components/bcourses/create/CreateCourseSiteHeader.vue
+++ b/src/components/bcourses/create/CreateCourseSiteHeader.vue
@@ -23,11 +23,11 @@
           <div>
             <b-button
               id="sections-by-uid-button"
+              type="submit"
               class="bc-canvas-button bc-canvas-button-primary"
               :disabled="!uid"
               aria-label="Load official sections for instructor"
               aria-controls="bc-page-create-course-site-steps-container"
-              @click="submit"
             >
               As instructor
             </b-button>
@@ -48,6 +48,7 @@
                   :aria-selected="currentAdminSemester === semester.slug"
                   role="tab"
                   @click="switchAdminSemester(semester)"
+                  @keyup.enter="switchAdminSemester(semester)"
                 />
                 <label
                   :for="`semester${index}`"
@@ -81,7 +82,6 @@
               aria-controls="bc-page-create-course-site-steps-container"
               :disabled="!$_.trim(ccns)"
               type="submit"
-              @click="submit"
             >
               Review matching CCNs
             </b-button>

--- a/src/views/CreateProjectSite.vue
+++ b/src/views/CreateProjectSite.vue
@@ -3,7 +3,7 @@
     <div v-if="loading" class="cc-spinner"></div>
     <div v-if="!loading && !error">
       <h1 class="bc-header bc-header2">Create a Project Site</h1>
-      <form class="bg-transparent border-0 bc-canvas-form">
+      <form class="bg-transparent border-0 bc-canvas-form" @submit.prevent="createProjectSite">
         <b-container>
           <b-row>
             <b-col class="float-right" sm="3">
@@ -28,13 +28,13 @@
             aria-controls="cc-page-reader-alert"
             class="bc-canvas-button bc-canvas-button-primary"
             type="submit"
-            @click="createProjectSite"
           >
             <span v-if="!isCreating">Create a Project Site</span>
             <span v-if="isCreating"><fa class="mr-1" icon="spinner" spin></fa> Creating...</span>
           </button>
           <b-button
             id="cancel-and-return-to-site-creation"
+            type="button"
             aria-label="Cancel and return to Site Creation Overview"
             class="bc-canvas-button"
             variant="link"


### PR DESCRIPTION
Fixes https://jira.ets.berkeley.edu/jira/browse/CLC-7615 and similar problems elsewhere. Using `type=“submit”` on buttons and `@submit.prevent` in forms is the accessibility lesson of the day.