### PR TITLE
CLC-7547 Remove unnecessary past-term API calls from course provision feed

### DIFF
--- a/app/models/berkeley/teaching.rb
+++ b/app/models/berkeley/teaching.rb
@@ -45,8 +45,8 @@ module Berkeley
       }
     end
 
-    def merge_canvas_sites(data)
-      if Canvas::Proxy.access_granted?(@uid) && (canvas_sites = Canvas::MergedUserSites.new(@uid).get_feed)
+    def merge_canvas_sites(data, terms)
+      if Canvas::Proxy.access_granted?(@uid) && (canvas_sites = Canvas::MergedUserSites.new(@uid, terms).get_feed)
         included_course_sites = {}
         canvas_sites[:courses].each do |course_site|
           if (merged_courses = course_site_merge(data, course_site))

--- a/app/models/canvas_csv/provide_course_site.rb
+++ b/app/models/canvas_csv/provide_course_site.rb
@@ -331,7 +331,7 @@ module CanvasCsv
         semesters = []
         academics_feed = {}
         Berkeley::Teaching.new(@uid).merge(academics_feed, current_terms)
-        Berkeley::Teaching.new(@uid).merge_canvas_sites academics_feed
+        Berkeley::Teaching.new(@uid).merge_canvas_sites(academics_feed, current_terms)
         if (teaching_semesters = academics_feed[:teachingSemesters])
           current_terms.each do |term|
             if (teaching_semester = teaching_semesters.find {|semester| semester[:slug] == term[:slug]})

--- a/spec/models/berkeley/teaching_spec.rb
+++ b/spec/models/berkeley/teaching_spec.rb
@@ -67,6 +67,22 @@ describe Berkeley::Teaching do
       expect(EdoOracle::UserCourses::Instructing).to receive(:new).and_return double(get_courses_instructing: edo_courses)
     end
     let(:uid) { '242881' }
+    let(:terms) do
+      [
+        {
+          name: 'Spring 2012',
+          slug: 'spring-2012',
+          term_yr: '2012',
+          term_cd: 'B' 
+        },
+        {
+          name: 'Fall 2013',
+          slug: 'fall-2013',
+          term_yr: '2013',
+          term_cd: 'D' 
+        }
+      ]
+    end
     let(:edo_courses) do
       {
         '2013-D' => [
@@ -381,6 +397,16 @@ describe Berkeley::Teaching do
     end
     let(:fake_term_yr) {2013}
     let(:fake_term_cd) {'D'}
+    let(:terms) do
+      [
+        {
+          name: 'Fall 2013',
+          slug: 'fall-2013',
+          term_yr: '2013',
+          term_cd: 'D' 
+        }
+      ]
+    end
     let(:teaching_classes) {[]}
     let(:fake_feed) do
       {
@@ -393,7 +419,7 @@ describe Berkeley::Teaching do
     end
 
     subject do
-      Berkeley::Teaching.new(uid).merge_canvas_sites(fake_feed)
+      Berkeley::Teaching.new(uid).merge_canvas_sites(fake_feed, terms)
     end
 
     context 'with no Canvas account' do
@@ -442,7 +468,7 @@ describe Berkeley::Teaching do
         }
       end
       before { Canvas::Proxy.stub(:access_granted?).with(uid).and_return(true) }
-      before { Canvas::MergedUserSites.stub(:new).with(uid).and_return(double(get_feed: canvas_sites)) }
+      before { Canvas::MergedUserSites.stub(:new).with(uid, terms).and_return(double(get_feed: canvas_sites)) }
 
       context 'when the Canvas site has an academic term' do
         let(:term_yr) {fake_term_yr}

--- a/spec/models/canvas/merged_user_sites_spec.rb
+++ b/spec/models/canvas/merged_user_sites_spec.rb
@@ -1,6 +1,14 @@
 describe Canvas::MergedUserSites do
   let(:uid) { rand(999999).to_s }
   let(:canvas_course_id) { rand(999999) }
+  let(:terms) do
+    [{
+      name: 'Fall 2013',
+      slug: 'fall-2013',
+      term_yr: '2013',
+      term_cd: 'D' 
+    }]
+  end
   let(:canvas_course) { {
     'id' => canvas_course_id,
     'course_code' => "ANTHRO #{canvas_course_id}",
@@ -25,7 +33,7 @@ describe Canvas::MergedUserSites do
       'course_id' => canvas_course_id,
       'name' => "Section #{canvas_section_id}"
     }}
-    subject { Canvas::MergedUserSites.new(uid).merge_course_with_sections(canvas_course, [canvas_section]) }
+    subject { Canvas::MergedUserSites.new(uid, terms).merge_course_with_sections(canvas_course, [canvas_section]) }
     context 'when a Canvas section has a possible SIS link' do
       let(:ccn) { random_ccn }
       let(:canvas_section) {canvas_section_base.merge({ 'sis_section_id' => "SEC:2013-D-#{ccn}" })}
@@ -73,7 +81,7 @@ describe Canvas::MergedUserSites do
       }],
       groups: []
     }}
-    subject { Canvas::MergedUserSites.new(uid).get_group_data(canvas_group) }
+    subject { Canvas::MergedUserSites.new(uid, terms).get_group_data(canvas_group) }
     context 'when a Canvas group site is associated with a course site' do
       let(:canvas_group) {canvas_group_base.merge({ 'context_type' => 'Course', 'course_id' => canvas_course_id })}
       it_behaves_like 'a group site item'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7547