### PR TITLE
CLC-7716 Stability improvements to Canvas enrollments refresh

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -189,7 +189,7 @@ cache:
     default: <%= 35.minutes %>
     failure: <%= 30.seconds %>
     BackgroundJobsCheck: <%= 29.days %>
-    User::Api: NEXT_08_00
+    User::Api: NEXT_00_00
     User::AuthenticationValidator: <%= 8.hours %>
     User::AuthenticationValidator::short: <%= 5.minutes %>
     Cal1card::Photo: <%= 4.hours %>
@@ -200,7 +200,7 @@ cache:
     CanvasLti::Egrades: <%= 1.minute %>
     CanvasLti::Lti: <%= 5.minutes %>
 
-    Berkeley::Terms: NEXT_08_00
+    Berkeley::Terms: NEXT_00_00
     Berkeley::LegacyTerms: <%= 29.days %>
 
     EdoOracle::CourseSections: <%= 8.hours %>

--- a/script/refresh-canvas-enrollments.sh
+++ b/script/refresh-canvas-enrollments.sh
@@ -27,5 +27,5 @@ echo "`date`: About to run the refresh script..." | $LOGIT
 set -o pipefail
 /usr/bin/flock -n /tmp/canvas-refresh.lock bundle exec rake canvas:full_refresh |& $LOGIT
 if [[ $? != 0 ]]; then
-  echo "Found a /tmp/canvas-refresh.lock file from another refresh in progress; will not run." |& $LOGIT
+  echo "Job failed. Immediate exit may indicate a /tmp/canvas-refresh.lock file from another refresh in progress." |& $LOGIT
 fi

--- a/script/refresh-canvas-recent.sh
+++ b/script/refresh-canvas-recent.sh
@@ -27,5 +27,5 @@ echo "`date`: About to run the refresh script..." | $LOGIT
 set -o pipefail
 /usr/bin/flock -n /tmp/canvas-refresh.lock bundle exec rake canvas:recent_refresh |& $LOGIT
 if [[ $? != 0 ]]; then
-  echo "Found a /tmp/canvas-refresh.lock file from another refresh in progress; will not run." |& $LOGIT
+  echo "Job failed. Immediate exit may indicate a /tmp/canvas-refresh.lock file from another refresh in progress." |& $LOGIT
 fi

--- a/script/refresh-canvas-users.sh
+++ b/script/refresh-canvas-users.sh
@@ -26,5 +26,5 @@ echo "`date`: About to run the refresh script..." | $LOGIT
 set -o pipefail
 /usr/bin/flock -n /tmp/canvas-refresh.lock bundle exec rake canvas:user_accounts_refresh |& $LOGIT
 if [[ $? != 0 ]]; then
-  echo "Found a /tmp/canvas-refresh.lock file from another refresh in progress; will not run." |& $LOGIT
+  echo "Job failed. Immediate exit may indicate a /tmp/canvas-refresh.lock file from another refresh in progress." |& $LOGIT
 fi

--- a/script/sync-canvas-guest-users.sh
+++ b/script/sync-canvas-guest-users.sh
@@ -26,5 +26,5 @@ echo "`date`: About to run the guest user sync script..." | $LOGIT
 set -o pipefail
 /usr/bin/flock -n /tmp/canvas-guest-user-sync.lock bundle exec rake canvas:guest_user_sync |& $LOGIT
 if [[ $? != 0 ]]; then
-  echo "Found a /tmp/canvas-guest-user-sync.lock file from another sync in progress; will not run." |& $LOGIT
+  echo "Job failed. Immediate exit may indicate a /tmp/canvas-guest-user-sync.lock file from another refresh in progress." |& $LOGIT
 fi


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7716

- Move some cache expirations from obsolete 8am to sensible midnight;
- Handle unexpectedly missing local CSV exports;
- Fix misleading message on script failure.