### PR TITLE
CLC-7620, Junction act-as no longer requires reauth

### DIFF
--- a/app/controllers/act_as_controller.rb
+++ b/app/controllers/act_as_controller.rb
@@ -2,8 +2,6 @@ class ActAsController < ApplicationController
   include ViewAsAuthorization
   include ClassLogger
 
-  skip_before_action :check_reauthentication, :only => [:stop_act_as]
-
   def initialize(options = {})
     @act_as_session_key = options[:act_as_session_key] || SessionKey.original_user_id
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -166,9 +166,8 @@ class ApplicationController < ActionController::Base
   end
 
   def session_state_requires_reauthentication?
-    Settings.features.reauthentication &&
-      (current_user.classic_viewing_as?) &&
-      !cookies[:reauthenticated]
+    # TODO: Rip out all re-authentication-related code. See CLC-7648
+    false
   end
 
   def get_settings

--- a/spec/controllers/bootstrap_controller_spec.rb
+++ b/spec/controllers/bootstrap_controller_spec.rb
@@ -13,38 +13,4 @@ describe BootstrapController do
     end
   end
 
-  describe 'reauthentication' do
-    let(:original_user_id) {nil}
-    before do
-      expect(Settings.features).to receive(:reauthentication).and_return(true)
-      session['user_id'] = user_id
-      session[SessionKey.original_user_id] = original_user_id
-    end
-    context 'when viewing as' do
-      let(:original_user_id) {random_id}
-      context 'when not already reauthenticated' do
-        it 'should redirect to reauthenticate' do
-          get :index
-          hostname = request.env['HTTP_HOST']
-          expect(response).to redirect_to "/auth/cas?renew=true&url=http://#{hostname}/"
-        end
-      end
-      context 'when already reauthenticated' do
-        before do
-          allow(controller).to receive(:cookies).and_return({reauthenticated: true})
-        end
-        it 'should not redirect' do
-          get :index
-          expect(response).not_to redirect_to('/auth/cas?renew=true&url=/')
-        end
-      end
-    end
-    context 'when not viewing as' do
-      it 'should not redirect' do
-        get :index
-        expect(response).not_to redirect_to('/auth/cas?renew=true&url=/')
-      end
-    end
-  end
-
 end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7620

This has no impact and no relation to masquerading in Canvas.