### PR TITLE
CLC-7646 Don't let Tomcat serve static html files

### DIFF
--- a/script/deploy/_start-tomcat.sh
+++ b/script/deploy/_start-tomcat.sh
@@ -51,8 +51,9 @@ cat ${TOMCAT_DEPLOY}/ROOT/WEB-INF/versions/git.txt | ${LOGIT}
 log_info "Copying assets into ${DOC_ROOT}"
 cp -Rvf ${TOMCAT_DEPLOY}/ROOT/WEB-INF/dist ${DOC_ROOT} | ${LOGIT}
 
-log_info "Move compiled 'index.html' into ${TOMCAT_DEPLOY}/ROOT"
-cp -vf "${TOMCAT_DEPLOY}/ROOT/WEB-INF/dist/static/index.html" "${TOMCAT_DEPLOY}/ROOT/" | ${LOGIT}
+log_info "Removing uncompiled html from ${TOMCAT_DEPLOY}/ROOT"
+rm "${TOMCAT_DEPLOY}/ROOT/index.html" | ${LOGIT}
+rm "${TOMCAT_DEPLOY}/ROOT/lti.html" | ${LOGIT}
 
 # Fix file permissions for Tomcat deploys
 cd ${DOC_ROOT}


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7646

Having a static index.html in place can short-circuit server-side auth logic on app load.