### PR TITLE
CLC-7711 bCourses mailing lists: set alternateId address source in configuration

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -235,7 +235,7 @@ background_jobs_check:
   time_between_pings: <%= 5.minutes %>
 
 canvas_mailing_lists:
-  prefer_canvas_email_addresses: false
+  preferred_email_address_source: 'ldapMail' # Possible values: 'ldapMail', 'ldapAlternateId', 'canvas'
   timestamp_tolerance: 60
 
 oec:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-7711